### PR TITLE
experiment: Add green screen with BodyPix

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -66,7 +66,10 @@
     "uuid": "^9.0.1",
     "vinxi": "^0.5.6",
     "webcodecs": "^0.1.0",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "@tensorflow-models/body-pix": "^2.2.0",
+    "@tensorflow/tfjs": "^4.16.0",
+    "@tensorflow/tfjs-backend-webgl": "^4.16.0"
   },
   "devDependencies": {
     "@fontsource/geist-sans": "^5.0.3",


### PR DESCRIPTION
## Summary
- add BodyPix and TFJS dependencies for person segmentation
- implement real-time green screen effect using BodyPix
- skip frames if segmentation is still processing to keep UI responsive

## Testing
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e9e54ad08332a715823ca81b2a29