### PR TITLE
Correct export color text

### DIFF
--- a/apps/desktop/src/routes/editor/ExportDialog.tsx
+++ b/apps/desktop/src/routes/editor/ExportDialog.tsx
@@ -710,7 +710,7 @@ export function ExportDialog() {
                                   <IconLucideCheck class="text-gray-1 size-5" />
                                 </div>
                                 <div class="flex flex-col gap-1 items-center">
-                                  <h1 class="text-xl font-medium text-gray-600">
+                                  <h1 class="text-xl font-medium text-gray-12">
                                     Export Completed
                                   </h1>
                                   <p class="text-sm text-gray-11">


### PR DESCRIPTION
After exporting in the editor, the Exported Completed titles color was not right.