### PR TITLE
Store capture metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ cidre = { git = "https://github.com/yury/cidre", rev = "ef04aaabe14ffbbce4a33097
 windows = "0.58.0"
 windows-sys = "0.59.0"
 windows-capture = "1.4.2"
+percent-encoding = "2.3.1"
 
 [workspace.lints.clippy]
 dbg_macro = "deny"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -76,6 +76,7 @@ cpal.workspace = true
 keyed_priority_queue = "0.4.2"
 sentry.workspace = true
 clipboard-rs = "0.2.2"
+percent-encoding = { workspace = true }
 
 cap-utils = { path = "../../../crates/utils" }
 cap-project = { path = "../../../crates/project" }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1263,7 +1263,7 @@ async fn upload_exported_video(
             }
         };
 
-        get_s3_config(&app, false, video_id).await
+        get_s3_config(&app, false, video_id, Some(duration), None).await
     }
     .await?;
 

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -193,12 +193,16 @@ pub async fn start_recording(
             window.set_content_protected(matches!(recording_options.mode, RecordingMode::Studio));
     }
 
+    let source_name = recording_options.capture_target.get_title();
+
     let video_upload_info = match recording_options.mode {
         RecordingMode::Instant => {
             match AuthStore::get(&app).ok().flatten() {
                 Some(_) => {
                     // Pre-create the video and get the shareable link
-                    if let Ok(s3_config) = get_s3_config(&app, false, None).await {
+                    if let Ok(s3_config) =
+                        get_s3_config(&app, false, None, None, source_name.clone()).await
+                    {
                         let link = app.make_app_url(format!("/s/{}", s3_config.id())).await;
                         info!("Pre-created shareable link: {}", link);
 

--- a/packages/database/types/metadata.ts
+++ b/packages/database/types/metadata.ts
@@ -11,6 +11,14 @@ export interface VideoMetadata {
    * This overrides the display of the actual createdAt timestamp
    */
   customCreatedAt?: string;
+  /**
+   * Title of the captured monitor or window
+   */
+  sourceName?: string;
+  /**
+   * Duration of the video in seconds
+   */
+  duration?: number;
   [key: string]: any;
 }
 


### PR DESCRIPTION
## Summary
- add optional `sourceName` and `duration` fields for video metadata
- save monitor/window name and video duration when creating a shareable link
- update desktop code to send these fields when requesting S3 config

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH)*