### PR TITLE
Fix: Change 'permission' to 'permissions' in window label matching

### DIFF
--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -23,7 +23,7 @@ impl CapWindow {
             "window-capture-occluder" => Self::WindowCaptureOccluder,
             "in-progress-recording" => Self::InProgressRecording { position: None },
             "prev-recordings" => Self::PrevRecordings,
-            "permission" => Self::Permissions,
+            "permissions" => Self::Permissions,
             "feedback" => Self::Feedback,
             "upgrade" => Self::Upgrade,
             "changelog" => Self::Changelog,


### PR DESCRIPTION
# Fix: Correct Window Label for Permissions

## Issue
The application was crashing due to an unknown window label "permissions". This was caused by a mismatch between the expected label in the code ("permission") and the actual label being used ("permissions").

## Changes
- In `apps/desktop/src-tauri/src/windows.rs`, changed the window label from "permission" to "permissions" in the `CapWindow::from_label` method.

## Impact
This fix resolves the "unknown window label: permissions" error that was causing the application to panic, specifically in the `CapWindow::from_label` function.

## Testing Performed
- [X] Verified that the application no longer crashes when referencing the "permissions" window.
- [X] Ran the application in development mode to confirm overall functionality.

Running on Mac Air M2