### PR TITLE
new: add video duration to cards

### DIFF
--- a/apps/web/app/(org)/dashboard/caps/components/CapCard/CapCard.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/CapCard/CapCard.tsx
@@ -105,7 +105,7 @@ export const CapCard = ({
 
 	const router = useRouter();
 
-	const formatDuration = (duration: number | undefined) => {
+	const formatDuration = (duration: string) => {
 		if (!duration) return "0 secs";
 
 		const momentDuration = moment.duration(duration, "milliseconds");
@@ -409,7 +409,7 @@ export const CapCard = ({
 				)}
 				{cap.metadata?.duration && (
 					<p className="text-white leading-0 px-2 py-px rounded-full backdrop-blur-sm absolute z-10 left-3 top-[112px] bg-black/50 text-[10px]">
-						{formatDuration(cap.metadata.duration as number)}
+						{formatDuration(cap.metadata.duration as string)}
 					</p>
 				)}
 				{!sharedCapCard && onSelectToggle && (
@@ -452,7 +452,6 @@ export const CapCard = ({
 					href={`/s/${cap.id}`}
 				>
 					<VideoThumbnail
-						videoMetaData={cap.metadata}
 						imageClass={clsx(
 							anyCapSelected
 								? "opacity-50"


### PR DESCRIPTION
**This PR**: You will be able to see video duration on newly uploaded videos since we added this as metadata.

<img width="295" height="320" alt="Screenshot 2025-08-18 at 15 50 50" src="https://github.com/user-attachments/assets/bc9ffcec-4610-46b3-838f-bebf3f863b36" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a duration badge on relevant dashboard cards that shows concise time (hrs/mins/secs) from available metadata; displays "0 secs" when no duration is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->