### PR TITLE
fix: no cname for domains

### DIFF
--- a/apps/web/app/(org)/dashboard/settings/organization/components/CustomDomainDialog/VerifyStep.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/CustomDomainDialog/VerifyStep.tsx
@@ -96,7 +96,7 @@ const VerifyStep = ({
 	const showARecord =
 		recommendedAValues.length > 0 && !aRecordConfigured && !isSubdomain(domain);
 	const showCNAMERecord =
-		hasRecommendedCNAME && !cnameConfigured && !isSubdomain(domain);
+		hasRecommendedCNAME && !cnameConfigured && isSubdomain(domain);
 	const showTXTRecord = hasTXTVerification && !isVerified;
 
 	const handleCopy = async (text: string, fieldId: string) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated custom domain verification to show CNAME record instructions only for subdomains. This prevents incorrect guidance for apex/root domains, reducing confusion and potential misconfigurations. Users should now see clearer, context-appropriate setup steps, leading to smoother verification and fewer errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->