### PR TITLE
Add OSS Friends page and loading skeleton

### DIFF
--- a/apps/web/app/(site)/oss-friends/loading.tsx
+++ b/apps/web/app/(site)/oss-friends/loading.tsx
@@ -1,0 +1,37 @@
+export default function Loading() {
+  return (
+    <div className="mt-[120px]">
+      <div className="relative z-10 px-5 pt-24 pb-36 w-full">
+        <div className="mx-auto text-center wrapper wrapper-sm mb-16">
+          <div className="animate-pulse">
+            <div className="h-16 bg-gray-200 rounded-lg mb-4 max-w-md mx-auto"></div>
+            <div className="h-6 bg-gray-200 rounded-lg mb-2 max-w-2xl mx-auto"></div>
+            <div className="h-6 bg-gray-200 rounded-lg mb-2 max-w-xl mx-auto"></div>
+            <div className="h-6 bg-gray-200 rounded-lg max-w-lg mx-auto"></div>
+          </div>
+        </div>
+
+        <div className="max-w-6xl mx-auto">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {Array.from({ length: 9 }).map((_, index) => (
+              <div
+                key={index}
+                className="animate-pulse bg-white border border-gray-200 rounded-lg p-6"
+              >
+                <div className="flex items-start justify-between mb-3">
+                  <div className="h-6 bg-gray-200 rounded flex-1 mr-2"></div>
+                  <div className="w-5 h-5 bg-gray-200 rounded"></div>
+                </div>
+                <div className="space-y-2">
+                  <div className="h-4 bg-gray-200 rounded"></div>
+                  <div className="h-4 bg-gray-200 rounded w-3/4"></div>
+                  <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(site)/oss-friends/page.tsx
+++ b/apps/web/app/(site)/oss-friends/page.tsx
@@ -1,0 +1,84 @@
+import { Metadata } from "next";
+import { ExternalLink } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "OSS Friends — Cap",
+  description:
+    "Discover amazing open source projects and tools built by our friends in the community.",
+};
+
+interface OSSFriend {
+  name: string;
+  description: string;
+  href: string;
+}
+
+interface OSSFriendsResponse {
+  data: OSSFriend[];
+}
+
+async function fetchOSSFriends(): Promise<OSSFriendsResponse> {
+  const response = await fetch("https://formbricks.com/api/oss-friends", {
+    next: { revalidate: 3600 },
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch OSS friends");
+  }
+
+  const data = await response.json();
+
+  const filteredData = {
+    ...data,
+    data: data.data.filter((friend: any) => friend.name !== "Cap"),
+  };
+
+  return filteredData;
+}
+
+export default async function OSSFriends() {
+  const data = await fetchOSSFriends();
+
+  return (
+    <div className="mt-[120px]">
+      <div className="relative z-10 px-5 pt-24 pb-36 w-full">
+        <div className="mx-auto text-center wrapper wrapper-sm mb-16">
+          <h1 className="fade-in-down text-[2rem] leading-[2.5rem] md:text-[3.75rem] md:leading-[4rem] relative z-10 text-black mb-4">
+            OSS Friends
+          </h1>
+          <p className="mx-auto mb-8 max-w-3xl text-md sm:text-xl text-zinc-500 fade-in-down animate-delay-1">
+            Discover amazing open source projects and tools built by our friends
+            in the community.
+          </p>
+        </div>
+
+        <div className="max-w-6xl mx-auto">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 fade-in-up animate-delay-2">
+            {data.data.map((friend, index) => (
+              <a
+                key={friend.name}
+                href={friend.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group bg-white border border-gray-200 rounded-lg p-6 hover:border-gray-300 hover:shadow-md transition-all duration-200 hover:-translate-y-1"
+                style={{
+                  animationDelay: `${index * 50}ms`,
+                }}
+              >
+                <div className="flex items-start justify-between mb-3">
+                  <h3 className="text-lg font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
+                    {friend.name}
+                  </h3>
+                  <ExternalLink className="w-5 h-5 text-gray-400 group-hover:text-blue-600 transition-colors flex-shrink-0 ml-2" />
+                </div>
+                <p className="text-gray-600 text-sm leading-relaxed">
+                  {friend.description}
+                </p>
+              </a>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Introduces a new OSS Friends page at /oss-friends, displaying open source projects from the community (excluding Cap) fetched from an external API. Also adds a loading skeleton for improved UX during data fetch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new page showcasing a curated list of open source software friends, each with a description and external link.
  * Added animated loading placeholders to enhance the user experience while data is being fetched.

* **Style**
  * Implemented visually appealing card layouts with responsive design, hover effects, and fade-in animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->