### PR TITLE
Handle audio samples as f32 internally

### DIFF
--- a/crates/export/src/lib.rs
+++ b/crates/export/src/lib.rs
@@ -1,6 +1,6 @@
 use cap_editor::Segment;
 use cap_media::{
-    data::{AudioInfo, RawVideoFormat, VideoInfo},
+    data::{cast_f32_slice_to_bytes, AudioInfo, RawVideoFormat, VideoInfo},
     encoders::{MP4Encoder, MP4Input},
     feeds::{AudioData, AudioFrameBuffer},
     MediaError,
@@ -207,7 +207,8 @@ where
                             .buffer
                             .next_frame_data(samples, project.timeline.as_ref().map(|t| t))
                         {
-                            let mut frame = audio_info.wrap_frame(&frame_data, 0);
+                            let mut frame = audio_info
+                                .wrap_frame(unsafe { cast_f32_slice_to_bytes(&frame_data) }, 0);
                             let pts = (frame_count as f64 * f64::from(audio_info.sample_rate)
                                 / f64::from(fps)) as i64;
                             frame.set_pts(Some(pts));

--- a/crates/export/src/lib.rs
+++ b/crates/export/src/lib.rs
@@ -186,8 +186,6 @@ where
                 let mut frame_count = 0;
                 let mut first_frame = None;
 
-                let mut audio_sample_count = 0;
-
                 while let Some(frame) = rx_image_data.recv().await {
                     (self.on_progress)(frame_count);
 
@@ -214,7 +212,6 @@ where
                             let pts = (frame_count as f64 * f64::from(audio_info.sample_rate)
                                 / f64::from(fps)) as i64;
                             frame.set_pts(Some(pts));
-                            audio_sample_count += frame.samples();
                             Some(frame)
                         } else {
                             None

--- a/crates/export/src/lib.rs
+++ b/crates/export/src/lib.rs
@@ -246,9 +246,6 @@ where
                     frame_count += 1;
                 }
 
-                println!("sent {frame_count} video frames");
-                println!("sent {audio_sample_count} audio samples");
-
                 // Save the first frame as a screenshot and thumbnail
                 if let Some(frame) = first_frame {
                     let rgb_img = ImageBuffer::<image::Rgb<u8>, Vec<u8>>::from_raw(

--- a/crates/media/src/data.rs
+++ b/crates/media/src/data.rs
@@ -204,6 +204,10 @@ impl AudioInfo {
     }
 }
 
+pub unsafe fn cast_f32_slice_to_bytes(slice: &[f32]) -> &[u8] {
+    std::slice::from_raw_parts(slice.as_ptr() as *const u8, slice.len() * f32::BYTE_SIZE)
+}
+
 #[derive(Debug, Copy, Clone)]
 pub struct VideoInfo {
     pub pixel_format: Pixel,

--- a/crates/media/src/encoders/mp4.rs
+++ b/crates/media/src/encoders/mp4.rs
@@ -2,6 +2,7 @@ use crate::{
     data::{
         AudioInfo, FFAudio, FFPacket, FFRational, FFVideo, PlanarData, RawVideoFormat, VideoInfo,
     },
+    feeds::AudioData,
     pipeline::{audio_buffer::AudioBuffer, task::PipelineSinkTask},
     MediaError,
 };
@@ -86,6 +87,13 @@ impl MP4Encoder {
             audio_ctx.set_threading(Config::count(4));
             let mut audio_enc = audio_ctx.encoder().audio()?;
 
+            dbg!(audio_codec
+                .audio()
+                .unwrap()
+                .rates()
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>());
             if !audio_codec
                 .audio()
                 .unwrap()
@@ -110,7 +118,7 @@ impl MP4Encoder {
 
             let resampler = software::resampler(
                 (
-                    Sample::F64(format::sample::Type::Packed),
+                    AudioData::FORMAT,
                     audio_config.channel_layout(),
                     audio_config.sample_rate,
                 ),
@@ -211,6 +219,7 @@ impl MP4Encoder {
             };
 
             let mut output = ffmpeg::util::frame::Audio::empty();
+
             audio.resampler.run(&buffered_frame, &mut output).unwrap();
 
             // Preserve PTS from input frame

--- a/crates/media/src/encoders/mp4.rs
+++ b/crates/media/src/encoders/mp4.rs
@@ -87,13 +87,6 @@ impl MP4Encoder {
             audio_ctx.set_threading(Config::count(4));
             let mut audio_enc = audio_ctx.encoder().audio()?;
 
-            dbg!(audio_codec
-                .audio()
-                .unwrap()
-                .rates()
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>());
             if !audio_codec
                 .audio()
                 .unwrap()

--- a/crates/media/src/encoders/mp4.rs
+++ b/crates/media/src/encoders/mp4.rs
@@ -223,9 +223,9 @@ impl MP4Encoder {
             audio.resampler.run(&buffered_frame, &mut output).unwrap();
 
             // Preserve PTS from input frame
-            if let Some(pts) = buffered_frame.pts() {
-                output.set_pts(Some(pts));
-            }
+            // if let Some(pts) = buffered_frame.pts() {
+            //     output.set_pts(Some(pts));
+            // }
 
             // println!(
             //     "MP4Encoder: Sending audio frame with PTS: {:?}, samples: {}",
@@ -245,11 +245,13 @@ impl MP4Encoder {
                 //     encoded_packet.size()
                 // );
 
+                // dbg!(encoded_packet.dts());
+                // dbg!(encoded_packet.pts());
                 encoded_packet.set_stream(1);
-                encoded_packet.rescale_ts(
-                    audio.encoder.time_base(),
-                    self.output_ctx.stream(1).unwrap().time_base(),
-                );
+                // encoded_packet.rescale_ts(
+                //     audio.encoder.time_base(),
+                //     self.output_ctx.stream(1).unwrap().time_base(),
+                // );
                 encoded_packet
                     .write_interleaved(&mut self.output_ctx)
                     .unwrap();


### PR DESCRIPTION
This PR fixes some audio processing issues we've been having by simplifying how we handle audio data.
Like many applications that process audio, we convert all audio to f32 samples (packed bc i've heard it's more memory efficient). Currently this data is represented as `Vec<u8>` - a Vec of f32 samples as their native endian representation.
This required extra bookkeeping to track both bytes and samples elapsed.
This PR changes `AudioData` to store a `Vec<f32>` directly, so we only need to consider elapsed samples.
In places that require a `Vec<u8>` (eg audio playback), we do a cast from `Vec<f32>` to `Vec<u8>` to prevent copying all the samples. This is safe since everywhere that expects `Vec<u8>` uses native endianness.