### PR TITLE
fix: add missing CAP_AWS_BUCKET and CAP_AWS_REGION to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,8 @@ CAP_AWS_ACCESS_KEY=capS3root
 CAP_AWS_SECRET_KEY=capS3root
 NEXT_PUBLIC_CAP_AWS_BUCKET=capso
 NEXT_PUBLIC_CAP_AWS_REGION=us-east-1
+CAP_AWS_BUCKET=${NEXT_PUBLIC_CAP_AWS_BUCKET}
+CAP_AWS_REGION=${NEXT_PUBLIC_CAP_AWS_REGION}
 # If you're not using AWS S3, point this to your custom S3 provider (default points to MinIO created by `pnpm dev`)
 NEXT_PUBLIC_CAP_AWS_ENDPOINT=http://localhost:3902
 CAP_AWS_ENDPOINT=${NEXT_PUBLIC_CAP_AWS_ENDPOINT}


### PR DESCRIPTION
Problem:
When Running apps/web locally, the app fails to start unless both the NEXT_PUBLIC_* and CAP_* AWS environment variables are defined.

This PR adds them, pointing to the existing NEXT_PUBLIC_* values. so new contributors don’t run into this.

- With only NEXT_PUBLIC_CAP_AWS_BUCKET / NEXT_PUBLIC_CAP_AWS_REGION → error occurs
<img width="1901" height="941" alt="Screenshot 2025-08-21 231329" src="https://github.com/user-attachments/assets/b6d60723-88fe-4e89-b1cd-235531fba72b" />

- With only CAP_AWS_BUCKET / CAP_AWS_REGION → error occurs
<img width="1905" height="942" alt="Screenshot 2025-08-21 224453" src="https://github.com/user-attachments/assets/cb31a940-32fa-4c95-a0e8-45a503a95b31" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated environment setup example to map internal AWS bucket and region from their public counterparts, simplifying configuration.
- Chores
  - Aligned internal AWS environment variables with public ones to reduce duplication and potential misconfiguration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->