### PR TITLE
Add custom logo option on share page

### DIFF
--- a/apps/web/actions/videos/edit-logo.ts
+++ b/apps/web/actions/videos/edit-logo.ts
@@ -1,0 +1,67 @@
+"use server";
+
+import { getCurrentUser } from "@cap/database/auth/session";
+import { videos } from "@cap/database/schema";
+import { db } from "@cap/database";
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { VideoMetadata } from "@cap/database/types";
+
+export async function editLogo(
+  videoId: string,
+  logoUrl: string | null,
+  width: number | null,
+  useOrganization: boolean,
+) {
+  const user = await getCurrentUser();
+
+  if (!user || !videoId) {
+    throw new Error("Missing required data for updating logo");
+  }
+
+  const userId = user.id;
+  const query = await db().select().from(videos).where(eq(videos.id, videoId));
+
+  if (query.length === 0) {
+    throw new Error("Video not found");
+  }
+
+  const video = query[0];
+  if (!video) {
+    throw new Error("Video not found");
+  }
+
+  if (video.ownerId !== userId) {
+    throw new Error("You don't have permission to update this video");
+  }
+
+  const currentMetadata = (video.metadata as VideoMetadata) || {};
+  const updatedMetadata: VideoMetadata = {
+    ...currentMetadata,
+    customLogo:
+      logoUrl || useOrganization
+        ? {
+            url: logoUrl || undefined,
+            width: width || undefined,
+            useOrganization,
+          }
+        : null,
+  };
+
+  try {
+    await db()
+      .update(videos)
+      .set({ metadata: updatedMetadata })
+      .where(eq(videos.id, videoId));
+
+    revalidatePath(`/s/${videoId}`);
+
+    return { success: true };
+  } catch (error) {
+    console.error("Error updating logo:", error);
+    if (error instanceof Error) {
+      throw new Error(error.message);
+    }
+    throw new Error("Failed to update logo");
+  }
+}

--- a/apps/web/app/s/[videoId]/Share.tsx
+++ b/apps/web/app/s/[videoId]/Share.tsx
@@ -38,6 +38,7 @@ interface ShareProps {
   customDomain: string | null;
   domainVerified: boolean;
   userOrganizations?: { id: string; name: string }[];
+  organizationLogoUrl?: string | null;
 }
 
 export const Share: React.FC<ShareProps> = ({
@@ -48,6 +49,7 @@ export const Share: React.FC<ShareProps> = ({
   customDomain,
   domainVerified,
   userOrganizations = [],
+  organizationLogoUrl,
 }) => {
   const [analytics, setAnalytics] = useState(initialAnalytics);
   const effectiveDate = data.metadata?.customCreatedAt
@@ -140,7 +142,23 @@ export const Share: React.FC<ShareProps> = ({
           className="flex justify-center items-center px-4 py-2 mx-auto space-x-2 bg-gray-1 rounded-full new-card-style w-fit"
         >
           <span className="text-sm">Recorded with</span>
-          <Logo className="w-14 h-auto" />
+          {(() => {
+            const logoSrc = data.metadata?.customLogo?.useOrganization
+              ? organizationLogoUrl
+              : data.metadata?.customLogo?.url;
+            const width = data.metadata?.customLogo?.width || 56;
+            return logoSrc ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={logoSrc}
+                style={{ width }}
+                className="h-auto"
+                alt="logo"
+              />
+            ) : (
+              <Logo className="w-14 h-auto" />
+            );
+          })()}
         </a>
       </div>
     </div>

--- a/apps/web/app/s/[videoId]/_components/AddLogoDialog.tsx
+++ b/apps/web/app/s/[videoId]/_components/AddLogoDialog.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@cap/ui";
+import { Button, Input, Switch } from "@cap/ui";
+import { useState } from "react";
+import { editLogo } from "@/actions/videos/edit-logo";
+import { toast } from "sonner";
+
+interface AddLogoDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  videoId: string;
+  organizationLogoUrl?: string | null;
+  initialLogo?: {
+    url?: string;
+    width?: number;
+    useOrganization?: boolean;
+  } | null;
+}
+
+export const AddLogoDialog = ({
+  open,
+  onOpenChange,
+  videoId,
+  organizationLogoUrl,
+  initialLogo,
+}: AddLogoDialogProps) => {
+  const [useOrg, setUseOrg] = useState(initialLogo?.useOrganization || false);
+  const [url, setUrl] = useState(initialLogo?.url || "");
+  const [width, setWidth] = useState(initialLogo?.width || 56);
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await editLogo(videoId, useOrg ? null : url, width, useOrg);
+      toast.success("Logo updated");
+      onOpenChange(false);
+    } catch (err: any) {
+      toast.error(err?.message || "Failed to update logo");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="p-0 w-full max-w-md rounded-xl border bg-gray-2 border-gray-4">
+        <DialogHeader description="Customize the logo shown on this page">
+          <DialogTitle>Add Custom Logo</DialogTitle>
+        </DialogHeader>
+        <div className="p-5 space-y-4">
+          {organizationLogoUrl && (
+            <div className="flex justify-between items-center">
+              <span className="text-sm">Use workspace logo</span>
+              <Switch checked={useOrg} onCheckedChange={setUseOrg} />
+            </div>
+          )}
+          {!useOrg && (
+            <Input
+              placeholder="Logo URL"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+            />
+          )}
+          <div>
+            <label className="text-sm">Width: {width}px</label>
+            <input
+              type="range"
+              min={20}
+              max={200}
+              value={width}
+              onChange={(e) => setWidth(Number(e.target.value))}
+              className="w-full"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button size="sm" variant="gray" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            variant="dark"
+            onClick={handleSave}
+            spinner={saving}
+          >
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/web/app/s/[videoId]/_components/ShareHeader.tsx
+++ b/apps/web/app/s/[videoId]/_components/ShareHeader.tsx
@@ -7,13 +7,14 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Copy, Globe2 } from "lucide-react";
+import { Copy, Globe2, Image } from "lucide-react";
 import { buildEnv, NODE_ENV } from "@cap/env";
 import { editTitle } from "@/actions/videos/edit-title";
 import { usePublicEnv } from "@/utils/public-env";
 import { isUserOnProPlan } from "@cap/utils";
 import { UpgradeModal } from "@/components/UpgradeModal";
 import { SharingDialog } from "@/app/dashboard/caps/components/SharingDialog";
+import { AddLogoDialog } from "./AddLogoDialog";
 import clsx from "clsx";
 
 export const ShareHeader = ({
@@ -23,6 +24,7 @@ export const ShareHeader = ({
   domainVerified,
   sharedOrganizations = [],
   userOrganizations = [],
+  organizationLogoUrl,
 }: {
   data: typeof videos.$inferSelect;
   user: typeof userSelectProps | null;
@@ -30,6 +32,7 @@ export const ShareHeader = ({
   domainVerified: boolean;
   sharedOrganizations?: { id: string; name: string }[];
   userOrganizations?: { id: string; name: string }[];
+  organizationLogoUrl?: string | null;
 }) => {
   const { push, refresh } = useRouter();
   const [isEditing, setIsEditing] = useState(false);
@@ -37,6 +40,7 @@ export const ShareHeader = ({
   const [isDownloading, setIsDownloading] = useState(false);
   const [upgradeModalOpen, setUpgradeModalOpen] = useState(false);
   const [isSharingDialogOpen, setIsSharingDialogOpen] = useState(false);
+  const [logoDialogOpen, setLogoDialogOpen] = useState(false);
   const [currentSharedOrganizations, setCurrentSharedOrganizations] =
     useState(sharedOrganizations);
 
@@ -70,16 +74,16 @@ export const ShareHeader = ({
     return customDomain && domainVerified
       ? `https://${customDomain}/s/${data.id}`
       : buildEnv.NEXT_PUBLIC_IS_CAP && NODE_ENV === "production"
-      ? `https://cap.link/${data.id}`
-      : `${webUrl}/s/${data.id}`;
+        ? `https://cap.link/${data.id}`
+        : `${webUrl}/s/${data.id}`;
   };
 
   const getDisplayLink = () => {
     return customDomain && domainVerified
       ? `${customDomain}/s/${data.id}`
       : buildEnv.NEXT_PUBLIC_IS_CAP && NODE_ENV === "production"
-      ? `cap.link/${data.id}`
-      : `${webUrl}/s/${data.id}`;
+        ? `cap.link/${data.id}`
+        : `${webUrl}/s/${data.id}`;
   };
 
   const isUserPro = user
@@ -91,8 +95,8 @@ export const ShareHeader = ({
   const handleSharingUpdated = (updatedSharedOrganizations: string[]) => {
     setCurrentSharedOrganizations(
       userOrganizations?.filter((organization) =>
-        updatedSharedOrganizations.includes(organization.id)
-      )
+        updatedSharedOrganizations.includes(organization.id),
+      ),
     );
     refresh();
   };
@@ -168,6 +172,14 @@ export const ShareHeader = ({
                     {title}
                   </h1>
                 )}
+                {isOwner && isUserPro && (
+                  <button
+                    onClick={() => setLogoDialogOpen(true)}
+                    className="p-1 text-gray-11 hover:text-gray-12"
+                  >
+                    <Image className="w-5 h-5" />
+                  </button>
+                )}
               </div>
               {user && renderSharedStatus()}
               <p className="text-sm text-gray-10 mt-1">
@@ -219,6 +231,13 @@ export const ShareHeader = ({
       <UpgradeModal
         open={upgradeModalOpen}
         onOpenChange={setUpgradeModalOpen}
+      />
+      <AddLogoDialog
+        open={logoDialogOpen}
+        onOpenChange={setLogoDialogOpen}
+        videoId={data.id}
+        organizationLogoUrl={organizationLogoUrl}
+        initialLogo={data.metadata?.customLogo || null}
       />
     </>
   );

--- a/packages/database/types/metadata.ts
+++ b/packages/database/types/metadata.ts
@@ -11,6 +11,17 @@ export interface VideoMetadata {
    * This overrides the display of the actual createdAt timestamp
    */
   customCreatedAt?: string;
+  /**
+   * Custom logo configuration for share pages
+   */
+  customLogo?: {
+    /** URL of the custom logo */
+    url?: string;
+    /** Width of the logo in pixels */
+    width?: number;
+    /** Whether to use the owner's workspace logo */
+    useOrganization?: boolean;
+  } | null;
   [key: string]: any;
 }
 
@@ -26,4 +37,4 @@ export interface SpaceMetadata {
  */
 export interface UserMetadata {
   [key: string]: any;
-} 
+}


### PR DESCRIPTION
## Summary
- allow editing share page logo metadata
- server action to edit logo settings
- add dialog for custom logo on share page
- fetch workspace logo and pass to share component
- show custom logo if configured

## Testing
- `npx prettier -w packages/database/types/metadata.ts apps/web/actions/videos/edit-logo.ts apps/web/app/s/[videoId]/_components/AddLogoDialog.tsx apps/web/app/s/[videoId]/page.tsx apps/web/app/s/[videoId]/Share.tsx apps/web/app/s/[videoId]/_components/ShareHeader.tsx`
- `pnpm lint` *(fails: turbo not found)*