### PR TITLE
Add macOS voice isolation toggle

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -57,6 +57,8 @@ pub struct GeneralSettingsStore {
     pub custom_cursor_capture: bool,
     #[serde(default)]
     pub system_audio_capture: bool,
+    #[serde(default)]
+    pub voice_isolation: bool,
     #[serde(default = "default_server_url")]
     pub server_url: String,
     #[serde(default, alias = "open_editor_after_recording")]
@@ -98,6 +100,7 @@ impl Default for GeneralSettingsStore {
             main_window_recording_start_behaviour: MainWindowRecordingStartBehaviour::Close,
             custom_cursor_capture: false,
             system_audio_capture: false,
+            voice_isolation: false,
             server_url: default_server_url(),
             _open_editor_after_recording: false,
         }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -163,7 +163,13 @@ async fn set_mic_input(state: MutableState<'_, App>, label: Option<String>) -> R
 
     match (label, &mut app.mic_feed) {
         (Some(label), None) => {
-            AudioInputFeed::init(&label)
+            let voice_iso = GeneralSettingsStore::get(&app.handle)
+                .ok()
+                .flatten()
+                .map(|s| s.voice_isolation)
+                .unwrap_or_default();
+
+            AudioInputFeed::init(&label, voice_iso)
                 .await
                 .map_err(|e| e.to_string())
                 .map(async |feed| {

--- a/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
@@ -3,6 +3,7 @@ import { createStore } from "solid-js/store";
 
 import { generalSettingsStore } from "~/store";
 import { type GeneralSettingsStore } from "~/utils/tauri";
+import { platform } from "@tauri-apps/plugin-os";
 import { ToggleSetting } from "./Setting";
 
 export default function ExperimentalSettings() {
@@ -23,6 +24,7 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
       hideDockIcon: false,
       autoCreateShareableLink: false,
       enableNotifications: true,
+      voiceIsolation: false,
     }
   );
 
@@ -63,6 +65,15 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
             value={!!settings.systemAudioCapture}
             onChange={(value) => handleChange("systemAudioCapture", value)}
           />
+
+          {platform() === "macos" && (
+            <ToggleSetting
+              label="Enable Voice Isolation (macOS only)"
+              description="Reduces background noise like fan hum using Apple's Voice Isolation. May improve audio clarity for client-facing videos."
+              value={!!settings.voiceIsolation}
+              onChange={(value) => handleChange("voiceIsolation", value)}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -321,7 +321,7 @@ export type ExportEstimates = { duration_seconds: number; estimated_time_seconds
 export type ExportSettings = { fps: number; resolution_base: XY<number>; compression: ExportCompression }
 export type Flags = { captions: boolean }
 export type FramesRendered = { renderedCount: number; totalFrames: number; type: "FramesRendered" }
-export type GeneralSettingsStore = { instanceId?: string; uploadIndividualFiles?: boolean; hideDockIcon?: boolean; hapticsEnabled?: boolean; autoCreateShareableLink?: boolean; enableNotifications?: boolean; disableAutoOpenLinks?: boolean; hasCompletedStartup?: boolean; theme?: AppTheme; commercialLicense?: CommercialLicense | null; lastVersion?: string | null; windowTransparency?: boolean; postStudioRecordingBehaviour?: PostStudioRecordingBehaviour; mainWindowRecordingStartBehaviour?: MainWindowRecordingStartBehaviour; customCursorCapture?: boolean; systemAudioCapture?: boolean; serverUrl?: string; 
+export type GeneralSettingsStore = { instanceId?: string; uploadIndividualFiles?: boolean; hideDockIcon?: boolean; hapticsEnabled?: boolean; autoCreateShareableLink?: boolean; enableNotifications?: boolean; disableAutoOpenLinks?: boolean; hasCompletedStartup?: boolean; theme?: AppTheme; commercialLicense?: CommercialLicense | null; lastVersion?: string | null; windowTransparency?: boolean; postStudioRecordingBehaviour?: PostStudioRecordingBehaviour; mainWindowRecordingStartBehaviour?: MainWindowRecordingStartBehaviour; customCursorCapture?: boolean; systemAudioCapture?: boolean; voiceIsolation?: boolean; serverUrl?: string;
 /**
  * @deprecated
  */


### PR DESCRIPTION
## Summary
- add `voice_isolation` to general settings backend
- expose voice isolation setting in generated types
- support enabling voice isolation when creating the microphone feed
- add UI toggle on the Experimental settings tab (macOS only)

## Testing
- `cargo check` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683cb56cb308833297d0818c5c2c1112