### PR TITLE
Add OG and Twitter player metadata

### DIFF
--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -80,6 +80,26 @@ export async function generateMetadata(
             height: 630,
           },
         ],
+        videos: [
+          {
+            url: new URL(
+              `/s/${videoId}`,
+              buildEnv.NEXT_PUBLIC_WEB_URL
+            ).toString(),
+            width: 1280,
+            height: 720,
+            type: "text/html",
+          },
+        ],
+      },
+      twitter: {
+        card: "player",
+        player: new URL(
+          `/s/${videoId}`,
+          buildEnv.NEXT_PUBLIC_WEB_URL
+        ).toString(),
+        playerWidth: 1280,
+        playerHeight: 720,
       },
     };
   }
@@ -97,6 +117,34 @@ export async function generateMetadata(
           width: 1200,
           height: 630,
         },
+      ],
+      videos: [
+        {
+          url: new URL(
+            `/s/${videoId}`,
+            buildEnv.NEXT_PUBLIC_WEB_URL
+          ).toString(),
+          width: 1280,
+          height: 720,
+          type: "text/html",
+        },
+      ],
+    },
+    twitter: {
+      card: "player",
+      player: new URL(
+        `/s/${videoId}`,
+        buildEnv.NEXT_PUBLIC_WEB_URL
+      ).toString(),
+      playerWidth: 1280,
+      playerHeight: 720,
+      title: video.name + " | Cap Recording",
+      description: "Watch this video on Cap",
+      images: [
+        new URL(
+          `/api/video/og?videoId=${videoId}`,
+          buildEnv.NEXT_PUBLIC_WEB_URL
+        ).toString(),
       ],
     },
   };


### PR DESCRIPTION
## Summary
- support rich embeds by adding Open Graph `videos` and Twitter Player card

## Testing
- `pnpm lint` *(fails: fetch failed)*