### PR TITLE
improvement: support cutting during playback

### DIFF
--- a/apps/desktop/src/routes/editor/Timeline/index.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/index.tsx
@@ -115,7 +115,7 @@ export function Timeline() {
 		}
 	}
 
-	createEventListener(window, "keydown", async (e) => {
+	createEventListener(window, "keydown", (e) => {
 		const hasNoModifiers = !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey;
 
 		if (e.code === "Backspace" || (e.code === "Delete" && hasNoModifiers)) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now split clips while playback is running using the split shortcut (no need to pause).

- Bug Fixes
  - Splitting at the exact start of the timeline (time 0) now works reliably.
  - Split operations correctly use the current playback position when no preview marker is set, improving consistency of cut timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->