### PR TITLE
Experiment: Add video import support

### DIFF
--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -20,6 +20,7 @@ pub enum TrayItem {
     TakeScreenshot,
     PreviousRecordings,
     PreviousScreenshots,
+    ImportVideo,
     OpenSettings,
     Quit,
 }
@@ -31,6 +32,7 @@ impl From<TrayItem> for MenuId {
             TrayItem::TakeScreenshot => "take_screenshot",
             TrayItem::PreviousRecordings => "previous_recordings",
             TrayItem::PreviousScreenshots => "previous_screenshots",
+            TrayItem::ImportVideo => "import_video",
             TrayItem::OpenSettings => "open_settings",
             TrayItem::Quit => "quit",
         }
@@ -47,6 +49,7 @@ impl TryFrom<MenuId> for TrayItem {
             "take_screenshot" => Ok(TrayItem::TakeScreenshot),
             "previous_recordings" => Ok(TrayItem::PreviousRecordings),
             "previous_screenshots" => Ok(TrayItem::PreviousScreenshots),
+            "import_video" => Ok(TrayItem::ImportVideo),
             "open_settings" => Ok(TrayItem::OpenSettings),
             "quit" => Ok(TrayItem::Quit),
             value => Err(format!("Invalid tray item id {value}")),
@@ -71,6 +74,13 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                 app,
                 TrayItem::PreviousRecordings,
                 "Previous Recordings",
+                true,
+                None::<&str>,
+            )?,
+            &MenuItem::with_id(
+                app,
+                TrayItem::ImportVideo,
+                "Import Video",
                 true,
                 None::<&str>,
             )?,
@@ -115,6 +125,10 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                         page: "screenshots".to_string(),
                     }
                     .emit(&app_handle);
+                }
+                Ok(TrayItem::ImportVideo) => {
+                    let app = app.clone();
+                    tokio::spawn(async move { ShowCapWindow::Import.show(&app).await });
                 }
                 Ok(TrayItem::OpenSettings) => {
                     let app = app.clone();

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -37,6 +37,7 @@ pub enum CapWindowId {
     InProgressRecording,
     Upgrade,
     ModeSelect,
+    Import,
     Debug,
 }
 
@@ -54,6 +55,7 @@ impl FromStr for CapWindowId {
             "recordings-overlay" => Self::RecordingsOverlay,
             "upgrade" => Self::Upgrade,
             "mode-select" => Self::ModeSelect,
+            "import" => Self::Import,
             "debug" => Self::Debug,
             s if s.starts_with("editor-") => Self::Editor {
                 id: s
@@ -87,6 +89,7 @@ impl std::fmt::Display for CapWindowId {
             Self::RecordingsOverlay => write!(f, "recordings-overlay"),
             Self::Upgrade => write!(f, "upgrade"),
             Self::ModeSelect => write!(f, "mode-select"),
+            Self::Import => write!(f, "import"),
             Self::Editor { id } => write!(f, "editor-{id}"),
             Self::Debug => write!(f, "debug"),
         }
@@ -107,6 +110,7 @@ impl CapWindowId {
             Self::InProgressRecording => "Cap In Progress Recording".to_string(),
             Self::Editor { .. } => "Cap Editor".to_string(),
             Self::ModeSelect => "Cap Mode Selection".to_string(),
+            Self::Import => "Cap Import".to_string(),
             Self::Camera => "Cap Camera".to_string(),
             Self::RecordingsOverlay => "Cap Recordings Overlay".to_string(),
             _ => "Cap".to_string(),
@@ -122,6 +126,7 @@ impl CapWindowId {
                 | Self::Settings
                 | Self::Upgrade
                 | Self::ModeSelect
+                | Self::Import
         )
     }
 
@@ -152,6 +157,7 @@ impl CapWindowId {
             Self::Camera => (460.0, 920.0),
             Self::Upgrade => (950.0, 850.0),
             Self::ModeSelect => (900.0, 500.0),
+            Self::Import => (600.0, 400.0),
             _ => return None,
         })
     }
@@ -170,6 +176,7 @@ pub enum ShowCapWindow {
     InProgressRecording { position: Option<(f64, f64)> },
     Upgrade,
     ModeSelect,
+    Import,
 }
 
 impl ShowCapWindow {
@@ -254,6 +261,15 @@ impl ShowCapWindow {
                 .build()?,
             Self::ModeSelect => self
                 .window_builder(app, "/mode-select")
+                .resizable(false)
+                .maximized(false)
+                .maximizable(false)
+                .center()
+                .focused(true)
+                .shadow(true)
+                .build()?,
+            Self::Import => self
+                .window_builder(app, "/import")
                 .resizable(false)
                 .maximized(false)
                 .maximizable(false)
@@ -544,6 +560,7 @@ impl ShowCapWindow {
             ShowCapWindow::InProgressRecording { .. } => CapWindowId::InProgressRecording,
             ShowCapWindow::Upgrade => CapWindowId::Upgrade,
             ShowCapWindow::ModeSelect => CapWindowId::ModeSelect,
+            ShowCapWindow::Import => CapWindowId::Import,
         }
     }
 }

--- a/apps/desktop/src/routes/import.tsx
+++ b/apps/desktop/src/routes/import.tsx
@@ -1,0 +1,35 @@
+import { Show } from "solid-js";
+import { commands } from "~/utils/tauri";
+
+export default function Import() {
+  const handleSelect = async () => {
+    const path = await commands.openVideoDialog();
+    if (path) {
+      const project = await commands.importVideo(path);
+      await commands.showWindow({ Editor: { project_path: project } });
+    }
+  };
+
+  const handleDrop = async (e: DragEvent) => {
+    e.preventDefault();
+    const file = e.dataTransfer?.files[0];
+    if (file && (file as any).path) {
+      const project = await commands.importVideo((file as any).path);
+      await commands.showWindow({ Editor: { project_path: project } });
+    }
+  };
+
+  return (
+    <div
+      class="flex flex-col items-center justify-center w-screen h-screen gap-4"
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
+      data-tauri-drag-region
+    >
+      <button class="px-4 py-2 rounded-md bg-blue-9 text-white" onClick={handleSelect}>
+        Select Video to Import
+      </button>
+      <p class="text-gray-11">or drag and drop a file here</p>
+    </div>
+  );
+}

--- a/apps/desktop/src/routes/recordings-overlay.tsx
+++ b/apps/desktop/src/routes/recordings-overlay.tsx
@@ -97,6 +97,9 @@ export default function () {
     >
       <div class="w-full relative left-0 bottom-0 flex flex-col-reverse pl-[40px] pb-[80px] gap-4 h-full overflow-y-auto scrollbar-none">
         <div class="flex flex-col gap-4 pt-12 w-full">
+          <div class="flex justify-end pr-2">
+            <Button onClick={() => commands.showWindow("Import")}>Import Video</Button>
+          </div>
           <TransitionGroup
             enterToClass="translate-y-0"
             enterClass="opacity-0 translate-y-4"

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -227,6 +227,12 @@ async deleteWhisperModel(modelPath: string) : Promise<null> {
 async exportCaptionsSrt(videoId: string) : Promise<string | null> {
     return await TAURI_INVOKE("export_captions_srt", { videoId });
 }
+async openVideoDialog() : Promise<string | null> {
+    return await TAURI_INVOKE("open_video_dialog");
+}
+async importVideo(path: string) : Promise<string> {
+    return await TAURI_INVOKE("import_video", { path });
+}
 }
 
 /** user-defined events **/
@@ -369,7 +375,7 @@ export type SegmentRecordings = { display: Video; camera: Video | null; mic: Aud
 export type SerializedEditorInstance = { framesSocketUrl: string; recordingDuration: number; savedProjectConfig: ProjectConfiguration; recordings: ProjectRecordings; path: string }
 export type ShadowConfiguration = { size: number; opacity: number; blur: number }
 export type SharingMeta = { id: string; link: string }
-export type ShowCapWindow = "Setup" | "Main" | { Settings: { page: string | null } } | { Editor: { project_path: string } } | "RecordingsOverlay" | { WindowCaptureOccluder: { screen_id: number } } | { CaptureArea: { screen_id: number } } | "Camera" | { InProgressRecording: { position: [number, number] | null } } | "Upgrade" | "ModeSelect"
+export type ShowCapWindow = "Setup" | "Main" | { Settings: { page: string | null } } | { Editor: { project_path: string } } | "RecordingsOverlay" | { WindowCaptureOccluder: { screen_id: number } } | { CaptureArea: { screen_id: number } } | "Camera" | { InProgressRecording: { position: [number, number] | null } } | "Upgrade" | "ModeSelect" | "Import"
 export type SingleSegment = { display: VideoMeta; camera?: VideoMeta | null; audio?: AudioMeta | null; cursor?: string | null }
 export type StartRecordingInputs = { capture_target: ScreenCaptureTarget; capture_system_audio?: boolean; mode: RecordingMode }
 export type StereoMode = "stereo" | "monoL" | "monoR"


### PR DESCRIPTION
## Summary
- add new Import window route to handle drag+drop video import
- extend tray to include Import Video option
- support `Import` window in window manager
- expose new Tauri commands for importing videos
- update overlay to show Import button

## Testing
- `pnpm lint` *(fails: turbo not found)*