### PR TITLE
chore: Update confirmation dialog text in Editor component

### DIFF
--- a/apps/desktop/src/routes/editor/Editor.tsx
+++ b/apps/desktop/src/routes/editor/Editor.tsx
@@ -296,9 +296,7 @@ function Dialogs() {
                     }
                   >
                     <p class="text-gray-400">
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit
-                      sed do eiusmod tempor incididunt ut labore et dolore magna
-                      aliqua.
+                      Are you sure you want to delete this preset?
                     </p>
                   </DialogContent>
                 );


### PR DESCRIPTION
Previously we had this show up while deleting the preset!

![image](https://github.com/user-attachments/assets/26510e30-0cc6-4f57-a597-bafcfc45dfcb)
