### PR TITLE
Get scap working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ target
 *.sw?
 .turbo
 pnpm-lock.yaml
+.zed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "bytes",
  "capture",
  "chrono",
+ "cocoa 0.25.0",
  "cpal",
  "dotenv_codegen",
  "ffmpeg-sidecar",
@@ -528,6 +529,7 @@ dependencies = [
  "futures",
  "image",
  "nix 0.20.0",
+ "objc",
  "regex",
  "reqwest 0.11.27",
  "scap",
@@ -3997,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "scap"
 version = "0.0.5"
-source = "git+https://github.com/CapSoftware/scap#5ee8692ab32ebb92055f997f0b9eacfc14f4d230"
+source = "git+https://github.com/brendonovich/scap?branch=fix-timing#43012cea0178dea1378727eb019517d1bacfc689"
 dependencies = [
  "apple-sys-helmer-fork",
  "cocoa 0.25.0",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ tauri = { version = "1.6.1", features = [
   "fs-copy-file",
   "fs-create-dir",
   "window-set-ignore-cursor-events",
+  "window-create",
   "window-unminimize",
   "window-minimize",
   "window-close",
@@ -72,7 +73,9 @@ nix = "0.20.0"
 bytes = "1.0"
 tauri-specta = { version = "1", features = ["javascript", "typescript"] }
 specta = "1"
-scap = { git = "https://github.com/CapSoftware/scap" }
+scap = { git = "https://github.com/brendonovich/scap", branch = "fix-timing" }
+objc = "0.2.7"
+cocoa = "0.25.0"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -22,6 +22,7 @@
       },
       "window": {
         "all": false,
+        "create": true,
         "close": true,
         "hide": true,
         "show": true,


### PR DESCRIPTION
Fixes the `scap-test` branch so that it works properly at 60fps. The ability to exclude the camera window exists, but is disabled at the moment so that a release with scap can be done.