### PR TITLE
improvement: better time formatting for clip track

### DIFF
--- a/apps/desktop/src/routes/editor/Timeline/ClipTrack.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/ClipTrack.tsx
@@ -18,6 +18,16 @@ import { produce } from "solid-js/store";
 
 import type { TimelineSegment } from "~/utils/tauri";
 import { useEditorContext } from "../context";
+import { useSegmentContext, useTimelineContext } from "./context";
+import { getSectionMarker } from "./sectionMarker";
+import {
+	SegmentContent,
+	SegmentHandle,
+	SegmentRoot,
+	TrackRoot,
+	useSegmentTranslateX,
+	useSegmentWidth,
+} from "./Track";
 
 function formatTime(totalSeconds: number): string {
 	const hours = Math.floor(totalSeconds / 3600);
@@ -32,16 +42,6 @@ function formatTime(totalSeconds: number): string {
 		return `${seconds}s`;
 	}
 }
-import { useSegmentContext, useTimelineContext } from "./context";
-import { getSectionMarker } from "./sectionMarker";
-import {
-	SegmentContent,
-	SegmentHandle,
-	SegmentRoot,
-	TrackRoot,
-	useSegmentTranslateX,
-	useSegmentWidth,
-} from "./Track";
 
 function WaveformCanvas(props: {
 	systemWaveform?: number[];


### PR DESCRIPTION
**This PR improves better formatting for time on the track**:

<img width="632" height="134" alt="4c45665197d2a97499faf9504bdaba5d" src="https://github.com/user-attachments/assets/a2183ded-1d58-4a0a-994e-966d27bba5ed" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Durations in the editor timeline and related controls now display in a human-readable format (e.g., 1h 2m 3s) instead of raw seconds.
  - Removed redundant trailing “s” and ensured unit suffixes are included consistently.
  - Prevented label text from wrapping on related buttons for a steadier layout.

- Refactor
  - Consolidated time formatting into a shared utility to ensure consistent display across the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->