### PR TITLE
set pts in ffmpeg screen encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "cap-desktop"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/recording/examples/recording-cli.rs
+++ b/crates/recording/examples/recording-cli.rs
@@ -56,7 +56,7 @@ pub async fn main() {
 
     tokio::time::sleep(Duration::from_millis(10)).await;
 
-    let (handle, _ready_rx) = instant_recording::Actor::builder(
+    let (handle, _ready_rx) = studio_recording::Actor::builder(
         dir.path().into(),
         ScreenCaptureTarget::Display {
             id: Display::primary().id(),

--- a/crates/recording/src/studio_recording.rs
+++ b/crates/recording/src/studio_recording.rs
@@ -752,6 +752,7 @@ async fn create_segment_pipeline(
                 pipeline_builder,
                 (screen_source, screen_rx),
                 screen_output_path.clone(),
+                start_time,
             )
             .unwrap();
         pipeline_builder = pipeline_builder_;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Start-time-aware timestamping in studio-mode recordings for consistent frame timing.
  - Cross-platform support (macOS and Windows) for aligned video timestamps.

- Bug Fixes
  - Improved audio/video synchronization and reduced drift/jitter in studio-mode recordings, especially on Windows screen capture.

- Improvements
  - Smoother playback due to more precise PTS sequencing.
  - Enhanced error logging for encoder failures to aid diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->