### PR TITLE
Enable multi-threaded rendering

### DIFF
--- a/crates/rendering/Cargo.toml
+++ b/crates/rendering/Cargo.toml
@@ -27,6 +27,7 @@ wgpu.workspace = true
 bezier_easing = "0.1.1"
 reactive_graph = "0.1.5"
 tracing.workspace = true
+num_cpus = "1.16"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cidre.workspace = true


### PR DESCRIPTION
## Summary
- add `num_cpus` to rendering crate
- make `RenderSegment` clonable
- parallelise `render_video_to_channel` using a worker pool

## Testing
- `cargo check --workspace` *(fails: failed to load source for dependency `screencapturekit`)*