### PR TITLE
Fix macOS build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 name = "cap-audio"
 version = "0.1.0"
 dependencies = [
- "cidre 0.10.1",
+ "cidre",
  "cpal 0.15.3 (git+https://github.com/RustAudio/cpal?rev=f43d36e55494993bbbde3299af0c53e5cdf4d4cf)",
  "ffmpeg-next",
  "tokio",
@@ -955,7 +955,7 @@ dependencies = [
 name = "cap-camera-avfoundation"
 version = "0.1.0"
 dependencies = [
- "cidre 0.10.1",
+ "cidre",
  "clap 4.5.41",
  "inquire",
 ]
@@ -1152,7 +1152,7 @@ dependencies = [
  "cap-flags",
  "cap-gpu-converters",
  "cap-project",
- "cidre 0.10.1",
+ "cidre",
  "cocoa 0.26.0",
  "core-foundation 0.10.0",
  "core-graphics 0.24.0",
@@ -1207,7 +1207,7 @@ dependencies = [
  "cap-project",
  "cap-utils",
  "chrono",
- "cidre 0.10.1",
+ "cidre",
  "cocoa 0.26.0",
  "device_query 2.1.0",
  "either",
@@ -1240,7 +1240,7 @@ dependencies = [
  "cap-flags",
  "cap-project",
  "cap-video-decode",
- "cidre 0.10.1",
+ "cidre",
  "ffmpeg-hw-device",
  "ffmpeg-next",
  "ffmpeg-sys-next",
@@ -1294,7 +1294,7 @@ dependencies = [
 name = "cap-video-decode"
 version = "0.1.0"
 dependencies = [
- "cidre 0.10.1",
+ "cidre",
  "ffmpeg-hw-device",
  "ffmpeg-next",
  "ffmpeg-sys-next",
@@ -1441,23 +1441,13 @@ dependencies = [
 
 [[package]]
 name = "cidre"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b83f5e597a8fb4ba25eec2683aa3e89f9890dd7524622639a38e3f854c60eb"
+version = "0.10.1"
+source = "git+https://github.com/CapSoftware/cidre?rev=517d097ae438#517d097ae4387ebb97f36c6e133b3c94dca78e25"
 dependencies = [
  "cidre-macros",
  "half",
  "parking_lot",
  "tokio",
-]
-
-[[package]]
-name = "cidre"
-version = "0.10.1"
-source = "git+https://github.com/CapSoftware/cidre?rev=517d097ae438#517d097ae4387ebb97f36c6e133b3c94dca78e25"
-dependencies = [
- "cidre-macros",
- "parking_lot",
 ]
 
 [[package]]
@@ -6715,9 +6705,9 @@ dependencies = [
 [[package]]
 name = "scap"
 version = "0.0.8"
-source = "git+https://github.com/CapSoftware/scap?rev=d69dcb2e653a#d69dcb2e653a714bf91d147333deb5fb06acb940"
+source = "git+https://github.com/CapSoftware/scap?rev=3fd6ec9c5ebf#3fd6ec9c5ebf14fdebc5b6350b6eb6fb315d3eff"
 dependencies = [
- "cidre 0.9.2",
+ "cidre",
  "cocoa 0.25.0",
  "core-graphics-helmer-fork",
  "cpal 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,9 +1445,7 @@ version = "0.10.1"
 source = "git+https://github.com/CapSoftware/cidre?rev=517d097ae438#517d097ae4387ebb97f36c6e133b3c94dca78e25"
 dependencies = [
  "cidre-macros",
- "half",
  "parking_lot",
- "tokio",
 ]
 
 [[package]]
@@ -6705,7 +6703,7 @@ dependencies = [
 [[package]]
 name = "scap"
 version = "0.0.8"
-source = "git+https://github.com/CapSoftware/scap?rev=3fd6ec9c5ebf#3fd6ec9c5ebf14fdebc5b6350b6eb6fb315d3eff"
+source = "git+https://github.com/CapSoftware/scap?rev=3782f9dd4ffb#3782f9dd4ffb9aba7f1a8b707dbddd777a9299ca"
 dependencies = [
  "cidre",
  "cocoa 0.25.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ specta = { version = "=2.0.0-rc.20", features = [
 	"uuid",
 ] }
 
-scap = { git = "https://github.com/CapSoftware/scap", rev = "3fd6ec9c5ebf" }
+scap = { git = "https://github.com/CapSoftware/scap", rev = "3782f9dd4ffb" }
 nokhwa = { git = "https://github.com/CapSoftware/nokhwa", rev = "b9c8079e82e2", features = [
 	"input-native",
 	"serialize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ specta = { version = "=2.0.0-rc.20", features = [
 	"uuid",
 ] }
 
-scap = { git = "https://github.com/CapSoftware/scap", rev = "d69dcb2e653a" }
+scap = { git = "https://github.com/CapSoftware/scap", rev = "3fd6ec9c5ebf" }
 nokhwa = { git = "https://github.com/CapSoftware/nokhwa", rev = "b9c8079e82e2", features = [
 	"input-native",
 	"serialize",
@@ -63,3 +63,4 @@ dbg_macro = "deny"
 [patch.crates-io]
 screencapturekit = { git = "https://github.com/CapSoftware/screencapturekit-rs", rev = "7ff1e103742e56c8f6c2e940b5e52684ed0bed69" } # branch = "cap-main"
 wry = { git = "https://github.com/CapSoftware/wry", rev = "293f510" }                                                               # branch = "cap"
+cidre = { git = "https://github.com/CapSoftware/cidre", rev = "517d097ae438" }


### PR DESCRIPTION
I'm unable to compile Cap for macOS due to multiple Cidre versions being in the crate graph and causing issues with types.

Error:
```bash
error[E0308]: mismatched types
   --> crates/media/src/sources/screen_capture.rs:718:25
    |
718 |                         sc::stream::OutputType::Audio => {
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `cidre::sc::stream::OutputType`, found `OutputType`
    |
note: two different versions of crate `cidre` are being used; two types coming from two different versions of the same crate are different types even if they look the same
   --> /Users/oscar/.cargo/git/checkouts/cidre-4fcea89888fe326d/517d097/cidre/src/sc/stream.rs:117:1
    |
117 | pub enum OutputType {
    | ^^^^^^^^^^^^^^^^^^^ this is the found type `OutputType`
    |
   ::: /Users/oscar/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cidre-0.9.2/src/sc/stream.rs:117:1
    |
117 | pub enum OutputType {
    | ^^^^^^^^^^^^^^^^^^^ this is the expected type `cidre::sc::stream::OutputType`
    |
   ::: crates/media/src/sources/screen_capture.rs:5:5
    |
5   | use scap::{
    |     ---- one version of crate `cidre` used here, as a dependency of crate `scap`
    |
   ::: crates/media/src/encoders/mp4_avassetwriter.rs:14:5
    |
14  | use cidre::{cm::SampleTimingInfo, objc::Obj, *};
    |     ----- one version of crate `cidre` used here, as a direct dependency of the current crate
    = help: you can use `cargo tree` to explore your dependency tree
```

Linked with https://github.com/CapSoftware/scap/pull/161