### PR TITLE
fix(MediaStream): cleanup unused media stream

### DIFF
--- a/apps/desktop/src/routes/camera.tsx
+++ b/apps/desktop/src/routes/camera.tsx
@@ -10,7 +10,6 @@ import {
   Show,
   Suspense,
   createEffect,
-  createResource,
   createSignal,
   on,
   onCleanup,
@@ -33,7 +32,7 @@ namespace CameraWindow {
   };
 }
 
-export default function () {
+export default function() {
   const options = createOptionsQuery();
 
   const camera = createCameraForLabel(() => options.data?.cameraLabel ?? "");
@@ -254,15 +253,18 @@ function createCameraPreview(deviceId: () => string | undefined) {
     } else if (ref) {
       ref.srcObject = null;
     }
+
+    // Cleanup effect
+    onCleanup(() => {
+      if (stream) {
+        stream.getTracks().forEach((track) => track.stop());
+      }
+      if (ref?.srcObject) {
+        ref.srcObject = null;
+      }
+    });
   });
 
-  // Cleanup effect
-  onCleanup(() => {
-    const stream = cameraStream();
-    if (stream) {
-      stream.getTracks().forEach((track) => track.stop());
-    }
-  });
 
   return [setCameraRef, () => cameraStream()] as const;
 }

--- a/apps/desktop/src/utils/media.ts
+++ b/apps/desktop/src/utils/media.ts
@@ -11,8 +11,12 @@ import { commands } from "./tauri";
 export function createDevices() {
   const [devices, { refetch }] = createResource(async () => {
     try {
-      await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
-      return await navigator.mediaDevices.enumerateDevices();
+      const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+      const result = await navigator.mediaDevices.enumerateDevices();
+      // this is not a better solution, since `navigator.mediaDevices.getUserMedia` is always return a new instance of the stream
+      // we need to clean up the stream because we just want to get the devices.
+      stream.getTracks().forEach(track => track.stop())
+      return result
     } catch (error) {
       console.error("Error accessing media devices:", error);
       return [];
@@ -75,8 +79,8 @@ export async function stopMediaStream(kind: "audio" | "video" | "both") {
 
   streams.getTracks().forEach((track) => {
     if ((kind === "audio" && track.kind === "audio") ||
-        (kind === "video" && track.kind === "video") ||
-        kind === "both") {
+      (kind === "video" && track.kind === "video") ||
+      kind === "both") {
       track.stop();
     }
   });


### PR DESCRIPTION
## Changes

* removed unused stream. Every getUserMedia called it will be return new instance of stream and make light camera in real device will be turn on. in this pr just "mongkey patch" for cleanup unused stream. this pr isn't a better solution but I think could be fix the current issue for light on.

@richiemcilroy 