### PR TITLE
Fix paths in setup script for Windows

### DIFF
--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -84,7 +84,7 @@ async function main() {
       console.log("Downloaded ffmpeg.zip");
     } else console.log("Using cached ffmpeg.zip");
 
-    const ffmpegDir = `${targetDir}\\ffmepg`;
+    const ffmpegDir = `${targetDir}\\ffmpeg`;
     if (!(await fileExists(ffmpegDir))) {
       await exec(`tar xf ${ffmpegZip} -C ${targetDir}`);
       await fs.rename(`${targetDir}\\${FFMPEG_ZIP_NAME}`, ffmpegDir);

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -12,7 +12,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const __root = path.resolve(path.join(__dirname, ".."));
-const targetDir = `${__root}/target`;
+const targetDir = path.join(__root, "target");
 
 const arch = process.arch === "arm64" ? "aarch64" : "x86_64";
 
@@ -68,12 +68,14 @@ async function main() {
         `${targetDir}/debug/${name}`
       );
     }
-    console.log("Copied ffmpeg dylibs to target/debug");
+    console.log("Copied ffmepg dylibs to target/debug");
   } else if (process.platform === "win32") {
     const FFMPEG_ZIP_NAME = "ffmpeg-7.1-full_build-shared";
     const FFMPEG_ZIP_URL = `https://github.com/GyanD/codexffmpeg/releases/download/7.1/${FFMPEG_ZIP_NAME}.zip`;
+    
+    await fs.mkdir(targetDir, { recursive: true });
 
-    const ffmpegZip = `${targetDir}/ffmpeg.zip`;
+    const ffmpegZip = `${targetDir}\\ffmpeg.zip`;
     if (!(await fileExists(ffmpegZip))) {
       const ffmpegZipBytes = await fetch(FFMPEG_ZIP_URL)
         .then((r) => r.blob())
@@ -82,18 +84,19 @@ async function main() {
       console.log("Downloaded ffmpeg.zip");
     } else console.log("Using cached ffmpeg.zip");
 
-    const ffmpegDir = `${targetDir}/ffmpeg`;
+    const ffmpegDir = `${targetDir}\\ffmepg`;
     if (!(await fileExists(ffmpegDir))) {
       await exec(`tar xf ${ffmpegZip} -C ${targetDir}`);
-      await fs.rename(`${targetDir}/${FFMPEG_ZIP_NAME}`, ffmpegDir);
+      await fs.rename(`${targetDir}\\${FFMPEG_ZIP_NAME}`, ffmpegDir);
       console.log("Extracted ffmpeg");
     } else console.log("Using cached ffmpeg");
 
     // alternative to adding ffmpeg/bin to PATH
-    for (const name of await fs.readdir(`${ffmpegDir}/bin`)) {
+    await fs.mkdir(`${targetDir}\\debug`, { recursive: true });
+    for (const name of await fs.readdir(`${ffmpegDir}\\bin`)) {
       await fs.copyFile(
-        `${ffmpegDir}/bin/${name}`,
-        `${targetDir}/debug/${name}`
+        `${ffmpegDir}\\bin\\${name}`,
+        `${targetDir}\\debug\\${name}`
       );
     }
     console.log("Copied ffmpeg dylibs to target/debug");

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -68,7 +68,7 @@ async function main() {
         `${targetDir}/debug/${name}`
       );
     }
-    console.log("Copied ffmepg dylibs to target/debug");
+    console.log("Copied ffmpeg dylibs to target/debug");
   } else if (process.platform === "win32") {
     const FFMPEG_ZIP_NAME = "ffmpeg-7.1-full_build-shared";
     const FFMPEG_ZIP_URL = `https://github.com/GyanD/codexffmpeg/releases/download/7.1/${FFMPEG_ZIP_NAME}.zip`;


### PR DESCRIPTION
## Summary
fix setup.js for Windows.

## Problem

It causes exception because of path representation.

```
Using cached ffmpeg.zip
node:internal/fs/promises:783
  return await PromisePrototypeThen(
         ^

Error: EPERM: operation not permitted, rename 'C:\Users\irisa\workspace\Cap\target\ffmpeg-7.1-full_build-shared' -> 'C:\Users\irisa\workspace\Cap\target\ffmpeg'
    at async Module.rename (node:internal/fs/promises:783:10)
    at async main (file:///C:/Users/irisa/workspace/Cap/scripts/setup.js:88:7) {
  errno: -4048,
  code: 'EPERM',
  syscall: 'rename',
  path: 'C:\\Users\\irisa\\workspace\\Cap\\target\\ffmpeg-7.1-full_build-shared',
  dest: 'C:\\Users\\irisa\\workspace\\Cap\\target\\ffmpeg'
}

Node.js v22.13.0
 ELIFECYCLE  Command failed with exit code 1.
```
