### PR TITLE
query for continuity camera properly

### DIFF
--- a/crates/camera-avfoundation/src/lib.rs
+++ b/crates/camera-avfoundation/src/lib.rs
@@ -18,9 +18,14 @@ pub fn list_video_devices() -> arc::R<ns::Array<av::CaptureDevice>> {
     ];
 
     if api::macos_available("14.0") {
-        device_types.push(unsafe { av::CaptureDeviceType::external().unwrap() })
+        if let Some(typ) = unsafe { av::CaptureDeviceType::external() } {
+            device_types.push(typ);
+        }
+        if let Some(typ) = unsafe { av::CaptureDeviceType::continuity_camera() } {
+            device_types.push(typ);
+        }
     } else {
-        device_types.push(av::CaptureDeviceType::external_unknown())
+        device_types.push(av::CaptureDeviceType::external_unknown());
     }
 
     let device_types = ns::Array::from_slice(&device_types);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Continuity Camera on macOS 14+, enabling detection and use of these devices.

* **Bug Fixes**
  * Improved stability during camera discovery by safely handling external and unknown devices, reducing the chance of crashes.

* **Chores**
  * Updated macOS compatibility logic without changing any public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->