### PR TITLE
feat: add functionality to update pretty name in editor

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -794,6 +794,15 @@ async fn get_editor_meta(editor: WindowEditorInstance) -> Result<RecordingMeta, 
     let path = editor.project_path.clone();
     RecordingMeta::load_for_project(&path).map_err(|e| e.to_string())
 }
+#[tauri::command]
+#[specta::specta]
+async fn set_pretty_name(editor: WindowEditorInstance, pretty_name: String) -> Result<(), String> {
+    let path = editor.project_path.clone();
+    let mut meta = RecordingMeta::load_for_project(&path).map_err(|e| e.to_string())?;
+
+    meta.pretty_name = pretty_name;
+    meta.save_for_project().map_err(|e| e.to_string())
+}
 
 #[tauri::command]
 #[specta::specta]
@@ -1797,6 +1806,7 @@ pub async fn run(recording_logging_handle: LoggingHandle) {
             update_auth_plan,
             set_window_transparent,
             get_editor_meta,
+            set_pretty_name,
             set_server_url,
             captions::create_dir,
             captions::save_model_file,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -797,9 +797,7 @@ async fn get_editor_meta(editor: WindowEditorInstance) -> Result<RecordingMeta, 
 #[tauri::command]
 #[specta::specta]
 async fn set_pretty_name(editor: WindowEditorInstance, pretty_name: String) -> Result<(), String> {
-    let path = editor.project_path.clone();
-    let mut meta = RecordingMeta::load_for_project(&path).map_err(|e| e.to_string())?;
-
+    let mut meta = editor.meta().clone();
     meta.pretty_name = pretty_name;
     meta.save_for_project().map_err(|e| e.to_string())
 }

--- a/apps/desktop/src/routes/editor/Header.tsx
+++ b/apps/desktop/src/routes/editor/Header.tsx
@@ -109,7 +109,12 @@ export function Header() {
           <Tooltip disabled={!truncated()} content={meta().prettyName}>
             <input
               ref={prettyNameRef}
-              class="text-sm text-gray-12 max-w-[300px] bg-transparent focus:border-b focus:border-gray-7 focus:outline-none"
+              class={cx(
+                "text-sm text-gray-12 max-w-[300px] bg-transparent focus:border-b focus:border-gray-7 focus:outline-none",
+                truncated() && "truncate",
+                (prettyName().length < 5 || prettyName().length > 100) &&
+                  "focus:border-red-500"
+              )}
               value={prettyName()}
               onInput={(e) => setPrettyName(e.currentTarget.value)}
               onBlur={async () => {

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -182,6 +182,9 @@ async setWindowTransparent(value: boolean) : Promise<void> {
 async getEditorMeta() : Promise<RecordingMeta> {
     return await TAURI_INVOKE("get_editor_meta");
 },
+async setPrettyName(prettyName: string) : Promise<null> {
+    return await TAURI_INVOKE("set_pretty_name", { prettyName });
+},
 async setServerUrl(serverUrl: string) : Promise<null> {
     return await TAURI_INVOKE("set_server_url", { serverUrl });
 },


### PR DESCRIPTION
Users can now rename their recordings right from the editor so that they can have their own identifier for indentifying recordings.

I have no previous background in Tauri but I went ahead and implemented this.
Please do let me know if this is the correct way to architect this feature or I should follow any other specific paradigm?