### PR TITLE
[CAP-287] Fix export dialog upload state

### DIFF
--- a/apps/desktop/src/routes/editor/context.ts
+++ b/apps/desktop/src/routes/editor/context.ts
@@ -119,6 +119,7 @@ export const [EditorContextProvider, useEditorContext] = createContextProvider(
 			| { type: "rendering" }
 			| { type: "uploading"; progress: number }
 			| { type: "link-copied" }
+			| { type: "complete" }
 		>({ type: "idle" });
 
 		//This is used in ShareButton.tsx to notify the component that the metadata has changed, from ExportDialog.tsx


### PR DESCRIPTION
**This PR**:

- During uploading in the export dialog, if the dialog is closed and re-opened, the state will remain maintained and not be lost.