### PR TITLE
fix: duplicate shortcut

### DIFF
--- a/apps/desktop/src/routes/editor/AspectRatioSelect.tsx
+++ b/apps/desktop/src/routes/editor/AspectRatioSelect.tsx
@@ -1,5 +1,4 @@
 import { Select as KSelect } from "@kobalte/core/select";
-import { createEventListener } from "@solid-primitives/event-listener";
 import { createSignal, Show } from "solid-js";
 import Tooltip from "~/components/Tooltip";
 import type { AspectRatio } from "~/utils/tauri";
@@ -17,15 +16,9 @@ function AspectRatioSelect() {
 	const { project, setProject } = useEditorContext();
 	const [open, setOpen] = createSignal(false);
 	let triggerSelect: HTMLDivElement | undefined;
-	createEventListener(document, "keydown", (e: KeyboardEvent) => {
-		if (e.code === "KeyA" && e.target === document.body) {
-			e.preventDefault();
-			setOpen((prev) => !prev);
-		}
-	});
 
 	return (
-		<Tooltip kbd={["A"]} content="Aspect Ratio">
+		<Tooltip content="Aspect Ratio">
 			<KSelect<AspectRatio | "auto">
 				open={open()}
 				onOpenChange={setOpen}

--- a/apps/desktop/src/routes/editor/Player.tsx
+++ b/apps/desktop/src/routes/editor/Player.tsx
@@ -174,7 +174,6 @@ export function Player() {
 						editorState.playbackTime,
 					),
 			},
-			{ combo: "C", handler: () => cropDialogHandler() },
 			{
 				combo: "Space",
 				handler: async () => {
@@ -198,7 +197,6 @@ export function Player() {
 				<AspectRatioSelect />
 				<EditorButton
 					tooltipText="Crop Video"
-					kbd={["C"]}
 					onClick={() => cropDialogHandler()}
 					leftIcon={<IconCapCrop class="w-5 text-gray-12" />}
 				>
@@ -258,7 +256,7 @@ export function Player() {
 				<div class="flex flex-row flex-1 gap-4 justify-end items-center">
 					<div class="flex-1" />
 					<EditorButton<typeof KToggleButton>
-						tooltipText="Split"
+						tooltipText="Toggle Split"
 						kbd={["S"]}
 						pressed={editorState.timeline.interactMode === "split"}
 						onChange={(v: boolean) =>


### PR DESCRIPTION
**This PR**: removes duplicate shortcut.

- Removed toggling Aspect Ratio menu shortcut.
- Also removed shortcut to toggle Crop dialog.

Don't think these are critical enough actions unless we get enough feedback on this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed keyboard shortcuts: “A” for Aspect Ratio selector and “C” for opening Crop.
* **Style**
  * Removed on-screen keyboard shortcut hints for Aspect Ratio and Crop buttons.
  * Updated tooltip label from “Split” to “Toggle Split.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->