### PR TITLE
Fix upgrade modal redirect logic

### DIFF
--- a/apps/web/app/(org)/onboarding/Onboarding.tsx
+++ b/apps/web/app/(org)/onboarding/Onboarding.tsx
@@ -33,10 +33,13 @@ export const Onboarding = () => {
       if (response.ok) {
         const data = await response.json();
 
-        if (!data.isMemberOfOrganization) setShowUpgradeModal(true);
+        if (!data.isMemberOfOrganization) {
+          setShowUpgradeModal(true);
+        } else {
+          router.push("/dashboard");
+        }
 
         toast.success("Name updated successfully");
-        router.push("/dashboard");
       } else {
         toast.error("Failed to update name");
       }


### PR DESCRIPTION
## Summary
- ensure the onboarding page only redirects to the dashboard if the user already belongs to an organization

## Testing
- `pnpm lint` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6884a9947ac88332a02fa2eb1761cc4f