### PR TITLE
FIX Resend "from" error for custom domain in ENV

### DIFF
--- a/packages/database/emails/config.ts
+++ b/packages/database/emails/config.ts
@@ -5,6 +5,8 @@ import { Resend } from "resend";
 export const resend = () =>
   serverEnv().RESEND_API_KEY ? new Resend(serverEnv().RESEND_API_KEY) : null;
 
+const resendCustomDomain = serverEnv().RESEND_FROM_DOMAIN ? serverEnv().RESEND_FROM_DOMAIN : buildEnv.NEXT_PUBLIC_WEB_URL
+
 // Augment the CreateEmailOptions type to include scheduledAt
 type EmailOptions = {
   from: string;
@@ -39,9 +41,7 @@ export const sendEmail = async ({
       ? "Richie from Cap <richie@send.cap.so>"
       : buildEnv.NEXT_PUBLIC_IS_CAP
       ? "Cap Auth <no-reply@auth.cap.so>"
-      : `auth@${
-          serverEnv().RESEND_FROM_DOMAIN ?? buildEnv.NEXT_PUBLIC_WEB_URL
-        }`,
+      : `auth@${resendCustomDomain}`,
     to: test ? "delivered@resend.dev" : email,
     subject,
     react,

--- a/packages/database/emails/config.ts
+++ b/packages/database/emails/config.ts
@@ -5,7 +5,7 @@ import { Resend } from "resend";
 export const resend = () =>
   serverEnv().RESEND_API_KEY ? new Resend(serverEnv().RESEND_API_KEY) : null;
 
-const resendCustomDomain = serverEnv().RESEND_FROM_DOMAIN ? serverEnv().RESEND_FROM_DOMAIN : buildEnv.NEXT_PUBLIC_WEB_URL
+const resendCustomDomain = serverEnv().RESEND_FROM_DOMAIN ? serverEnv().RESEND_FROM_DOMAIN : null
 
 // Augment the CreateEmailOptions type to include scheduledAt
 type EmailOptions = {
@@ -41,7 +41,7 @@ export const sendEmail = async ({
       ? "Richie from Cap <richie@send.cap.so>"
       : buildEnv.NEXT_PUBLIC_IS_CAP
       ? "Cap Auth <no-reply@auth.cap.so>"
-      : `auth@${resendCustomDomain}`,
+      : `auth@${resendCustomDomain || ''}`,
     to: test ? "delivered@resend.dev" : email,
     subject,
     react,


### PR DESCRIPTION
# Problem
`serverEnv().RESEND_FROM_DOMAIN` is not correctly retrieving the value of `RESEND_FROM_DOMAIN`. Because of that, Resend returns a `422` error. This happens due to the piece of code that uses the domain URL as a fallback in `NEXT_PUBLIC_WEB_URL`.

https://github.com/CapSoftware/Cap/blob/b1094ab418069b46cace4bc0ae55c16746f72bfc/packages/database/emails/config.ts#L43

## Reproducing the Issue
[Railway](https://railway.com/deploy/PwpGcf) .ENV configuration
<img width="785" alt="image" src="https://github.com/user-attachments/assets/3035c0e3-7168-4749-95d6-88744f11db02" />

### Example of a request made by Cap web
```JSON
{
    "to": "someone@example.com",
    "from": "auth@https://cap-web-production.up.railway.app",
    "html": "<BODY>",
    "subject": "Your Cap Login Link"
}
```
### Response from Resend
```JSON
{
    "name": "validation_error",
    "message": "Invalid `from` field. The email address contains a colon.",
    "statusCode": 422
}
```

### Expected request to be made from Cap web with this fix
```JSON
{
    "to": "someone@example.com",
    "from": "auth@resend.example.com",
    "html": "<BODY>",
    "subject": "Your Cap Login Link"
}
```

# Possible Solution
Implement a more robust check and reference the variable globally, as the .ENV for RESEND_API_KEY is working correctly this way. If none of the options are available, an error should be thrown and the request to Resend should not be made.

I wasn’t able to test this change, so someone with a properly configured environment will need to test this solution or propose a better one for this issue.

If you're looking for this fix as well, let us know by reacting with 👀
If you have tested this solution and it worked, please react with 👍
otherwise, feel free to engage by proposing a solution
