### PR TITLE
Add share branding toggle

### DIFF
--- a/apps/web/actions/organization/update-details.ts
+++ b/apps/web/actions/organization/update-details.ts
@@ -9,6 +9,7 @@ import { revalidatePath } from "next/cache";
 export async function updateOrganizationDetails(
   organizationName: string,
   allowedEmailDomain: string,
+  showCapBranding: boolean,
   organizationId: string
 ) {
   const user = await getCurrentUser();
@@ -35,6 +36,7 @@ export async function updateOrganizationDetails(
     .set({
       name: organizationName,
       allowedEmailDomain: allowedEmailDomain || null,
+      showCapBranding,
     })
     .where(eq(organizations.id, organizationId));
 

--- a/apps/web/app/dashboard/settings/organization/Organization.tsx
+++ b/apps/web/app/dashboard/settings/organization/Organization.tsx
@@ -23,6 +23,9 @@ export const Organization = () => {
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
   const ownerToastShown = useRef(false);
   const [saveLoading, setSaveLoading] = useState(false);
+  const [showCapBranding, setShowCapBranding] = useState(
+    activeOrganization?.organization.showCapBranding ?? true
+  );
 
   const showOwnerToast = useCallback(() => {
     if (!ownerToastShown.current) {
@@ -52,6 +55,7 @@ export const Organization = () => {
         await updateOrganizationDetails(
           organizationName,
           allowedEmailDomain,
+          showCapBranding,
           activeOrganization?.organization.id as string
         );
         toast.success("Settings updated successfully");
@@ -63,7 +67,13 @@ export const Organization = () => {
         setSaveLoading(false);
       }
     },
-    [isOwner, showOwnerToast, activeOrganization?.organization.id, router]
+    [
+      isOwner,
+      showOwnerToast,
+      activeOrganization?.organization.id,
+      router,
+      showCapBranding,
+    ]
   );
 
   const handleManageBilling = useCallback(async () => {
@@ -102,6 +112,8 @@ export const Organization = () => {
           saveLoading={saveLoading}
           showOwnerToast={showOwnerToast}
           organizationName={organizationName}
+          showCapBranding={showCapBranding}
+          setShowCapBranding={setShowCapBranding}
         />
         <CustomDomainIconCard
           isOwner={isOwner}

--- a/apps/web/app/dashboard/settings/organization/components/OrganizationDetailsCard.tsx
+++ b/apps/web/app/dashboard/settings/organization/components/OrganizationDetailsCard.tsx
@@ -1,25 +1,24 @@
 "use client";
 
 import { useSharedContext } from "@/app/dashboard/_components/DynamicSharedLayout";
-import {
-  Button,
-  Card,
-  Input,
-  Label
-} from "@cap/ui";
+import { Button, Card, Input, Label, Switch } from "@cap/ui";
 
 interface OrganizationDetailsCardProps {
   isOwner: boolean;
   saveLoading: boolean;
   showOwnerToast: () => void;
   organizationName: string | undefined;
+  showCapBranding: boolean;
+  setShowCapBranding: (value: boolean) => void;
 }
 
 export const OrganizationDetailsCard = ({
   isOwner,
   saveLoading,
   showOwnerToast,
-  organizationName
+  organizationName,
+  showCapBranding,
+  setShowCapBranding,
 }: OrganizationDetailsCardProps) => {
   const { activeOrganization } = useSharedContext();
 
@@ -68,6 +67,21 @@ export const OrganizationDetailsCard = ({
               if (!isOwner) showOwnerToast();
             }}
           />
+          <div className="flex items-center gap-2 mt-4">
+            <Switch
+              id="showCapBranding"
+              checked={showCapBranding}
+              disabled={!isOwner}
+              onCheckedChange={(checked) => {
+                if (!isOwner) {
+                  showOwnerToast();
+                  return;
+                }
+                setShowCapBranding(checked);
+              }}
+            />
+            <Label htmlFor="showCapBranding">Show "Recorded with Cap" link</Label>
+          </div>
         </div>
       </div>
       <Button

--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -499,12 +499,14 @@ async function AuthorizedContent({
 
   let customDomain: string | null = null;
   let domainVerified = false;
+  let showCapBranding = true;
 
   if (video.sharedOrganization?.organizationId) {
     const organizationData = await db()
       .select({
         customDomain: organizations.customDomain,
         domainVerified: organizations.domainVerified,
+        showCapBranding: organizations.showCapBranding,
       })
       .from(organizations)
       .where(eq(organizations.id, video.sharedOrganization.organizationId))
@@ -519,6 +521,7 @@ async function AuthorizedContent({
       if (organizationData[0].domainVerified !== null) {
         domainVerified = true;
       }
+      showCapBranding = organizationData[0].showCapBranding;
     }
   }
 
@@ -527,6 +530,7 @@ async function AuthorizedContent({
       .select({
         customDomain: organizations.customDomain,
         domainVerified: organizations.domainVerified,
+        showCapBranding: organizations.showCapBranding,
       })
       .from(organizations)
       .where(eq(organizations.ownerId, video.ownerId))
@@ -541,6 +545,7 @@ async function AuthorizedContent({
       if (ownerOrganizations[0].domainVerified !== null) {
         domainVerified = true;
       }
+      showCapBranding = ownerOrganizations[0].showCapBranding;
     }
   }
 
@@ -650,16 +655,18 @@ async function AuthorizedContent({
           aiUiEnabled={aiUiEnabled}
         />
       </div>
-      <div className="py-4 mt-auto">
-        <a
-          target="_blank"
-          href={`/?ref=video_${video.id}`}
-          className="flex justify-center items-center px-4 py-2 mx-auto space-x-2 bg-gray-1 rounded-full new-card-style w-fit"
-        >
-          <span className="text-sm">Recorded with</span>
-          <Logo className="w-14 h-auto" />
-        </a>
-      </div>
+      {showCapBranding && (
+        <div className="py-4 mt-auto">
+          <a
+            target="_blank"
+            href={`/?ref=video_${video.id}`}
+            className="flex justify-center items-center px-4 py-2 mx-auto space-x-2 bg-gray-1 rounded-full new-card-style w-fit"
+          >
+            <span className="text-sm">Recorded with</span>
+            <Logo className="w-14 h-auto" />
+          </a>
+        </div>
+      )}
     </>
   );
 }

--- a/packages/database/migrations/0002_disable_cap_branding.sql
+++ b/packages/database/migrations/0002_disable_cap_branding.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `organizations` ADD `showCapBranding` boolean NOT NULL DEFAULT true;

--- a/packages/database/migrations/meta/0000_snapshot.json
+++ b/packages/database/migrations/meta/0000_snapshot.json
@@ -743,6 +743,14 @@
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false
+        },
+        "showCapBranding": {
+          "name": "showCapBranding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "true"
         }
       },
       "indexes": {

--- a/packages/database/migrations/meta/0001_snapshot.json
+++ b/packages/database/migrations/meta/0001_snapshot.json
@@ -610,6 +610,14 @@
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false
+        },
+        "showCapBranding": {
+          "name": "showCapBranding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "true"
         }
       },
       "indexes": {

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1749268354138,
       "tag": "0001_white_young_avengers",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "5",
+      "when": 1749268354139,
+      "tag": "0002_disable_cap_branding",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -141,6 +141,7 @@ export const organizations = mysqlTable(
     updatedAt: timestamp("updatedAt").notNull().defaultNow().onUpdateNow(),
     workosOrganizationId: varchar("workosOrganizationId", { length: 255 }),
     workosConnectionId: varchar("workosConnectionId", { length: 255 }),
+    showCapBranding: boolean("showCapBranding").notNull().default(true),
   },
   (table) => ({
     ownerIdIndex: index("owner_id_idx").on(table.ownerId),


### PR DESCRIPTION
## Summary
- add `showCapBranding` column and migration
- allow updating branding visibility in organization settings
- respect setting on the share page

## Testing
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fa6cf8e08332817ab8756f8b68ab