### PR TITLE
feat: Add configurable recording countdown feature

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -21,6 +21,20 @@ pub enum MainWindowRecordingStartBehaviour {
     Minimise,
 }
 
+#[derive(Serialize, Deserialize, Type, Debug, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
+pub enum RecordingCountdown {
+    Off,
+    Three,
+    Five,
+}
+
+impl Default for RecordingCountdown {
+    fn default() -> Self {
+        RecordingCountdown::Three
+    }
+}
+
 #[derive(Serialize, Deserialize, Type, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct GeneralSettingsStore {
@@ -57,6 +71,8 @@ pub struct GeneralSettingsStore {
     pub custom_cursor_capture: bool,
     #[serde(default = "default_server_url")]
     pub server_url: String,
+    #[serde(default)]
+    pub recording_countdown: RecordingCountdown,
     #[serde(default, alias = "open_editor_after_recording")]
     #[deprecated]
     _open_editor_after_recording: bool,
@@ -96,6 +112,7 @@ impl Default for GeneralSettingsStore {
             main_window_recording_start_behaviour: MainWindowRecordingStartBehaviour::Close,
             custom_cursor_capture: false,
             server_url: default_server_url(),
+            recording_countdown: RecordingCountdown::Three,
             _open_editor_after_recording: false,
         }
     }

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -455,25 +455,7 @@ pub async fn start_recording(
         }
     });
 
-    if let Some(window) = CapWindowId::Main.get(&app) {
-        match GeneralSettingsStore::get(&app)
-            .ok()
-            .flatten()
-            .map(|s| s.main_window_recording_start_behaviour)
-            .unwrap_or_default()
-        {
-            MainWindowRecordingStartBehaviour::Close => {
-                let _ = window.close();
-            }
-            MainWindowRecordingStartBehaviour::Minimise => {
-                let _ = window.minimize();
-            }
-        }
-    }
-
-    if let Some(window) = CapWindowId::InProgressRecording.get(&app) {
-        window.eval("window.location.reload()").ok();
-    } else {
+    if CapWindowId::InProgressRecording.get(&app).is_none() {
         let _ = ShowCapWindow::InProgressRecording { position: None }
             .show(&app)
             .await;

--- a/apps/desktop/src/routes/(window-chrome)/(main).tsx
+++ b/apps/desktop/src/routes/(window-chrome)/(main).tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "@solidjs/router";
 import {
   createMutation,
   createQuery,
-  useQueryClient
+  useQueryClient,
 } from "@tanstack/solid-query";
 import { getVersion } from "@tauri-apps/api/app";
 import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
@@ -191,11 +191,18 @@ function Page() {
   const toggleRecording = createMutation(() => ({
     mutationFn: async () => {
       if (!isRecording()) {
-        await commands.startRecording({
-          capture_target: options.target(),
-          mode: rawOptions.mode,
-          capture_system_audio: rawOptions.captureSystemAudio,
-        });
+        const settings = await generalSettingsStore.get();
+
+        await commands.showWindow({ InProgressRecording: { position: null } });
+
+        const mainWindow = getCurrentWindow();
+        const mainWindowBehavior =
+          settings?.mainWindowRecordingStartBehaviour ?? "close";
+        if (mainWindowBehavior === "close") {
+          await mainWindow.close();
+        } else if (mainWindowBehavior === "minimise") {
+          await mainWindow.minimize();
+        }
       } else await commands.stopRecording();
     },
   }));
@@ -296,16 +303,17 @@ function Page() {
                     await commands.showWindow("Upgrade");
                   }
                 }}
-                class={`text-[0.6rem] ${license.data?.type === "pro"
-                  ? "bg-[--blue-400] text-gray-1 dark:text-gray-12"
-                  : "bg-gray-3 cursor-pointer hover:bg-gray-5"
-                  } rounded-lg px-1.5 py-0.5`}
+                class={`text-[0.6rem] ${
+                  license.data?.type === "pro"
+                    ? "bg-[--blue-400] text-gray-1 dark:text-gray-12"
+                    : "bg-gray-3 cursor-pointer hover:bg-gray-5"
+                } rounded-lg px-1.5 py-0.5`}
               >
                 {license.data?.type === "commercial"
                   ? "Commercial"
                   : license.data?.type === "pro"
-                    ? "Pro"
-                    : "Personal"}
+                  ? "Pro"
+                  : "Personal"}
               </span>
             </Suspense>
           </ErrorBoundary>
@@ -336,7 +344,7 @@ function Page() {
             "flex flex-row items-center rounded-[0.5rem] relative border h-8 transition-all duration-500",
             (rawOptions.captureTarget.variant === "screen" ||
               rawOptions.captureTarget.variant === "area") &&
-            "ml-[2.4rem]"
+              "ml-[2.4rem]"
           )}
           style={{
             "transition-timing-function":
@@ -575,8 +583,8 @@ function AreaSelectButton(props: {
         props.targetVariant === "area"
           ? "Remove selection"
           : areaSelection.pending
-            ? "Selecting area..."
-            : "Select area"
+          ? "Selecting area..."
+          : "Select area"
       }
       childClass="flex fixed flex-row items-center w-8 h-8"
     >
@@ -647,7 +655,7 @@ function AreaSelectButton(props: {
                 class={cx(
                   "w-[1rem] h-[1rem]",
                   areaSelection.pending &&
-                  "animate-gentle-bounce duration-1000 text-gray-12 mt-1"
+                    "animate-gentle-bounce duration-1000 text-gray-12 mt-1"
                 )}
               />
             </button>
@@ -971,8 +979,8 @@ function TargetSelectInfoPill<T>(props: {
       {!props.permissionGranted
         ? "Request Permission"
         : props.value !== null
-          ? "On"
-          : "Off"}
+        ? "On"
+        : "Off"}
     </InfoPill>
   );
 }

--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -16,6 +16,7 @@ import {
   type GeneralSettingsStore,
   type MainWindowRecordingStartBehaviour,
   type PostStudioRecordingBehaviour,
+  type RecordingCountdown,
 } from "~/utils/tauri";
 // import { themeStore } from "~/store/theme";
 import { CheckMenuItem, Menu } from "@tauri-apps/api/menu";
@@ -115,6 +116,7 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
       hideDockIcon: false,
       autoCreateShareableLink: false,
       enableNotifications: true,
+      recordingCountdown: "three",
     }
   );
 
@@ -143,8 +145,8 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
     label: string;
     type: "select";
     description: string;
-    value: MainWindowRecordingStartBehaviour | PostStudioRecordingBehaviour;
-    onChange: (value: MainWindowRecordingStartBehaviour | PostStudioRecordingBehaviour) => void | Promise<void>;
+    value: MainWindowRecordingStartBehaviour | PostStudioRecordingBehaviour | RecordingCountdown;
+    onChange: (value: MainWindowRecordingStartBehaviour | PostStudioRecordingBehaviour | RecordingCountdown) => void | Promise<void>;
   };
 
   type SettingItem = ToggleSettingItem | SelectSettingItem;
@@ -195,11 +197,19 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
       title: "Recording",
       items: [
         {
+          label: "Recording countdown",
+          description: "Countdown before recording starts",
+          type: "select",
+          get value() { return settings.recordingCountdown ?? "three"; },
+          onChange: (value: MainWindowRecordingStartBehaviour | PostStudioRecordingBehaviour | RecordingCountdown) =>
+            handleChange("recordingCountdown", value as RecordingCountdown),
+        },
+        {
           label: "Main window recording start behaviour",
           description: "The main window recording start behaviour",
           type: "select",
           get value() { return settings.mainWindowRecordingStartBehaviour ?? "close"; },
-          onChange: (value: MainWindowRecordingStartBehaviour | PostStudioRecordingBehaviour) =>
+          onChange: (value: MainWindowRecordingStartBehaviour | PostStudioRecordingBehaviour | RecordingCountdown) =>
             handleChange("mainWindowRecordingStartBehaviour", value as MainWindowRecordingStartBehaviour),
         },
         {
@@ -207,7 +217,7 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
           description: "The studio recording finish behaviour",
           type: "select",
           get value() { return settings.postStudioRecordingBehaviour ?? "openEditor"; },
-          onChange: (value: MainWindowRecordingStartBehaviour | PostStudioRecordingBehaviour) =>
+          onChange: (value: MainWindowRecordingStartBehaviour | PostStudioRecordingBehaviour | RecordingCountdown) =>
             handleChange("postStudioRecordingBehaviour", value as PostStudioRecordingBehaviour),
         },
       ],
@@ -339,6 +349,18 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
                             [
                               { text: "Open editor", value: "openEditor" },
                               { text: "Show in overlay", value: "showOverlay" },
+                            ]
+                          );
+                        } else if (item.label === "Recording countdown") {
+                          return renderRecordingSelect(
+                            item.label,
+                            item.description,
+                            item.value,
+                            item.onChange,
+                            [
+                              { text: "Off", value: "off" },
+                              { text: "3 seconds", value: "three" },
+                              { text: "5 seconds", value: "five" },
                             ]
                           );
                         }

--- a/apps/desktop/src/routes/in-progress-recording.tsx
+++ b/apps/desktop/src/routes/in-progress-recording.tsx
@@ -4,23 +4,43 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import * as dialog from "@tauri-apps/plugin-dialog";
 import { type as ostype } from "@tauri-apps/plugin-os";
 import { cx } from "cva";
-import { createEffect, createSignal, type ComponentProps } from "solid-js";
+import {
+  createEffect,
+  createSignal,
+  type ComponentProps,
+  Show,
+  onMount,
+  onCleanup,
+} from "solid-js";
 import { createStore, produce } from "solid-js/store";
+
+import IconCapStopCircle from "~icons/cap/stop-circle";
+import IconCapMicrophone from "~icons/cap/microphone";
+import IconLucideMicOff from "~icons/lucide/mic-off";
+import IconCapPlayCircle from "~icons/cap/play-circle";
+import IconCapPauseCircle from "~icons/cap/pause-circle";
+import IconCapRestart from "~icons/cap/restart";
+import IconCapTrash from "~icons/cap/trash";
+import IconCapMoreVertical from "~icons/cap/more-vertical";
 
 import {
   createCurrentRecordingQuery,
   createOptionsQuery,
 } from "~/utils/queries";
 import { commands, events } from "~/utils/tauri";
+import { generalSettingsStore } from "~/store";
 
-type State = "recording" | "paused" | "stopped";
+type State = "countdown" | "recording" | "paused" | "stopped";
 
 export default function () {
-  const start = Date.now();
+  const [countdown, setCountdown] = createSignal<number>(0);
+  const [countdownDuration, setCountdownDuration] = createSignal<number>(3);
+  const [start, setStart] = createSignal(Date.now());
   const [time, setTime] = createSignal(Date.now());
   const [state, setState] = createSignal<State>("recording");
   const currentRecording = createCurrentRecordingQuery();
-  const { rawOptions } = createOptionsQuery();
+  const optionsQuery = createOptionsQuery();
+  let countdownInterval: ReturnType<typeof setInterval> | undefined;
 
   const audioLevel = createAudioInputLevel();
 
@@ -31,6 +51,66 @@ export default function () {
         { pause: number; resume?: number }
       ]
   >([]);
+
+  onMount(async () => {
+    const settings = await generalSettingsStore.get();
+    const countdownSetting = settings?.recordingCountdown ?? "three";
+
+    const unlistenRecordingStarted = await events.recordingStarted.listen(
+      () => {
+        setState("recording");
+        setStart(Date.now());
+      }
+    );
+
+    const { rawOptions } = optionsQuery;
+
+    if (countdownSetting !== "off") {
+      setState("countdown");
+      const countdownSeconds = countdownSetting === "five" ? 5 : 3;
+      setCountdown(countdownSeconds);
+      setCountdownDuration(countdownSeconds);
+
+      countdownInterval = setInterval(() => {
+        setCountdown((c) => {
+          if (c <= 1) {
+            clearInterval(countdownInterval!);
+            countdownInterval = undefined;
+            if (rawOptions) {
+              commands
+                .startRecording({
+                  capture_target: rawOptions.captureTarget,
+                  mode: rawOptions.mode,
+                  capture_system_audio: rawOptions.captureSystemAudio,
+                })
+                .catch((err) =>
+                  console.error("Failed to start recording:", err)
+                );
+            }
+            return 0;
+          }
+          return c - 1;
+        });
+      }, 1000);
+    } else {
+      if (rawOptions) {
+        commands
+          .startRecording({
+            capture_target: rawOptions.captureTarget,
+            mode: rawOptions.mode,
+            capture_system_audio: rawOptions.captureSystemAudio,
+          })
+          .catch((err) => console.error("Failed to start recording:", err));
+      }
+    }
+
+    onCleanup(() => {
+      unlistenRecordingStarted();
+      if (countdownInterval) {
+        clearInterval(countdownInterval);
+      }
+    });
+  });
 
   createTimer(
     () => {
@@ -43,6 +123,7 @@ export default function () {
 
   createEffect(() => {
     if (
+      state() === "stopped" &&
       !currentRecording.isPending &&
       (currentRecording.data === undefined || currentRecording.data === null)
     )
@@ -108,7 +189,8 @@ export default function () {
   }));
 
   const adjustedTime = () => {
-    let t = time() - start;
+    if (state() === "countdown") return 0;
+    let t = time() - start();
     for (const { pause, resume } of pauseResumes) {
       if (pause && resume) t -= resume - pause;
     }
@@ -118,74 +200,147 @@ export default function () {
   return (
     <div class="flex flex-row items-stretch w-full h-full bg-gray-1 animate-in fade-in">
       <div class="flex flex-row justify-between p-[0.25rem] flex-1">
-        <button
-          disabled={stopRecording.isPending}
-          class="py-[0.25rem] px-[0.5rem] text-red-300 gap-[0.25rem] flex flex-row items-center rounded-lg transition-opacity disabled:opacity-60"
-          type="button"
-          onClick={() => stopRecording.mutate()}
-        >
-          <IconCapStopCircle />
-          <span class="font-[500] text-[0.875rem] tabular-nums">
-            {formatTime(adjustedTime() / 1000)}
-          </span>
-        </button>
+        <Show when={state() === "countdown"}>
+          <div class="flex items-center gap-3 px-3 flex-1">
+            <div class="text-gray-11 text-xs flex-1">
+              Recording starting soon.
+            </div>
+
+            <button
+              onClick={() => {
+                if (countdownInterval) {
+                  clearInterval(countdownInterval);
+                  countdownInterval = undefined;
+                }
+                setCountdown(0);
+                const { rawOptions } = optionsQuery;
+                if (rawOptions) {
+                  commands
+                    .startRecording({
+                      capture_target: rawOptions.captureTarget,
+                      mode: rawOptions.mode,
+                      capture_system_audio: rawOptions.captureSystemAudio,
+                    })
+                    .catch((err) =>
+                      console.error("Failed to start recording:", err)
+                    );
+                }
+              }}
+              class="text-red-300 text-sm font-medium hover:text-red-400 hover:bg-gray-3 px-3 py-2 rounded-md transition-all flex items-center gap-2"
+              type="button"
+            >
+              Continue
+              <div class="relative w-5 h-5">
+                <svg
+                  class="absolute inset-0 w-5 h-5 -rotate-90"
+                  viewBox="0 0 20 20"
+                >
+                  <circle
+                    cx="10"
+                    cy="10"
+                    r="8"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    opacity="0.2"
+                  />
+                  <circle
+                    cx="10"
+                    cy="10"
+                    r="8"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-dasharray={`${
+                      (countdown() / countdownDuration()) * 50.265
+                    } 50.265`}
+                    stroke-linecap="round"
+                    class="transition-all duration-1000 ease-linear"
+                  />
+                </svg>
+                <span class="absolute inset-0 flex items-center justify-center text-xs">
+                  {countdown()}
+                </span>
+              </div>
+            </button>
+          </div>
+        </Show>
+        <Show when={state() !== "countdown"}>
+          <button
+            disabled={stopRecording.isPending}
+            class="py-[0.25rem] px-[0.5rem] text-red-300 gap-[0.25rem] flex flex-row items-center rounded-lg transition-opacity disabled:opacity-60"
+            type="button"
+            onClick={() => stopRecording.mutate()}
+          >
+            <IconCapStopCircle />
+            <span class="font-[500] text-[0.875rem] tabular-nums">
+              {formatTime(adjustedTime() / 1000)}
+            </span>
+          </button>
+        </Show>
 
         <div class="flex gap-1 items-center">
-          <div class="flex relative justify-center items-center w-8 h-8">
-            {rawOptions.micName != null ? (
-              <>
-                <IconCapMicrophone class="size-5 text-gray-12" />
-                <div class="absolute bottom-1 left-1 right-1 h-0.5 bg-gray-10 overflow-hidden rounded-full">
-                  <div
-                    class="absolute inset-0 transition-transform duration-100 bg-blue-9"
-                    style={{
-                      transform: `translateX(-${(1 - audioLevel()) * 100}%)`,
-                    }}
-                  />
-                </div>
-              </>
-            ) : (
-              <IconLucideMicOff
-                class="text-gray-7 size-5"
-                data-tauri-drag-region
-              />
-            )}
-          </div>
-
-          {(currentRecording.data?.type === "studio" ||
-            ostype() === "macos") && (
-            <ActionButton
-              disabled={togglePause.isPending}
-              onClick={() => togglePause.mutate()}
-            >
-              {state() === "paused" ? (
-                <IconCapPlayCircle />
+          <Show when={state() !== "countdown"}>
+            <div class="flex relative justify-center items-center w-8 h-8">
+              {optionsQuery.rawOptions.micName != null ? (
+                <>
+                  <IconCapMicrophone class="size-5 text-gray-12" />
+                  <div class="absolute bottom-1 left-1 right-1 h-0.5 bg-gray-10 overflow-hidden rounded-full">
+                    <div
+                      class="absolute inset-0 transition-transform duration-100 bg-blue-9"
+                      style={{
+                        transform: `translateX(-${(1 - audioLevel()) * 100}%)`,
+                      }}
+                    />
+                  </div>
+                </>
               ) : (
-                <IconCapPauseCircle />
+                <IconLucideMicOff
+                  class="text-gray-7 size-5"
+                  data-tauri-drag-region
+                />
               )}
-            </ActionButton>
-          )}
+            </div>
+          </Show>
 
-          <ActionButton
-            disabled={restartRecording.isPending}
-            onClick={() => restartRecording.mutate()}
-          >
-            <IconCapRestart />
-          </ActionButton>
-          <ActionButton
-            disabled={deleteRecording.isPending}
-            onClick={() => deleteRecording.mutate()}
-          >
-            <IconCapTrash />
-          </ActionButton>
+          <Show when={state() !== "countdown"}>
+            {(currentRecording.data?.type === "studio" ||
+              ostype() === "macos") && (
+              <ActionButton
+                disabled={togglePause.isPending}
+                onClick={() => togglePause.mutate()}
+              >
+                {state() === "paused" ? (
+                  <IconCapPlayCircle />
+                ) : (
+                  <IconCapPauseCircle />
+                )}
+              </ActionButton>
+            )}
+
+            <ActionButton
+              disabled={restartRecording.isPending}
+              onClick={() => restartRecording.mutate()}
+            >
+              <IconCapRestart />
+            </ActionButton>
+            <ActionButton
+              disabled={deleteRecording.isPending}
+              onClick={() => deleteRecording.mutate()}
+            >
+              <IconCapTrash />
+            </ActionButton>
+          </Show>
         </div>
       </div>
-      <div
-        class="non-styled-move cursor-move flex items-center justify-center p-[0.25rem] border-l border-gray-5 hover:cursor-move"
-        data-tauri-drag-region
-      >
-        <IconCapMoreVertical class="pointer-events-none text-gray-10" />
-      </div>
+      <Show when={state() !== "countdown"}>
+        <div
+          class="non-styled-move cursor-move flex items-center justify-center p-[0.25rem] border-l border-gray-5 hover:cursor-move"
+          data-tauri-drag-region
+        >
+          <IconCapMoreVertical class="pointer-events-none text-gray-10" />
+        </div>
+      </Show>
     </div>
   );
 }
@@ -195,9 +350,10 @@ function ActionButton(props: ComponentProps<"button">) {
     <button
       {...props}
       class={cx(
-        "p-[0.25rem] rounded-lg transition-colors",
+        "p-[0.25rem] rounded-lg transition-all",
         "text-gray-11",
         "h-8 w-8 flex items-center justify-center",
+        "disabled:opacity-50 disabled:cursor-not-allowed",
         props.class
       )}
       type="button"

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -330,7 +330,7 @@ export type ExportEstimates = { duration_seconds: number; estimated_time_seconds
 export type ExportSettings = ({ format: "Mp4" } & Mp4ExportSettings) | ({ format: "Gif" } & GifExportSettings)
 export type Flags = { captions: boolean }
 export type FramesRendered = { renderedCount: number; totalFrames: number; type: "FramesRendered" }
-export type GeneralSettingsStore = { instanceId?: string; uploadIndividualFiles?: boolean; hideDockIcon?: boolean; hapticsEnabled?: boolean; autoCreateShareableLink?: boolean; enableNotifications?: boolean; disableAutoOpenLinks?: boolean; hasCompletedStartup?: boolean; theme?: AppTheme; commercialLicense?: CommercialLicense | null; lastVersion?: string | null; windowTransparency?: boolean; postStudioRecordingBehaviour?: PostStudioRecordingBehaviour; mainWindowRecordingStartBehaviour?: MainWindowRecordingStartBehaviour; customCursorCapture?: boolean; serverUrl?: string; 
+export type GeneralSettingsStore = { instanceId?: string; uploadIndividualFiles?: boolean; hideDockIcon?: boolean; hapticsEnabled?: boolean; autoCreateShareableLink?: boolean; enableNotifications?: boolean; disableAutoOpenLinks?: boolean; hasCompletedStartup?: boolean; theme?: AppTheme; commercialLicense?: CommercialLicense | null; lastVersion?: string | null; windowTransparency?: boolean; postStudioRecordingBehaviour?: PostStudioRecordingBehaviour; mainWindowRecordingStartBehaviour?: MainWindowRecordingStartBehaviour; customCursorCapture?: boolean; serverUrl?: string; recordingCountdown?: RecordingCountdown; 
 /**
  * @deprecated
  */
@@ -361,6 +361,7 @@ export type Preset = { name: string; config: ProjectConfiguration }
 export type PresetsStore = { presets: Preset[]; default: number | null }
 export type ProjectConfiguration = { aspectRatio: AspectRatio | null; background: BackgroundConfiguration; camera: Camera; audio: AudioConfiguration; cursor: CursorConfiguration; hotkeys: HotkeysConfiguration; timeline?: TimelineConfiguration | null; captions?: CaptionsData | null }
 export type ProjectRecordingsMeta = { segments: SegmentRecordings[] }
+export type RecordingCountdown = "off" | "three" | "five"
 export type RecordingMeta = (StudioRecordingMeta | InstantRecordingMeta) & { platform: Platform | null; pretty_name: string; sharing?: SharingMeta | null }
 export type RecordingMetaWithType = ((StudioRecordingMeta | InstantRecordingMeta) & { platform: Platform | null; pretty_name: string; sharing?: SharingMeta | null }) & { type: RecordingType }
 export type RecordingMode = "studio" | "instant"


### PR DESCRIPTION
Introduces a 'recordingCountdown' setting to general settings, allowing users to select a countdown (off, 3s, 5s) before recording starts. Updates UI and logic to support countdown display and flow, and refactors main window recording start behavior handling.