### PR TITLE
Remove system audio feature flag

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -55,8 +55,6 @@ pub struct GeneralSettingsStore {
     pub main_window_recording_start_behaviour: MainWindowRecordingStartBehaviour,
     #[serde(default)]
     pub custom_cursor_capture: bool,
-    #[serde(default)]
-    pub system_audio_capture: bool,
     #[serde(default = "default_server_url")]
     pub server_url: String,
     #[serde(default, alias = "open_editor_after_recording")]
@@ -97,7 +95,6 @@ impl Default for GeneralSettingsStore {
             post_studio_recording_behaviour: PostStudioRecordingBehaviour::OpenEditor,
             main_window_recording_start_behaviour: MainWindowRecordingStartBehaviour::Close,
             custom_cursor_capture: false,
-            system_audio_capture: false,
             server_url: default_server_url(),
             _open_editor_after_recording: false,
         }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2048,7 +2048,9 @@ pub async fn run(recording_logging_handle: LoggingHandle) {
 
                                 tokio::spawn(EditorInstances::remove(window.clone()));
                             }
-                            CapWindowId::Settings | CapWindowId::Upgrade | CapWindowId::ModeSelect => {
+                            CapWindowId::Settings
+                            | CapWindowId::Upgrade
+                            | CapWindowId::ModeSelect => {
                                 if let Some(window) = CapWindowId::Main.get(&app) {
                                     let _ = window.show();
                                 }

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -232,7 +232,7 @@ impl ShowCapWindow {
                 if let Some(main) = CapWindowId::Main.get(app) {
                     let _ = main.hide();
                 }
-                
+
                 self.window_builder(
                     app,
                     format!("/settings/{}", page.clone().unwrap_or_default()),
@@ -289,7 +289,7 @@ impl ShowCapWindow {
                 if let Some(main) = CapWindowId::Main.get(app) {
                     let _ = main.hide();
                 }
-                
+
                 let mut builder = self
                     .window_builder(app, "/mode-select")
                     .inner_size(900.0, 500.0)

--- a/apps/desktop/src/routes/(window-chrome)/(main).tsx
+++ b/apps/desktop/src/routes/(window-chrome)/(main).tsx
@@ -43,10 +43,10 @@ import {
   ScreenCaptureTarget,
 } from "~/utils/tauri";
 
-function getWindowSize(systemAudioRecording: boolean) {
+function getWindowSize() {
   return {
     width: 300,
-    height: 290 + (systemAudioRecording ? 50 : 0),
+    height: 340,
   };
 }
 
@@ -97,9 +97,7 @@ function Page() {
     const unlistenFocus = currentWindow.onFocusChanged(
       ({ payload: focused }) => {
         if (focused) {
-          const size = getWindowSize(
-            generalSettings.data?.systemAudioCapture ?? false
-          );
+          const size = getWindowSize();
 
           currentWindow.setSize(new LogicalSize(size.width, size.height));
         }
@@ -108,9 +106,7 @@ function Page() {
 
     // Listen for resize events
     const unlistenResize = currentWindow.onResized(() => {
-      const size = getWindowSize(
-        generalSettings.data?.systemAudioCapture ?? false
-      );
+      const size = getWindowSize();
 
       currentWindow.setSize(new LogicalSize(size.width, size.height));
     });
@@ -122,9 +118,7 @@ function Page() {
   });
 
   createEffect(() => {
-    const size = getWindowSize(
-      generalSettings.data?.systemAudioCapture ?? false
-    );
+    const size = getWindowSize();
     getCurrentWindow().setSize(new LogicalSize(size.width, size.height));
   });
 
@@ -427,7 +421,7 @@ function Page() {
         value={mics.isPending ? rawOptions.micName : options.micName() ?? null}
         onChange={(v) => setMicInput.mutate(v)}
       />
-      {generalSettings.data?.systemAudioCapture && <SystemAudio />}
+      <SystemAudio />
       <div class="flex items-center space-x-1 w-full">
         {rawOptions.mode === "instant" && !auth.data ? (
           <SignInButton>

--- a/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
@@ -57,12 +57,6 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
             onChange={(value) => handleChange("customCursorCapture", value)}
           />
 
-          <ToggleSetting
-            label="System audio capture"
-            description="Provides the option for capturing audio coming from your system, such as music or video playback."
-            value={!!settings.systemAudioCapture}
-            onChange={(value) => handleChange("systemAudioCapture", value)}
-          />
         </div>
       </div>
     </div>

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -321,7 +321,7 @@ export type ExportEstimates = { duration_seconds: number; estimated_time_seconds
 export type ExportSettings = { fps: number; resolution_base: XY<number>; compression: ExportCompression }
 export type Flags = { captions: boolean }
 export type FramesRendered = { renderedCount: number; totalFrames: number; type: "FramesRendered" }
-export type GeneralSettingsStore = { instanceId?: string; uploadIndividualFiles?: boolean; hideDockIcon?: boolean; hapticsEnabled?: boolean; autoCreateShareableLink?: boolean; enableNotifications?: boolean; disableAutoOpenLinks?: boolean; hasCompletedStartup?: boolean; theme?: AppTheme; commercialLicense?: CommercialLicense | null; lastVersion?: string | null; windowTransparency?: boolean; postStudioRecordingBehaviour?: PostStudioRecordingBehaviour; mainWindowRecordingStartBehaviour?: MainWindowRecordingStartBehaviour; customCursorCapture?: boolean; systemAudioCapture?: boolean; serverUrl?: string; 
+export type GeneralSettingsStore = { instanceId?: string; uploadIndividualFiles?: boolean; hideDockIcon?: boolean; hapticsEnabled?: boolean; autoCreateShareableLink?: boolean; enableNotifications?: boolean; disableAutoOpenLinks?: boolean; hasCompletedStartup?: boolean; theme?: AppTheme; commercialLicense?: CommercialLicense | null; lastVersion?: string | null; windowTransparency?: boolean; postStudioRecordingBehaviour?: PostStudioRecordingBehaviour; mainWindowRecordingStartBehaviour?: MainWindowRecordingStartBehaviour; customCursorCapture?: boolean; serverUrl?: string;
 /**
  * @deprecated
  */


### PR DESCRIPTION
## Summary
- remove `system_audio_capture` setting in the desktop backend
- drop the experimental toggle for system audio
- always allocate space for the System Audio button
- expose System Audio option to all users

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm typecheck` *(fails: dependencies missing)*
- `cargo check` *(fails: network failure when fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845bbb427508332877fa36c2ca2d274