### PR TITLE
feat(desktop): implement previous selection audio and camera

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -17,6 +17,7 @@
     "core:window:allow-set-focus",
     "core:window:allow-start-dragging",
     "core:window:allow-set-position",
+    "core:webview:default",
     "core:webview:allow-create-webview-window",
     "core:app:allow-version",
     "shell:default",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2232,6 +2232,12 @@ async fn reset_microphone_permissions(app: AppHandle) -> Result<(), ()> {
     Ok(())
 }
 
+#[tauri::command]
+#[specta::specta]
+async fn is_camera_window_open(app: AppHandle) -> bool {
+    CapWindow::Camera { ws_port: 0 }.get(&app).is_some()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub async fn run() {
     let specta_builder = tauri_specta::Builder::new()
@@ -2286,7 +2292,8 @@ pub async fn run() {
             set_general_settings,
             delete_auth_open_signin,
             reset_camera_permissions,
-            reset_microphone_permissions
+            reset_microphone_permissions,
+            is_camera_window_open
         ])
         .events(tauri_specta::collect_events![
             RecordingOptionsChanged,

--- a/apps/desktop/src/routes/(window-chrome)/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/index.tsx
@@ -4,7 +4,6 @@ import { createEventListener } from "@solid-primitives/event-listener";
 import { cache, createAsync, redirect, useNavigate } from "@solidjs/router";
 import { createMutation, createQuery } from "@tanstack/solid-query";
 import { getVersion } from "@tauri-apps/api/app";
-import { Window } from "@tauri-apps/api/window";
 import { cx } from "cva";
 import {
   Show,
@@ -47,7 +46,7 @@ export const route = {
 };
 
 export default function () {
-  const options = createOptionsQuery();
+  const { options, setOptions } = createOptionsQuery();
   const windows = createQuery(() => listWindows);
   const videoDevices = createVideoDevicesQuery();
   const audioDevices = createQuery(() => listAudioDevices);
@@ -179,7 +178,7 @@ export default function () {
 
     if (!item || !options.data) return;
 
-    commands.setRecordingOptions({
+    setOptions({
       ...options.data,
       audioInputName: item.name !== "No Audio" ? item.name : null,
     });
@@ -247,7 +246,7 @@ export default function () {
         value={selectedWindow() ?? null}
         onChange={(d: CaptureWindow | null) => {
           if (!d || !options.data) return;
-          commands.setRecordingOptions({
+          setOptions({
             ...options.data,
             captureTarget: { variant: "window", ...d },
           });
@@ -265,7 +264,7 @@ export default function () {
               return;
             }
             if (s === "screen") {
-              commands.setRecordingOptions({
+              setOptions({
                 ...options.data,
                 captureTarget: { variant: "screen" },
               });
@@ -330,12 +329,12 @@ export default function () {
               if (!options.data) return;
 
               if (!item || !item.isCamera) {
-                await commands.setRecordingOptions({
+                await setOptions({
                   ...options.data,
                   cameraLabel: null,
                 });
               } else {
-                await commands.setRecordingOptions({
+                await setOptions({
                   ...options.data,
                   cameraLabel: item.name,
                 });
@@ -401,7 +400,7 @@ export default function () {
                         return requestPermission("camera");
                       }
                       if (!options.data?.cameraLabel) return;
-                      commands.setRecordingOptions({
+                      setOptions({
                         ...options.data,
                         cameraLabel: null,
                       });
@@ -492,14 +491,14 @@ export default function () {
                 if (permissions?.data?.microphone !== "granted") {
                   await requestPermission("microphone");
                   if (permissions?.data?.microphone === "granted") {
-                    commands.setRecordingOptions({
+                    setOptions({
                       ...options.data!,
                       audioInputName: audioDevice().name,
                     });
                   }
                 } else {
                   if (!options.data?.audioInputName) return;
-                  commands.setRecordingOptions({
+                  setOptions({
                     ...options.data,
                     audioInputName: null,
                   });

--- a/apps/desktop/src/routes/(window-chrome)/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/index.tsx
@@ -86,7 +86,6 @@ export default function () {
     }
   });
 
-  // important for sign in redirect, trust me
   createAsync(() => getAuth());
 
   createUpdateCheck();
@@ -183,6 +182,19 @@ export default function () {
       audioInputName: item.name !== "No Audio" ? item.name : null,
     });
   };
+
+  onMount(async () => {
+    if (options.data?.cameraLabel && options.data.cameraLabel !== "No Camera") {
+      const cameraWindowActive = await commands.isCameraWindowOpen();
+
+      if (!cameraWindowActive) {
+        console.log("cameraWindow not found");
+        setOptions({
+          ...options.data,
+        });
+      }
+    }
+  });
 
   return (
     <div class="flex justify-center flex-col p-[1rem] gap-[0.75rem] text-[0.875rem] font-[400] bg-gray-50 h-full">

--- a/apps/desktop/src/routes/(window-chrome)/update.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/update.tsx
@@ -59,12 +59,13 @@ export default function () {
             <div>
               <Switch fallback={<IconCapLogo class="animate-spin size-4" />}>
                 <Match when={updateStatus()?.type === "done"}>
-                  Update has been installed. Restart Cap to finish updating.
-                  <div class="flex flex-row gap-4">
-                    <Button variant="secondary" onClick={() => navigate("/")}>
-                      Restart Later
-                    </Button>
-                    <Button onClick={() => relaunch()}>Restart Now</Button>
+                  <div class="flex flex-col gap-4">
+                    <p>
+                      Update has been installed. Restart Cap to finish updating.
+                    </p>
+                    <div class="flex flex-row">
+                      <Button onClick={() => relaunch()}>Restart Now</Button>
+                    </div>
                   </div>
                 </Match>
                 <Match

--- a/apps/desktop/src/routes/camera.tsx
+++ b/apps/desktop/src/routes/camera.tsx
@@ -19,7 +19,6 @@ import { ToggleButton as KToggleButton } from "@kobalte/core/toggle-button";
 import { cx } from "cva";
 
 import { createOptionsQuery } from "~/utils/queries";
-import { commands } from "~/utils/tauri";
 import { createImageDataWS, createLazySignal } from "~/utils/socket";
 
 namespace CameraWindow {
@@ -37,7 +36,7 @@ const BAR_HEIGHT = 56;
 const { cameraWsPort } = (window as any).__CAP__;
 
 export default function () {
-  const options = createOptionsQuery();
+  const { options, setOptions } = createOptionsQuery();
 
   const [state, setState] = makePersisted(
     createStore<CameraWindow.State>({
@@ -133,7 +132,7 @@ export default function () {
                 <div class="flex flex-row gap-[0.25rem] p-[0.25rem] opacity-0 group-hover:opacity-100 translate-y-2 group-hover:translate-y-0 rounded-xl transition-[opacity,transform] bg-gray-500 border border-white-transparent-20 text-gray-400">
                   <ControlButton
                     onClick={() => {
-                      commands.setRecordingOptions({
+                      setOptions({
                         ...options(),
                         cameraLabel: null,
                       });

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -307,6 +307,9 @@ async resetMicrophonePermissions() : Promise<Result<null, null>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async isCameraWindowOpen() : Promise<boolean> {
+    return await TAURI_INVOKE("is_camera_window_open");
 }
 }
 


### PR DESCRIPTION
## Changes

* Change API of  `createOptionsQuery`
  * add `setOptions`: is same with `commands.setRecordOptions`.
* Change `commands.setRecordOptions` to --> `setOptions`
  
### Screen Record

https://github.com/user-attachments/assets/3fe78ae4-3576-493c-b42a-1aa90f7b5704


 
/claim #123