### PR TITLE
fix: build error on linux due to tauri-plugin-context-menu

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3938,18 +3938,22 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-context-menu"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93737f332761822f2d1ee6f7dbe4c1f94c4d03020a349bc1f8070d75b6409e8"
+checksum = "408c121f5a61ef57b6246f87ef6205a9602efffd1c2db8fd5d696f61b055fac2"
 dependencies = [
  "cocoa",
  "dispatch",
+ "gdk",
+ "glib",
+ "gtk",
  "image",
  "lazy_static",
  "libc",
  "objc",
  "serde",
  "tauri",
+ "time",
  "winapi",
 ]
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ tauri-build = { version = "1.5.0", features = [] }
 tauri = { version = "1.5.0", features = [ "window-set-position", "fs-write-file", "fs-remove-file", "fs-read-file", "fs-rename-file", "fs-exists", "fs-remove-dir", "fs-read-dir", "fs-copy-file", "fs-create-dir", "window-set-ignore-cursor-events", "macos-private-api", "window-unminimize", "window-minimize", "window-close", "window-show", "window-start-dragging", "window-hide", "window-unmaximize", "window-maximize", "window-set-always-on-top", "shell-open", "devtools"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tauri-plugin-context-menu = "0.5.0"
+tauri-plugin-context-menu = "0.7.0"
 tauri-plugin-positioner = { version = "1.0.4", features = ["system-tray"] }
 ffmpeg-sidecar = "0.5.1"
 which = "4.2.2"


### PR DESCRIPTION
This PR fixes the following error when compiling `tauri-plugin-context-menu` on linux as discussed over on Discord: `error[E0433]: failed to resolve: use of undeclared crate or module 'os'`

Extended error:
```
error[E0433]: failed to resolve: use of undeclared crate or module `os`
  --> /home/luca/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tauri-plugin-context-menu-0.5.0/src/lib.rs:60:9
   |
60 |         os::show_context_menu(context_menu, window, pos, items);
   |         ^^ use of undeclared crate or module `os`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `tauri-plugin-context-menu` (lib) due to previous error
```