### PR TITLE
contributing: Drizzle Studio + Docs update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ There are many ways to contribute to Cap. You can:
 - Cargo 1.77.0+ (previous versions may work)
 - pnpm 8.10.5+
 - Docker ([OrbStack](https://orbstack.dev/) recommended)
+- pkg-config
 
 ### How do I get started with development on my local machine?
 
@@ -39,6 +40,9 @@ This is a very top level guide right now, but if you want to develop for both th
 4. At the root of the directory, run the app with `pnpm dev`. This will create a local database simulator, run the necessary DB migrations, and start both the web app and desktop app concurrently.
 5. Make sure both the the desktop app, and web app can be built without any errors. For the desktop app, use `pnpm tauri:build`. For the web app, use `pnpm build`
 6. Submit a PR with your changes
+
+> [!NOTE]
+> When running the app locally on a MacOS machine, you will need to give permissions to Cap - this will show up as your **Terminal app** in the Security & Privacy settings page.
 
 ### How do I run the desktop app locally without needing to use auth?
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "db:push": "dotenv -e .env -- pnpm --dir packages/database db:push",
     "db:generate": "dotenv -e .env -- pnpm --dir packages/database db:generate",
+    "db:studio": "dotenv -e .env -- pnpm --dir packages/database db:studio",
     "tauri:build": "dotenv -e .env -- pnpm --dir apps/desktop tauri build --verbose",
     "typecheck": "pnpm tsc -b"
   },

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -8,7 +8,8 @@
     "db:push": "drizzle-kit push:mysql --config=drizzle.config.ts",
     "db:check": "drizzle-kit check:mysql --config=drizzle.config.ts",
     "db:up": "drizzle-kit up:mysql --config=drizzle.config.ts",
-    "db:drop": "drizzle-kit drop --config=drizzle.config.ts"
+    "db:drop": "drizzle-kit drop --config=drizzle.config.ts",
+    "db:studio": "drizzle-kit studio --config=drizzle.config.ts"
   },
   "dependencies": {
     "@mattrax/mysql-planetscale": "^0.0.3",


### PR DESCRIPTION
This PR adds:

Drizzle Studio can now be run with `pnpn run db:studio` from the root of the repo

New in contribution doc:
- new `pkg-config` requirement
- note about giving permissions on macOS