### PR TITLE
Camera overlay improvements (and fix, again)

### DIFF
--- a/apps/desktop/src-tauri/src/app/commands.rs
+++ b/apps/desktop/src-tauri/src/app/commands.rs
@@ -1,4 +1,4 @@
-use tauri::Window;
+use tauri::{Manager, Window};
 use tauri_plugin_oauth::start;
 
 macro_rules! generate_handler {
@@ -92,4 +92,20 @@ pub fn reset_camera_permissions() {
         .arg("so.cap.desktop")
         .spawn()
         .expect("failed to reset camera permissions");
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn close_webview(app_handle: tauri::AppHandle, label: String) -> bool {
+    app_handle
+        .get_window(&label)
+        .is_some_and(|window| window.close().is_ok())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn set_webview_shadow(app_handle: tauri::AppHandle, label: String, enable: bool) -> bool {
+    app_handle
+        .get_window(&label)
+        .is_some_and(|window| window_shadows::set_shadow(window, enable).is_ok())
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -322,7 +322,9 @@ fn main() {
                 has_screen_capture_access,
                 reset_screen_permissions,
                 reset_microphone_permissions,
-                reset_camera_permissions
+                reset_camera_permissions,
+                close_webview,
+                set_webview_shadow
             ]
         )
         .plugin(tauri_plugin_context_menu::init())

--- a/apps/desktop/src-tauri/src/media/video.rs
+++ b/apps/desktop/src-tauri/src/media/video.rs
@@ -1,21 +1,13 @@
 use image::codecs::jpeg::JpegEncoder;
-use image::{ImageBuffer, Rgba};
-use scap::{
-    capturer::{Capturer, Options, Resolution},
-    frame::{Frame, FrameType},
-};
-use std::{
-    future::Future,
-    path::{Path, PathBuf},
-    sync::Arc,
-    time::Duration,
-};
+use image::{ ImageBuffer, Rgba };
+use scap::{ capturer::{ Capturer, Options, Resolution }, frame::{ Frame, FrameType } };
+use std::{ future::Future, path::{ Path, PathBuf }, sync::Arc, time::Duration };
 use tokio::sync::mpsc::error::TrySendError;
-use tokio::{fs::File, io::AsyncWriteExt, sync::mpsc};
+use tokio::{ fs::File, io::AsyncWriteExt, sync::mpsc };
 
-use super::{Instant, RecordingOptions, SharedFlag, SharedInstant};
+use super::{ Instant, RecordingOptions, SharedFlag, SharedInstant };
 use crate::app::config;
-use crate::upload::{upload_file, FileType};
+use crate::upload::{ upload_file, FileType };
 
 pub struct VideoCapturer {
     capturer: Option<Capturer>,
@@ -26,7 +18,7 @@ pub struct VideoCapturer {
 }
 
 impl VideoCapturer {
-    pub const FPS: u32 = 60;
+    pub const FPS: u32 = 30;
 
     pub fn new(_width: usize, _height: usize, should_stop: SharedFlag) -> VideoCapturer {
         let mut capturer = Capturer::new(Options {
@@ -55,10 +47,9 @@ impl VideoCapturer {
         &mut self,
         start_time: SharedInstant,
         screenshot_dir: impl AsRef<Path>,
-        recording_options: RecordingOptions,
+        recording_options: RecordingOptions
     ) {
-        let mut capturer = self
-            .capturer
+        let mut capturer = self.capturer
             .take()
             .expect("Video capturing thread has already been started!");
         let (sender, receiver) = mpsc::channel(2048);
@@ -90,19 +81,22 @@ impl VideoCapturer {
                         let width = frame.width;
                         let height = frame.height;
                         let frame_data = match frame.width == 0 && frame.height == 0 {
-                            true => match last_frame.take() {
-                                Some(data) => data,
-                                None => {
-                                    tracing::error!(
-                                        "Somehow got an idle frame before any complete frame"
-                                    );
-                                    continue;
+                            true =>
+                                match last_frame.take() {
+                                    Some(data) => data,
+                                    None => {
+                                        tracing::error!(
+                                            "Somehow got an idle frame before any complete frame"
+                                        );
+                                        continue;
+                                    }
                                 }
-                            },
                             false => Arc::new(frame.data),
                         };
 
-                        if now - capture_start_time >= take_screenshot_delay && !screenshot_captured
+                        if
+                            now - capture_start_time >= take_screenshot_delay &&
+                            !screenshot_captured
                         {
                             screenshot_captured = true;
                             let mut frame_data_clone = (*frame_data).clone();
@@ -115,14 +109,16 @@ impl VideoCapturer {
                                 let image: ImageBuffer<Rgba<u8>, Vec<u8>> = ImageBuffer::from_raw(
                                     width.try_into().unwrap(),
                                     height.try_into().unwrap(),
-                                    frame_data_clone,
-                                )
-                                .expect("Failed to create image buffer");
+                                    frame_data_clone
+                                ).expect("Failed to create image buffer");
 
-                                let mut output_file = std::fs::File::create(&screenshot_path)
+                                let mut output_file = std::fs::File
+                                    ::create(&screenshot_path)
                                     .expect("Failed to create output file");
-                                let mut encoder =
-                                    JpegEncoder::new_with_quality(&mut output_file, 70);
+                                let mut encoder = JpegEncoder::new_with_quality(
+                                    &mut output_file,
+                                    70
+                                );
 
                                 if let Err(e) = encoder.encode_image(&image) {
                                     tracing::warn!("Failed to save screenshot: {}", e);
@@ -136,20 +132,27 @@ impl VideoCapturer {
                                 if !config::is_local_mode() {
                                     let rt = tokio::runtime::Runtime::new().unwrap();
                                     rt.block_on(async move {
-                                        let upload_task = tokio::spawn(upload_file(
-                                            Some(options_clone),
-                                            screenshot_path.clone(),
-                                            FileType::Screenshot,
-                                        ));
+                                        let upload_task = tokio::spawn(
+                                            upload_file(
+                                                Some(options_clone),
+                                                screenshot_path.clone(),
+                                                FileType::Screenshot
+                                            )
+                                        );
                                         match upload_task.await {
-                                            Ok(result) => match result {
-                                                Ok(_) => tracing::info!(
-                                                    "Screenshot successfully uploaded"
-                                                ),
-                                                Err(e) => {
-                                                    tracing::warn!("Failed to upload file: {}", e)
+                                            Ok(result) =>
+                                                match result {
+                                                    Ok(_) =>
+                                                        tracing::info!(
+                                                            "Screenshot successfully uploaded"
+                                                        ),
+                                                    Err(e) => {
+                                                        tracing::warn!(
+                                                            "Failed to upload file: {}",
+                                                            e
+                                                        )
+                                                    }
                                                 }
-                                            },
                                             Err(e) => {
                                                 tracing::error!("Failed to join task: {}", e)
                                             }
@@ -207,8 +210,7 @@ impl VideoCapturer {
 
     pub fn collect_frames(&mut self, destination: PathBuf) -> impl Future<Output = ()> + 'static {
         tracing::trace!("Starting video channel senders...");
-        let mut receiver = self
-            .frame_receiver
+        let mut receiver = self.frame_receiver
             .take()
             .expect("Video frame collection already started!");
         let should_stop = self.should_stop.clone();
@@ -217,9 +219,7 @@ impl VideoCapturer {
             let mut pipe = File::create(destination).await.unwrap();
 
             while let Some(bytes) = receiver.recv().await {
-                pipe.write_all(&bytes)
-                    .await
-                    .expect("Failed to write video data to FFmpeg stdin");
+                pipe.write_all(&bytes).await.expect("Failed to write video data to FFmpeg stdin");
 
                 if should_stop.get() {
                     receiver.close();

--- a/apps/desktop/src/app/camera/page.tsx
+++ b/apps/desktop/src/app/camera/page.tsx
@@ -10,8 +10,8 @@ export default function CameraPage() {
       id="app"
       data-tauri-drag-region
       style={{
-        borderRadius: "50%",
-        background: "none !important",
+        border: "none",
+        background: "none",
         outline: "none",
         boxShadow: "none",
       }}

--- a/apps/desktop/src/app/page.tsx
+++ b/apps/desktop/src/app/page.tsx
@@ -107,10 +107,12 @@ export default function CameraPage() {
   }, []);
 
   useEffect(() => {
-    if (isSignedIn && !cameraWindowOpen && permissions.confirmed === true) {
-      initializeCameraWindow();
-      setCameraWindowOpen(true);
-    }
+    commands.closeWebview("camera").then(() => {
+      if (isSignedIn && !cameraWindowOpen && permissions.confirmed === true) {
+        initializeCameraWindow();
+        setCameraWindowOpen(true);
+      }
+    });
   }, [isSignedIn, cameraWindowOpen, permissions.confirmed]);
 
   if (process.env.NEXT_PUBLIC_LOCAL_MODE === "true") {

--- a/apps/desktop/src/components/icons/Expand.tsx
+++ b/apps/desktop/src/components/icons/Expand.tsx
@@ -1,0 +1,19 @@
+export const Expand = ({ className }: { className: string }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m21 21-6-6m6 6v-4.8m0 4.8h-4.8"/>
+      <path d="M3 16.2V21m0 0h4.8M3 21l6-6"/>
+      <path d="M21 7.8V3m0 0h-4.8M21 3l-6 6"/>
+      <path d="M3 7.8V3m0 0h4.8M3 3l6 6"/>
+    </svg>
+  );
+};

--- a/apps/desktop/src/components/icons/MicrophoneOff.tsx
+++ b/apps/desktop/src/components/icons/MicrophoneOff.tsx
@@ -1,0 +1,21 @@
+export const MicrophoneOff = ({ className }: { className: string }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+        <line x1="2" x2="22" y1="2" y2="22"/>
+        <path d="M18.89 13.23A7.12 7.12 0 0 0 19 12v-2"/>
+        <path d="M5 10v2a7 7 0 0 0 12 5"/>
+        <path d="M15 9.34V5a3 3 0 0 0-5.68-1.33"/>
+        <path d="M9 9v3a3 3 0 0 0 5.12 2.12"/>
+        <line x1="12" x2="12" y1="19" y2="22"/>
+    </svg>
+  );
+};

--- a/apps/desktop/src/components/icons/Minimize.tsx
+++ b/apps/desktop/src/components/icons/Minimize.tsx
@@ -1,0 +1,19 @@
+export const Minimize = ({ className }: { className: string }) => {
+  return (
+    <svg 
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <polyline points="4 14 10 14 10 20"/>
+      <polyline points="20 10 14 10 14 4"/>
+      <line x1="14" x2="21" y1="10" y2="3"/>
+      <line x1="3" x2="10" y1="21" y2="14"/>
+    </svg>
+  );
+};

--- a/apps/desktop/src/components/icons/Squircle.tsx
+++ b/apps/desktop/src/components/icons/Squircle.tsx
@@ -1,0 +1,16 @@
+export const Squircle = ({ className }: { className: string }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M12 3c7.2 0 9 1.8 9 9s-1.8 9-9 9-9-1.8-9-9 1.8-9 9-9" />
+    </svg>
+  );
+};

--- a/apps/desktop/src/components/icons/VideoOff.tsx
+++ b/apps/desktop/src/components/icons/VideoOff.tsx
@@ -1,0 +1,18 @@
+export const VideoOff = ({ className }: { className: string }) => {
+  return (
+    <svg 
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+        <path d="M10.66 6H14a2 2 0 0 1 2 2v2.5l5.248-3.062A.5.5 0 0 1 22 7.87v8.196"/>
+        <path d="M16 16a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h2"/>
+        <path d="m2 2 20 20"/>
+    </svg>
+  );
+};

--- a/apps/desktop/src/components/windows/Camera.tsx
+++ b/apps/desktop/src/components/windows/Camera.tsx
@@ -78,8 +78,8 @@ export const Camera = () => {
     tauriWindowImport.then(
       ({ currentMonitor, appWindow, LogicalSize, LogicalPosition }) => {
         currentMonitor().then((monitor) => {
-          const windowWidth = type === "sm" ? 240 : 410;
-          const windowHeight = type === "sm" ? 240 : 410;
+          const windowWidth = type === "sm" ? 230 : 400;
+          const windowHeight = type === "sm" ? 230 : 400;
 
           if (monitor && monitor.size) {
             const scalingFactor = monitor.scaleFactor;

--- a/apps/desktop/src/components/windows/Camera.tsx
+++ b/apps/desktop/src/components/windows/Camera.tsx
@@ -22,10 +22,14 @@ export const Camera = () => {
   );
   const [overlaySize, setOverlaySize] = useState<"sm" | "lg">("sm");
   const [overlayShape, setOverlayShape] = useState<"round" | "square">(
-    localStorage.getItem("cameraOverlayShape") as "round" | "square" || "round"
+    (localStorage.getItem("cameraOverlayShape") as "round" | "square") ||
+      "round"
   );
 
-  useEffect(() => localStorage.setItem("cameraOverlayShape", overlayShape), [overlayShape]);
+  useEffect(
+    () => localStorage.setItem("cameraOverlayShape", overlayShape),
+    [overlayShape]
+  );
 
   useEffect(() => {
     if (!videoRef.current || !selectedVideoDevice) return;
@@ -126,7 +130,7 @@ export const Camera = () => {
     }
   }, []);
 
-  const getOverlayBorderRadius= () => {
+  const getOverlayBorderRadius = () => {
     if (overlayShape === "round") return "9999px";
     if (overlaySize === "sm") return "3rem";
     else return "4rem";
@@ -134,13 +138,16 @@ export const Camera = () => {
 
   const handleContextMenu = async () => {
     const { showMenu } = await import("tauri-plugin-context-menu");
-    const videoDevices = devices.filter((device) => device.kind === "videoinput");
+    const videoDevices = devices.filter(
+      (device) => device.kind === "videoinput"
+    );
 
     const select = async (device: Device | null) => {
-      emit("change-device", { type: "videoinput", device: device })
-        .catch((error) => console.log("Failed to emit change-device event:", error));
+      emit("change-device", { type: "videoinput", device: device }).catch(
+        (error) => console.log("Failed to emit change-device event:", error)
+      );
     };
-    
+
     const menuItems = [
       {
         label: "Select Video:",
@@ -155,6 +162,14 @@ export const Camera = () => {
         is_separator: true,
       },
       {
+        label: "Refresh Overlay",
+        event: async () => {
+          if (typeof window !== "undefined") {
+            window.location.reload();
+          }
+        },
+      },
+      {
         label: "Close Overlay",
         checked: selectedVideoDevice === null,
         event: async () => select(null),
@@ -164,12 +179,10 @@ export const Camera = () => {
     await showMenu({
       items: [...menuItems],
       ...(videoDevices.length === 0 && {
-        items: [
-          { label: "Nothing found." },
-        ],
+        items: [{ label: "Nothing found." }],
       }),
     });
-  }
+  };
 
   return (
     <div
@@ -228,8 +241,12 @@ export const Camera = () => {
           className="h-full flex items-center justify-center p-2 hover:bg-gray-900"
         >
           <div>
-            {overlaySize === "sm" && <Expand className="w-5 h-5 stroke-gray-200" />}
-            {overlaySize === "lg" && <Minimize className="w-5 h-5 stroke-gray-200" />}
+            {overlaySize === "sm" && (
+              <Expand className="w-5 h-5 stroke-gray-200" />
+            )}
+            {overlaySize === "lg" && (
+              <Minimize className="w-5 h-5 stroke-gray-200" />
+            )}
           </div>
         </div>
         <div
@@ -238,8 +255,14 @@ export const Camera = () => {
           }}
           className="h-full flex items-center justify-center p-2 hover:bg-gray-900"
         >
-          {overlayShape === "round" && <div><Squircle className="w-5 h-5 stroke-gray-200" /></div>}
-          {overlayShape === "square" && <span className="w-3 h-3 bg-gray-200 rounded-full"></span>}
+          {overlayShape === "round" && (
+            <div>
+              <Squircle className="w-5 h-5 stroke-gray-200" />
+            </div>
+          )}
+          {overlayShape === "square" && (
+            <span className="w-3 h-3 bg-gray-200 rounded-full"></span>
+          )}
         </div>
         <div
           onClick={mirrorCamera}
@@ -259,7 +282,9 @@ export const Camera = () => {
         autoPlay
         playsInline
         muted
-        className={"absolute top-0 left-0 w-full h-full object-cover pointer-events-none"}
+        className={
+          "absolute top-0 left-0 w-full h-full object-cover pointer-events-none"
+        }
         style={{ borderRadius: getOverlayBorderRadius() }}
       />
     </div>

--- a/apps/desktop/src/components/windows/Camera.tsx
+++ b/apps/desktop/src/components/windows/Camera.tsx
@@ -1,15 +1,18 @@
 "use client";
 
 import React, { use, useEffect, useRef, useState } from "react";
-import { useMediaDevices } from "@/utils/recording/MediaDeviceContext";
+import { Device, useMediaDevices } from "@/utils/recording/MediaDeviceContext";
 import { CloseX } from "@/components/icons/CloseX";
 import { Flip } from "@/components/icons/Flip";
 import { emit } from "@tauri-apps/api/event";
+import { Expand } from "../icons/Expand";
+import { Minimize } from "../icons/Minimize";
+import { Squircle } from "../icons/Squircle";
 
 export const Camera = () => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const { selectedVideoDevice } = useMediaDevices();
+  const { selectedVideoDevice, devices } = useMediaDevices();
   const [isLoading, setIsLoading] = useState(true);
   const tauriWindowImport = import("@tauri-apps/api/window");
   const [cameraMirrored, setCameraMirrored] = useState(
@@ -17,6 +20,12 @@ export const Camera = () => {
       ? localStorage.getItem("cameraMirrored") || "false"
       : "false"
   );
+  const [overlaySize, setOverlaySize] = useState<"sm" | "lg">("sm");
+  const [overlayShape, setOverlayShape] = useState<"round" | "square">(
+    localStorage.getItem("cameraOverlayShape") as "round" | "square" || "round"
+  );
+
+  useEffect(() => localStorage.setItem("cameraOverlayShape", overlayShape), [overlayShape]);
 
   useEffect(() => {
     if (!videoRef.current || !selectedVideoDevice) return;
@@ -69,8 +78,8 @@ export const Camera = () => {
     tauriWindowImport.then(
       ({ currentMonitor, appWindow, LogicalSize, LogicalPosition }) => {
         currentMonitor().then((monitor) => {
-          const windowWidth = type === "sm" ? 230 : 400;
-          const windowHeight = type === "sm" ? 230 : 400;
+          const windowWidth = type === "sm" ? 240 : 410;
+          const windowHeight = type === "sm" ? 240 : 410;
 
           if (monitor && monitor.size) {
             const scalingFactor = monitor.scaleFactor;
@@ -88,24 +97,23 @@ export const Camera = () => {
 
             appWindow.setSize(new LogicalSize(windowWidth, windowHeight));
             appWindow.setPosition(new LogicalPosition(x / scalingFactor, y));
+            setOverlaySize(type);
           }
         });
       }
     );
   };
 
-  const closeWindow = () => {
+  const closeWindow = (emitSetDevice = true) => {
     if (typeof window === "undefined") return;
 
     tauriWindowImport.then(async ({ appWindow }) => {
-      await emit("change-device", {
-        type: "video",
-        device: {
-          label: "None",
-          index: -1,
-          kind: "video",
-        },
-      });
+      if (emitSetDevice) {
+        await emit("change-device", {
+          type: "videoinput",
+          device: null,
+        });
+      }
       appWindow.close();
     });
   };
@@ -118,10 +126,60 @@ export const Camera = () => {
     }
   }, []);
 
+  const getOverlayBorderRadius= () => {
+    if (overlayShape === "round") return "9999px";
+    if (overlaySize === "sm") return "3rem";
+    else return "4rem";
+  };
+
+  const handleContextMenu = async () => {
+    const { showMenu } = await import("tauri-plugin-context-menu");
+    const videoDevices = devices.filter((device) => device.kind === "videoinput");
+
+    const select = async (device: Device | null) => {
+      emit("change-device", { type: "videoinput", device: device })
+        .catch((error) => console.log("Failed to emit change-device event:", error));
+    };
+    
+    const menuItems = [
+      {
+        label: "Select Video:",
+        disabled: true,
+      },
+      ...videoDevices.map((device) => ({
+        label: device.label,
+        checked: selectedVideoDevice.index === device.index,
+        event: async () => select(device),
+      })),
+      {
+        is_separator: true,
+      },
+      {
+        label: "Close Overlay",
+        checked: selectedVideoDevice === null,
+        event: async () => select(null),
+      },
+    ];
+
+    await showMenu({
+      items: [...menuItems],
+      ...(videoDevices.length === 0 && {
+        items: [
+          { label: "Nothing found." },
+        ],
+      }),
+    });
+  }
+
   return (
     <div
       data-tauri-drag-region
-      className="cursor-move group w-full h-full bg-gray-200 rounded-full m-0 p-0 relative overflow-hidden flex items-center justify-center border-none outline-none focus:outline-none rounded-full"
+      onContextMenu={(e) => {
+        e.preventDefault();
+        handleContextMenu();
+      }}
+      className="cursor-move group w-full h-full bg-gray-200 m-0 p-0 relative overflow-hidden flex items-center justify-center outline-none focus:outline-none border-2 border-sm border-gray-300"
+      style={{ borderRadius: getOverlayBorderRadius() }}
     >
       {isLoading && (
         <div className="w-full h-full absolute top-0 left-0 bg-gray-200 z-10 flex items-center justify-center">
@@ -152,7 +210,7 @@ export const Camera = () => {
           </svg>
         </div>
       )}
-      <div className="opacity-0 group-hover:opacity-100 absolute top-3 left-1/2 transform -translate-x-1/2 bg-gray-800 rounded-xl z-20 grid grid-cols-4 overflow-hidden">
+      <div className="opacity-0 group-hover:opacity-100 absolute top-5 left-1/2 transform -translate-x-1/2 bg-gray-800 bg-opacity-75 backdrop-blur-sm rounded-xl z-20 grid grid-cols-4 overflow-hidden transition-opacity">
         <div
           onClick={() => {
             closeWindow();
@@ -165,19 +223,23 @@ export const Camera = () => {
         </div>
         <div
           onClick={async () => {
-            await setWindowSize("sm");
+            await setWindowSize(overlaySize === "sm" ? "lg" : "sm");
           }}
           className="h-full flex items-center justify-center p-2 hover:bg-gray-900"
         >
-          <span className="w-1 h-1 m-0 p-0 bg-gray-200 rounded-full"></span>
+          <div>
+            {overlaySize === "sm" && <Expand className="w-5 h-5 stroke-gray-200" />}
+            {overlaySize === "lg" && <Minimize className="w-5 h-5 stroke-gray-200" />}
+          </div>
         </div>
         <div
-          onClick={async () => {
-            await setWindowSize("lg");
+          onClick={() => {
+            setOverlayShape(overlayShape === "round" ? "square" : "round");
           }}
           className="h-full flex items-center justify-center p-2 hover:bg-gray-900"
         >
-          <span className="w-3 h-3 bg-gray-200 rounded-full"></span>
+          {overlayShape === "round" && <div><Squircle className="w-5 h-5 stroke-gray-200" /></div>}
+          {overlayShape === "square" && <span className="w-3 h-3 bg-gray-200 rounded-full"></span>}
         </div>
         <div
           onClick={mirrorCamera}
@@ -197,7 +259,8 @@ export const Camera = () => {
         autoPlay
         playsInline
         muted
-        className="absolute top-0 left-0 w-full h-full object-cover pointer-events-none rounded-full"
+        className={"absolute top-0 left-0 w-full h-full object-cover pointer-events-none"}
+        style={{ borderRadius: getOverlayBorderRadius() }}
       />
     </div>
   );

--- a/apps/desktop/src/components/windows/inner/ActionSelect.tsx
+++ b/apps/desktop/src/components/windows/inner/ActionSelect.tsx
@@ -1,0 +1,66 @@
+import React, { ReactNode, useRef, MouseEvent, useMemo, useState, useEffect } from "react";
+
+export const ActionSelect = ({
+  iconEnabled = null,
+  iconDisabled = null,
+  width = "auto",
+  active = true,
+  showStatus = false,
+  status = "on",
+  options = [],
+  selectedValue = null,
+  onSelect,
+  onStatusClick,
+}: {
+  iconEnabled?: ReactNode;
+  iconDisabled?: ReactNode;
+  width?: "full" | "auto";
+  active?: boolean;
+  showStatus?: boolean;
+  status: "on" | "off";
+  options: { value: string | number; label: string; disabled?: boolean }[];
+  selectedValue?: string | number;
+  onSelect: (value: string | number) => void;
+  onStatusClick?: (currentStatus: "on" | "off") => void;
+}) => (
+  <div className={`flex-grow ${width === "full" ? "w-full" : "w-auto"}`}>
+    <div
+      className={`
+        ${active ? "bg-white hover:bg-gray-100" : "bg-gray-200 hover:bg-white"}
+        border-gray-300 w-full h-[50px] py-2 px-4 text-[14px] border-2 flex items-center rounded-[15px] transition-all shadow-sm shadow-[0px 0px 180px rgba(255, 255, 255, 0.18)] cursor-pointer
+      `}
+    >
+      <div className="flex items-center min-w-0 flex-grow h-full">
+        <span className="flex-shrink-0 mr-2">{status === "off" && iconDisabled ? iconDisabled : iconEnabled}</span>
+        <select
+          className="bg-transparent border-none appearance-none w-full min-w-0 cursor-pointer h-full truncate"
+          value={selectedValue || -1}
+          onChange={(e) => onSelect(e.target.value)}
+        >
+          {options.map((option) => (
+            <option key={option.value} value={option.value} disabled={option.disabled}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      {showStatus && (
+        <div
+          className={onStatusClick ? "transition-transform active:scale-95" : ""}
+          onClick={(e) => {
+            e.stopPropagation();
+            onStatusClick?.(status);
+          }}
+        >
+          <span
+            className={`${
+              status === "on" ? "bg-tertiary text-primary" : "bg-red-600 text-white" 
+            } h-5 w-8 font-medium text-xs rounded-full flex items-center justify-center`}
+          >
+            <span>{status === "on" ? "On" : "Off"}</span>
+          </span>
+        </div>
+      )}
+    </div>
+  </div>
+);

--- a/apps/desktop/src/utils/commands.ts
+++ b/apps/desktop/src/utils/commands.ts
@@ -54,4 +54,12 @@ export function resetCameraPermissions() {
     return invoke()<null>("reset_camera_permissions")
 }
 
+export function closeWebview(label: string) {
+    return invoke()<boolean>("close_webview", { label })
+}
+
+export function setWebviewShadow(label: string, enable: boolean) {
+    return invoke()<boolean>("set_webview_shadow", { label,enable })
+}
+
 export type RecordingOptions = { user_id: string; video_id: string; screen_index: string; video_index: string; audio_name: string; aws_region: string; aws_bucket: string }

--- a/apps/desktop/src/utils/recording/utils.ts
+++ b/apps/desktop/src/utils/recording/utils.ts
@@ -80,6 +80,8 @@ export const initializeCameraWindow = async () => {
             decorations: false,
             alwaysOnTop: true,
             center: false,
+          }).once("tauri://created", () => {
+            commands.setWebviewShadow("camera", false);
           });
         }
       }


### PR DESCRIPTION
(_This is a re-apply of a previous PR. Also applies the fix from #25 which seems to have gotten removed in main_)

New in this PR: Shape of the camera view now persists.

**Changes**
- This fixes an issue where the camera overlay didn't properly respect the selected input.
- Removes the shadow from the overlay (not sure how to explain it well, but if you look at the corners of any transparent windows with shadows enabled you can see an outline that's lagging behind and most of the time it gets stuck until you move the window)

* New component for selecting input devices
* You can click on the status button on the right to toggle the device on or off.
* The Icon changes to better visualize the disabled status.

* The change size buttons are now a single toggle
* Added option to change the shape of the overlay between circle and rounded square.
* Opacity animation for overlay controls.
* Added context menu on the overlay for changing the video device or closing the overlay.
 
![cap-oi1](https://github.com/user-attachments/assets/2377f953-678e-4ca1-a24b-f4067ad4ed5d)
![cap-oi2](https://github.com/user-attachments/assets/532201d5-d8b3-4894-9b28-93878fd2320d)
