### PR TITLE
fix: video playback failure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,7 @@ NEXT_PUBLIC_CAP_AWS_BUCKET=capso
 NEXT_PUBLIC_CAP_AWS_REGION=us-east-1
 # If you're not using AWS S3, point this to your custom S3 provider (default points to MinIO created by `pnpm dev`)
 NEXT_PUBLIC_CAP_AWS_ENDPOINT=http://localhost:3902
+CAP_AWS_ENDPOINT=${NEXT_PUBLIC_CAP_AWS_ENDPOINT}
 # If using a proxy such as CloudFront, set this the full URL of the bucket
 # NEXT_PUBLIC_CAP_AWS_BUCKET_URL=https://v.cap.so
 

--- a/apps/web/app/api/playlist/route.ts
+++ b/apps/web/app/api/playlist/route.ts
@@ -73,8 +73,11 @@ const app = new Hono()
 
       const bucket = await createBucketProvider(customBucket);
 
+      // Handle case where source is a JSON string instead of parsed object
+      const source = typeof video.source === "string" ? JSON.parse(video.source) : video.source;
+
       if (!customBucket || video.awsBucket === serverEnv().CAP_AWS_BUCKET) {
-        if (video.source.type === "desktopMP4") {
+        if (source.type === "desktopMP4") {
           return c.redirect(
             await bucket.getSignedObjectUrl(
               `${video.ownerId}/${videoId}/result.mp4`
@@ -82,7 +85,7 @@ const app = new Hono()
           );
         }
 
-        if (video.source.type === "MediaConvert") {
+        if (source.type === "MediaConvert") {
           return c.redirect(
             await bucket.getSignedObjectUrl(
               `${video.ownerId}/${videoId}/output/video_recording_000.m3u8`
@@ -125,7 +128,7 @@ const app = new Hono()
       const audioPrefix = `${video.ownerId}/${videoId}/audio/`;
 
       try {
-        if (video.source.type === "local") {
+        if (source.type === "local") {
           const playlistText =
             (await bucket.getObject(
               `${video.ownerId}/${videoId}/combined-source/stream.m3u8`
@@ -150,7 +153,7 @@ const app = new Hono()
           });
         }
 
-        if (video.source.type === "desktopMP4") {
+        if (source.type === "desktopMP4") {
           const playlistUrl = await bucket.getSignedObjectUrl(
             `${video.ownerId}/${videoId}/result.mp4`
           );

--- a/apps/web/app/embed/[videoId]/_components/EmbedVideo.tsx
+++ b/apps/web/app/embed/[videoId]/_components/EmbedVideo.tsx
@@ -141,17 +141,20 @@ export const EmbedVideo = forwardRef<
     let videoSrc: string;
     let enableCrossOrigin = false;
 
-    if (data.source.type === "desktopMP4") {
+    // Handle case where source is a JSON string instead of parsed object
+    const source = typeof data.source === "string" ? JSON.parse(data.source) : data.source;
+
+    if (source.type === "desktopMP4") {
       videoSrc = `/api/playlist?userId=${data.ownerId}&videoId=${data.id}&videoType=mp4`;
       // Start with CORS enabled for desktopMP4, but CapVideoPlayer will dynamically disable if needed
       enableCrossOrigin = true;
     } else if (
       NODE_ENV === "development" ||
       ((data.skipProcessing === true || data.jobStatus !== "COMPLETE") &&
-        data.source.type === "MediaConvert")
+        source.type === "MediaConvert")
     ) {
       videoSrc = `/api/playlist?userId=${data.ownerId}&videoId=${data.id}&videoType=master`;
-    } else if (data.source.type === "MediaConvert") {
+    } else if (source.type === "MediaConvert") {
       videoSrc = `${publicEnv.s3BucketUrl}/${data.ownerId}/${data.id}/output/video_recording_000.m3u8`;
     } else {
       videoSrc = `${publicEnv.s3BucketUrl}/${data.ownerId}/${data.id}/combined-source/stream.m3u8`;
@@ -187,7 +190,7 @@ export const EmbedVideo = forwardRef<
       <>
 
         <div className="relative w-screen h-screen rounded-xl">
-          {data.source.type === "desktopMP4" ? (
+          {source.type === "desktopMP4" ? (
             <CapVideoPlayer
               mediaPlayerClassName="w-full h-full"
               videoSrc={videoSrc}

--- a/apps/web/app/s/[videoId]/_components/ShareVideo.tsx
+++ b/apps/web/app/s/[videoId]/_components/ShareVideo.tsx
@@ -115,17 +115,20 @@ export const ShareVideo = forwardRef<
   let videoSrc: string;
   let enableCrossOrigin = false;
 
-  if (data.source.type === "desktopMP4") {
+  // Handle case where source is a JSON string instead of parsed object
+  const source = typeof data.source === "string" ? JSON.parse(data.source) : data.source;
+
+  if (source.type === "desktopMP4") {
     videoSrc = `/api/playlist?userId=${data.ownerId}&videoId=${data.id}&videoType=mp4`;
     // Start with CORS enabled for desktopMP4, but CapVideoPlayer will dynamically disable if needed
     enableCrossOrigin = true;
   } else if (
     NODE_ENV === "development" ||
     ((data.skipProcessing === true || data.jobStatus !== "COMPLETE") &&
-      data.source.type === "MediaConvert")
+      source.type === "MediaConvert")
   ) {
     videoSrc = `/api/playlist?userId=${data.ownerId}&videoId=${data.id}&videoType=master`;
-  } else if (data.source.type === "MediaConvert") {
+  } else if (source.type === "MediaConvert") {
     videoSrc = `${publicEnv.s3BucketUrl}/${data.ownerId}/${data.id}/output/video_recording_000.m3u8`;
   } else {
     videoSrc = `${publicEnv.s3BucketUrl}/${data.ownerId}/${data.id}/combined-source/stream.m3u8`;
@@ -135,7 +138,7 @@ export const ShareVideo = forwardRef<
     <>
 
       <div className="relative h-full">
-        {data.source.type === "desktopMP4" ? (
+        {source.type === "desktopMP4" ? (
           <CapVideoPlayer
             mediaPlayerClassName="w-full h-full max-w-full max-h-full rounded-xl"
             videoSrc={videoSrc}


### PR DESCRIPTION
Changes:

- [x] Parse `data.source` when it's a JSON string instead of an object, causing incorrect `videoSrc` returned, and eventually causing the video playback to fail when the type if `desktopMP4` (the browser would be guided to attempt the m3u8 file, while in case of desktopMP4 no m3u8 was generated).