### PR TITLE
Fix camera and mic permissions

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1678,7 +1678,7 @@ fn open_external_link(app: tauri::AppHandle, url: String) -> Result<(), String> 
 
 #[tauri::command]
 #[specta::specta]
-async fn reset_camera_permissions(_app: AppHandle) -> Result<(), ()> {
+async fn reset_camera_permissions(_app: AppHandle) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
         #[cfg(debug_assertions)]
@@ -1692,7 +1692,7 @@ async fn reset_camera_permissions(_app: AppHandle) -> Result<(), ()> {
             .arg("Camera")
             .arg(bundle_id)
             .output()
-            .expect("Failed to reset camera permissions");
+            .map_err(|_| "Failed to reset camera permissions".to_string())?;
     }
 
     Ok(())

--- a/apps/desktop/src-tauri/src/permissions.rs
+++ b/apps/desktop/src-tauri/src/permissions.rs
@@ -61,15 +61,28 @@ pub fn open_permission_settings(permission: OSPermission) {
 pub async fn request_permission(permission: OSPermission) {
     #[cfg(target_os = "macos")]
     {
+        use futures::executor::block_on;
+
         match permission {
             OSPermission::ScreenRecording => {
                 scap::request_permission();
             }
             OSPermission::Camera => {
-                av::CaptureDevice::request_access_for_media_type(av::MediaType::video());
+                println!("BRUH");
+                std::thread::spawn(|| {
+                    let res = block_on(av::CaptureDevice::request_access_for_media_type(
+                        av::MediaType::video(),
+                    ));
+
+                    dbg!(res);
+                });
             }
             OSPermission::Microphone => {
-                av::CaptureDevice::request_access_for_media_type(av::MediaType::audio());
+                std::thread::spawn(|| {
+                    block_on(av::CaptureDevice::request_access_for_media_type(
+                        av::MediaType::audio(),
+                    ))
+                });
             }
             OSPermission::Accessibility => request_accessibility_permission(),
         }

--- a/apps/desktop/src-tauri/src/permissions.rs
+++ b/apps/desktop/src-tauri/src/permissions.rs
@@ -68,20 +68,17 @@ pub async fn request_permission(permission: OSPermission) {
                 scap::request_permission();
             }
             OSPermission::Camera => {
-                println!("BRUH");
                 std::thread::spawn(|| {
-                    let res = block_on(av::CaptureDevice::request_access_for_media_type(
+                    let _ = block_on(av::CaptureDevice::request_access_for_media_type(
                         av::MediaType::video(),
                     ));
-
-                    dbg!(res);
                 });
             }
             OSPermission::Microphone => {
                 std::thread::spawn(|| {
-                    block_on(av::CaptureDevice::request_access_for_media_type(
+                    let _ = block_on(av::CaptureDevice::request_access_for_media_type(
                         av::MediaType::audio(),
-                    ))
+                    ));
                 });
             }
             OSPermission::Accessibility => request_accessibility_permission(),

--- a/apps/desktop/src/routes/(window-chrome)/(main).tsx
+++ b/apps/desktop/src/routes/(window-chrome)/(main).tsx
@@ -493,6 +493,7 @@ function useRequestPermission() {
         console.log("wowzers");
         await commands.resetMicrophonePermissions();
       }
+      console.log({ type });
       await commands.requestPermission(type);
       await queryClient.refetchQueries(getPermissions);
     } catch (error) {
@@ -719,6 +720,11 @@ function CameraSelect(props: {
         disabled={!!currentRecording.data || props.disabled}
         class="flex flex-row items-center h-[2rem] px-[0.375rem] gap-[0.375rem] border rounded-lg border-gray-3 w-full disabled:text-gray-11 transition-colors KSelect"
         onClick={() => {
+          if (!permissionGranted()) {
+            requestPermission("camera");
+            return;
+          }
+
           Promise.all([
             CheckMenuItem.new({
               text: NO_CAMERA,
@@ -820,6 +826,11 @@ function MicrophoneSelect(props: {
         disabled={!!currentRecording.data || props.disabled}
         class="relative flex flex-row items-center h-[2rem] px-[0.375rem] gap-[0.375rem] border rounded-lg border-gray-3 w-full disabled:text-gray-11 transition-colors KSelect overflow-hidden z-10"
         onClick={() => {
+          if (!permissionGranted()) {
+            requestPermission("microphone");
+            return;
+          }
+
           Promise.all([
             CheckMenuItem.new({
               text: NO_MICROPHONE,
@@ -976,6 +987,7 @@ function TargetSelectInfoPill<T>(props: {
       onClick={(e) => {
         if (!props.permissionGranted) {
           props.requestPermission();
+          e.stopPropagation();
           return;
         }
 

--- a/apps/desktop/src/routes/(window-chrome)/(main).tsx
+++ b/apps/desktop/src/routes/(window-chrome)/(main).tsx
@@ -422,7 +422,6 @@ function Page() {
         options={cameras}
         value={options.cameraID() ?? null}
         onChange={(v) => {
-          console.log({ v });
           if (!v) setCamera.mutate(null);
           else if (v.model_id) setCamera.mutate({ ModelID: v.model_id });
           else setCamera.mutate({ DeviceID: v.device_id });
@@ -493,7 +492,6 @@ function useRequestPermission() {
         console.log("wowzers");
         await commands.resetMicrophonePermissions();
       }
-      console.log({ type });
       await commands.requestPermission(type);
       await queryClient.refetchQueries(getPermissions);
     } catch (error) {
@@ -575,7 +573,6 @@ function AreaSelectButton(props: {
     }
 
     const { screen } = props;
-    console.log({ screen });
     if (!screen) return;
 
     trackEvent("crop_area_enabled", {
@@ -941,7 +938,6 @@ function TargetSelect<T extends { id: number; name: string }>(props: {
       disabled={props.disabled}
       onClick={() => {
         if (props.options.length > 1) {
-          console.log({ options: props.options, value: props.value });
           Promise.all(
             props.options.map((o) =>
               CheckMenuItem.new({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit permission checks before opening camera and microphone selection menus. If permission is not granted, the app now requests permission and prevents the menu from opening until access is allowed.

* **Bug Fixes**
  * Improved error handling when resetting camera permissions, providing clearer error messages instead of abrupt failures.

* **Style**
  * Removed unnecessary debug and console log statements from the interface for a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->