### PR TITLE
Make sure camera and in-progress-recording windows stay on top of occluder

### DIFF
--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -15,8 +15,8 @@ use crate::{
     RecordingStarted, RecordingStopped, UploadMode,
 };
 use cap_flags::FLAGS;
-use cap_media::feeds::CameraFeed;
 use cap_media::sources::{CaptureScreen, CaptureWindow};
+use cap_media::{feeds::CameraFeed, sources::ScreenCaptureTarget};
 use cap_project::{
     Content, ProjectConfiguration, TimelineConfiguration, TimelineSegment, ZoomSegment, XY,
 };
@@ -96,6 +96,14 @@ pub async fn start_recording(
             }
         }
     }
+
+    if matches!(
+        state.start_recording_options.capture_target,
+        ScreenCaptureTarget::Window(_) | ScreenCaptureTarget::Area(_)
+    ) {
+        let _ = ShowCapWindow::WindowCaptureOccluder.show(&app);
+    }
+
     let (actor, actor_done_rx) = cap_recording::spawn_recording_actor(
         id,
         recording_dir,

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -135,8 +135,7 @@ pub async fn start_recording(
     }
 
     if let Some(window) = CapWindowId::InProgressRecording.get(&app) {
-        window.eval("window.location.reload()").unwrap();
-        window.show().unwrap();
+        window.eval("window.location.reload()").ok();
     } else {
         ShowCapWindow::InProgressRecording { position: None }
             .show(&app)

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -245,10 +245,7 @@ impl ShowCapWindow {
 
                 #[cfg(target_os = "macos")]
                 {
-                    crate::platform::set_window_level(
-                        window.as_ref().window(),
-                        objc2_app_kit::NSScreenSaverWindowLevel,
-                    );
+                    crate::platform::set_window_level(window.as_ref().window(), 1000);
                 }
 
                 window
@@ -277,10 +274,7 @@ impl ShowCapWindow {
 
                 #[cfg(target_os = "macos")]
                 {
-                    crate::platform::set_window_level(
-                        window.as_ref().window(),
-                        objc2_app_kit::NSScreenSaverWindowLevel,
-                    );
+                    crate::platform::set_window_level(window.as_ref().window(), 900);
                 }
 
                 window
@@ -364,10 +358,7 @@ impl ShowCapWindow {
 
                 #[cfg(target_os = "macos")]
                 {
-                    crate::platform::set_window_level(
-                        window.as_ref().window(),
-                        objc2_app_kit::NSScreenSaverWindowLevel,
-                    );
+                    crate::platform::set_window_level(window.as_ref().window(), 1000);
                 }
 
                 window

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -241,7 +241,17 @@ impl ShowCapWindow {
                     ))
                     .transparent(true);
 
-                window_builder.build()?
+                let window = window_builder.build()?;
+
+                #[cfg(target_os = "macos")]
+                {
+                    crate::platform::set_window_level(
+                        window.as_ref().window(),
+                        objc2_app_kit::NSScreenSaverWindowLevel,
+                    );
+                }
+
+                window
             }
             Self::WindowCaptureOccluder => {
                 let mut window_builder = self
@@ -334,7 +344,8 @@ impl ShowCapWindow {
 
                 let height = 40.0;
 
-                self.window_builder(app, "/in-progress-recording")
+                let window = self
+                    .window_builder(app, "/in-progress-recording")
                     .maximized(false)
                     .resizable(false)
                     .fullscreen(false)
@@ -349,7 +360,17 @@ impl ShowCapWindow {
                         (monitor.size().height as f64) / monitor.scale_factor() - height - 120.0,
                     )
                     .skip_taskbar(true)
-                    .build()?
+                    .build()?;
+
+                #[cfg(target_os = "macos")]
+                {
+                    crate::platform::set_window_level(
+                        window.as_ref().window(),
+                        objc2_app_kit::NSScreenSaverWindowLevel,
+                    );
+                }
+
+                window
             }
             Self::PrevRecordings => {
                 let window = self

--- a/apps/desktop/src/components/CropAreaRenderer.tsx
+++ b/apps/desktop/src/components/CropAreaRenderer.tsx
@@ -282,7 +282,7 @@ export default function CropAreaRenderer(
   });
 
   return (
-    <div class="*:h-full *:w-full">
+    <div class="*:h-full *:w-full animate-in fade-in">
       <canvas ref={canvasRef} class="pointer-events-none absolute" />
       <div>{props.children}</div>
     </div>

--- a/apps/desktop/src/routes/window-capture-occluder.tsx
+++ b/apps/desktop/src/routes/window-capture-occluder.tsx
@@ -1,10 +1,20 @@
+import { getAllWindows } from "@tauri-apps/api/window";
 import { type as ostype } from "@tauri-apps/plugin-os";
-import { Show, Suspense } from "solid-js";
+import { onMount, Show, Suspense } from "solid-js";
 import CropAreaRenderer from "~/components/CropAreaRenderer";
 import { createCurrentRecordingQuery } from "~/utils/queries";
 
 export default function () {
   const currentRecording = createCurrentRecordingQuery();
+
+  onMount(() => {
+    getAllWindows().then((w) =>
+      w.forEach((w) => {
+        if (w.label === "camera" || w.label === "in-progress-recordings")
+          w.setFocus();
+      })
+    );
+  });
 
   return (
     <Suspense>

--- a/apps/desktop/src/routes/window-capture-occluder.tsx
+++ b/apps/desktop/src/routes/window-capture-occluder.tsx
@@ -9,7 +9,7 @@ export default function () {
 
   getAllWindows().then((w) =>
     w.forEach((w) => {
-      if (w.label === "camera" || w.label === "in-progress-recordings")
+      if (w.label === "camera" || w.label === "in-progress-recording")
         w.setFocus();
     })
   );
@@ -26,7 +26,7 @@ export default function () {
         {(bounds) => {
           getAllWindows().then((w) =>
             w.forEach((w) => {
-              if (w.label === "camera" || w.label === "in-progress-recordings")
+              if (w.label === "camera" || w.label === "in-progress-recording")
                 w.setFocus();
             })
           );

--- a/apps/desktop/src/routes/window-capture-occluder.tsx
+++ b/apps/desktop/src/routes/window-capture-occluder.tsx
@@ -7,14 +7,12 @@ import { createCurrentRecordingQuery } from "~/utils/queries";
 export default function () {
   const currentRecording = createCurrentRecordingQuery();
 
-  onMount(() => {
-    getAllWindows().then((w) =>
-      w.forEach((w) => {
-        if (w.label === "camera" || w.label === "in-progress-recordings")
-          w.setFocus();
-      })
-    );
-  });
+  getAllWindows().then((w) =>
+    w.forEach((w) => {
+      if (w.label === "camera" || w.label === "in-progress-recordings")
+        w.setFocus();
+    })
+  );
 
   return (
     <Suspense>
@@ -25,12 +23,21 @@ export default function () {
           currentRecording.data.captureTarget.bounds
         }
       >
-        {(bounds) => (
-          <CropAreaRenderer
-            bounds={bounds()}
-            borderRadius={ostype() === "macos" ? 9 : 7}
-          />
-        )}
+        {(bounds) => {
+          getAllWindows().then((w) =>
+            w.forEach((w) => {
+              if (w.label === "camera" || w.label === "in-progress-recordings")
+                w.setFocus();
+            })
+          );
+
+          return (
+            <CropAreaRenderer
+              bounds={bounds()}
+              borderRadius={ostype() === "macos" ? 9 : 7}
+            />
+          );
+        }}
       </Show>
     </Suspense>
   );


### PR DESCRIPTION
on macOS this is enforced by `set_window_level`, on windows we rely on `setFocus` on the camera and IPR windows to lift them above.