### PR TITLE
Added needed variables to .env.example file for setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ RUST_BACKTRACE=full
 ### @cap/web
 NODE_ENV=development
 WEB_PORT=3000
+WEB_URL=http://localhost:${WEB_PORT}         # <-- Added server-side WEB_URL
 NEXT_PUBLIC_WEB_URL=http://localhost:${WEB_PORT}
 NEXTAUTH_URL=${NEXT_PUBLIC_WEB_URL}
 
@@ -47,10 +48,13 @@ DATABASE_ENCRYPTION_KEY=
 ## AWS/S3
 
 # By default these are configured for the MinIO instance created by `pnpm dev`
-CAP_AWS_ACCESS_KEY=capS3root
-CAP_AWS_SECRET_KEY=capS3root
+CAP_AWS_ACCESS_KEY=capS3root                 # <-- Added server-side AWS key
+CAP_AWS_SECRET_KEY=capS3root                 # <-- Added server-side AWS secret
+CAP_AWS_BUCKET=capso                         # <-- Added server-side bucket name
+CAP_AWS_REGION=us-east-1                     # <-- Added server-side AWS region
 NEXT_PUBLIC_CAP_AWS_BUCKET=capso
 NEXT_PUBLIC_CAP_AWS_REGION=us-east-1
+
 # If you're not using AWS S3, point this to your custom S3 provider (default points to MinIO created by `pnpm dev`)
 NEXT_PUBLIC_CAP_AWS_ENDPOINT=http://localhost:3902
 CAP_AWS_ENDPOINT=${NEXT_PUBLIC_CAP_AWS_ENDPOINT}


### PR DESCRIPTION
When I was setting up the project locally, copying .env.example to .env and starting the web app causes it to fail at startup with “Invalid environment variables” errors. 

This happens because a few required server-side variables (WEB_URL, CAP_AWS_BUCKET, CAP_AWS_REGION, CAP_AWS_ACCESS_KEY, CAP_AWS_SECRET_KEY) were missing from .env.example. The file only included their NEXT_PUBLIC_* counterparts, which are ignored by the backend schema. 

Adding these missing variables with local-dev defaults allows the app to start successfully without manual troubleshooting. If there's any issue specific to my environment to where this is an accurate I would love to know! But I don't think that's the case.