### PR TITLE
Experiment: Add basic video editor to dashboard for shareable links

### DIFF
--- a/apps/web/actions/videos/replace.ts
+++ b/apps/web/actions/videos/replace.ts
@@ -1,0 +1,34 @@
+'use server';
+
+import { getCurrentUser } from '@cap/database/auth/session';
+import { createVideoAndGetUploadUrl } from '@/actions/video/upload';
+import { transcribeVideo } from '@/actions/videos/transcribe';
+
+export async function getVideoReplacePresignedUrl(
+  videoId: string,
+  options: { duration?: number; resolution?: string; videoCodec?: string; audioCodec?: string } = {}
+) {
+  const user = await getCurrentUser();
+  if (!user) {
+    throw new Error('Unauthorized');
+  }
+
+  const data = await createVideoAndGetUploadUrl({
+    videoId,
+    duration: options.duration,
+    resolution: options.resolution,
+    videoCodec: options.videoCodec,
+    audioCodec: options.audioCodec,
+  });
+
+  return data.presignedPostData;
+}
+
+export async function restartVideoTranscription(videoId: string) {
+  const user = await getCurrentUser();
+  if (!user) {
+    throw new Error('Unauthorized');
+  }
+
+  await transcribeVideo(videoId, user.id);
+}

--- a/apps/web/app/dashboard/caps/[videoId]/edit/page.tsx
+++ b/apps/web/app/dashboard/caps/[videoId]/edit/page.tsx
@@ -1,0 +1,31 @@
+import { db } from "@cap/database";
+import { getCurrentUser } from "@cap/database/auth/session";
+import { videos } from "@cap/database/schema";
+import { eq } from "drizzle-orm";
+import { redirect } from "next/navigation";
+import { VideoEditor } from "@/components/VideoEditor";
+
+export const revalidate = 0;
+
+export default async function EditCapPage({
+  params,
+}: {
+  params: { videoId: string };
+}) {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+
+  const videoId = params.videoId;
+  const [video] = await db()
+    .select()
+    .from(videos)
+    .where(eq(videos.id, videoId));
+
+  if (!video || video.ownerId !== user.id) {
+    redirect("/dashboard/caps");
+  }
+
+  const playlistUrl = `/api/playlist?userId=${video.ownerId}&videoId=${video.id}`;
+
+  return <VideoEditor videoId={video.id} playlistUrl={playlistUrl} />;
+}

--- a/apps/web/app/dashboard/caps/components/CapCard.tsx
+++ b/apps/web/app/dashboard/caps/components/CapCard.tsx
@@ -16,6 +16,7 @@ import {
   faTrash,
   faLock,
   faUnlock,
+  faPen,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import clsx from "clsx";
@@ -333,6 +334,17 @@ export const CapCard = ({
                     <path d="M20 6 9 17l-5-5" />
                   </svg>
                 )}
+              </Button>
+            </Tooltip>
+            <Tooltip content="Edit Cap">
+              <Button
+                href={`/dashboard/caps/${cap.id}/edit`}
+                className="!size-8 delay-25 hover:opacity-80 rounded-full min-w-fit !p-0"
+                variant="white"
+                size="sm"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <FontAwesomeIcon className="text-gray-12 size-3" icon={faPen} />
               </Button>
             </Tooltip>
             <Tooltip

--- a/apps/web/components/VideoEditor.tsx
+++ b/apps/web/components/VideoEditor.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Button } from "@cap/ui";
+import {
+  getVideoReplacePresignedUrl,
+  restartVideoTranscription,
+} from "@/actions/videos/replace";
+import * as MediaParser from "@remotion/media-parser";
+import * as WebCodecs from "@remotion/webcodecs";
+
+interface Segment {
+  start: number;
+  end: number;
+  speed: number;
+}
+
+export function VideoEditor({
+  videoId,
+  playlistUrl,
+}: {
+  videoId: string;
+  playlistUrl: string;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [segments, setSegments] = useState<Segment[]>([]);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(false);
+
+  const initSegments = () => {
+    const video = videoRef.current;
+    if (!video) return;
+    const d = video.duration;
+    setSegments([{ start: 0, end: d, speed: 1 }]);
+  };
+
+  const splitAtCurrent = () => {
+    const video = videoRef.current;
+    if (!video) return;
+    const time = video.currentTime;
+    setSegments((prev) => {
+      for (let i = 0; i < prev.length; i++) {
+        const seg = prev[i];
+        if (time > seg.start && time < seg.end) {
+          const first = { start: seg.start, end: time, speed: seg.speed };
+          const second = { start: time, end: seg.end, speed: seg.speed };
+          return [...prev.slice(0, i), first, second, ...prev.slice(i + 1)];
+        }
+      }
+      return prev;
+    });
+  };
+
+  const removeSegment = (idx: number) => {
+    setSegments((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  const changeSpeed = (idx: number, speed: number) => {
+    setSegments((prev) =>
+      prev.map((s, i) => (i === idx ? { ...s, speed } : s))
+    );
+  };
+
+  const generateEditedVideo = async () => {
+    const controller = MediaParser.mediaParserController
+      ? MediaParser.mediaParserController()
+      : undefined;
+    const clips: Blob[] = [];
+
+    for (const seg of segments) {
+      // WebCodecs API used for trimming and speeding segments
+      const result = await WebCodecs.convertMedia({
+        src: playlistUrl,
+        startInSeconds: seg.start,
+        endInSeconds: seg.end,
+        playbackRate: seg.speed,
+        controller: controller as any,
+      } as any);
+      const blob = await (result as any).save();
+      clips.push(blob);
+    }
+
+    // Combine all edited clips back into one video
+    const stitched = await (WebCodecs as any).concatVideos({ videos: clips });
+    const finalBlob = await (stitched as any).save();
+    return finalBlob as Blob;
+  };
+
+  const saveChanges = async () => {
+    setProcessing(true);
+    try {
+      const blob = await generateEditedVideo();
+      const presigned = await getVideoReplacePresignedUrl(videoId, {
+        duration: Math.round(videoRef.current?.duration || 0),
+      });
+      const form = new FormData();
+      Object.entries(presigned.fields).forEach(([k, v]) =>
+        form.append(k, v as string)
+      );
+      form.append("file", blob);
+
+      await new Promise<void>((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open("POST", presigned.url);
+        xhr.onload = () =>
+          xhr.status >= 200 && xhr.status < 300
+            ? resolve()
+            : reject(new Error("upload failed"));
+        xhr.onerror = () => reject(new Error("upload failed"));
+        xhr.send(form);
+      });
+
+      setPreviewUrl(URL.createObjectURL(blob));
+      await restartVideoTranscription(videoId);
+      alert("Video saved and uploaded");
+    } catch (err) {
+      console.error(err);
+      alert("Failed to save video");
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <video
+        ref={videoRef}
+        src={playlistUrl}
+        controls
+        onLoadedMetadata={initSegments}
+        className="w-full rounded"
+      />
+      <div className="space-y-2">
+        {segments.map((seg, i) => (
+          <div key={i} className="flex items-center space-x-2">
+            <span>
+              {seg.start.toFixed(2)}s - {seg.end.toFixed(2)}s
+            </span>
+            <input
+              type="number"
+              min={0.25}
+              max={3}
+              step={0.25}
+              value={seg.speed}
+              onChange={(e) => changeSpeed(i, parseFloat(e.target.value))}
+              className="w-20 border rounded px-1"
+            />
+            <Button variant="white" onClick={() => removeSegment(i)}>
+              Delete
+            </Button>
+          </div>
+        ))}
+      </div>
+      <div className="space-x-2">
+        <Button variant="white" onClick={splitAtCurrent}>
+          Split at Current Time
+        </Button>
+        <Button variant="primary" onClick={saveChanges} disabled={processing}>
+          {processing ? "Saving..." : "Save"}
+        </Button>
+      </div>
+      {previewUrl && (
+        <div>
+          <p className="font-medium">Preview</p>
+          <video src={previewUrl} controls className="w-full rounded" />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add server utilities to reupload edited videos and re-trigger transcripts
- create a `VideoEditor` client component with trimming, splitting and segment speed controls
- expose the new editor on `/dashboard/caps/[videoId]/edit`
- add an edit button to each cap card

## Testing
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e69cbdab483328e6a674b1854bf09