### PR TITLE
new: editor shortcuts

### DIFF
--- a/apps/desktop/src/components/Tooltip.tsx
+++ b/apps/desktop/src/components/Tooltip.tsx
@@ -30,9 +30,9 @@ export default function Tooltip(props: Props) {
 			<KTooltip.Portal>
 				<KTooltip.Content class="z-50 px-1.5 flex items-center py-1 text-xs border border-gray-3 bg-gray-12 text-gray-1 rounded-md shadow-lg duration-100 animate-in fade-in slide-in-from-top-1 min-w-6 gap-1.5 text-center">
 					<span>{props.content}</span>
-					{props.kbd?.length && (
+					{props.kbd && props.kbd.length > 0 && (
 						<div class="space-x-1">
-							{props.kbd.map((kbd) => (
+							{props.kbd?.map((kbd) => (
 								<kbd class="py-0.5 px-[5px] text-[10px] rounded-md text-gray-12 bg-gray-1">
 									{kbdSymbolModifier(kbd, os)}
 								</kbd>

--- a/apps/desktop/src/components/Tooltip.tsx
+++ b/apps/desktop/src/components/Tooltip.tsx
@@ -1,21 +1,44 @@
 import { Tooltip as KTooltip } from "@kobalte/core";
+import { type as ostype } from "@tauri-apps/plugin-os";
 import { cx } from "cva";
 import type { ComponentProps, JSX } from "solid-js";
 
 interface Props extends ComponentProps<typeof KTooltip.Root> {
 	content: JSX.Element;
 	childClass?: string;
+	kbd?: string[];
 }
 
+type Os = "android" | "ios" | "linux" | "macos" | "windows";
+
+const kbdSymbolModifier = (key: string, os: Os) => {
+	const obj = {
+		meta: os === "macos" ? "⌘" : "ctrl",
+		shift: "⇧",
+		alt: os === "macos" ? "⌥" : "⎇",
+	};
+	return obj[key as keyof typeof obj] || key;
+};
+
 export default function Tooltip(props: Props) {
+	const os = ostype();
 	return (
 		<KTooltip.Root {...props} openDelay={props.openDelay ?? 200}>
 			<KTooltip.Trigger class={cx(props.childClass)}>
 				{props.children}
 			</KTooltip.Trigger>
 			<KTooltip.Portal>
-				<KTooltip.Content class="z-50 px-1.5 py-1 text-xs border border-gray-3 bg-gray-12 text-gray-1 rounded shadow-lg duration-100 animate-in fade-in slide-in-from-top-1 min-w-6 text-center">
-					{props.content}
+				<KTooltip.Content class="z-50 px-1.5 flex items-center py-1 text-xs border border-gray-3 bg-gray-12 text-gray-1 rounded-md shadow-lg duration-100 animate-in fade-in slide-in-from-top-1 min-w-6 gap-1.5 text-center">
+					<span>{props.content}</span>
+					{props.kbd?.length && (
+						<div class="space-x-1">
+							{props.kbd.map((kbd) => (
+								<kbd class="py-0.5 px-[5px] text-[10px] rounded-md text-gray-12 bg-gray-1">
+									{kbdSymbolModifier(kbd, os)}
+								</kbd>
+							))}
+						</div>
+					)}
 					<KTooltip.Arrow size={16} />
 				</KTooltip.Content>
 			</KTooltip.Portal>

--- a/apps/desktop/src/routes/editor/AspectRatioSelect.tsx
+++ b/apps/desktop/src/routes/editor/AspectRatioSelect.tsx
@@ -1,6 +1,7 @@
 import { Select as KSelect } from "@kobalte/core/select";
-import { Show } from "solid-js";
-
+import { createEventListener } from "@solid-primitives/event-listener";
+import { createSignal, Show } from "solid-js";
+import Tooltip from "~/components/Tooltip";
 import type { AspectRatio } from "~/utils/tauri";
 import { useEditorContext } from "./context";
 import { ASPECT_RATIOS } from "./projectConfig";
@@ -14,80 +15,94 @@ import {
 
 function AspectRatioSelect() {
 	const { project, setProject } = useEditorContext();
-	return (
-		<KSelect<AspectRatio | "auto">
-			value={project.aspectRatio ?? "auto"}
-			onChange={(v) => {
-				if (v === null) return;
-				setProject("aspectRatio", v === "auto" ? null : v);
-			}}
-			defaultValue="auto"
-			options={
-				["auto", "wide", "vertical", "square", "classic", "tall"] as const
-			}
-			multiple={false}
-			itemComponent={(props) => {
-				const item = () =>
-					props.item.rawValue === "auto"
-						? null
-						: ASPECT_RATIOS[props.item.rawValue];
+	const [open, setOpen] = createSignal(false);
+	let triggerSelect: HTMLDivElement | undefined;
+	createEventListener(document, "keydown", (e: KeyboardEvent) => {
+		if (e.code === "KeyA" && e.target === document.body) {
+			e.preventDefault();
+			setOpen((prev) => !prev);
+		}
+	});
 
-				return (
-					<MenuItem<typeof KSelect.Item> as={KSelect.Item} item={props.item}>
-						<KSelect.ItemLabel class="flex-1">
-							{props.item.rawValue === "auto"
-								? "Auto"
-								: ASPECT_RATIOS[props.item.rawValue].name}
-							<Show when={item()}>
-								{(item) => (
-									<span class="text-gray-11">
-										{"⋅"}
-										{item().ratio[0]}:{item().ratio[1]}
-									</span>
-								)}
-							</Show>
-						</KSelect.ItemLabel>
-						<KSelect.ItemIndicator class="ml-auto">
-							<IconCapCircleCheck />
-						</KSelect.ItemIndicator>
-					</MenuItem>
-				);
-			}}
-			placement="top-start"
-		>
-			<EditorButton<typeof KSelect.Trigger>
-				as={KSelect.Trigger}
-				class="w-28"
-				leftIcon={<IconCapLayout />}
-				rightIcon={
-					<KSelect.Icon>
-						<IconCapChevronDown />
-					</KSelect.Icon>
+	return (
+		<Tooltip kbd={["A"]} content="Aspect Ratio">
+			<KSelect<AspectRatio | "auto">
+				open={open()}
+				onOpenChange={setOpen}
+				ref={triggerSelect}
+				value={project.aspectRatio ?? "auto"}
+				onChange={(v) => {
+					if (v === null) return;
+					setProject("aspectRatio", v === "auto" ? null : v);
+				}}
+				defaultValue="auto"
+				options={
+					["auto", "wide", "vertical", "square", "classic", "tall"] as const
 				}
-				rightIconEnd={true}
+				multiple={false}
+				itemComponent={(props) => {
+					const item = () =>
+						props.item.rawValue === "auto"
+							? null
+							: ASPECT_RATIOS[props.item.rawValue];
+
+					return (
+						<MenuItem<typeof KSelect.Item> as={KSelect.Item} item={props.item}>
+							<KSelect.ItemLabel class="flex-1">
+								{props.item.rawValue === "auto"
+									? "Auto"
+									: ASPECT_RATIOS[props.item.rawValue].name}
+								<Show when={item()}>
+									{(item) => (
+										<span class="text-gray-11">
+											{"⋅"}
+											{item().ratio[0]}:{item().ratio[1]}
+										</span>
+									)}
+								</Show>
+							</KSelect.ItemLabel>
+							<KSelect.ItemIndicator class="ml-auto">
+								<IconCapCircleCheck />
+							</KSelect.ItemIndicator>
+						</MenuItem>
+					);
+				}}
+				placement="top-start"
 			>
-				<KSelect.Value<AspectRatio | "auto">>
-					{(state) => {
-						const text = () => {
-							const option = state.selectedOption();
-							return option === "auto" ? "Auto" : ASPECT_RATIOS[option].name;
-						};
-						return <>{text()}</>;
-					}}
-				</KSelect.Value>
-			</EditorButton>
-			<KSelect.Portal>
-				<PopperContent<typeof KSelect.Content>
-					as={KSelect.Content}
-					class={topLeftAnimateClasses}
+				<EditorButton<typeof KSelect.Trigger>
+					as={KSelect.Trigger}
+					class="w-28"
+					leftIcon={<IconCapLayout />}
+					rightIcon={
+						<KSelect.Icon>
+							<IconCapChevronDown />
+						</KSelect.Icon>
+					}
+					rightIconEnd={true}
 				>
-					<MenuItemList<typeof KSelect.Listbox>
-						as={KSelect.Listbox}
-						class="w-[12.5rem]"
-					/>
-				</PopperContent>
-			</KSelect.Portal>
-		</KSelect>
+					<KSelect.Value<AspectRatio | "auto">>
+						{(state) => {
+							const text = () => {
+								const option = state.selectedOption();
+								return option === "auto" ? "Auto" : ASPECT_RATIOS[option].name;
+							};
+							return <>{text()}</>;
+						}}
+					</KSelect.Value>
+				</EditorButton>
+				<KSelect.Portal>
+					<PopperContent<typeof KSelect.Content>
+						as={KSelect.Content}
+						class={topLeftAnimateClasses}
+					>
+						<MenuItemList<typeof KSelect.Listbox>
+							as={KSelect.Listbox}
+							class="w-[12.5rem]"
+						/>
+					</PopperContent>
+				</KSelect.Portal>
+			</KSelect>
+		</Tooltip>
 	);
 }
 

--- a/apps/desktop/src/routes/editor/ExportDialog.tsx
+++ b/apps/desktop/src/routes/editor/ExportDialog.tsx
@@ -409,8 +409,8 @@ export function ExportDialog() {
 										)}
 									>
 										<p class="flex gap-4 items-center">
-											<span class="flex items-center text-[--gray-500]">
-												<IconCapCamera class="w-[14px] h-[14px] mr-1.5 text-[--gray-500]" />
+											<span class="flex items-center text-gray-12">
+												<IconCapCamera class="w-[14px] h-[14px] mr-1.5 text-gray-12" />
 												{(() => {
 													const totalSeconds = Math.round(
 														est().duration_seconds,
@@ -433,16 +433,16 @@ export function ExportDialog() {
 														.padStart(2, "0")}`;
 												})()}
 											</span>
-											<span class="flex items-center text-[--gray-500]">
-												<IconLucideMonitor class="w-[14px] h-[14px] mr-1.5 text-[--gray-500]" />
+											<span class="flex items-center text-gray-12">
+												<IconLucideMonitor class="w-[14px] h-[14px] mr-1.5 text-gray-12" />
 												{settings.resolution.width}×{settings.resolution.height}
 											</span>
-											<span class="flex items-center text-[--gray-500]">
-												<IconLucideHardDrive class="w-[14px] h-[14px] mr-1.5 text-[--gray-500]" />
+											<span class="flex items-center text-gray-12">
+												<IconLucideHardDrive class="w-[14px] h-[14px] mr-1.5 text-gray-12" />
 												{est().estimated_size_mb.toFixed(2)} MB
 											</span>
-											<span class="flex items-center text-[--gray-500]">
-												<IconLucideClock class="w-[14px] h-[14px] mr-1.5 text-[--gray-500]" />
+											<span class="flex items-center text-gray-12">
+												<IconLucideClock class="w-[14px] h-[14px] mr-1.5 text-gray-12" />
 												{(() => {
 													const totalSeconds = Math.round(
 														est().estimated_time_seconds,
@@ -474,7 +474,7 @@ export function ExportDialog() {
 				>
 					<div class="flex flex-wrap gap-3">
 						{/* Export to */}
-						<div class="flex-1 p-4 rounded-xl bg-gray-2">
+						<div class="flex-1 p-4 rounded-xl dark:bg-gray-2 bg-gray-3">
 							<div class="flex flex-col gap-3">
 								<h3 class="text-gray-12">Export to</h3>
 								<div class="flex gap-2">
@@ -497,7 +497,7 @@ export function ExportDialog() {
 							</div>
 						</div>
 						{/* Format */}
-						<div class="p-4 rounded-xl bg-gray-2">
+						<div class="p-4 rounded-xl dark:bg-gray-2 bg-gray-3">
 							<div class="flex flex-col gap-3">
 								<h3 class="text-gray-12">Format</h3>
 								<div class="flex flex-row gap-2">
@@ -552,7 +552,7 @@ export function ExportDialog() {
 							</div>
 						</div>
 						{/* Frame rate */}
-						<div class="overflow-hidden relative p-4 rounded-xl bg-gray-2">
+						<div class="overflow-hidden relative p-4 rounded-xl dark:bg-gray-2 bg-gray-3">
 							<div class="flex flex-col gap-3">
 								<h3 class="text-gray-12">Frame rate</h3>
 								<KSelect<{ label: string; value: number }>
@@ -585,7 +585,7 @@ export function ExportDialog() {
 										</MenuItem>
 									)}
 								>
-									<KSelect.Trigger class="flex flex-row gap-2 items-center px-3 w-full h-10 rounded-xl transition-colors bg-gray-3 disabled:text-gray-11">
+									<KSelect.Trigger class="flex flex-row gap-2 items-center px-3 w-full h-10 rounded-xl transition-colors dark:bg-gray-3 bg-gray-4 disabled:text-gray-11">
 										<KSelect.Value<
 											(typeof FPS_OPTIONS)[number]
 										> class="flex-1 text-sm text-left truncate tabular-nums text-[--gray-500]">
@@ -606,7 +606,7 @@ export function ExportDialog() {
 											class={cx(topSlideAnimateClasses, "z-50")}
 										>
 											<MenuItemList<typeof KSelect.Listbox>
-												class="overflow-y-auto max-h-32"
+												class="max-h-32 custom-scroll"
 												as={KSelect.Listbox}
 											/>
 										</PopperContent>
@@ -615,7 +615,7 @@ export function ExportDialog() {
 							</div>
 						</div>
 						{/* Compression */}
-						<div class="p-4 rounded-xl bg-gray-2">
+						<div class="p-4 rounded-xl dark:bg-gray-2 bg-gray-3">
 							<div class="flex flex-col gap-3">
 								<h3 class="text-gray-12">Compression</h3>
 								<div class="flex gap-2">
@@ -642,7 +642,7 @@ export function ExportDialog() {
 							</div>
 						</div>
 						{/* Resolution */}
-						<div class="flex-1 p-4 rounded-xl bg-gray-2">
+						<div class="flex-1 p-4 rounded-xl dark:bg-gray-2 bg-gray-3">
 							<div class="flex flex-col gap-3">
 								<h3 class="text-gray-12">Resolution</h3>
 								<div class="flex gap-2">

--- a/apps/desktop/src/routes/editor/Player.tsx
+++ b/apps/desktop/src/routes/editor/Player.tsx
@@ -9,8 +9,8 @@ import { commands } from "~/utils/tauri";
 import AspectRatioSelect from "./AspectRatioSelect";
 import { FPS, OUTPUT_SIZE, useEditorContext } from "./context";
 import { EditorButton, Slider } from "./ui";
-import { formatTime } from "./utils";
 import { useEditorShortcuts } from "./useEditorShortcuts";
+import { formatTime } from "./utils";
 
 export function Player() {
 	const {

--- a/apps/desktop/src/routes/editor/Player.tsx
+++ b/apps/desktop/src/routes/editor/Player.tsx
@@ -248,17 +248,19 @@ export function Player() {
 					>
 						<IconCapPrev class="text-gray-12 size-3" />
 					</button>
-					<button
-						type="button"
-						onClick={handlePlayPauseClick}
-						class="flex justify-center items-center rounded-full border border-gray-300 transition-colors bg-gray-3 hover:bg-gray-4 hover:text-black size-9"
-					>
-						{!editorState.playing || isAtEnd() ? (
-							<IconCapPlay class="text-gray-12 size-3" />
-						) : (
-							<IconCapPause class="text-gray-12 size-3" />
-						)}
-					</button>
+					<Tooltip kbd={["Space"]} content="Play/Pause video">
+						<button
+							type="button"
+							onClick={handlePlayPauseClick}
+							class="flex justify-center items-center rounded-full border border-gray-300 transition-colors bg-gray-3 hover:bg-gray-4 hover:text-black size-9"
+						>
+							{!editorState.playing || isAtEnd() ? (
+								<IconCapPlay class="text-gray-12 size-3" />
+							) : (
+								<IconCapPause class="text-gray-12 size-3" />
+							)}
+						</button>
+					</Tooltip>
 					<button
 						type="button"
 						class="transition-opacity hover:opacity-70 will-change-[opacity]"

--- a/apps/desktop/src/routes/editor/Timeline/LayoutTrack.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/LayoutTrack.tsx
@@ -469,7 +469,7 @@ export function LayoutTrack(props: {
 							end: time() + maxAvailableDuration(),
 						}}
 					>
-						<SegmentContent class="bg-gradient-to-r hover:border duration-200 hover:border-gray-500 from-[#3B82F6] via-[#60A5FA] to-[#3B82F6] transition-colors group shadow-[inset_0_8px_12px_3px_rgba(255,255,255,0.2)]">
+						<SegmentContent class="bg-gradient-to-r hover:border duration-200 hover:border-gray-500 from-[#5C1BC4] via-[#975CFA] to-[#5C1BC4] transition-colors group shadow-[inset_0_8px_12px_3px_rgba(255,255,255,0.2)]">
 							<p class="w-full text-center text-gray-1 dark:text-gray-12 text-md text-primary">
 								+
 							</p>

--- a/apps/desktop/src/routes/editor/ui.tsx
+++ b/apps/desktop/src/routes/editor/ui.tsx
@@ -344,6 +344,7 @@ type EditorButtonProps<T extends ValidComponent = "button"> =
 		children?: JSX.Element | string;
 		leftIcon?: JSX.Element;
 		rightIcon?: JSX.Element;
+		kbd?: string[];
 		tooltipText?: string;
 		comingSoon?: boolean;
 		rightIconEnd?: boolean;
@@ -359,6 +360,8 @@ export function EditorButton<T extends ValidComponent = "button">(
 			"leftIcon",
 			"rightIcon",
 			"tooltipText",
+			"kbd",
+			"ref",
 			"comingSoon",
 			"rightIconEnd",
 		],
@@ -382,7 +385,10 @@ export function EditorButton<T extends ValidComponent = "button">(
 	return (
 		<>
 			{local.tooltipText || local.comingSoon ? (
-				<Tooltip content={local.comingSoon ? "Coming Soon" : local.tooltipText}>
+				<Tooltip
+					kbd={local.kbd}
+					content={local.comingSoon ? "Coming Soon" : local.tooltipText}
+				>
 					<Polymorphic
 						as="button"
 						{...others}

--- a/apps/desktop/src/routes/editor/useEditorShortcuts.ts
+++ b/apps/desktop/src/routes/editor/useEditorShortcuts.ts
@@ -1,0 +1,53 @@
+import { createEventListener } from "@solid-primitives/event-listener";
+
+export type ShortcutBinding = {
+	combo: string; // e.g. "Mod+=", "Mod+-", "Space", "S", "C"
+	handler: (e: KeyboardEvent) => void | Promise<void>;
+	preventDefault?: boolean; // default: true
+	when?: () => boolean; // optional enablement gate
+};
+
+const isMod = (e: KeyboardEvent) => e.metaKey || e.ctrlKey; // treat Cmd/Ctrl as Mod
+
+function normalizeCombo(e: KeyboardEvent): string {
+	const parts: string[] = [];
+	if (isMod(e)) parts.push("Mod");
+
+	let key: string;
+	switch (e.code) {
+		case "Equal":
+			key = "=";
+			break;
+		case "Minus":
+			key = "-";
+			break;
+		default:
+			key = e.code.startsWith("Key") ? e.code.slice(3) : e.code;
+	}
+
+	parts.push(key);
+	return parts.join("+");
+}
+
+export function useEditorShortcuts(
+	getScopeActive: () => boolean,
+	bindings: ShortcutBinding[],
+) {
+	const map = new Map<string, ShortcutBinding>(
+		bindings.map((b) => [b.combo, b]),
+	);
+
+	createEventListener(document, "keydown", async (e: KeyboardEvent) => {
+		// Basic guards
+		if (!getScopeActive()) return;
+		if (e.repeat) return;
+
+		const binding = map.get(normalizeCombo(e));
+		if (!binding) return;
+		if (binding.when && !binding.when()) return;
+
+		if (binding.preventDefault !== false) e.preventDefault();
+
+		await binding.handler(e);
+	});
+}

--- a/packages/ui-solid/src/Button.tsx
+++ b/packages/ui-solid/src/Button.tsx
@@ -14,7 +14,7 @@ const styles = cva(
 				primary:
 					"bg-gray-12 text-gray-1 hover:bg-gray-11 enabled:hover:bg-gray-11 disabled:bg-gray-6 disabled:text-gray-9 outline-blue-300 disabled:bg-gray-4 disabled:dark:text-gray-9",
 				secondary:
-					"bg-gray-4 enabled:hover:bg-gray-5 text-gray-500 disabled:bg-gray-6 disabled:text-gray-9 outline-blue-300 disabled:outline-blue-10",
+					"dark:bg-gray-4 bg-gray-5 enabled:hover:bg-gray-5 text-gray-500 disabled:bg-gray-6 disabled:text-gray-9 outline-blue-300 disabled:outline-blue-10",
 				destructive:
 					"bg-red-300 text-gray-50 dark:text-gray-12 disabled:bg-gray-6 disabled:text-gray-9 enabled:hover:bg-red-400 disabled:bg-red-200 outline-red-300",
 				white:


### PR DESCRIPTION
**This PR**: 

- Adds new shortcuts to editor for Zoom in, zoom out, split crop, and opening the aspect ratio dialog.
- Adjusts color of adding new layout segment.

**Preview:**

<img width="197" height="89" alt="Screenshot 2025-08-25 at 13 28 12" src="https://github.com/user-attachments/assets/eb436747-a0c7-4abd-9f10-b7c05badeb2b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - OS-aware keyboard shortcut hints in tooltips.
  - New shortcuts: A opens Aspect Ratio, S toggles Split mode, Cmd/Ctrl + +/- zooms, C opens Crop.

- Improvements
  - Tooltips on editor controls now show shortcut hints.
  - Crop dialog initializes with smarter defaults for size/position.
  - Keyboard-driven open/close for Aspect Ratio selector and global shortcut support.

- Style
  - Export dialog dark-mode contrast and custom scrolling improved.
  - Timeline hover gradient updated to purple; button/tooltip spacing and borders refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->