### PR TITLE
fix: fixed Navbar and visible CTA on SelfHostingPage

### DIFF
--- a/apps/web/app/(site)/Navbar.tsx
+++ b/apps/web/app/(site)/Navbar.tsx
@@ -102,7 +102,7 @@ export const Navbar = () => {
 
   return (
     <>
-      <header className="sticky inset-0 top-4 z-[51] md:top-10  animate-in fade-in slide-in-from-top-4 duration-500">
+      <header className="fixed inset-0 top-4 z-[51] md:top-10  animate-in fade-in slide-in-from-top-4 duration-500">
         <nav className="p-2 mx-auto w-full max-w-[calc(100%-20px)] bg-white rounded-full border backdrop-blur-md md:max-w-fit border-zinc-200 h-fit">
           <div className="flex gap-12 justify-between items-center mx-auto max-w-4xl h-full transition-all">
             <div className="flex items-center">

--- a/apps/web/components/CommercialGetStarted.tsx
+++ b/apps/web/components/CommercialGetStarted.tsx
@@ -20,7 +20,11 @@ export function CommercialGetStarted() {
   return (
     <div
       className="custom-bg max-w-[1000px] mx-auto rounded-[20px] overflow-hidden relative flex flex-col justify-center p-8"
-      style={{ minHeight: "264px" }}
+      style={{
+        minHeight: "264px",
+        background:
+          "linear-gradient(135deg, #4f46e5 0%, #3b82f6 50%, #0ea5e9 100%)",
+      }}
     >
       <div
         id="cloud-4"


### PR DESCRIPTION
This PR addresses two UI issues:

**Navbar Position:**
Ensures the Navbar always appears visually above the Final CTA section, providing a consistent navigation experience.

### Before & After

| Before | After |
|--------|-------|
| <img width="1436" alt="Screenshot 2025-07-09 at 00 46 20" src="https://github.com/user-attachments/assets/e83c6b59-163f-4d0d-8df3-1d83b4766309" /> | <img width="1436" alt="image" src="https://github.com/user-attachments/assets/87cbd976-da12-415e-af6b-26f7cd4db8c5" /> |

**Background Gradient Update:**
Updates the background gradient for improved visual appeal and consistency across SeoPageTemplate-based pages.

| Before | After |
|--------|-------|
| <img width="1436" alt="Screenshot 2025-07-09 at 00 50 41" src="https://github.com/user-attachments/assets/1c1bdf42-0866-49c6-94fa-830f5eb8a599" /> | <img width="1436" alt="image" src="https://github.com/user-attachments/assets/99f0f61f-c494-4d4c-bb9d-c389e4fa52f6" /> |
