### PR TITLE
Use `@mattrax/mysql-planetscale` in dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,12 @@ NEXT_PUBLIC_TASKS_URL=http://localhost:3002
 NEXT_PUBLIC_LOCAL_MODE=false
 
 # -- database ****************
-DATABASE_URL=mysql://root@localhost:3900/cap
+#
+# This is the URL for the PlanetScale database simulator,
+# which will automatically be created on pnpm dev.
+# It is used for local development only.
+# For production, use the DATABASE_URL from your DB provider. Must include https for production use, mysql:// for local.
+DATABASE_URL=mysql://root:@localhost:3306/planetscale
 
 # Generate a secret with `openssl rand -base64 32`
 NEXTAUTH_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -26,10 +26,7 @@ NEXT_PUBLIC_TASKS_URL=http://localhost:3002
 NEXT_PUBLIC_LOCAL_MODE=false
 
 # -- database ****************
-DB_PLANETSCALE_HOST=localhost:3900
-DB_PLANETSCALE_DATABASE=planetscale
-DB_PLANETSCALE_USERNAME=root
-DB_PLANETSCALE_PASSWORD=planetscale
+DATABASE_URL=mysql://root@localhost:3900/cap
 
 # Generate a secret with `openssl rand -base64 32`
 NEXTAUTH_SECRET=

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -1,0 +1,36 @@
+# This is meant for local development only. Do not use this in production.
+version: "3.8"
+services:
+  ps-mysql:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_DATABASE: planetscale
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    command:
+      [
+        "--max_connections=1000",
+        "--default-authentication-plugin=mysql_native_password",
+      ]
+    ports:
+      - 3306:3306
+    volumes:
+      - ps-mysql:/var/lib/mysql
+  planetscale-proxy:
+    image: ghcr.io/mattrobenolt/ps-http-sim:latest
+    command:
+      [
+        "-mysql-no-pass",
+        "-listen-port=3900",
+        "-mysql-dbname=planetscale",
+        "-mysql-addr=ps-mysql",
+      ]
+    depends_on:
+      - ps-mysql
+    ports:
+      - 3900:3900
+    links:
+      - ps-mysql
+volumes:
+  ps-mysql:

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -4,6 +4,12 @@ import million from "million/compiler";
 
 import("dotenv").then(({ config }) => config({ path: "../../.env" }));
 
+if (process.env.DB_PLANETSCALE_HOST !== undefined) {
+  throw new Error(
+    "DB_PLANETSCALE_HOST no longer supported. Use DATABASE_URL instead. Must start with mysql:// for local dev, and https:// for production."
+  );
+}
+
 import fs from "fs";
 import path from "path";
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "build": "dotenv -e .env -- turbo run build",
-    "dev": "dotenv -e .env -- turbo run dev --no-cache",
+    "dev": "(cd apps/web && docker-compose up -d)  && dotenv -e .env -- pnpm --dir packages/database db:generate && dotenv -e .env -- pnpm --dir packages/database db:push && dotenv -e .env -- turbo run dev --no-cache",
+    "dev:manual": "dotenv -e .env -- turbo run dev --no-cache",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "db:push": "dotenv -e .env -- pnpm --dir packages/database db:push",

--- a/packages/database/.gitignore
+++ b/packages/database/.gitignore
@@ -1,0 +1,1 @@
+/migrations

--- a/packages/database/drizzle.config.ts
+++ b/packages/database/drizzle.config.ts
@@ -10,5 +10,6 @@ export default {
   dbCredentials: {
     uri: process.env.DATABASE_URL,
   },
+  out: "./migrations",
   driver: "mysql2",
 } satisfies Config;

--- a/packages/database/drizzle.config.ts
+++ b/packages/database/drizzle.config.ts
@@ -1,9 +1,14 @@
 import type { Config } from "drizzle-kit";
 
+if (!process.env.DATABASE_URL?.startsWith("mysql://"))
+  throw new Error(
+    "DATABASE_URL must be a 'mysql://' URI. Drizzle Kit doesn't support the fetch adapter!"
+  );
+
 export default {
   schema: "./schema.ts",
   dbCredentials: {
-    uri: `mysql://${process.env.DB_PLANETSCALE_USERNAME}:${process.env.DB_PLANETSCALE_PASSWORD}@${process.env.DB_PLANETSCALE_HOST}/${process.env.DB_PLANETSCALE_DATABASE}?ssl={"rejectUnauthorized":false}`,
+    uri: process.env.DATABASE_URL,
   },
   driver: "mysql2",
 } satisfies Config;

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -1,8 +1,24 @@
 import { drizzle } from "drizzle-orm/planetscale-serverless";
-import { Client } from "@planetscale/database";
+import { Client, Config } from "@planetscale/database";
+
+const URL = process.env.DATABASE_URL!;
+
+let fetchHandler: Config["fetch"] = undefined;
 
 export const connection = new Client({
-  url: `mysql://${process.env.DB_PLANETSCALE_USERNAME}:${process.env.DB_PLANETSCALE_PASSWORD}@${process.env.DB_PLANETSCALE_HOST}/${process.env.DB_PLANETSCALE_DATABASE}?ssl={"rejectUnauthorized":false}`,
+  url: URL,
+  fetch: async (input, init) => {
+    if (
+      process.env.NEXT_PUBLIC_ENVIRONMENT === "development" &&
+      URL.startsWith("mysql://")
+    ) {
+      fetchHandler = (
+        await import("@mattrax/mysql-planetscale")
+      ).createFetchHandler(URL);
+    }
+
+    return await (fetchHandler || fetch)(input, init);
+  },
 });
 
 export const db = drizzle(connection);

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -11,6 +11,7 @@
     "db:drop": "drizzle-kit drop --config=drizzle.config.ts"
   },
   "dependencies": {
+    "@mattrax/mysql-planetscale": "^0.0.2",
     "@paralleldrive/cuid2": "^2.2.2",
     "@planetscale/database": "^1.13.0",
     "@react-email/components": "^0.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,6 +532,9 @@ importers:
 
   packages/database:
     dependencies:
+      '@mattrax/mysql-planetscale':
+        specifier: ^0.0.2
+        version: 0.0.2
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
         version: 2.2.2
@@ -3849,6 +3852,13 @@ packages:
       read-yaml-file: 1.1.0
     dev: false
 
+  /@mattrax/mysql-planetscale@0.0.2:
+    resolution: {integrity: sha512-wrbsQ8c5FOcicJV1VgV791MWRDkNOpMZapmKAUzXWRMfZrmm7msHZ8IcL78BtTBSUXKf+VvE9zN+qg4p/LafWw==}
+    dependencies:
+      '@planetscale/database': 1.18.0
+      mysql2: 3.9.7
+    dev: false
+
   /@mdx-js/mdx@2.3.0:
     resolution: {integrity: sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==}
     dependencies:
@@ -4355,6 +4365,11 @@ packages:
 
   /@planetscale/database@1.13.0:
     resolution: {integrity: sha512-sb9tUoF+Po55o+3PRHZVeH8XzUIABKBKcnq6oBUa+p/2uau/E2EXhnUPXmkC/x7oB6ILBqmqTL6dPP5Dn6d6iA==}
+    engines: {node: '>=16'}
+    dev: false
+
+  /@planetscale/database@1.18.0:
+    resolution: {integrity: sha512-t2XdOfrVgcF7AW791FtdPS27NyNqcE1SpoXgk3HpziousvUMsJi4Q6NL3JyOBpsMOrvk94749o8yyonvX5quPw==}
     engines: {node: '>=16'}
     dev: false
 
@@ -10018,7 +10033,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.13.1)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3


### PR DESCRIPTION
Implements the `@mattrax/mysql-planetscale` library in development to allow `@planetscale/database` to connect with a plain mysql database.
The way i've implemented this requires moving from the `DB_*` environment variables to a single `DATABASE_URL` connection string.
The url needs to start `mysql://` during development and when using drizzle kit, and should start with `https://` in production or when testing locally using planetscale.