### PR TITLE
Enable twitter player card for shareable videos

### DIFF
--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -214,7 +214,7 @@ export async function generateMetadata(
       ],
     },
     twitter: {
-      card: "summary_large_image",
+      card: "player",
       title: video.name + " | Cap Recording",
       description: "Watch this video on Cap",
       images: [
@@ -223,6 +223,17 @@ export async function generateMetadata(
           buildEnv.NEXT_PUBLIC_WEB_URL
         ).toString(),
       ],
+      player: new URL(
+        `/s/${videoId}`,
+        buildEnv.NEXT_PUBLIC_WEB_URL
+      ).toString(),
+      playerWidth: 1280,
+      playerHeight: 720,
+      playerStream: new URL(
+        `/api/playlist?userId=${video.ownerId}&videoId=${video.id}`,
+        buildEnv.NEXT_PUBLIC_WEB_URL
+      ).toString(),
+      playerStreamContentType: "video/mp4",
     },
     robots: robotsDirective,
   };


### PR DESCRIPTION
## Summary
- use the Twitter `player` card on shared videos so services like X, Slack and Notion can play the video directly

## Testing
- `pnpm lint` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442c6d5e4c83328e74235f001537aa