### PR TITLE
Switch between zoom segments without having to cancel selection

### DIFF
--- a/apps/desktop/src/routes/editor/Timeline.tsx
+++ b/apps/desktop/src/routes/editor/Timeline.tsx
@@ -148,7 +148,9 @@ export function Timeline() {
           createRoot((dispose) => {
             createEventListener(e.currentTarget, "mouseup", () => {
               handleUpdatePlayhead(e);
-              setState("timelineSelection", null);
+              if (zoomSegmentDragState.type === "idle") {
+                setState("timelineSelection", null);
+              }
             });
             createEventListener(window, "mouseup", () => {
               dispose();
@@ -659,14 +661,10 @@ function ZoomTrack(props: {
                   resumeHistory();
                   if (!moved) {
                     e.stopPropagation();
-                    if (
-                      state.timelineSelection?.type !== "zoom" &&
-                      state.timelineSelection?.index !== i()
-                    )
-                      setState("timelineSelection", {
-                        type: "zoom",
-                        index: i(),
-                      });
+                    setState("timelineSelection", {
+                      type: "zoom",
+                      index: i(),
+                    });
                     props.handleUpdatePlayhead(e);
                   }
                   props.onDragStateChanged({ type: "idle" });


### PR DESCRIPTION
This PR makes it so you can click on another zoom segment without having to cancel the current selection.