### PR TITLE
[#290] Upgrade dark colors correction

### DIFF
--- a/apps/desktop/src/routes/(window-chrome)/upgrade.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/upgrade.tsx
@@ -72,13 +72,12 @@ export default function Page() {
   return (
     <div
       class={`py-5 max-w-[700px] mx-auto relative ${
-        upgradeComplete() ? "h-full" : ""
-      }`}
+        upgradeComplete() ? "h-full" : ""}`}
     >
       {upgradeComplete() && (
-        <div class="h-full flex items-center justify-center bg-gray-800 bg-opacity-75">
-          <div class="bg-white p-6 rounded-lg shadow-lg text-center relative z-10">
-            <h2 class="text-2xl font-bold mb-4">
+        <div class="flex justify-center items-center h-full bg-gray-800 bg-opacity-75">
+          <div class="relative z-10 p-6 text-center bg-white rounded-lg shadow-lg">
+            <h2 class="mb-4 text-2xl font-bold">
               Upgrade complete - Welcome to Cap Pro!
             </h2>
             <Button
@@ -110,28 +109,28 @@ export default function Page() {
             </p>
           </div>
           <div class="flex flex-col p-[1rem] gap-[0.75rem] text-[0.875rem] font-[400] flex-1 bg-gray-100">
-            <div class="border text-card-foreground shadow-sm bg-blue-300 p-3 md:p-3 rounded-xl flex-grow border-blue-500/20">
+            <div class="flex-grow p-3 bg-blue-300 rounded-xl border shadow-sm text-card-foreground md:p-3 border-blue-500/20">
               <div class="space-y-3">
                 <div class="flex flex-col space-y-1.5 pt-6 px-6 pb-3">
-                  <h3 class="font-medium tracking-tight text-2xl text-gray-50">
+                  <h3 class="text-2xl font-medium tracking-tight text-gray-50 dark:text-[--text-primary]">
                     Cap Pro — Early Adopter Pricing
                   </h3>
-                  <p class="text-[0.875rem] leading-[1.25rem] text-gray-50">
+                  <p class="text-[0.875rem] leading-[1.25rem] text-gray-50 dark:text-[--text-primary]">
                     For professional use and teams.
                   </p>
                   <div>
                     <div class="flex items-center space-x-3">
-                      <h3 class="text-4xl text-gray-50">
+                      <h3 class="text-4xl text-gray-50 dark:text-[--text-primary]">
                         {isAnnual() ? "$6/mo" : "$9/mo"}
                       </h3>
                       <div>
-                        <p class="text-sm font-medium text-gray-50">
+                        <p class="text-sm font-medium text-gray-50 dark:text-[--text-primary]">
                           {isAnnual()
                             ? "per user, billed annually."
                             : "per user, billed monthly."}
                         </p>
                         {isAnnual() && (
-                          <p class="text-sm text-gray-50">
+                          <p class="text-sm text-gray-50 dark:text-[--text-primary]">
                             or, $9/month, billed monthly.
                           </p>
                         )}
@@ -139,9 +138,9 @@ export default function Page() {
                     </div>
                   </div>
                 </div>
-                <div class="mt-3 px-3 md:px-8">
-                  <div class="flex items-center mt-3 pt-4 pb-1 border-t-2 border-gray-50/20">
-                    <span class="text-xs text-gray-50 mr-2">
+                <div class="px-3 mt-3 md:px-8">
+                  <div class="flex items-center pt-4 pb-1 mt-3 border-t-2 border-[--gray-400]">
+                    <span class="mr-2 text-xs text-gray-50 dark:text-[--text-primary]">
                       Switch to {isAnnual() ? "monthly" : "annually"}
                     </span>
                     <button
@@ -160,25 +159,26 @@ export default function Page() {
                     </button>
                   </div>
                 </div>
-                <div class="px-6 pb-4 pt-0">
+                <div class="px-6 pt-0 pb-4">
                   <button
                     onClick={openCheckoutInExternalBrowser}
-                    class="flex items-center justify-center rounded-full bg-[--gray-50] hover:bg-[--gray-200] disabled:bg-[--gray-100] border border-[--gray-300] font-medium text-lg px-6 h-12 w-full no-underline"
+                    class="flex items-center justify-center rounded-full bg-[--gray-50] hover:bg-[--gray-200] disabled:bg-[--gray-100] border
+                     border-[--gray-300] font-medium text-lg px-6 h-12 w-full no-underline dark:text-[--text-primary]"
                     disabled={loading()}
                   >
                     {loading() ? "Loading..." : "Upgrade to Cap Pro"}
                   </button>
                 </div>
-                <div class="flex items-center px-6 pb-6 pt-0">
+                <div class="flex items-center px-6 pt-0 pb-6">
                   <div class="space-y-6">
                     <div>
-                      <ul class="list-none p-0 space-y-3">
+                      <ul class="p-0 space-y-3 list-none">
                         {proFeatures.map((feature) => (
-                          <li class="flex items-center justify-start">
-                            <div class="w-6 h-6 m-0 p-0 flex items-center border-[2px] border-white justify-center rounded-full">
-                              <IconLucideCheck class="w-4 h-4 stroke-[4px] text-[--gray-50]" />
+                          <li class="flex justify-start items-center">
+                            <div class="w-6 h-6 m-0 p-0 flex items-center border-[2px] border-[--gray-400] justify-center rounded-full">
+                              <IconLucideCheck class="w-4 h-4 text-[--gray-50] dark:text-[--text-primary]" />
                             </div>
-                            <span class="ml-2 text-[0.9rem] text-gray-50">
+                            <span class="ml-2 text-[0.9rem] dark:text-[--text-primary]">
                               {feature}
                             </span>
                           </li>

--- a/apps/desktop/src/routes/(window-chrome)/upgrade.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/upgrade.tsx
@@ -99,10 +99,10 @@ export default function Page() {
             <h1 class="text-4xl md:text-4xl mb-3 tracking-[-.05em] font-medium text-[--text-primary]">
               Upgrade to Cap Pro
             </h1>
-            <p class="text-base font-normal leading-6 text-gray-400">
+            <p class="text-base font-normal leading-6 text-gray-400 dark:text-[--black-transparent-60]">
               Cap is currently in public beta, and we're offering special early
               adopter pricing to our first users.{" "}
-              <span class="text-gray-500">
+              <span class="text-gray-500 dark:text-[--text-primary]">
                 This pricing will be locked in for the lifetime of your
                 subscription.
               </span>
@@ -139,7 +139,7 @@ export default function Page() {
                   </div>
                 </div>
                 <div class="px-3 mt-3 md:px-8">
-                  <div class="flex items-center pt-4 pb-1 mt-3 border-t-2 border-[--gray-400]">
+                  <div class="flex items-center pt-4 pb-1 mt-3 border-t-2 border-[--gray-50] dark:border-[--gray-500]">
                     <span class="mr-2 text-xs text-gray-50 dark:text-[--text-primary]">
                       Switch to {isAnnual() ? "monthly" : "annually"}
                     </span>
@@ -149,12 +149,20 @@ export default function Page() {
                       aria-checked={isAnnual()}
                       data-state={isAnnual() ? "unchecked" : "checked"}
                       value={isAnnual() ? "on" : "off"}
-                      class="peer inline-flex h-4 w-8 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 bg-[--blue-400]"
+                      class="peer inline-flex h-4 w-8 shrink-0
+                       cursor-pointer items-center rounded-full border-2 border-transparent
+                       dark:bg-[#3F75E0]
+                        transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 
+                      focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 bg-[--blue-400]"
                       onClick={togglePricing}
                     >
                       <span
                         data-state={isAnnual() ? "unchecked" : "checked"}
-                        class="pointer-events-none block h-4 w-4 rounded-full bg-[--gray-50] shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+                        class={`pointer-events-none block h-4 w-4 rounded-full dark:bg-gray-500
+                           bg-gray-50 shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4
+                            data-[state=unchecked]:translate-x-0 border-2 ${
+                         isAnnual() ? "border-blue-400 dark:border-[#3F75E0]" : "border-gray-300 dark:border-[--white-transparent-20]"
+                        }`}
                       />
                     </button>
                   </div>
@@ -162,8 +170,8 @@ export default function Page() {
                 <div class="px-6 pt-0 pb-4">
                   <button
                     onClick={openCheckoutInExternalBrowser}
-                    class="flex items-center justify-center rounded-full bg-[--gray-50] hover:bg-[--gray-200] disabled:bg-[--gray-100] border
-                     border-[--gray-300] font-medium text-lg px-6 h-12 w-full no-underline dark:text-[--text-primary]"
+                    class="flex items-center justify-center rounded-full bg-[--gray-50] dark:bg-[--gray-500] hover:bg-[--gray-200] disabled:bg-[--gray-100]
+                     font-medium text-lg px-6 h-12 w-full no-underline text-gray-500 dark:text-gray-50"
                     disabled={loading()}
                   >
                     {loading() ? "Loading..." : "Upgrade to Cap Pro"}
@@ -175,10 +183,10 @@ export default function Page() {
                       <ul class="p-0 space-y-3 list-none">
                         {proFeatures.map((feature) => (
                           <li class="flex justify-start items-center">
-                            <div class="w-6 h-6 m-0 p-0 flex items-center border-[2px] border-[--gray-400] justify-center rounded-full">
-                              <IconLucideCheck class="w-4 h-4 text-[--gray-50] dark:text-[--text-primary]" />
+                            <div class="w-6 h-6 m-0 p-0 flex items-center border-[2px] border-[--gray-50] dark:border-[--gray-500] justify-center rounded-full">
+                              <IconLucideCheck class="w-4 h-4  text-gray-50 dark:text-[--text-primary]" />
                             </div>
-                            <span class="ml-2 text-[0.9rem] dark:text-[--text-primary]">
+                            <span class="ml-2 text-[0.9rem] text-gray-50 dark:text-[--text-primary]">
                               {feature}
                             </span>
                           </li>


### PR DESCRIPTION
This PR: adjusts the colors of the upgrade screen in dark mode, from the editor.

<img width="794" alt="Screenshot 2025-02-03 at 12 43 26" src="https://github.com/user-attachments/assets/2179520f-d151-4dbd-baad-7820d9720a0d" />
