### PR TITLE
Use frame format instead of camera format as source of truth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3760,7 +3760,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "nokhwa"
 version = "0.10.3"
-source = "git+https://github.com/filleduchaos/nokhwa?rev=408354f6bcdd#408354f6bcddb00bfc2cb4f9e62ce3854e438ade"
+source = "git+https://github.com/capsoftware/nokhwa?rev=3f7e33a7f49c#3f7e33a7f49c037690b11a2e2463777c36389350"
 dependencies = [
  "flume 0.10.14",
  "image 0.24.9",
@@ -3774,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "nokhwa-bindings-macos"
 version = "0.2.0"
-source = "git+https://github.com/filleduchaos/nokhwa?rev=408354f6bcdd#408354f6bcddb00bfc2cb4f9e62ce3854e438ade"
+source = "git+https://github.com/capsoftware/nokhwa?rev=3f7e33a7f49c#3f7e33a7f49c037690b11a2e2463777c36389350"
 dependencies = [
  "block",
  "cocoa-foundation 0.1.2",
@@ -3789,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "nokhwa-core"
 version = "0.1.0"
-source = "git+https://github.com/filleduchaos/nokhwa?rev=408354f6bcdd#408354f6bcddb00bfc2cb4f9e62ce3854e438ade"
+source = "git+https://github.com/capsoftware/nokhwa?rev=3f7e33a7f49c#3f7e33a7f49c037690b11a2e2463777c36389350"
 dependencies = [
  "bytes",
  "image 0.24.9",

--- a/apps/desktop/src/routes/(window-chrome)/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/index.tsx
@@ -1,4 +1,4 @@
-import { Button, SwitchTab } from "@cap/ui-solid";
+import { Button } from "@cap/ui-solid";
 import { Select as KSelect } from "@kobalte/core/select";
 import { cache, createAsync, redirect, useNavigate } from "@solidjs/router";
 import { createMutation, createQuery } from "@tanstack/solid-query";

--- a/crates/media/Cargo.toml
+++ b/crates/media/Cargo.toml
@@ -13,7 +13,7 @@ ffmpeg.workspace = true
 ffmpeg-sys-next.workspace = true
 flume = "0.11.0"
 indexmap = "2.5.0"
-nokhwa = { git = "https://github.com/filleduchaos/nokhwa", rev = "408354f6bcdd", features = [
+nokhwa = { git = "https://github.com/capsoftware/nokhwa", rev = "3f7e33a7f49c", features = [
 	"input-avfoundation",
 	"serialize",
 ] }
@@ -31,4 +31,4 @@ core-foundation = "0.10.0"
 objc = "0.2.7"
 objc-foundation = "0.1.1"
 objc2-foundation = { version = "0.2.2", features = ["NSValue"] }
-nokhwa-bindings-macos = { git = "https://github.com/filleduchaos/nokhwa", rev = "408354f6bcdd" }
+nokhwa-bindings-macos = { git = "https://github.com/capsoftware/nokhwa", rev = "3f7e33a7f49c" }

--- a/crates/media/src/data.rs
+++ b/crates/media/src/data.rs
@@ -22,7 +22,7 @@ pub enum RawAudioFormat {
 pub enum RawVideoFormat {
     Bgra,
     Mjpeg,
-    Yuyv,
+    Uyvy,
     RawRgb,
     Nv12,
     Gray,
@@ -112,7 +112,7 @@ impl VideoInfo {
             pixel_format: match format {
                 RawVideoFormat::Bgra => Pixel::BGRA,
                 RawVideoFormat::Mjpeg => Pixel::YUVJ422P,
-                RawVideoFormat::Yuyv => Pixel::UYVY422,
+                RawVideoFormat::Uyvy => Pixel::UYVY422,
                 RawVideoFormat::RawRgb => Pixel::RGB24,
                 RawVideoFormat::Nv12 => Pixel::NV12,
                 RawVideoFormat::Gray => Pixel::GRAY8,

--- a/crates/media/src/feeds/camera.rs
+++ b/crates/media/src/feeds/camera.rs
@@ -149,6 +149,13 @@ fn create_camera(info: &CameraInfo) -> Result<Camera, MediaError> {
 
     let index = info.index().clone();
 
+    #[cfg(target_os = "macos")]
+    {
+        let device = nokhwa_bindings_macos::AVCaptureDevice::new(&index).unwrap();
+        let formats = device.supported_formats()?;
+        dbg!(formats);
+    }
+
     Ok(Camera::new(index, format)?)
 }
 


### PR DESCRIPTION
- nokhwa fork updated to ignore format in Closest calculation + provide
frame format alongside data buffer
- camera frame converter created based on frame format instead of camera
format