### PR TITLE
Fix videos.id error

### DIFF
--- a/.github/workflows/docker-build-web.yml
+++ b/.github/workflows/docker-build-web.yml
@@ -55,7 +55,7 @@ jobs:
           file: apps/web/Dockerfile
           platforms: linux/${{ matrix.platform }}
           push: true
-          outputs: type=image,name=ghcr.io/capsoftware/cap-web,push-by-digest=true
+          outputs: type=image,name=ghcr.io/mogita/cap-web,push-by-digest=true
           cache-from: type=gha,scope=buildx-${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=buildx-${{ matrix.platform }}
 
@@ -101,5 +101,5 @@ jobs:
 
       - name: Create Image Manifest
         run: |
-          docker buildx imagetools create -t ghcr.io/capsoftware/cap-web:${{ inputs.tag || 'latest' }} \
-            $(find /tmp/digests -type f -not -path "*/\.*" -exec basename {} \; | xargs -I {} echo "ghcr.io/capsoftware/cap-web@sha256:{}")
+          docker buildx imagetools create -t ghcr.io/mogita/cap-web:${{ inputs.tag || 'latest' }} \
+            $(find /tmp/digests -type f -not -path "*/\.*" -exec basename {} \; | xargs -I {} echo "ghcr.io/mogita/cap-web@sha256:{}")

--- a/.github/workflows/docker-build-web.yml
+++ b/.github/workflows/docker-build-web.yml
@@ -55,7 +55,7 @@ jobs:
           file: apps/web/Dockerfile
           platforms: linux/${{ matrix.platform }}
           push: true
-          outputs: type=image,name=ghcr.io/mogita/cap-web,push-by-digest=true
+          outputs: type=image,name=ghcr.io/capsoftware/cap-web,push-by-digest=true
           cache-from: type=gha,scope=buildx-${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=buildx-${{ matrix.platform }}
 
@@ -101,5 +101,5 @@ jobs:
 
       - name: Create Image Manifest
         run: |
-          docker buildx imagetools create -t ghcr.io/mogita/cap-web:${{ inputs.tag || 'latest' }} \
-            $(find /tmp/digests -type f -not -path "*/\.*" -exec basename {} \; | xargs -I {} echo "ghcr.io/mogita/cap-web@sha256:{}")
+          docker buildx imagetools create -t ghcr.io/capsoftware/cap-web:${{ inputs.tag || 'latest' }} \
+            $(find /tmp/digests -type f -not -path "*/\.*" -exec basename {} \; | xargs -I {} echo "ghcr.io/capsoftware/cap-web@sha256:{}")

--- a/apps/web/actions/folders/getVideosByFolderId.ts
+++ b/apps/web/actions/folders/getVideosByFolderId.ts
@@ -7,10 +7,83 @@ import {
   users,
   organizations,
   sharedVideos,
+  spaceVideos,
+  spaces,
 } from "@cap/database/schema";
 import { eq, desc } from "drizzle-orm";
 import { sql } from "drizzle-orm/sql";
 import { revalidatePath } from "next/cache";
+
+// Helper function to fetch shared spaces data for videos
+async function getSharedSpacesForVideos(videoIds: string[]) {
+  if (videoIds.length === 0) return {};
+
+  // Fetch space-level sharing
+  const spaceSharing = await db()
+    .select({
+      videoId: spaceVideos.videoId,
+      id: spaces.id,
+      name: spaces.name,
+      organizationId: spaces.organizationId,
+      iconUrl: organizations.iconUrl,
+    })
+    .from(spaceVideos)
+    .innerJoin(spaces, eq(spaceVideos.spaceId, spaces.id))
+    .innerJoin(organizations, eq(spaces.organizationId, organizations.id))
+    .where(sql`${spaceVideos.videoId} IN (${sql.join(videoIds.map(id => sql`${id}`), sql`, `)})`);
+
+  // Fetch organization-level sharing
+  const orgSharing = await db()
+    .select({
+      videoId: sharedVideos.videoId,
+      id: organizations.id,
+      name: organizations.name,
+      organizationId: organizations.id,
+      iconUrl: organizations.iconUrl,
+    })
+    .from(sharedVideos)
+    .innerJoin(organizations, eq(sharedVideos.organizationId, organizations.id))
+    .where(sql`${sharedVideos.videoId} IN (${sql.join(videoIds.map(id => sql`${id}`), sql`, `)})`);
+
+  // Combine and group by videoId
+  const sharedSpacesMap: Record<string, Array<{
+    id: string;
+    name: string;
+    organizationId: string;
+    iconUrl: string;
+    isOrg: boolean;
+  }>> = {};
+
+  // Add space-level sharing
+  spaceSharing.forEach(space => {
+    if (!sharedSpacesMap[space.videoId]) {
+      sharedSpacesMap[space.videoId] = [];
+    }
+    sharedSpacesMap[space.videoId].push({
+      id: space.id,
+      name: space.name,
+      organizationId: space.organizationId,
+      iconUrl: space.iconUrl || '',
+      isOrg: false,
+    });
+  });
+
+  // Add organization-level sharing
+  orgSharing.forEach(org => {
+    if (!sharedSpacesMap[org.videoId]) {
+      sharedSpacesMap[org.videoId] = [];
+    }
+    sharedSpacesMap[org.videoId].push({
+      id: org.id,
+      name: org.name,
+      organizationId: org.organizationId,
+      iconUrl: org.iconUrl || '',
+      isOrg: true,
+    });
+  });
+
+  return sharedSpacesMap;
+}
 
 export async function getVideosByFolderId(folderId: string) {
   if (!folderId) throw new Error("Folder ID is required");
@@ -36,57 +109,7 @@ export async function getVideosByFolderId(folderId: string) {
           JSON_ARRAY()
         )
       `,
-      sharedSpaces: sql<
-        {
-          id: string;
-          name: string;
-          organizationId: string;
-          iconUrl: string;
-          isOrg: boolean;
-        }[]
-      >`
-        COALESCE(
-          (
-            SELECT JSON_ARRAYAGG(
-              JSON_OBJECT(
-                'id', s.id,
-                'name', s.name,
-                'organizationId', s.organizationId,
-                'iconUrl', s.iconUrl,
-                'isOrg', s.isOrg
-              )
-            )
-            FROM (
-              -- Include spaces where the video is directly added via space_videos
-              SELECT DISTINCT
-                s.id,
-                s.name,
-                s.organizationId,
-                o.iconUrl as iconUrl,
-                FALSE as isOrg
-              FROM space_videos sv
-              JOIN spaces s ON sv.spaceId = s.id
-              JOIN organizations o ON s.organizationId = o.id
-              WHERE sv.videoId = videos.id
 
-              UNION
-
-              -- For organization-level sharing, include the organization details
-              -- and mark it as an organization with isOrg=TRUE
-              SELECT DISTINCT
-                o.id as id,
-                o.name as name,
-                o.id as organizationId,
-                o.iconUrl as iconUrl,
-                TRUE as isOrg
-              FROM shared_videos sv
-              JOIN organizations o ON sv.organizationId = o.id
-              WHERE sv.videoId = videos.id
-            ) AS s
-          ),
-          JSON_ARRAY()
-        )
-      `,
       ownerName: users.name,
       effectiveDate: sql<string>`
         COALESCE(
@@ -117,6 +140,10 @@ export async function getVideosByFolderId(folderId: string) {
     )`)
     );
 
+  // Fetch shared spaces data for all videos
+  const videoIds = videoData.map(video => video.id);
+  const sharedSpacesMap = await getSharedSpacesForVideos(videoIds);
+
   // Process the video data to match the expected format
   const processedVideoData = videoData.map((video) => {
     const { effectiveDate, ...videoWithoutEffectiveDate } = video;
@@ -126,7 +153,7 @@ export async function getVideosByFolderId(folderId: string) {
       sharedOrganizations: video.sharedOrganizations.filter(
         (organization) => organization.id !== null
       ),
-      sharedSpaces: video.sharedSpaces.filter((space) => space.id !== null),
+      sharedSpaces: sharedSpacesMap[video.id] || [],
       ownerName: video.ownerName ?? "",
       metadata: video.metadata as
         | {

--- a/apps/web/actions/folders/getVideosByFolderId.ts
+++ b/apps/web/actions/folders/getVideosByFolderId.ts
@@ -58,30 +58,30 @@ export async function getVideosByFolderId(folderId: string) {
             )
             FROM (
               -- Include spaces where the video is directly added via space_videos
-              SELECT DISTINCT 
-                s.id, 
-                s.name, 
-                s.organizationId, 
+              SELECT DISTINCT
+                s.id,
+                s.name,
+                s.organizationId,
                 o.iconUrl as iconUrl,
                 FALSE as isOrg
               FROM space_videos sv
               JOIN spaces s ON sv.spaceId = s.id
               JOIN organizations o ON s.organizationId = o.id
-              WHERE sv.videoId = ${videos.id}
-              
+              WHERE sv.videoId = videos.id
+
               UNION
-              
+
               -- For organization-level sharing, include the organization details
               -- and mark it as an organization with isOrg=TRUE
-              SELECT DISTINCT 
-                o.id as id, 
-                o.name as name, 
-                o.id as organizationId, 
+              SELECT DISTINCT
+                o.id as id,
+                o.name as name,
+                o.id as organizationId,
                 o.iconUrl as iconUrl,
                 TRUE as isOrg
               FROM shared_videos sv
               JOIN organizations o ON sv.organizationId = o.id
-              WHERE sv.videoId = ${videos.id}
+              WHERE sv.videoId = videos.id
             ) AS s
           ),
           JSON_ARRAY()

--- a/apps/web/actions/folders/getVideosByFolderId.ts
+++ b/apps/web/actions/folders/getVideosByFolderId.ts
@@ -150,10 +150,12 @@ export async function getVideosByFolderId(folderId: string) {
 
     return {
       ...videoWithoutEffectiveDate,
-      sharedOrganizations: video.sharedOrganizations.filter(
-        (organization) => organization.id !== null
-      ),
-      sharedSpaces: sharedSpacesMap[video.id] || [],
+      sharedOrganizations: Array.isArray(video.sharedOrganizations)
+        ? video.sharedOrganizations.filter((organization) => organization.id !== null)
+        : [],
+      sharedSpaces: Array.isArray(sharedSpacesMap[video.id])
+        ? sharedSpacesMap[video.id]
+        : [],
       ownerName: video.ownerName ?? "",
       metadata: video.metadata as
         | {

--- a/apps/web/app/(org)/dashboard/caps/page.tsx
+++ b/apps/web/app/(org)/dashboard/caps/page.tsx
@@ -3,7 +3,7 @@ import { getCurrentUser } from "@cap/database/auth/session";
 import {
   comments,
   folders, organizations,
-  sharedVideos, users,
+  sharedVideos, spaceVideos, spaces, users,
   videos
 } from "@cap/database/schema";
 import { and, count, desc, eq, isNull, sql } from "drizzle-orm";
@@ -15,6 +15,77 @@ import { serverEnv } from "@cap/env";
 export const metadata: Metadata = {
   title: "My Caps — Cap",
 };
+
+// Helper function to fetch shared spaces data for videos
+async function getSharedSpacesForVideos(videoIds: string[]) {
+  if (videoIds.length === 0) return {};
+
+  // Fetch space-level sharing
+  const spaceSharing = await db()
+    .select({
+      videoId: spaceVideos.videoId,
+      id: spaces.id,
+      name: spaces.name,
+      organizationId: spaces.organizationId,
+      iconUrl: organizations.iconUrl,
+    })
+    .from(spaceVideos)
+    .innerJoin(spaces, eq(spaceVideos.spaceId, spaces.id))
+    .innerJoin(organizations, eq(spaces.organizationId, organizations.id))
+    .where(sql`${spaceVideos.videoId} IN (${sql.join(videoIds.map(id => sql`${id}`), sql`, `)})`);
+
+  // Fetch organization-level sharing
+  const orgSharing = await db()
+    .select({
+      videoId: sharedVideos.videoId,
+      id: organizations.id,
+      name: organizations.name,
+      organizationId: organizations.id,
+      iconUrl: organizations.iconUrl,
+    })
+    .from(sharedVideos)
+    .innerJoin(organizations, eq(sharedVideos.organizationId, organizations.id))
+    .where(sql`${sharedVideos.videoId} IN (${sql.join(videoIds.map(id => sql`${id}`), sql`, `)})`);
+
+  // Combine and group by videoId
+  const sharedSpacesMap: Record<string, Array<{
+    id: string;
+    name: string;
+    organizationId: string;
+    iconUrl: string;
+    isOrg: boolean;
+  }>> = {};
+
+  // Add space-level sharing
+  spaceSharing.forEach(space => {
+    if (!sharedSpacesMap[space.videoId]) {
+      sharedSpacesMap[space.videoId] = [];
+    }
+    sharedSpacesMap[space.videoId].push({
+      id: space.id,
+      name: space.name,
+      organizationId: space.organizationId,
+      iconUrl: space.iconUrl || '',
+      isOrg: false,
+    });
+  });
+
+  // Add organization-level sharing
+  orgSharing.forEach(org => {
+    if (!sharedSpacesMap[org.videoId]) {
+      sharedSpacesMap[org.videoId] = [];
+    }
+    sharedSpacesMap[org.videoId].push({
+      id: org.id,
+      name: org.name,
+      organizationId: org.organizationId,
+      iconUrl: org.iconUrl || '',
+      isOrg: true,
+    });
+  });
+
+  return sharedSpacesMap;
+}
 
 export default async function CapsPage({
   searchParams,
@@ -88,57 +159,7 @@ export default async function CapsPage({
           JSON_ARRAY()
         )
       `,
-      sharedSpaces: sql<
-        {
-          id: string;
-          name: string;
-          organizationId: string;
-          iconUrl: string;
-          isOrg: boolean;
-        }[]
-      >`
-        COALESCE(
-          (
-            SELECT JSON_ARRAYAGG(
-              JSON_OBJECT(
-                'id', s.id,
-                'name', s.name,
-                'organizationId', s.organizationId,
-                'iconUrl', s.iconUrl,
-                'isOrg', s.isOrg
-              )
-            )
-            FROM (
-              -- Include spaces where the video is directly added via space_videos
-              SELECT DISTINCT
-                s.id,
-                s.name,
-                s.organizationId,
-                o.iconUrl as iconUrl,
-                FALSE as isOrg
-              FROM space_videos sv
-              JOIN spaces s ON sv.spaceId = s.id
-              JOIN organizations o ON s.organizationId = o.id
-              WHERE sv.videoId = videos.id
 
-              UNION
-
-              -- For organization-level sharing, include the organization details
-              -- and mark it as an organization with isOrg=TRUE
-              SELECT DISTINCT
-                o.id as id,
-                o.name as name,
-                o.id as organizationId,
-                o.iconUrl as iconUrl,
-                TRUE as isOrg
-              FROM shared_videos sv
-              JOIN organizations o ON sv.organizationId = o.id
-              WHERE sv.videoId = videos.id
-            ) AS s
-          ),
-          JSON_ARRAY()
-        )
-      `,
       ownerName: users.name,
       effectiveDate: sql<string>`
         COALESCE(
@@ -190,6 +211,10 @@ export default async function CapsPage({
       )
     );
 
+  // Fetch shared spaces data for all videos
+  const videoIds = videoData.map(video => video.id);
+  const sharedSpacesMap = await getSharedSpacesForVideos(videoIds);
+
   const processedVideoData = videoData.map((video) => {
     const { effectiveDate, ...videoWithoutEffectiveDate } = video;
 
@@ -199,7 +224,7 @@ export default async function CapsPage({
       sharedOrganizations: video.sharedOrganizations.filter(
         (organization) => organization.id !== null
       ),
-      sharedSpaces: video.sharedSpaces.filter((space) => space.id !== null),
+      sharedSpaces: sharedSpacesMap[video.id] || [],
       ownerName: video.ownerName ?? "",
       metadata: video.metadata as
         | {

--- a/apps/web/app/(org)/dashboard/caps/page.tsx
+++ b/apps/web/app/(org)/dashboard/caps/page.tsx
@@ -110,30 +110,30 @@ export default async function CapsPage({
             )
             FROM (
               -- Include spaces where the video is directly added via space_videos
-              SELECT DISTINCT 
-                s.id, 
-                s.name, 
-                s.organizationId, 
+              SELECT DISTINCT
+                s.id,
+                s.name,
+                s.organizationId,
                 o.iconUrl as iconUrl,
                 FALSE as isOrg
               FROM space_videos sv
               JOIN spaces s ON sv.spaceId = s.id
               JOIN organizations o ON s.organizationId = o.id
-              WHERE sv.videoId = ${videos.id}
-              
+              WHERE sv.videoId = videos.id
+
               UNION
-              
+
               -- For organization-level sharing, include the organization details
               -- and mark it as an organization with isOrg=TRUE
-              SELECT DISTINCT 
-                o.id as id, 
-                o.name as name, 
-                o.id as organizationId, 
+              SELECT DISTINCT
+                o.id as id,
+                o.name as name,
+                o.id as organizationId,
                 o.iconUrl as iconUrl,
                 TRUE as isOrg
               FROM shared_videos sv
               JOIN organizations o ON sv.organizationId = o.id
-              WHERE sv.videoId = ${videos.id}
+              WHERE sv.videoId = videos.id
             ) AS s
           ),
           JSON_ARRAY()

--- a/apps/web/app/(org)/dashboard/caps/page.tsx
+++ b/apps/web/app/(org)/dashboard/caps/page.tsx
@@ -221,10 +221,12 @@ export default async function CapsPage({
     return {
       ...videoWithoutEffectiveDate,
       foldersData,
-      sharedOrganizations: video.sharedOrganizations.filter(
-        (organization) => organization.id !== null
-      ),
-      sharedSpaces: sharedSpacesMap[video.id] || [],
+      sharedOrganizations: Array.isArray(video.sharedOrganizations)
+        ? video.sharedOrganizations.filter((organization) => organization.id !== null)
+        : [],
+      sharedSpaces: Array.isArray(sharedSpacesMap[video.id])
+        ? sharedSpacesMap[video.id]
+        : [],
       ownerName: video.ownerName ?? "",
       metadata: video.metadata as
         | {


### PR DESCRIPTION
### Issue

Dashboard was crashing because of broken SQL queries that couldn't properly reference video IDs. This PR fixes the crash, addressing the issue #721.

A test build with this patch can be pulled here:

```
docker pull ghcr.io/mogita/cap-web:fix-videos-id-error.3
```

### What Changed

Split one complex query into separate simpler procedures to avoid correlation errors.

### Why The Approach

Raw SQL is powerful but can miss proper correlation syntax. By using simpler queries, it's more reliable and easier to debug when things go wrong.
