### PR TITLE
feat: Cursor implementation + HW accel

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[env]
-FFMPEG_DIR = { relative = true, force = true, value = "target/native-deps" }
-LIBCLANG_PATH = "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/LLVM/x64/bin/libclang.dll"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [env]
 FFMPEG_DIR = { relative = true, force = true, value = "target/native-deps" }
+LIBCLANG_PATH = "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/LLVM/x64/bin/libclang.dll"

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ apps/storybook/storybook-static
 
 *.tsbuildinfo
 .cargo/config.toml
+tauri.windows.conf.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9136,8 +9136,8 @@ checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
 dependencies = [
  "windows-implement 0.59.0",
  "windows-interface 0.59.0",
- "windows-result 0.3.0",
- "windows-strings 0.3.0",
+ "windows-result 0.3.1",
+ "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
@@ -9208,6 +9208,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9249,11 +9255,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08106ce80268c4067c0571ca55a9b4e9516518eaa1a1fe9b37ca403ae1d1a34"
+checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
 dependencies = [
- "windows-targets 0.53.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -9277,11 +9283,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b888f919960b42ea4e11c2f408fadb55f78a9f236d5eef084103c8ce52893491"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-targets 0.53.0",
+ "windows-link",
 ]
 
 [[package]]

--- a/apps/desktop/scripts/prepare.js
+++ b/apps/desktop/scripts/prepare.js
@@ -33,9 +33,8 @@ async function semverToWIXCompatibleVersion(cargoFilePath) {
     const numMatch = buildOrPrerelease.match(/\d+$/);
     build = numMatch ? parseInt(numMatch[0]) : 0;
   }
-  const wixVersion = `${major}.${minor}.${patch}${
-    build === 0 ? "" : `.${build}`
-  }`;
+  const wixVersion = `${major}.${minor}.${patch}${build === 0 ? "" : `.${build}`
+    }`;
   if (wixVersion !== ver)
     console.log(`Using wix-compatible version ${ver} --> ${wixVersion}`);
   return wixVersion;
@@ -80,7 +79,9 @@ export async function createTauriPlatformConfigs(
     baseConfig = {
       ...baseConfig,
       bundle: {
-        "../../../target/ffmpeg/bin/*.dll": "./",
+        resources: {
+          "../../../target/ffmpeg/bin/*.dll": "./",
+        },
         windows: {
           wix: {
             version: await semverToWIXCompatibleVersion(

--- a/apps/desktop/scripts/prepare.js
+++ b/apps/desktop/scripts/prepare.js
@@ -80,6 +80,7 @@ export async function createTauriPlatformConfigs(
     baseConfig = {
       ...baseConfig,
       bundle: {
+        "../../../target/ffmpeg/bin/*.dll": "./",
         windows: {
           wix: {
             version: await semverToWIXCompatibleVersion(

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -35,6 +35,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "icon": [
       "icons/32x32.png",

--- a/apps/desktop/src-tauri/tauri.prod.conf.json
+++ b/apps/desktop/src-tauri/tauri.prod.conf.json
@@ -17,7 +17,6 @@
     }
   },
   "bundle": {
-    "createUpdaterArtifacts": true,
     "macOS": {
       "entitlements": "Entitlements.plist"
     },

--- a/apps/desktop/src-tauri/tauri.windows.conf.json
+++ b/apps/desktop/src-tauri/tauri.windows.conf.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://schema.tauri.app/config/2",
   "bundle": {
-    "resources": {
-      "../../../target/ffmpeg/bin/*.dll": "./"
+    "windows": {
+      "wix": {
+        "version": "0.3.26"
+      }
     }
   }
 }

--- a/apps/desktop/src-tauri/tauri.windows.conf.json
+++ b/apps/desktop/src-tauri/tauri.windows.conf.json
@@ -1,7 +1,9 @@
 {
   "bundle": {
+    "resources": {
+      "../../../target/ffmpeg/bin/*.dll": "./"
+    },
     "windows": {
-      "../../../target/ffmpeg/bin/*.dll": "./",
       "wix": {
         "version": "0.3.26"
       }

--- a/apps/desktop/src-tauri/tauri.windows.conf.json
+++ b/apps/desktop/src-tauri/tauri.windows.conf.json
@@ -1,6 +1,7 @@
 {
   "bundle": {
     "windows": {
+      "../../../target/ffmpeg/bin/*.dll": "./",
       "wix": {
         "version": "0.3.26"
       }

--- a/apps/desktop/src/routes/(window-chrome)/(main).tsx
+++ b/apps/desktop/src/routes/(window-chrome)/(main).tsx
@@ -7,7 +7,7 @@ import {
   useQueryClient,
 } from "@tanstack/solid-query";
 import { getVersion } from "@tauri-apps/api/app";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { availableMonitors, getCurrentWindow } from "@tauri-apps/api/window";
 import { LogicalSize } from "@tauri-apps/api/window";
 import { cx } from "cva";
 import {

--- a/apps/desktop/src/routes/(window-chrome)/settings.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings.tsx
@@ -96,12 +96,12 @@ export default function Settings(props: RouteSectionProps) {
                   name: "Feedback",
                   icon: IconLucideMessageSquarePlus,
                 },
-                {
-                  type: "button",
-                  name: "Live Chat",
-                  icon: IconLucideMessageCircle,
-                  onClick: handleLiveChat,
-                },
+                // {
+                //   type: "button",
+                //   name: "Live Chat",
+                //   icon: IconLucideMessageCircle,
+                //   onClick: handleLiveChat,
+                // },
                 {
                   type: "link",
                   href: "changelog",

--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -22,6 +22,13 @@ const settingsList: Array<{
   onChange?: (value: boolean) => Promise<void>;
 }> = [
   {
+    key: "autoCreateShareableLink",
+    label: "Automatically generate shareable link after recording",
+    description:
+      "When enabled, a shareable link will be created automatically after stopping the recording. You'll be redirected to the URL while the upload continues in the background.",
+    pro: true,
+  },
+  {
     key: "uploadIndividualFiles",
     label: "Upload individual recording files when creating shareable link",
     description:
@@ -45,13 +52,6 @@ const settingsList: Array<{
     label: "Enable Haptics",
     platforms: ["macos"],
     description: "Use haptics on Force Touch™ trackpads",
-  },
-  {
-    key: "autoCreateShareableLink",
-    label: "Automatically create shareable link after recording",
-    description:
-      "When enabled, a shareable link will be created automatically after stopping the recording. You'll be redirected to the URL while the upload continues in the background.",
-    pro: true,
   },
   {
     key: "disableAutoOpenLinks",

--- a/apps/desktop/src/routes/editor/Timeline.tsx
+++ b/apps/desktop/src/routes/editor/Timeline.tsx
@@ -185,8 +185,9 @@ export function Timeline() {
           else {
             let delta: number = 0;
 
-            if (platform() === "macos" && e.shiftKey) delta = e.deltaX;
-            else if (platform() === "windows" && e.shiftKey) delta = e.deltaY;
+            if (platform() === "macos")
+              delta = e.shiftKey ? e.deltaX : e.deltaY;
+            else if (platform() === "windows") delta = e.deltaY;
 
             state.timelineTransform.setPosition(
               state.timelineTransform.position + secsPerPixel() * delta

--- a/crates/ffmpeg-hw-device/src/lib.rs
+++ b/crates/ffmpeg-hw-device/src/lib.rs
@@ -84,18 +84,17 @@ impl CodecContextExt for codec::decoder::decoder::Decoder {
                 return Err("no hw config");
             };
 
-            HW_PIX_FMT.set((*hw_config).pix_fmt);
-
-            let context = self.as_mut_ptr();
-
-            (*context).get_format = Some(get_format);
-
             let mut hw_device_ctx = null_mut();
 
             if av_hwdevice_ctx_create(&mut hw_device_ctx, device_type, null(), null_mut(), 0) < 0 {
                 return Err("failed to create hw device context");
             }
 
+            HW_PIX_FMT.set((*hw_config).pix_fmt);
+
+            let context = self.as_mut_ptr();
+
+            (*context).get_format = Some(get_format);
             (*context).hw_device_ctx = av_buffer_ref(hw_device_ctx);
 
             Ok(HwDevice {

--- a/crates/flags/src/lib.rs
+++ b/crates/flags/src/lib.rs
@@ -6,6 +6,6 @@ pub struct Flags {
 }
 
 pub const FLAGS: Flags = Flags {
-    record_mouse_state: false, // cfg!(debug_assertions),
+    record_mouse_state: cfg!(debug_assertions),
     split: false,
 };

--- a/crates/flags/src/lib.rs
+++ b/crates/flags/src/lib.rs
@@ -6,6 +6,6 @@ pub struct Flags {
 }
 
 pub const FLAGS: Flags = Flags {
-    record_mouse_state: false, // cfg!(debug_assertions),
+    record_mouse_state: true, // cfg!(debug_assertions),
     split: false,
 };

--- a/crates/flags/src/lib.rs
+++ b/crates/flags/src/lib.rs
@@ -6,6 +6,6 @@ pub struct Flags {
 }
 
 pub const FLAGS: Flags = Flags {
-    record_mouse_state: true, // cfg!(debug_assertions),
+    record_mouse_state: false, // cfg!(debug_assertions),
     split: false,
 };

--- a/crates/media/src/encoders/mp4.rs
+++ b/crates/media/src/encoders/mp4.rs
@@ -56,17 +56,19 @@ impl MP4File {
     }
 
     pub fn finish(&mut self) {
-        println!("MP4Encoder: Finishing encoding");
+        tracing::info!("MP4Encoder: Finishing encoding");
 
         self.video.finish(&mut self.output);
 
         if let Some(audio) = &mut self.audio {
-            println!("MP4Encoder: Flushing audio encoder");
+            tracing::info!("MP4Encoder: Flushing audio encoder");
             audio.finish(&mut self.output);
         }
 
-        println!("MP4Encoder: Writing trailer");
-        self.output.write_trailer().unwrap();
+        tracing::info!("MP4Encoder: Writing trailer");
+        if let Err(e) = self.output.write_trailer() {
+            tracing::error!("Failed to write MP4 trailer: {:?}", e);
+        }
     }
 }
 

--- a/crates/media/src/feeds/camera.rs
+++ b/crates/media/src/feeds/camera.rs
@@ -368,12 +368,19 @@ fn buffer_to_ffvideo(buffer: nokhwa::Buffer) -> FFVideo {
                 }
             }),
             FrameFormat::YUYV => {
-                // let bytes = buffer.buffer().len() as f32;
-                // let ratio = bytes / (buffer.resolution().x() * buffer.resolution().y()) as f32;
-                // if ratio == 2.0
+                // nokhwa moment
+                let pix_fmt = if cfg!(windows) {
+                    Pixel::YUYV422
+                } else {
+                    // let bytes = buffer.buffer().len() as f32;
+                    // let ratio = bytes / (buffer.resolution().x() * buffer.resolution().y()) as f32;
+                    // if ratio == 2.0
 
-                // nokhwa merges yuvu420 and uyvy422 into the same format, we should probably distinguish them with the frame size
-                (Pixel::UYVY422, |frame, buffer| {
+                    // nokhwa merges yuvu420 and uyvy422 into the same format, we should probably distinguish them with the frame size
+                    Pixel::UYVY422
+                };
+
+                (pix_fmt, |frame, buffer| {
                     let width = frame.width() as usize;
                     let height = frame.height() as usize;
 

--- a/crates/media/src/feeds/camera.rs
+++ b/crates/media/src/feeds/camera.rs
@@ -229,13 +229,30 @@ fn run_camera_feed(
                 FrameFormat::RAWRGB => Pixel::RGB24,
                 FrameFormat::NV12 => Pixel::NV12,
                 FrameFormat::GRAY => Pixel::GRAY8,
-                FrameFormat::YUYV => Pixel::UYVY422,
+                FrameFormat::YUYV => {
+                    let pix_fmt = if cfg!(windows) {
+                        tracing::debug!("Using YUYV422 format for Windows camera in buffer_to_ffvideo");
+                        Pixel::YUYV422  // This is correct for Windows
+                    } else {
+                        // let bytes = buffer.buffer().len() as f32;
+                        // let ratio = bytes / (buffer.resolution().x() * buffer.resolution().y()) as f32;
+                        // if ratio == 2.0
+
+                        // nokhwa merges yuvu420 and uyvy422 into the same format, we should probably distinguish them with the frame size
+                        tracing::debug!("Using UYVY422 format for non-Windows camera in buffer_to_ffvideo");
+                        Pixel::UYVY422
+                    };
+
+                    pix_fmt
+                },
             },
             camera_format.width(),
             camera_format.height(),
             camera_format.frame_rate(),
         )
     };
+
+    debug!("Camera video info: {:?}", video_info);
 
     let mut senders: Vec<Sender<RawCameraFrame>> = vec![];
 
@@ -272,7 +289,16 @@ fn run_camera_feed(
                                     FrameFormat::RAWRGB => Pixel::RGB24,
                                     FrameFormat::NV12 => Pixel::NV12,
                                     FrameFormat::GRAY => Pixel::GRAY8,
-                                    FrameFormat::YUYV => Pixel::UYVY422,
+                                    FrameFormat::YUYV => {
+                                        let pix_fmt = if cfg!(windows) {
+                                            tracing::debug!("Using YUYV422 format for Windows camera in buffer_to_ffvideo");
+                                            Pixel::YUYV422  // This is correct for Windows
+                                        } else {
+                                            tracing::debug!("Using UYVY422 format for non-Windows camera in buffer_to_ffvideo");
+                                            Pixel::UYVY422
+                                        };
+                                        pix_fmt
+                                    },
                                 },
                                 camera_format.width(),
                                 camera_format.height(),
@@ -370,13 +396,15 @@ fn buffer_to_ffvideo(buffer: nokhwa::Buffer) -> FFVideo {
             FrameFormat::YUYV => {
                 // nokhwa moment
                 let pix_fmt = if cfg!(windows) {
-                    Pixel::YUYV422
+                    tracing::debug!("Using YUYV422 format for Windows camera in buffer_to_ffvideo");
+                    Pixel::YUYV422  // This is correct for Windows
                 } else {
                     // let bytes = buffer.buffer().len() as f32;
                     // let ratio = bytes / (buffer.resolution().x() * buffer.resolution().y()) as f32;
                     // if ratio == 2.0
 
                     // nokhwa merges yuvu420 and uyvy422 into the same format, we should probably distinguish them with the frame size
+                    tracing::debug!("Using UYVY422 format for non-Windows camera in buffer_to_ffvideo");
                     Pixel::UYVY422
                 };
 

--- a/crates/media/src/platform/macos.rs
+++ b/crates/media/src/platform/macos.rs
@@ -8,7 +8,7 @@ use core_foundation::{
 };
 use core_graphics::{
     base::boolean_t,
-    display::{CFArrayGetValueAtIndex, CFDictionaryRef, CGRect},
+    display::{CFArrayGetValueAtIndex, CFDictionaryRef, CGDisplay, CGDisplayBounds, CGRect},
     window::{
         kCGNullWindowID, kCGWindowBounds, kCGWindowLayer, kCGWindowListExcludeDesktopElements,
         kCGWindowListOptionOnScreenOnly, kCGWindowName, kCGWindowNumber, kCGWindowOwnerName,
@@ -369,4 +369,20 @@ pub fn display_for_window(
     }
 
     None
+}
+
+pub fn primary_monitor_bounds() -> Bounds {
+    let display = CGDisplay::main();
+    let height = display.pixels_high();
+    let width = display.pixels_wide();
+    let bounds = unsafe { CGDisplayBounds(display.id) };
+
+    dbg!(bounds);
+
+    Bounds {
+        x: bounds.origin.x,
+        y: bounds.origin.y,
+        width: width as f64,
+        height: height as f64,
+    }
 }

--- a/crates/media/src/platform/macos.rs
+++ b/crates/media/src/platform/macos.rs
@@ -377,8 +377,6 @@ pub fn primary_monitor_bounds() -> Bounds {
     let width = display.pixels_wide();
     let bounds = unsafe { CGDisplayBounds(display.id) };
 
-    dbg!(bounds);
-
     Bounds {
         x: bounds.origin.x,
         y: bounds.origin.y,

--- a/crates/media/src/platform/win.rs
+++ b/crates/media/src/platform/win.rs
@@ -25,6 +25,8 @@ use windows::Win32::UI::WindowsAndMessaging::{
     IDC_CROSS, IDC_HAND, IDC_HELP, IDC_IBEAM, IDC_NO, IDC_PERSON, IDC_PIN, IDC_SIZEALL,
     IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_UPARROW, IDC_WAIT,
 };
+use windows::Win32::UI::WindowsAndMessaging::{DrawIconEx, GetIconInfo, ICONINFO, DI_NORMAL};
+use tracing::debug;
 
 #[inline]
 pub fn bring_window_to_focus(window_id: u32) {
@@ -268,6 +270,10 @@ pub fn monitor_bounds(id: u32) -> Bounds {
 
         if id == *target_id {
             let rect = minfo.monitorInfo.rcMonitor;
+            debug!(
+                "Found monitor with ID {}: bounds: left={}, top={}, right={}, bottom={}",
+                id, rect.left, rect.top, rect.right, rect.bottom
+            );
             *bounds = Some(Bounds {
                 x: rect.left as f64,
                 y: rect.top as f64,
@@ -289,7 +295,18 @@ pub fn monitor_bounds(id: u32) -> Bounds {
         )
     };
 
-    bounds.unwrap_or_default()
+    // If we didn't find the monitor with the given ID, log a warning and return a default bounds
+    if lparams.1.is_none() {
+        debug!("Could not find monitor with ID: {}", id);
+        return Bounds {
+            x: 0.0,
+            y: 0.0,
+            width: 1920.0, // Default to a common resolution
+            height: 1080.0,
+        };
+    }
+
+    lparams.1.unwrap()
 }
 
 pub fn display_names() -> HashMap<u32, String> {

--- a/crates/media/src/platform/win.rs
+++ b/crates/media/src/platform/win.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use super::{Bounds, CursorShape, Window};
 
+use tracing::debug;
 use windows::core::{PCWSTR, PWSTR};
 use windows::Win32::Foundation::{CloseHandle, BOOL, FALSE, HWND, LPARAM, RECT, TRUE};
 use windows::Win32::Graphics::Dwm::{
@@ -19,14 +20,13 @@ use windows::Win32::System::Threading::{
     OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_FORMAT, PROCESS_QUERY_LIMITED_INFORMATION,
 };
 use windows::Win32::UI::HiDpi::GetDpiForWindow;
+use windows::Win32::UI::WindowsAndMessaging::{DrawIconEx, GetIconInfo, DI_NORMAL, ICONINFO};
 use windows::Win32::UI::WindowsAndMessaging::{
     EnumWindows, GetCursorInfo, GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId,
     IsWindowVisible, LoadCursorW, SetForegroundWindow, CURSORINFO, IDC_APPSTARTING, IDC_ARROW,
     IDC_CROSS, IDC_HAND, IDC_HELP, IDC_IBEAM, IDC_NO, IDC_PERSON, IDC_PIN, IDC_SIZEALL,
     IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_UPARROW, IDC_WAIT,
 };
-use windows::Win32::UI::WindowsAndMessaging::{DrawIconEx, GetIconInfo, ICONINFO, DI_NORMAL};
-use tracing::debug;
 
 #[inline]
 pub fn bring_window_to_focus(window_id: u32) {

--- a/crates/media/src/platform/win.rs
+++ b/crates/media/src/platform/win.rs
@@ -270,10 +270,6 @@ pub fn monitor_bounds(id: u32) -> Bounds {
 
         if id == *target_id {
             let rect = minfo.monitorInfo.rcMonitor;
-            debug!(
-                "Found monitor with ID {}: bounds: left={}, top={}, right={}, bottom={}",
-                id, rect.left, rect.top, rect.right, rect.bottom
-            );
             *bounds = Some(Bounds {
                 x: rect.left as f64,
                 y: rect.top as f64,

--- a/crates/recording/src/cursor.rs
+++ b/crates/recording/src/cursor.rs
@@ -118,13 +118,82 @@ pub fn spawn_cursor_recorder(
                 };
 
                 if mouse_state.coords != last_mouse_state.coords {
+                    // Get the actual mouse coordinates
+                    let (mouse_x, mouse_y) = mouse_state.coords;
+                    
+                    #[cfg(windows)]
+                    let (mouse_x, mouse_y) = {
+                        // On Windows, ensure we're using the correct coordinate system
+                        // by getting the virtual screen metrics
+                        use windows::Win32::UI::WindowsAndMessaging::GetSystemMetrics;
+                        use windows::Win32::UI::WindowsAndMessaging::{
+                            SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN
+                        };
+                        
+                        let virtual_screen_x = unsafe { GetSystemMetrics(SM_XVIRTUALSCREEN) };
+                        let virtual_screen_y = unsafe { GetSystemMetrics(SM_YVIRTUALSCREEN) };
+                        let virtual_screen_width = unsafe { GetSystemMetrics(SM_CXVIRTUALSCREEN) };
+                        let virtual_screen_height = unsafe { GetSystemMetrics(SM_CYVIRTUALSCREEN) };
+                        
+                        // If screen_bounds doesn't match the virtual screen, adjust the coordinates
+                        if (screen_bounds.x as i32 != virtual_screen_x || 
+                            screen_bounds.y as i32 != virtual_screen_y ||
+                            screen_bounds.width as i32 != virtual_screen_width ||
+                            screen_bounds.height as i32 != virtual_screen_height) &&
+                           screen_bounds.width > 0.0 && screen_bounds.height > 0.0 {
+                            
+                            // Convert to normalized coordinates in the virtual screen space first
+                            let norm_x = (mouse_x as f64 - virtual_screen_x as f64) / virtual_screen_width as f64;
+                            let norm_y = (mouse_y as f64 - virtual_screen_y as f64) / virtual_screen_height as f64;
+                            
+                            // Then convert to the target screen coordinates
+                            let adjusted_x = (norm_x * screen_bounds.width + screen_bounds.x) as i32;
+                            let adjusted_y = (norm_y * screen_bounds.height + screen_bounds.y) as i32;
+
+                            (adjusted_x, adjusted_y)
+                        } else {
+                            (mouse_x, mouse_y)
+                        }
+                    };
+                    
+                    // Calculate normalized coordinates (0.0 to 1.0) within the screen bounds
+                    // Check if screen_bounds dimensions are valid to avoid division by zero
+                    let x = if screen_bounds.width > 0.0 {
+                        (mouse_x as f64 - screen_bounds.x) / screen_bounds.width
+                    } else {
+                        0.5 // Fallback if width is invalid
+                    };
+                    
+                    let y = if screen_bounds.height > 0.0 {
+                        (mouse_y as f64 - screen_bounds.y) / screen_bounds.height
+                    } else {
+                        0.5 // Fallback if height is invalid
+                    };
+                    
+                    // Clamp values to ensure they're within valid range
+                    let x = if x.is_nan() || x.is_infinite() { 
+                        debug!("X coordinate is invalid: {}", x);
+                        0.5 
+                    } else { 
+                        x.max(0.0).min(1.0) 
+                    };
+                    
+                    let y = if y.is_nan() || y.is_infinite() { 
+                        debug!("Y coordinate is invalid: {}", y);
+                        0.5 
+                    } else { 
+                        y.max(0.0).min(1.0) 
+                    };
+                    
+                    debug!("Normalized coords: ({}, {})", x, y);
+                    
                     let mouse_event = CursorMoveEvent {
                         active_modifiers: vec![],
                         cursor_id: cursor_id.clone(),
                         process_time_ms: elapsed,
                         unix_time_ms: unix_time,
-                        x: (mouse_state.coords.0 as f64 - screen_bounds.x) / screen_bounds.width,
-                        y: (mouse_state.coords.1 as f64 - screen_bounds.y) / screen_bounds.height,
+                        x,
+                        y,
                     };
                     response.moves.push(mouse_event);
                 }
@@ -138,6 +207,62 @@ pub fn spawn_cursor_recorder(
                         continue;
                     }
 
+                    // Get the actual mouse coordinates
+                    let (mouse_x, mouse_y) = mouse_state.coords;
+                    
+                    #[cfg(windows)]
+                    let (mouse_x, mouse_y) = {
+                        // On Windows, ensure we're using the correct coordinate system
+                        // by getting the virtual screen metrics
+                        use windows::Win32::UI::WindowsAndMessaging::GetSystemMetrics;
+                        use windows::Win32::UI::WindowsAndMessaging::{
+                            SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN
+                        };
+                        
+                        let virtual_screen_x = unsafe { GetSystemMetrics(SM_XVIRTUALSCREEN) };
+                        let virtual_screen_y = unsafe { GetSystemMetrics(SM_YVIRTUALSCREEN) };
+                        let virtual_screen_width = unsafe { GetSystemMetrics(SM_CXVIRTUALSCREEN) };
+                        let virtual_screen_height = unsafe { GetSystemMetrics(SM_CYVIRTUALSCREEN) };
+                        
+                        // If screen_bounds doesn't match the virtual screen, adjust the coordinates
+                        if (screen_bounds.x as i32 != virtual_screen_x || 
+                            screen_bounds.y as i32 != virtual_screen_y ||
+                            screen_bounds.width as i32 != virtual_screen_width ||
+                            screen_bounds.height as i32 != virtual_screen_height) &&
+                           screen_bounds.width > 0.0 && screen_bounds.height > 0.0 {
+                            
+                            // Convert to normalized coordinates in the virtual screen space first
+                            let norm_x = (mouse_x as f64 - virtual_screen_x as f64) / virtual_screen_width as f64;
+                            let norm_y = (mouse_y as f64 - virtual_screen_y as f64) / virtual_screen_height as f64;
+                            
+                            // Then convert to the target screen coordinates
+                            let adjusted_x = (norm_x * screen_bounds.width + screen_bounds.x) as i32;
+                            let adjusted_y = (norm_y * screen_bounds.height + screen_bounds.y) as i32;
+                            
+                            (adjusted_x, adjusted_y)
+                        } else {
+                            (mouse_x, mouse_y)
+                        }
+                    };
+                    
+                    // Calculate normalized coordinates (0.0 to 1.0) within the screen bounds
+                    // Check if screen_bounds dimensions are valid to avoid division by zero
+                    let x = if screen_bounds.width > 0.0 {
+                        (mouse_x as f64 - screen_bounds.x) / screen_bounds.width
+                    } else {
+                        0.5 // Fallback if width is invalid
+                    };
+                    
+                    let y = if screen_bounds.height > 0.0 {
+                        (mouse_y as f64 - screen_bounds.y) / screen_bounds.height
+                    } else {
+                        0.5 // Fallback if height is invalid
+                    };
+                    
+                    // Clamp values to ensure they're within valid range
+                    let x = if x.is_nan() || x.is_infinite() { 0.5 } else { x.max(0.0).min(1.0) };
+                    let y = if y.is_nan() || y.is_infinite() { 0.5 } else { y.max(0.0).min(1.0) };
+
                     let mouse_event = CursorClickEvent {
                         down: pressed,
                         active_modifiers: vec![],
@@ -145,8 +270,8 @@ pub fn spawn_cursor_recorder(
                         cursor_id: cursor_id.clone(),
                         process_time_ms: elapsed,
                         unix_time_ms: unix_time,
-                        x: (mouse_state.coords.0 as f64 - screen_bounds.x) / screen_bounds.width,
-                        y: (mouse_state.coords.1 as f64 - screen_bounds.y) / screen_bounds.height,
+                        x,
+                        y,
                     };
                     response.clicks.push(mouse_event);
                 }
@@ -229,11 +354,11 @@ fn get_cursor_image_data() -> Option<CursorData> {
 fn get_cursor_image_data() -> Option<CursorData> {
     use windows::Win32::Foundation::{HWND, POINT};
     use windows::Win32::Graphics::Gdi::{
-        BitBlt, CreateCompatibleDC, CreateDIBSection, DeleteDC, DeleteObject, GetDC, GetObjectA,
-        ReleaseDC, SelectObject, BITMAP, BITMAPINFO, BITMAPINFOHEADER, DIB_RGB_COLORS, SRCCOPY,
+        CreateCompatibleDC, CreateDIBSection, DeleteDC, DeleteObject, GetDC, 
+        GetObjectA, ReleaseDC, SelectObject, BITMAP, BITMAPINFO, BITMAPINFOHEADER, DIB_RGB_COLORS,
     };
     use windows::Win32::UI::WindowsAndMessaging::{GetCursorInfo, CURSORINFO, CURSORINFO_FLAGS};
-    use windows::Win32::UI::WindowsAndMessaging::{GetIconInfo, ICONINFO};
+    use windows::Win32::UI::WindowsAndMessaging::{DrawIconEx, GetIconInfo, ICONINFO, DI_NORMAL};
 
     unsafe {
         // Get cursor info
@@ -244,45 +369,64 @@ fn get_cursor_image_data() -> Option<CursorData> {
             ptScreenPos: POINT::default(),
         };
 
-        // Handle Result return type
         if GetCursorInfo(&mut cursor_info).is_err() {
             return None;
         }
 
-        // If no cursor, return None
         if cursor_info.hCursor.is_invalid() {
             return None;
         }
 
         // Get icon info
         let mut icon_info = ICONINFO::default();
-        // Handle Result return type
         if GetIconInfo(cursor_info.hCursor, &mut icon_info).is_err() {
             return None;
         }
 
-        // Get bitmap info
+        // Get bitmap info for the cursor
         let mut bitmap = BITMAP::default();
+        let bitmap_handle = if !icon_info.hbmColor.is_invalid() {
+            icon_info.hbmColor
+        } else {
+            icon_info.hbmMask
+        };
+
         if GetObjectA(
-            icon_info.hbmColor,
+            bitmap_handle,
             std::mem::size_of::<BITMAP>() as i32,
             Some(&mut bitmap as *mut _ as *mut _),
         ) == 0
         {
+            // Clean up handles
+            if !icon_info.hbmColor.is_invalid() {
+                DeleteObject(icon_info.hbmColor);
+            }
+            if !icon_info.hbmMask.is_invalid() {
+                DeleteObject(icon_info.hbmMask);
+            }
             return None;
         }
 
-        // Create compatible DC
+        // Create DCs
         let screen_dc = GetDC(HWND::default());
         let mem_dc = CreateCompatibleDC(screen_dc);
+        
+        // Get cursor dimensions
+        let width = bitmap.bmWidth;
+        let height = if icon_info.hbmColor.is_invalid() && bitmap.bmHeight > 0 {
+            // For mask cursors, the height is doubled (AND mask + XOR mask)
+            bitmap.bmHeight / 2
+        } else {
+            bitmap.bmHeight
+        };
 
-        // Create bitmap info header
+        // Create bitmap info header for 32-bit RGBA
         let bi = BITMAPINFOHEADER {
             biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
-            biWidth: bitmap.bmWidth,
-            biHeight: -bitmap.bmHeight, // Negative height for top-down bitmap
+            biWidth: width,
+            biHeight: -height, // Negative for top-down DIB
             biPlanes: 1,
-            biBitCount: 32,
+            biBitCount: 32,    // 32-bit RGBA
             biCompression: 0,
             biSizeImage: 0,
             biXPelsPerMeter: 0,
@@ -301,6 +445,15 @@ fn get_cursor_image_data() -> Option<CursorData> {
         let dib = CreateDIBSection(mem_dc, &bitmap_info, DIB_RGB_COLORS, &mut bits, None, 0);
 
         if dib.is_err() {
+            // Clean up
+            DeleteDC(mem_dc);
+            ReleaseDC(HWND::default(), screen_dc);
+            if !icon_info.hbmColor.is_invalid() {
+                DeleteObject(icon_info.hbmColor);
+            }
+            if !icon_info.hbmMask.is_invalid() {
+                DeleteObject(icon_info.hbmMask);
+            }
             return None;
         }
 
@@ -309,42 +462,172 @@ fn get_cursor_image_data() -> Option<CursorData> {
         // Select DIB into DC
         let old_bitmap = SelectObject(mem_dc, dib);
 
-        // Copy cursor image
-        if BitBlt(
+        // Draw the cursor onto our bitmap with transparency
+        if DrawIconEx(
             mem_dc,
             0,
             0,
-            bitmap.bmWidth,
-            bitmap.bmHeight,
-            screen_dc,
-            cursor_info.ptScreenPos.x,
-            cursor_info.ptScreenPos.y,
-            SRCCOPY,
-        )
-        .is_err()
-        {
+            cursor_info.hCursor,
+            0,          // Use actual size
+            0,          // Use actual size
+            0,
+            None,
+            DI_NORMAL,
+        ).is_err() {
+            // Clean up
+            SelectObject(mem_dc, old_bitmap);
+            DeleteObject(dib);
+            DeleteDC(mem_dc);
+            ReleaseDC(HWND::default(), screen_dc);
+            if !icon_info.hbmColor.is_invalid() {
+                DeleteObject(icon_info.hbmColor);
+            }
+            if !icon_info.hbmMask.is_invalid() {
+                DeleteObject(icon_info.hbmMask);
+            }
             return None;
         }
 
         // Get image data
-        let size = (bitmap.bmWidth * bitmap.bmHeight * 4) as usize;
+        let size = (width * height * 4) as usize;
         let mut image_data = vec![0u8; size];
         std::ptr::copy_nonoverlapping(bits, image_data.as_mut_ptr() as *mut _, size);
+
+        // Calculate hotspot
+        let mut hotspot_x = if icon_info.fIcon.as_bool() == false { 
+            icon_info.xHotspot as f64 / width as f64 
+        } else { 
+            0.5 
+        };
+        
+        let mut hotspot_y = if icon_info.fIcon.as_bool() == false { 
+            icon_info.yHotspot as f64 / height as f64 
+        } else { 
+            0.5 
+        };
 
         // Cleanup
         SelectObject(mem_dc, old_bitmap);
         DeleteObject(dib);
         DeleteDC(mem_dc);
         ReleaseDC(HWND::default(), screen_dc);
-        DeleteObject(icon_info.hbmColor);
-        DeleteObject(icon_info.hbmMask);
+        if !icon_info.hbmColor.is_invalid() {
+            DeleteObject(icon_info.hbmColor);
+        }
+        if !icon_info.hbmMask.is_invalid() {
+            DeleteObject(icon_info.hbmMask);
+        }
 
+        // Process the image data to ensure proper alpha channel
+        for i in (0..size).step_by(4) {
+            // Windows DIB format is BGRA, we need to:
+            // 1. Swap B and R channels
+            let b = image_data[i];
+            image_data[i] = image_data[i + 2]; // B <- R
+            image_data[i + 2] = b;             // R <- B
+            
+            // 2. Pre-multiply alpha if needed
+            // This is already handled by DrawIconEx
+        }
+
+        // Convert to RGBA image
+        let mut rgba_image = image::RgbaImage::from_raw(width as u32, height as u32, image_data)?;
+        
+        // For text cursor (I-beam), enhance visibility by adding a shadow/outline
+        // Check if this is likely a text cursor by examining dimensions and pixels
+        let is_text_cursor = width <= 20 && height >= 20 && width <= height / 2;
+        
+        if is_text_cursor {
+            // Add a subtle shadow/outline to make it visible on white backgrounds
+            for y in 0..height as u32 {
+                for x in 0..width as u32 {
+                    let pixel = rgba_image.get_pixel(x, y);
+                    // If this is a solid pixel of the cursor
+                    if pixel[3] > 200 {  // If alpha is high (visible pixel)
+                        // Add shadow pixels around it
+                        for dx in [-1, 0, 1].iter() {
+                            for dy in [-1, 0, 1].iter() {
+                                let nx = x as i32 + dx;
+                                let ny = y as i32 + dy;
+                                
+                                // Skip if out of bounds or same pixel
+                                if nx < 0 || ny < 0 || nx >= width as i32 || ny >= height as i32 || (*dx == 0 && *dy == 0) {
+                                    continue;
+                                }
+                                
+                                let nx = nx as u32;
+                                let ny = ny as u32;
+                                
+                                let shadow_pixel = rgba_image.get_pixel(nx, ny);
+                                // Only add shadow where there isn't already content
+                                if shadow_pixel[3] < 100 {
+                                    rgba_image.put_pixel(nx, ny, image::Rgba([0, 0, 0, 100]));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        // Find the bounds of non-transparent pixels to trim whitespace
+        let mut min_x = width as u32;
+        let mut min_y = height as u32;
+        let mut max_x = 0u32;
+        let mut max_y = 0u32;
+        
+        let mut has_content = false;
+        
+        for y in 0..height as u32 {
+            for x in 0..width as u32 {
+                let pixel = rgba_image.get_pixel(x, y);
+                if pixel[3] > 0 {  // If pixel has any opacity
+                    has_content = true;
+                    min_x = min_x.min(x);
+                    min_y = min_y.min(y);
+                    max_x = max_x.max(x);
+                    max_y = max_y.max(y);
+                }
+            }
+        }
+        
+        // Only trim if we found content and there's actually whitespace to trim
+        let trimmed_image = if has_content && (min_x > 0 || min_y > 0 || max_x < width as u32 - 1 || max_y < height as u32 - 1) {
+            // Add a small padding (2 pixels) around the content
+            let padding = 2u32;
+            let trim_min_x = min_x.saturating_sub(padding);
+            let trim_min_y = min_y.saturating_sub(padding);
+            let trim_max_x = (max_x + padding).min(width as u32 - 1);
+            let trim_max_y = (max_y + padding).min(height as u32 - 1);
+            
+            let trim_width = trim_max_x - trim_min_x + 1;
+            let trim_height = trim_max_y - trim_min_y + 1;
+            
+            // Create a new image with the trimmed dimensions
+            let mut trimmed = image::RgbaImage::new(trim_width, trim_height);
+            
+            // Copy the content to the new image
+            for y in 0..trim_height {
+                for x in 0..trim_width {
+                    let src_x = trim_min_x + x;
+                    let src_y = trim_min_y + y;
+                    let pixel = rgba_image.get_pixel(src_x, src_y);
+                    trimmed.put_pixel(x, y, *pixel);
+                }
+            }
+            
+            // Adjust hotspot coordinates for the trimmed image
+            hotspot_x = (hotspot_x * width as f64 - trim_min_x as f64) / trim_width as f64;
+            hotspot_y = (hotspot_y * height as f64 - trim_min_y as f64) / trim_height as f64;
+            
+            trimmed
+        } else {
+            rgba_image
+        };
+        
         // Convert to PNG format
-        let image =
-            image::RgbaImage::from_raw(bitmap.bmWidth as u32, bitmap.bmHeight as u32, image_data)?;
-
         let mut png_data = Vec::new();
-        image
+        trimmed_image
             .write_to(
                 &mut std::io::Cursor::new(&mut png_data),
                 image::ImageFormat::Png,
@@ -353,7 +636,7 @@ fn get_cursor_image_data() -> Option<CursorData> {
 
         Some(CursorData {
             image: png_data,
-            hotspot: XY::new(0.0, 0.0),
+            hotspot: XY::new(hotspot_x, hotspot_y),
         })
     }
 }

--- a/crates/rendering/src/decoder/ffmpeg.rs
+++ b/crates/rendering/src/decoder/ffmpeg.rs
@@ -122,9 +122,45 @@ impl FfmpegDecoder {
                     .try_use_hw_device(AVHWDeviceType::AV_HWDEVICE_TYPE_VIDEOTOOLBOX, Pixel::NV12)
                     .ok()
             } else if cfg!(target_os = "windows") {
-                decoder
-                    .try_use_hw_device(AVHWDeviceType::AV_HWDEVICE_TYPE_DXVA2, Pixel::DXVA2_VLD)
-                    .ok()
+                // For now, disable hardware acceleration on Windows as it's causing issues
+                // This ensures reliable playback while we debug the hardware acceleration issues
+                None
+                
+                // Uncomment the below code once hardware acceleration issues are resolved
+                /*
+                // Try D3D11VA first - most widely supported on modern Windows
+                let d3d11va = decoder
+                    .try_use_hw_device(AVHWDeviceType::AV_HWDEVICE_TYPE_D3D11VA, Pixel::D3D11)
+                    .ok();
+                
+                if d3d11va.is_some() {
+                    println!("Using D3D11VA hardware acceleration");
+                    d3d11va
+                } else {
+                    // Try CUDA for NVIDIA GPUs
+                    let cuda = decoder
+                        .try_use_hw_device(AVHWDeviceType::AV_HWDEVICE_TYPE_CUDA, Pixel::CUDA)
+                        .ok();
+                    
+                    if cuda.is_some() {
+                        println!("Using CUDA hardware acceleration");
+                        cuda
+                    } else {
+                        // Try QSV for Intel GPUs
+                        let qsv = decoder
+                            .try_use_hw_device(AVHWDeviceType::AV_HWDEVICE_TYPE_QSV, Pixel::QSV)
+                            .ok();
+                        
+                        if qsv.is_some() {
+                            println!("Using QSV hardware acceleration");
+                            qsv
+                        } else {
+                            println!("Falling back to software decoding");
+                            None
+                        }
+                    }
+                }
+                */
             } else {
                 None
             };


### PR DESCRIPTION
This pull request includes several changes across multiple files to improve functionality, enhance logging, and update configurations. The most important changes include enhancements to logging, updates to the Tauri configuration, and improvements to the ffmpeg hardware device handling.

### Enhancements to Logging:
* [`crates/media/src/encoders/h264.rs`](diffhunk://#diff-c75130fd2653dea9489ac6bbe57c66d4aca4af6a172cc422e765102ddcb6e238R46-R50): Added detailed logging for frame conversion and error handling in the `H264Encoder` class. [[1]](diffhunk://#diff-c75130fd2653dea9489ac6bbe57c66d4aca4af6a172cc422e765102ddcb6e238R46-R50) [[2]](diffhunk://#diff-c75130fd2653dea9489ac6bbe57c66d4aca4af6a172cc422e765102ddcb6e238L54-R62) [[3]](diffhunk://#diff-c75130fd2653dea9489ac6bbe57c66d4aca4af6a172cc422e765102ddcb6e238L96-R122) [[4]](diffhunk://#diff-c75130fd2653dea9489ac6bbe57c66d4aca4af6a172cc422e765102ddcb6e238L115-R145)
* [`crates/media/src/encoders/mp4.rs`](diffhunk://#diff-de8d3c4c9cee0cbf6ffdc5835fd8ea9c09b2afdf59562340862d7d0b56331bd9L59-R71): Replaced `println` statements with `tracing::info` and added error logging for writing the MP4 trailer.
* [`crates/media/src/feeds/camera.rs`](diffhunk://#diff-eb3319cb16168a21e9e5fa86e124012d8dcef4067ba7f7fa0719b61299efcd21L232-R256): Added debug logging for pixel format selection based on the platform in the `run_camera_feed` and `buffer_to_ffvideo` functions. [[1]](diffhunk://#diff-eb3319cb16168a21e9e5fa86e124012d8dcef4067ba7f7fa0719b61299efcd21L232-R256) [[2]](diffhunk://#diff-eb3319cb16168a21e9e5fa86e124012d8dcef4067ba7f7fa0719b61299efcd21L275-R301) [[3]](diffhunk://#diff-eb3319cb16168a21e9e5fa86e124012d8dcef4067ba7f7fa0719b61299efcd21R397-R411)

### Tauri Configuration Updates:
* [`apps/desktop/src-tauri/tauri.conf.json`](diffhunk://#diff-25f93a9e45647c833a5769e5c21fb1735e0ffd08f536dad2337de462ed7d14ddR38): Enabled `createUpdaterArtifacts` for the bundle configuration.
* [`apps/desktop/src-tauri/tauri.prod.conf.json`](diffhunk://#diff-da36f91b47e1f24302802544b65222385b2c55fef2de50e371986050565dea90L20): Removed the `createUpdaterArtifacts` setting from the production configuration.
* [`apps/desktop/src-tauri/tauri.windows.conf.json`](diffhunk://#diff-5dc2cbf8e3c962c0b33ddd99357f5dade768ebef1a1f4cc0fd128d4ab69d7a96L2-R9): Added Windows-specific bundle configuration with `wix` version set to `0.3.26`.

### Improvements to ffmpeg Hardware Device Handling:
* [`crates/ffmpeg-hw-device/src/lib.rs`](diffhunk://#diff-33e788157c40c67733c0e2123c77bb216c2fea82eca7e89aff61c0354223336eL13-R14): Simplified the `try_use_hw_device` method and added a new `CodecExt` trait to iterate over hardware configurations. [[1]](diffhunk://#diff-33e788157c40c67733c0e2123c77bb216c2fea82eca7e89aff61c0354223336eL13-R14) [[2]](diffhunk://#diff-33e788157c40c67733c0e2123c77bb216c2fea82eca7e89aff61c0354223336eL44) [[3]](diffhunk://#diff-33e788157c40c67733c0e2123c77bb216c2fea82eca7e89aff61c0354223336eL73-R126)

### JavaScript and TypeScript Changes:
* [`apps/desktop/scripts/prepare.js`](diffhunk://#diff-2520ebf8c329f2a34cc5fb8f9a33645223d2ae3c7b9590a6af0d5be94b0346ecL36-R36): Updated the `semverToWIXCompatibleVersion` function to fix a template string issue and added resources to the `createTauriPlatformConfigs` function. [[1]](diffhunk://#diff-2520ebf8c329f2a34cc5fb8f9a33645223d2ae3c7b9590a6af0d5be94b0346ecL36-R36) [[2]](diffhunk://#diff-2520ebf8c329f2a34cc5fb8f9a33645223d2ae3c7b9590a6af0d5be94b0346ecR82-R84)
* [`apps/desktop/src/routes/(window-chrome)/(main).tsx`](diffhunk://#diff-a3969738bceb6321bf674149e0bbe8986167b7f3c8aca37014a810fc7fd80d81L10-R10): Added `availableMonitors` import from `@tauri-apps/api/window`.

### Miscellaneous Changes:
* [`.cargo/config.toml`](diffhunk://#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268L1-L2): Removed the `FFMPEG_DIR` environment variable configuration.
* [`crates/flags/src/lib.rs`](diffhunk://#diff-637f6734937f48ddc2fc6ee7ff1c0cd83b62c6dd8c6896ddba6da2c7cac5db64L9-R9): Set `record_mouse_state` to be enabled in debug mode.
* [`crates/media/src/platform/macos.rs`](diffhunk://#diff-3a70d14f5af632dce357a30f5c7284a85bc86e4bb2eb8179e4306bb8e4e9b83bR373-R386): Added a function to get the primary monitor bounds.
* [`crates/media/src/platform/win.rs`](diffhunk://#diff-149e0dbbde7d92aad8456849fede0432cfa860c153bd0d96223ff0b506accbc6R8): Added `tracing::debug` import for Windows platform-specific code.