### PR TITLE
cancel instead of stop recording on restart

### DIFF
--- a/apps/cli/src/record.rs
+++ b/apps/cli/src/record.rs
@@ -83,7 +83,7 @@ impl RecordStart {
                 capture_system_audio: self.system_audio,
             },
             camera.map(|c| Arc::new(Mutex::new(c))),
-            None,
+            &None,
         )
         .await
         .map_err(|e| e.to_string())?;

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -188,6 +188,7 @@ impl ShowCapWindow {
                         .resizable(false)
                         .maximized(false)
                         .maximizable(false)
+                        .always_on_top(true)
                         .center()
                         .build()?;
 

--- a/crates/media/src/feeds/audio_input.rs
+++ b/crates/media/src/feeds/audio_input.rs
@@ -17,7 +17,7 @@ pub struct AudioInputSamples {
     pub info: InputCallbackInfo,
 }
 
-enum AudioInputControl {
+pub enum AudioInputControl {
     Switch(String, Sender<Result<SupportedStreamConfig, MediaError>>),
     AttachSender(AudioInputSamplesSender),
     Shutdown,
@@ -47,7 +47,7 @@ pub const MAX_AUDIO_CHANNELS: u16 = 2;
 
 #[derive(Clone)]
 pub struct AudioInputFeed {
-    control_tx: Sender<AudioInputControl>,
+    pub control_tx: Sender<AudioInputControl>,
     audio_info: AudioInfo,
     // rx: Receiver<AudioInputSamples>,
 }
@@ -295,6 +295,7 @@ fn start_capturing(
                     info!("New audio sender attached");
                 }
                 Err(flume::TryRecvError::Disconnected) => {
+                    dbg!(control.sender_count());
                     warn!("Control receiver is unreachable! Shutting down audio capture");
                     return;
                 }


### PR DESCRIPTION
fixes issues where the mic input would be dropped as the recording was stopped normally, rather than just the pipeline being stopped and erroring out everywhere else