### PR TITLE
Delete video input in web recorder

### DIFF
--- a/apps/web/app/record/useRecorder.ts
+++ b/apps/web/app/record/useRecorder.ts
@@ -251,6 +251,12 @@ async function muxSegment({
     }
 
     try {
+      await ffmpeg.deleteFile(segmentPaths.videoInput.replace(".ts", "0.ts"));
+    } catch (error) {
+      console.error("Error deleting video input file:", error);
+    }
+
+    try {
       await ffmpeg.deleteFile(segmentPaths.videoOutput);
     } catch (error) {
       console.error("Error deleting video output file:", error);


### PR DESCRIPTION
The web recorder isn't deleting old `videoInput` files at the moment, as the file addressed by `videoInput` is the hls playlist file, not the video