### PR TITLE
Improvement: If video date is the same don't trigger update

### DIFF
--- a/apps/web/app/dashboard/caps/components/CapCard.tsx
+++ b/apps/web/app/dashboard/caps/components/CapCard.tsx
@@ -178,6 +178,11 @@ export const CapCard = ({
       return;
     }
 
+    if (selectedDate.isSame(effectiveDate)) {
+      setIsDateEditing(false);
+      return;
+    }
+
     try {
       await editDate(cap.id, selectedDate.toISOString());
       toast.success("Video date updated");

--- a/apps/web/app/dashboard/settings/organization/components/OrganizationIcon.tsx
+++ b/apps/web/app/dashboard/settings/organization/components/OrganizationIcon.tsx
@@ -3,10 +3,10 @@
 import { removeOrganizationIcon } from "@/actions/organization/remove-icon";
 import { uploadOrganizationIcon } from "@/actions/organization/upload-icon";
 import { useSharedContext } from "@/app/dashboard/_components/DynamicSharedLayout";
+import { FileInput } from "@/components/FileInput";
 import { CardDescription, Label } from "@cap/ui";
 import { useState } from "react";
 import { toast } from "sonner";
-import { FileInput } from "@/components/FileInput";
 
 interface OrganizationIconProps {
   isOwner: boolean;
@@ -55,7 +55,6 @@ export const OrganizationIcon = ({
     if (!isOwner || !organizationId) return;
     
     try {
-      setIsUploading(true);
       const result = await removeOrganizationIcon(organizationId);
       
       if (result.success) {
@@ -64,8 +63,6 @@ export const OrganizationIcon = ({
     } catch (error) {
       console.error("Error removing organization icon:", error);
       toast.error(error instanceof Error ? error.message : "Failed to remove icon");
-    } finally {
-      setIsUploading(false);
     }
   };
 
@@ -83,7 +80,7 @@ export const OrganizationIcon = ({
           id="icon"
           name="icon"
           onChange={handleFileChange}
-          disabled={!isOwner}
+          disabled={!isOwner || isUploading}
           isLoading={isUploading}
           initialPreviewUrl={existingIconUrl || null}
           onRemove={handleRemoveIcon}

--- a/apps/web/components/FileInput.tsx
+++ b/apps/web/components/FileInput.tsx
@@ -130,7 +130,7 @@ export const FileInput: React.FC<FileInputProps> = ({
       // Create a new preview URL for immediate feedback
       const newPreviewUrl = URL.createObjectURL(file);
       setPreviewUrl(newPreviewUrl);
-      setSelectedFile(file);
+      setSelectedFile(null);
       
       // Call the onChange callback
       if (onChange) {
@@ -169,18 +169,8 @@ export const FileInput: React.FC<FileInputProps> = ({
     <div className={`relative ${className}`}>
       <div className="h-[46.5px]"> {/* Fixed height container to prevent resizing */}
         {(selectedFile || previewUrl) ? (
-          <div className="flex gap-2 items-center p-1.5 rounded-xl border border-gray-4 h-full">
+          <div className="flex gap-2 items-center p-1.5 rounded-xl border bg-gray-3 border-gray-4 h-full">
             <div className="flex flex-1 gap-1.5 items-center">
-              <div className="overflow-hidden relative flex-shrink-0 rounded-md size-5">
-                {previewUrl && (
-                  <Image 
-                    src={previewUrl} 
-                    alt="File preview" 
-                    fill 
-                    className="object-contain"
-                  />
-                )}
-              </div>
               <div className="flex flex-1 gap-1 items-center">
                 {selectedFile ? (
                   <>
@@ -188,7 +178,19 @@ export const FileInput: React.FC<FileInputProps> = ({
                     <p className="text-xs text-gray-10 min-w-fit">{(selectedFile.size / 1024).toFixed(1)} KB</p>
                   </>
                 ) : (
-                  <p className="text-xs font-medium text-gray-12">Current file</p>
+                  <div className="flex gap-2 items-center">
+                  <p className="text-xs font-medium text-gray-12">Current icon: </p>
+                  <div className="overflow-hidden relative flex-shrink-0 rounded-md size-5">
+                  {previewUrl && (
+                    <Image 
+                      src={previewUrl} 
+                      alt="File preview" 
+                      fill 
+                      className="object-contain rounded-full"
+                    />
+                  )}
+                </div>
+                </div>
                 )}
               </div>
             </div>
@@ -205,9 +207,7 @@ export const FileInput: React.FC<FileInputProps> = ({
               {isLoading ? (
                 <FontAwesomeIcon icon={faSpinner} className="animate-spin" />
               ) : (
-                <>
-                  Remove
-                </>
+                <>Remove</>
               )}
             </Button>
           </div>

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva(
         secondary:
           "bg-blue-400 text-gray-50 hover:bg-blue-500 disabled:bg-blue-200 disabled:text-gray-8 border-blue-300",
         destructive:
-          "bg-gradient-to-t shadow-[0_0_0_1px] shadow-red-900 hover:brightness-110 from-red-600 to-red-400 text-gray-50 button-gradient-border hover:bg-red-400 disabled:bg-red-200 border-red-300",
+          "bg-gradient-to-t disabled:opacity-50 disabled:from-red-800 disabled:to-red-600 disabled:cursor-not-allowed shadow-[0_0_0_1px] shadow-red-900 hover:brightness-110 from-red-600 to-red-400 text-gray-50 button-gradient-border hover:bg-red-400 border-red-300",
         white:
           "bg-gray-2 text-gray-12 hover:border-gray-4 hover:bg-gray-3 border disabled:bg-gray-1 border-gray-3",
         gray: "bg-gray-4 text-gray-12 hover:bg-gray-6 hover:border-gray-7 disabled:bg-gray-1 border-gray-5 border",


### PR DESCRIPTION
**This PR does the following**:

- When editing video date of a Cap, if the date is the same don't trigger an update.
- Minor visual tweaks to icon uploading