### PR TITLE
a bunch of things requested on discord

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -15,6 +15,8 @@ import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import "@cap/ui-solid/main.css";
 import "unfonts.css";
 import "./styles/theme.css";
+
+import titlebar from "./utils/titlebar-state";
 import { generalSettingsStore } from "./store";
 import { commands, type AppTheme } from "./utils/tauri";
 import {
@@ -24,6 +26,7 @@ import {
 import { Button } from "@cap/ui-solid";
 import { Toaster } from "solid-toast";
 import { initAnonymousUser } from "./utils/analytics";
+import { initializeTitlebar } from "./utils/titlebar-state";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -57,6 +60,9 @@ function Inner() {
     <>
       <Toaster
         position="top-right"
+        containerStyle={{
+          "margin-top": titlebar.height,
+        }}
         toastOptions={{
           duration: 3500,
           style: {

--- a/apps/desktop/src/routes/(window-chrome)/settings/recordings.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/recordings.tsx
@@ -1,9 +1,10 @@
 import { createQuery } from "@tanstack/solid-query";
-import { For, Show, Suspense, createSignal } from "solid-js";
+import { For, ParentProps, Show, Suspense, createSignal } from "solid-js";
 import { convertFileSrc } from "@tauri-apps/api/core";
 
 import { commands, events, type RecordingMeta } from "~/utils/tauri";
 import { trackEvent } from "~/utils/analytics";
+import Tooltip from "@corvu/tooltip";
 
 type MediaEntry = {
   id: string;
@@ -114,37 +115,48 @@ function RecordingItem(props: {
         <span>{props.recording.prettyName}</span>
       </div>
       <div class="flex items-center">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            props.onOpenFolder();
-          }}
-          class="p-2 hover:bg-gray-200 rounded-full mr-2"
+        <TooltipIconButton
+          tooltipText="Open project files"
+          onClick={() => props.onOpenFolder()}
         >
           <IconLucideFolder class="size-5" />
-        </button>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            props.onOpenEditor();
-          }}
-          class="p-2 hover:bg-gray-200 rounded-full mr-2"
+        </TooltipIconButton>
+        <TooltipIconButton
+          tooltipText="Open in editor"
+          onClick={() => props.onOpenEditor()}
         >
           <IconLucideEdit class="size-5" />
-        </button>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            props.onClick();
-          }}
-          class="p-2 hover:bg-gray-200 rounded-full"
+        </TooltipIconButton>
+        <TooltipIconButton
+          tooltipText="Show in recordings overlay"
+          onClick={() => props.onClick()}
         >
           <IconLucideEye class="size-5" />
-        </button>
+        </TooltipIconButton>
       </div>
     </li>
+  );
+}
+
+function TooltipIconButton(
+  props: ParentProps<{ onClick: () => void; tooltipText: string }>
+) {
+  return (
+    <Tooltip>
+      <Tooltip.Trigger
+        onClick={(e) => {
+          e.stopPropagation();
+          props.onClick();
+        }}
+        class="p-2 hover:bg-gray-200 rounded-full mr-2"
+      >
+        {props.children}
+      </Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Content class="py-1 px-2 font-medium bg-gray-100 text-gray-400 border border-gray-300 text-xs rounded-lg animate-in fade-in slide-in-from-top-0.5">
+          {props.tooltipText}
+        </Tooltip.Content>
+      </Tooltip.Portal>
+    </Tooltip>
   );
 }

--- a/apps/desktop/src/routes/editor/ConfigSidebar.tsx
+++ b/apps/desktop/src/routes/editor/ConfigSidebar.tsx
@@ -50,6 +50,7 @@ import { generalSettingsStore } from "~/store";
 import { type as ostype } from "@tauri-apps/plugin-os";
 import toast from "solid-toast";
 import { createElementBounds } from "@solid-primitives/bounds";
+import { TextInput } from "./TextInput";
 
 const BACKGROUND_SOURCES = {
   wallpaper: "Wallpaper",
@@ -1417,7 +1418,6 @@ export function ConfigSidebar() {
                         const render = () => {
                           const ctx = canvasRef.getContext("2d");
                           ctx!.imageSmoothingEnabled = false;
-                          console.log(canvasRef.width);
                           ctx!.drawImage(
                             video,
                             croppedPosition().x,
@@ -1573,7 +1573,7 @@ function RgbInput(props: {
           if (value) props.onChange(value);
         }}
       />
-      <input
+      <TextInput
         class="w-[5rem] p-[0.375rem] border text-gray-400 rounded-[0.5rem] bg-gray-50"
         value={text()}
         onFocus={() => {

--- a/apps/desktop/src/routes/editor/Player.tsx
+++ b/apps/desktop/src/routes/editor/Player.tsx
@@ -269,7 +269,7 @@ export function Player() {
               setPlaybackTime(totalDuration());
             }}
           >
-            <IconCapFrameLast class="size-[1rem]" />
+            <IconCapFrameLast class="size-[1.2rem]" />
           </button>
         </div>
         <div class="flex-1 flex flex-row justify-end items-center gap-2">
@@ -280,6 +280,8 @@ export function Player() {
           ) : (
             <ComingSoonTooltip>{splitButton()}</ComingSoonTooltip>
           )}
+          <div class="w-[0.5px] h-7 bg-gray-300 mx-1" />
+          <IconIcRoundSearch class="mt-0.5" />
           <Slider
             class="w-24"
             minValue={0}

--- a/apps/desktop/src/routes/editor/TextInput.tsx
+++ b/apps/desktop/src/routes/editor/TextInput.tsx
@@ -1,0 +1,18 @@
+import { ComponentProps } from "solid-js";
+import { composeEventHandlers } from "~/utils/composeEventHandlers";
+
+// It's important to use this instead of plain text inputs as we use global key listeners
+// for keybinds
+export function TextInput(props: ComponentProps<"input">) {
+  return (
+    <input
+      {...props}
+      onKeyDown={composeEventHandlers<HTMLInputElement>([
+        props.onKeyDown,
+        (e) => {
+          e.stopPropagation();
+        },
+      ])}
+    />
+  );
+}

--- a/apps/desktop/src/routes/editor/ui.tsx
+++ b/apps/desktop/src/routes/editor/ui.tsx
@@ -15,6 +15,7 @@ import {
   splitProps,
 } from "solid-js";
 import { useEditorContext } from "./context";
+import { TextInput } from "./TextInput";
 
 export function Field(
   props: ParentProps<{ name: string; icon?: JSX.Element; value?: JSX.Element }>
@@ -96,7 +97,7 @@ export function Slider(props: ComponentProps<typeof KSlider>) {
 
 export function Input(props: ComponentProps<"input">) {
   return (
-    <input
+    <TextInput
       {...props}
       class={cx(
         "rounded-[0.5rem] h-[2rem] p-[0.375rem] border w-full text-[0.875rem] focus:border-blue-300 outline-none text-gray-500 dark:text-gray-50 placeholder:text-black-transparent-20",

--- a/apps/desktop/src/utils/composeEventHandlers.ts
+++ b/apps/desktop/src/utils/composeEventHandlers.ts
@@ -1,0 +1,28 @@
+import { JSX } from "solid-js";
+
+/** Call a JSX.EventHandlerUnion with the event. */
+export function callHandler<T, E extends Event>(
+  event: E & { currentTarget: T; target: Element },
+  handler: JSX.EventHandlerUnion<T, E> | undefined
+) {
+  if (handler) {
+    if (typeof handler === "function") {
+      handler(event);
+    } else {
+      handler[0](handler[1], event);
+    }
+  }
+
+  return event?.defaultPrevented;
+}
+
+/** Create a new event handler which calls all given handlers in the order they were chained with the same event. */
+export function composeEventHandlers<T>(
+  handlers: Array<JSX.EventHandlerUnion<T, any> | undefined>
+) {
+  return (event: any) => {
+    for (const handler of handlers) {
+      callHandler(event, handler);
+    }
+  };
+}

--- a/crates/export/src/lib.rs
+++ b/crates/export/src/lib.rs
@@ -206,7 +206,7 @@ where
 
                 loop {
                     let Some((frame, frame_number)) =
-                        tokio::time::timeout(Duration::from_secs(3), rx_image_data.recv()).await?
+                        tokio::time::timeout(Duration::from_secs(6), rx_image_data.recv()).await?
                     else {
                         break;
                     };

--- a/packages/ui-solid/src/auto-imports.d.ts
+++ b/packages/ui-solid/src/auto-imports.d.ts
@@ -49,6 +49,7 @@ declare global {
   const IconCapUndo: typeof import('~icons/cap/undo.jsx')['default']
   const IconCapUpload: typeof import('~icons/cap/upload.jsx')['default']
   const IconHugeiconsEaseCurveControlPoints: typeof import('~icons/hugeicons/ease-curve-control-points.jsx')['default']
+  const IconIcRoundSearch: typeof import('~icons/ic/round-search.jsx')['default']
   const IconLucideBell: typeof import('~icons/lucide/bell.jsx')['default']
   const IconLucideCamera: typeof import('~icons/lucide/camera.jsx')['default']
   const IconLucideCheck: typeof import('~icons/lucide/check.jsx')['default']


### PR DESCRIPTION
- Toasts sit below the titlebar
- Previous Recordings page buttons have tooltips
- Delete and Backspace can be used to delete zoom segments (all text inputs now have e.stopPropagation)
- Forward & Back buttons are the same size
- Zoom slider has an icon next to it
- Timeline scroll should work on windows with Shift + Scroll
- Increased frame render timeout