### PR TITLE
chore: fix dashboard logo on collapse & make name of org text bigger

### DIFF
--- a/apps/web/app/(org)/dashboard/_components/DashboardInner.tsx
+++ b/apps/web/app/(org)/dashboard/_components/DashboardInner.tsx
@@ -171,12 +171,10 @@ export default function DashboardInner({
 			{/*End of NavBar*/}
 			<main
 				className={
-					"flex overscroll-contain flex-col flex-1 flex-grow p-5 h-full border border-b-0 custom-scroll bg-gray-2 border-gray-3 lg:rounded-tl-2xl lg:p-8"
+					"flex overscroll-contain flex-col flex-1 p-5 h-full border border-b-0 custom-scroll bg-gray-2 border-gray-3 lg:rounded-tl-2xl lg:p-8"
 				}
 			>
-				<div className="flex flex-col flex-1 flex-grow gap-4 min-h-fit">
-					{children}
-				</div>
+				<div className="flex flex-col flex-1 gap-4 min-h-fit">{children}</div>
 			</main>
 			{isSharedCapsPage && activeOrganization?.members && (
 				<MembersDialog

--- a/apps/web/app/(org)/dashboard/_components/MobileTab.tsx
+++ b/apps/web/app/(org)/dashboard/_components/MobileTab.tsx
@@ -92,7 +92,7 @@ const Orgs = ({
 					name={activeOrg?.organization.name ?? "No organization found"}
 				/>
 			)}
-			<p className="text-xs mr-2 text-gray-12 truncate w-fit max-w-[90px]">
+			<p className="text-sm mr-2 text-gray-12 truncate w-fit max-w-[90px]">
 				{activeOrg?.organization.name}
 			</p>
 			<ChevronDown

--- a/apps/web/app/(org)/dashboard/_components/Navbar/Desktop.tsx
+++ b/apps/web/app/(org)/dashboard/_components/Navbar/Desktop.tsx
@@ -36,9 +36,7 @@ export const DesktopNav = () => {
 
 	return (
 		<motion.div
-			initial={{
-				width: sidebarCollapsed ? "70px" : "230px",
-			}}
+			initial={false}
 			animate={{
 				width: sidebarCollapsed ? "70px" : "230px",
 				transition: {
@@ -47,7 +45,10 @@ export const DesktopNav = () => {
 					bounce: 0.25,
 				},
 			}}
-			className={clsx("hidden z-50 h-full lg:flex group", "relative")}
+			className={clsx(
+				"hidden z-50 h-full will-change-[width] lg:flex group",
+				"relative",
+			)}
 		>
 			<div className="flex flex-col w-full max-w-[220px] mx-auto h-full">
 				<div className="flex justify-start items-center px-3 pt-5 mb-3.5 w-full truncate min-h-8">

--- a/apps/web/app/(org)/dashboard/_components/Navbar/Desktop.tsx
+++ b/apps/web/app/(org)/dashboard/_components/Navbar/Desktop.tsx
@@ -26,19 +26,15 @@ export const DesktopNav = () => {
 				toggleSidebarCollapsed();
 			}
 		};
-
 		window.addEventListener("keydown", handleKeyDown);
-
-		return () => {
-			window.removeEventListener("keydown", handleKeyDown);
-		};
+		return () => window.removeEventListener("keydown", handleKeyDown);
 	}, [toggleSidebarCollapsed]);
 
 	return (
 		<motion.div
 			initial={false}
 			animate={{
-				width: sidebarCollapsed ? "70px" : "230px",
+				width: sidebarCollapsed ? 70 : 230,
 				transition: {
 					duration: 0.6,
 					type: "spring",
@@ -46,8 +42,7 @@ export const DesktopNav = () => {
 				},
 			}}
 			className={clsx(
-				"hidden z-50 h-full will-change-[width] lg:flex group",
-				"relative",
+				"hidden relative z-50 h-full will-change-[width] lg:flex group bg-gray-1",
 			)}
 		>
 			<div className="flex flex-col w-full max-w-[220px] mx-auto h-full">
@@ -60,13 +55,11 @@ export const DesktopNav = () => {
 						/>
 					</Link>
 				</div>
-
 				<div className="flex overflow-y-auto flex-col flex-grow">
 					<div className="flex flex-col px-3 h-full">
 						<AdminNavItems />
 					</div>
 				</div>
-
 				<Tooltip
 					kbd={[cmdSymbol, "Shift", "S"]}
 					position="right"

--- a/apps/web/app/(org)/dashboard/_components/Navbar/Desktop.tsx
+++ b/apps/web/app/(org)/dashboard/_components/Navbar/Desktop.tsx
@@ -54,6 +54,7 @@ export const DesktopNav = () => {
 					<Link href="/dashboard">
 						<Logo
 							hideLogoName={sidebarCollapsed}
+							viewBoxDimensions={sidebarCollapsed ? "0 0 40 40" : "0 0 120 40"}
 							className="mx-auto w-[120px] h-[40px]"
 						/>
 					</Link>

--- a/apps/web/app/(org)/dashboard/layout.tsx
+++ b/apps/web/app/(org)/dashboard/layout.tsx
@@ -80,7 +80,7 @@ export default async function DashboardLayout({
 				userPreferences={userPreferences}
 			>
 				<div className="grid grid-cols-[auto,1fr] bg-gray-1 grid-rows-[auto,1fr] h-dvh min-h-dvh">
-					<aside className="hidden z-10 col-span-1 row-span-2 lg:flex">
+					<aside className="hidden z-10 col-span-1 row-span-2 w-full lg:flex">
 						<DesktopNav />
 					</aside>
 					<div className="flex col-span-2 row-span-2 h-full md:col-span-1 focus:outline-none">

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -597,14 +597,14 @@ slot:not(.dashboard-layout slot) {
 /* Custom scrollbar */
 .custom-scroll {
 	overflow-y: auto;
-	scrollbar-gutter: stable; 
+	scrollbar-gutter: stable;
 }
 
 /* Fallback for scrollbar-gutter */
 @supports not (scrollbar-gutter: stable) {
-  .custom-scroll {
-    padding-right: 3px; /* Reserve space for scrollbar */
-  }
+	.custom-scroll {
+		padding-right: 3px; /* Reserve space for scrollbar */
+	}
 }
 .custom-scroll::-webkit-scrollbar {
 	width: 3px;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -594,7 +594,6 @@ slot:not(.dashboard-layout slot) {
 .hide-scroll::-webkit-scrollbar {
 	display: none;
 }
-
 /* Custom scrollbar */
 .custom-scroll {
 	overflow-y: auto;
@@ -607,7 +606,6 @@ slot:not(.dashboard-layout slot) {
     padding-right: 3px; /* Reserve space for scrollbar */
   }
 }
-
 .custom-scroll::-webkit-scrollbar {
 	width: 3px;
 	background-color: transparent;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -598,6 +598,14 @@ slot:not(.dashboard-layout slot) {
 /* Custom scrollbar */
 .custom-scroll {
 	overflow-y: auto;
+	scrollbar-gutter: stable; 
+}
+
+/* Fallback for scrollbar-gutter */
+@supports not (scrollbar-gutter: stable) {
+  .custom-scroll {
+    padding-right: 3px; /* Reserve space for scrollbar */
+  }
 }
 
 .custom-scroll::-webkit-scrollbar {

--- a/packages/ui/src/components/icons/Logo.tsx
+++ b/packages/ui/src/components/icons/Logo.tsx
@@ -4,7 +4,7 @@ export const Logo = ({
 	showBeta,
 	white,
 	hideLogoName,
-	viewBoxDimensions,
+	viewBoxDimensions = "0 0 120 40",
 	style,
 }: {
 	className?: string;
@@ -18,7 +18,7 @@ export const Logo = ({
 	return (
 		<div className="flex items-center">
 			<svg
-				viewBox={viewBoxDimensions || "0 0 120 40"}
+				viewBox={viewBoxDimensions}
 				xmlns="http://www.w3.org/2000/svg"
 				preserveAspectRatio="xMidYMid meet"
 				fill="none"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Increased organization name text size on mobile for better readability.
  - Disabled an initial navbar width animation and enabled smoother width transitions for a more stable desktop experience.
  - Improved logo sizing in the desktop navbar to adapt when the sidebar is collapsed or expanded.

- Refactor
  - Simplified logo sizing with a default setting for more consistent rendering.

- Chores
  - Minor UI polish with no user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->