### PR TITLE
ignore and warn about frames that have underflowing timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,6 +895,7 @@ dependencies = [
  "cidre",
  "clap",
  "inquire",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/camera-avfoundation/Cargo.toml
+++ b/crates/camera-avfoundation/Cargo.toml
@@ -12,3 +12,6 @@ workspace = true
 [dev-dependencies]
 clap = { version = "4.5.40", features = ["derive"] }
 inquire = "0.7.5"
+
+[dependencies]
+tracing.workspace = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of timestamp calculations to prevent errors when the current presentation timestamp is earlier than the stream start, avoiding potential crashes and logging a warning instead.

* **Chores**
  * Updated dependencies to include workspace-wide support for tracing and reorganized import statements for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->