### PR TITLE
Mode select window controls (+hide main window on open)

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2048,7 +2048,7 @@ pub async fn run(recording_logging_handle: LoggingHandle) {
 
                                 tokio::spawn(EditorInstances::remove(window.clone()));
                             }
-                            CapWindowId::Settings | CapWindowId::Upgrade => {
+                            CapWindowId::Settings | CapWindowId::Upgrade | CapWindowId::ModeSelect => {
                                 if let Some(window) = CapWindowId::Main.get(&app) {
                                     let _ = window.show();
                                 }

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -130,6 +130,14 @@ impl CapWindowId {
         app.get_webview_window(&label)
     }
 
+    #[cfg(target_os = "windows")]
+    pub fn should_have_decorations(&self) -> bool {
+        matches!(
+            self,
+            Self::Setup | Self::Settings | Self::Editor { .. } | Self::Upgrade | Self::ModeSelect
+        )
+    }
+
     #[cfg(target_os = "macos")]
     pub fn traffic_lights_position(&self) -> Option<Option<LogicalPosition<f64>>> {
         match self {
@@ -219,15 +227,21 @@ impl ShowCapWindow {
                     Box::pin(Self::Setup.show(app)).await?
                 }
             }
-            Self::Settings { page } => self
-                .window_builder(
+            Self::Settings { page } => {
+                // Hide main window when settings window opens
+                if let Some(main) = CapWindowId::Main.get(app) {
+                    let _ = main.hide();
+                }
+                
+                self.window_builder(
                     app,
                     format!("/settings/{}", page.clone().unwrap_or_default()),
                 )
                 .resizable(true)
                 .maximized(false)
                 .center()
-                .build()?,
+                .build()?
+            }
             Self::Editor { .. } => {
                 if let Some(main) = CapWindowId::Main.get(app) {
                     let _ = main.close();
@@ -242,25 +256,49 @@ impl ShowCapWindow {
 
                 window
             }
-            Self::Upgrade => self
-                .window_builder(app, "/upgrade")
-                .resizable(false)
-                .focused(true)
-                .always_on_top(true)
-                .maximized(false)
-                .shadow(true)
-                .transparent(true)
-                .center()
-                .build()?,
-            Self::ModeSelect => self
-                .window_builder(app, "/mode-select")
-                .resizable(false)
-                .maximized(false)
-                .maximizable(false)
-                .center()
-                .focused(true)
-                .shadow(true)
-                .build()?,
+            Self::Upgrade => {
+                // Hide main window when upgrade window opens
+                if let Some(main) = CapWindowId::Main.get(app) {
+                    let _ = main.hide();
+                }
+
+                let mut builder = self
+                    .window_builder(app, "/upgrade")
+                    .resizable(false)
+                    .focused(true)
+                    .always_on_top(true)
+                    .maximized(false)
+                    .shadow(true)
+                    .center();
+
+                #[cfg(target_os = "windows")]
+                {
+                    if !id.should_have_decorations() {
+                        builder = builder.transparent(true);
+                    }
+                }
+                #[cfg(not(target_os = "windows"))]
+                {
+                    builder = builder.transparent(true);
+                }
+
+                builder.build()?
+            }
+            Self::ModeSelect => {
+                // Hide main window when mode select window opens
+                if let Some(main) = CapWindowId::Main.get(app) {
+                    let _ = main.hide();
+                }
+                
+                self.window_builder(app, "/mode-select")
+                    .resizable(false)
+                    .maximized(false)
+                    .maximizable(false)
+                    .center()
+                    .focused(true)
+                    .shadow(true)
+                    .build()?
+            }
             Self::Camera => {
                 const WINDOW_SIZE: f64 = 230.0 * 2.0;
 
@@ -516,7 +554,9 @@ impl ShowCapWindow {
 
         #[cfg(target_os = "windows")]
         {
-            builder = builder.decorations(false);
+            if !id.should_have_decorations() {
+                builder = builder.decorations(false);
+            }
         }
 
         builder

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -294,7 +294,7 @@ impl ShowCapWindow {
                     .window_builder(app, "/mode-select")
                     .inner_size(900.0, 500.0)
                     .min_inner_size(900.0, 500.0)
-                    .resizable(false)
+                    .resizable(true)
                     .maximized(false)
                     .maximizable(false)
                     .center()

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -134,7 +134,7 @@ impl CapWindowId {
     pub fn should_have_decorations(&self) -> bool {
         matches!(
             self,
-            Self::Setup | Self::Settings | Self::Editor { .. } | Self::Upgrade | Self::ModeSelect
+            Self::Setup | Self::Settings | Self::Editor { .. } | Self::ModeSelect
         )
     }
 
@@ -290,14 +290,28 @@ impl ShowCapWindow {
                     let _ = main.hide();
                 }
                 
-                self.window_builder(app, "/mode-select")
+                let mut builder = self
+                    .window_builder(app, "/mode-select")
+                    .inner_size(900.0, 500.0)
                     .resizable(false)
                     .maximized(false)
                     .maximizable(false)
                     .center()
                     .focused(true)
-                    .shadow(true)
-                    .build()?
+                    .shadow(true);
+
+                #[cfg(target_os = "windows")]
+                {
+                    if !id.should_have_decorations() {
+                        builder = builder.transparent(true);
+                    }
+                }
+                #[cfg(not(target_os = "windows"))]
+                {
+                    builder = builder.transparent(true);
+                }
+
+                builder.build()?
             }
             Self::Camera => {
                 const WINDOW_SIZE: f64 = 230.0 * 2.0;

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -293,6 +293,7 @@ impl ShowCapWindow {
                 let mut builder = self
                     .window_builder(app, "/mode-select")
                     .inner_size(900.0, 500.0)
+                    .min_inner_size(900.0, 500.0)
                     .resizable(false)
                     .maximized(false)
                     .maximizable(false)

--- a/apps/desktop/src/routes/mode-select.tsx
+++ b/apps/desktop/src/routes/mode-select.tsx
@@ -1,6 +1,22 @@
 import ModeSelect from "~/components/ModeSelect";
+import { onMount } from "solid-js";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { LogicalSize } from "@tauri-apps/api/window";
 
 const ModeSelectWindow = () => {
+  onMount(async () => {
+    const window = getCurrentWindow();
+    try {
+      const currentSize = await window.innerSize();
+      
+      if (currentSize.width !== 900 || currentSize.height !== 500) {
+        await window.setSize(new LogicalSize(900, 500));
+      }
+    } catch (error) {
+      console.error("Failed to set window size:", error);
+    }
+  });
+
   return (
     <div
       data-tauri-drag-region


### PR DESCRIPTION
- Adds controls to the mode select window (on Windows)
- Hides the main window when mode select window is opened, then on close of mode select reopens main