### PR TITLE
Improve preview playhead

### DIFF
--- a/apps/desktop/src/routes/editor/Player.tsx
+++ b/apps/desktop/src/routes/editor/Player.tsx
@@ -43,6 +43,7 @@ export function Player() {
     setDialog,
     playbackTime,
     setPlaybackTime,
+    previewTime,
     playing,
     setPlaying,
     split,
@@ -117,6 +118,11 @@ export function Player() {
   createEventListener(document, "keydown", async (e: KeyboardEvent) => {
     if (e.code === "Space" && e.target === document.body) {
       e.preventDefault();
+      const time = previewTime();
+			if (!playing() && time !== undefined) {
+				setPlaybackTime(time);
+				await commands.seekTo(videoId, Math.floor(time * FPS));
+			}
       await handlePlayPauseClick();
     }
   });

--- a/apps/desktop/src/routes/editor/Timeline.tsx
+++ b/apps/desktop/src/routes/editor/Timeline.tsx
@@ -43,6 +43,7 @@ export function Timeline() {
     history,
     split,
     setState,
+    playing
   } = useEditorContext();
 
   const duration = () => editorInstance.recordingDuration;
@@ -138,7 +139,7 @@ export function Timeline() {
           setPreviewTime(undefined);
         }}
       >
-        <Show when={previewTime()}>
+        <Show when={!playing() && previewTime()}>
           {(time) => (
             <div
               class={cx(


### PR DESCRIPTION
Improves the UX of the preview playhead in the editor.

- When previewing and pressing <kbd>Space</kbd>, start playback from the preview playhead
- Hide the preview playhead during playback