### PR TITLE
fix: Update setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,10 +39,11 @@ Configure the necessary environment variables by copying the `.env.example` file
 `.env.example` by default assumes you want to run both `@cap/desktop` and `@cap/web` locally.
 Follow the instructions in the file for how to configure the environment variables for which apps you want to run.
 
-Run `pnpm cap-setup` to install native dependencies such as FFmpeg,
-then run `pnpm install`.
+Run `pnpm install`,
+then run `pnpm cap-setup` to install native dependencies such as FFmpeg.
 
 On Windows, llvm, clang, and VCPKG must be installed.
+On MacOS, cmake must be installed.
 `pnpm cap-setup` does not yet install these dependencies for you.
 
 To run both `@cap/desktop` and `@cap/web` together, use `pnpm dev`.


### PR DESCRIPTION
`pnpm cap-setup` requires dotenv,
for that `pnpm install` should be called first.

cmake is required to build the app on MacOS and hence it is required before building the app. 