### PR TITLE
Refactor Pro subscription check for third-party support

### DIFF
--- a/apps/web/app/api/desktop/[...route]/root.ts
+++ b/apps/web/app/api/desktop/[...route]/root.ts
@@ -97,10 +97,6 @@ app.get("/plan", async (c) => {
 
 	let isSubscribed = userIsPro(user);
 
-	if (user.thirdPartyStripeSubscriptionId) {
-		isSubscribed = true;
-	}
-
 	if (!isSubscribed && !user.stripeSubscriptionId && user.stripeCustomerId) {
 		try {
 			const subscriptions = await stripe().subscriptions.list({

--- a/packages/utils/src/constants/plans.ts
+++ b/packages/utils/src/constants/plans.ts
@@ -21,13 +21,21 @@ export const getProPlanId = (billingCycle: "yearly" | "monthly") => {
 export const userIsPro = (
 	user?: {
 		stripeSubscriptionStatus?: string | null;
+		thirdPartyStripeSubscriptionId?: string | null;
 	} | null,
 ) => {
 	if (!buildEnv.NEXT_PUBLIC_IS_CAP) return true;
 
 	if (!user) return false;
 
-	const { stripeSubscriptionStatus } = user;
+	const { stripeSubscriptionStatus, thirdPartyStripeSubscriptionId } = user;
+
+	// Check for third-party subscription first
+	if (thirdPartyStripeSubscriptionId) {
+		return true;
+	}
+
+	// Then check regular subscription status
 	return (
 		stripeSubscriptionStatus === "active" ||
 		stripeSubscriptionStatus === "trialing" ||


### PR DESCRIPTION
Moved the check for thirdPartyStripeSubscriptionId into the userIsPro utility function, ensuring consistent logic for determining Pro status. Removed redundant check from the API route.