### PR TITLE
fix(camera): use absolute highest resolution as fallback

### DIFF
--- a/apps/desktop/src-tauri/src/camera.rs
+++ b/apps/desktop/src-tauri/src/camera.rs
@@ -290,7 +290,16 @@ impl CameraFeed {
         std::thread::spawn({
             let camera_info = camera_info.clone();
             move || {
-                let mut camera = Camera::new(camera_info.index().clone(), format).unwrap();
+                let mut camera =
+                    Camera::new(camera_info.index().clone(), format).unwrap_or_else(|_| {
+                        Camera::new(
+                            camera_info.index().clone(),
+                            RequestedFormat::new::<RgbFormat>(
+                                RequestedFormatType::AbsoluteHighestResolution,
+                            ),
+                        )
+                        .expect("Failed to create camera")
+                    });
 
                 camera.open_stream().unwrap();
 


### PR DESCRIPTION
## Changes

* fixing bugs based on discussion in [Discord](https://ptb.discord.com/channels/1177608475682029568/1177630370611593256/1293614554277875784)

## Notes

In file [src/camera.rs ](https://github.com/CapSoftware/Cap/blob/main/apps/desktop/src-tauri/src/camera.rs#L276-L281), Resolution is 1920x1080, User maybe use the camera device under 1920x1080.
Example:
```
// builtin Apple Macbook pro m1 camera (Facetime Camera) using 1280x720
CameraFormat { resolution: Resolution { width_x: 1280, height_y: 720 }, format: YUYV, frame_rate: 30 }
```

In this PR just make a fallback to use AbsoluteHighestResolution - in Apple MBP M1 camera, the highest resolution is 1280x720. 

In Documentation of Nokhwa `closes` may be fail to resolve format camera. In this changes, I just make a fallback to `AbsoluteHighestResolutions`. 

<img width="982" alt="image" src="https://github.com/user-attachments/assets/4953c5aa-f5d2-47b2-bc95-14446631099d">

See https://docs.rs/nokhwa-core/0.1.0/nokhwa_core/types/enum.RequestedFormatType.html#