### PR TITLE
Implement Rust testing framework

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,7 +5,8 @@
     "dev": "dotenv -e ../../.env -- tauri dev",
     "localdev": "dotenv -e ../../.env -- vinxi dev --port 3001",
     "build": "vinxi build",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test:desktop": "cargo test --manifest-path src-tauri/Cargo.toml"
   },
   "dependencies": {
     "@cap/database": "workspace:*",

--- a/apps/desktop/src-tauri/tests/desktop_tests.rs
+++ b/apps/desktop/src-tauri/tests/desktop_tests.rs
@@ -1,0 +1,49 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tauri::AppHandle;
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn test_start_recording() {
+        let app = AppHandle::default();
+        let state = MutableState::default();
+        let result = start_recording(app, state).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_stop_recording() {
+        let app = AppHandle::default();
+        let state = MutableState::default();
+        let result = stop_recording(app, state).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_copy_file_to_path() {
+        let app = AppHandle::default();
+        let src = "test_src.txt".to_string();
+        let dst = "test_dst.txt".to_string();
+        let result = copy_file_to_path(app, src, dst).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_copy_screenshot_to_clipboard() {
+        let app = AppHandle::default();
+        let path = PathBuf::from("test_screenshot.png");
+        let result = copy_screenshot_to_clipboard(app, path).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_export_video() {
+        let app = AppHandle::default();
+        let video_id = "test_video_id".to_string();
+        let project = ProjectConfiguration::default();
+        let progress = tauri::ipc::Channel::new(|_| Ok(()));
+        let result = export_video(app, video_id, project, progress, true).await;
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION
Related to #184

Implement a scalable testing system for Rust functions in the Cap desktop application.

* **Add test cases**: Create a new file `apps/desktop/src-tauri/tests/desktop_tests.rs` with test cases for `start_recording`, `stop_recording`, `copy_file_to_path`, `copy_screenshot_to_clipboard`, and `export_video`.
* **Update package.json**: Add a new command `test:desktop` in `apps/desktop/package.json` to run the Rust tests using `cargo test --manifest-path src-tauri/Cargo.toml`.

CMD:`cargo add --dev tokio --dev anyhow --dev tempfile --dev assert_cmd --dev predicates`

/claim #184