### PR TITLE
Handle windows rgb types properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,6 +1259,7 @@ dependencies = [
  "cap-audio",
  "cap-camera",
  "cap-camera-ffmpeg",
+ "cap-camera-windows",
  "cap-cursor-capture",
  "cap-cursor-info",
  "cap-enc-avfoundation",

--- a/crates/camera-directshow/Cargo.toml
+++ b/crates/camera-directshow/Cargo.toml
@@ -17,6 +17,7 @@ windows = { workspace = true, features = [
 	"Win32_System_Com_StructuredStorage",
 	"Win32_System_Ole",
 	"Win32_System_Variant",
+	"Win32_System_Performance",
 	"Win32_Media_KernelStreaming",
 ] }
 

--- a/crates/camera-ffmpeg/examples/cli.rs
+++ b/crates/camera-ffmpeg/examples/cli.rs
@@ -23,7 +23,7 @@ fn main() {
 
     let _handle = selected_camera
         .start_capturing(selected_format.0, |frame| {
-            let Ok(ff_frame) = frame.to_ffmpeg() else {
+            let Ok(ff_frame) = frame.as_ffmpeg() else {
                 eprintln!("Failed to convert frame to FFmpeg");
                 return;
             };

--- a/crates/camera-ffmpeg/src/lib.rs
+++ b/crates/camera-ffmpeg/src/lib.rs
@@ -11,5 +11,5 @@ pub use windows::*;
 pub trait CapturedFrameExt {
     /// Creates an ffmpeg video frame from the native frame.
     /// Only size, format, and data are set.
-    fn to_ffmpeg(&self) -> Result<ffmpeg::frame::Video, ToFfmpegError>;
+    fn as_ffmpeg(&self) -> Result<ffmpeg::frame::Video, AsFFmpegError>;
 }

--- a/crates/camera-ffmpeg/src/macos.rs
+++ b/crates/camera-ffmpeg/src/macos.rs
@@ -5,7 +5,7 @@ use cidre::*;
 use crate::CapturedFrameExt;
 
 #[derive(thiserror::Error, Debug)]
-pub enum ToFfmpegError {
+pub enum AsFFmpegError {
     #[error("Unsupported media subtype '{0}'")]
     UnsupportedSubType(String),
     #[error("{0}")]
@@ -13,7 +13,7 @@ pub enum ToFfmpegError {
 }
 
 impl CapturedFrameExt for CapturedFrame {
-    fn to_ffmpeg(&self) -> Result<ffmpeg::frame::Video, ToFfmpegError> {
+    fn as_ffmpeg(&self) -> Result<ffmpeg::frame::Video, AsFFmpegError> {
         let native = self.native().clone();
 
         let width = native.image_buf().width();
@@ -112,7 +112,7 @@ impl CapturedFrameExt for CapturedFrame {
                 ff_frame
             }
             format => {
-                return Err(ToFfmpegError::UnsupportedSubType(format.to_string()));
+                return Err(AsFFmpegError::UnsupportedSubType(format.to_string()));
             }
         };
 

--- a/crates/camera-ffmpeg/src/windows.rs
+++ b/crates/camera-ffmpeg/src/windows.rs
@@ -5,18 +5,18 @@ use ffmpeg::{format::Pixel, frame::Video as FFVideo};
 use crate::CapturedFrameExt;
 
 #[derive(thiserror::Error, Debug)]
-pub enum ToFfmpegError {
+pub enum AsFFmpegError {
     #[error("FailedToGetBytes: {0}")]
     FailedToGetBytes(windows_core::Error),
 }
 
 impl CapturedFrameExt for CapturedFrame {
-    fn to_ffmpeg(&self) -> Result<ffmpeg::frame::Video, ToFfmpegError> {
+    fn as_ffmpeg(&self) -> Result<ffmpeg::frame::Video, AsFFmpegError> {
         let native = self.native();
         let width = native.width;
         let height = native.height;
 
-        let bytes = native.bytes().map_err(ToFfmpegError::FailedToGetBytes)?;
+        let bytes = native.bytes().map_err(AsFFmpegError::FailedToGetBytes)?;
 
         Ok(match native.pixel_format {
             PixelFormat::YUV420P => {
@@ -79,13 +79,18 @@ impl CapturedFrameExt for CapturedFrame {
                 ff_frame
             }
             PixelFormat::ARGB => {
-                let mut ff_frame = FFVideo::new(Pixel::ARGB, width as u32, height as u32);
+                let mut ff_frame = FFVideo::new(
+                    // ik it's weird but that's how windows works
+                    Pixel::BGRA,
+                    width as u32,
+                    height as u32,
+                );
 
                 let stride = ff_frame.stride(0);
 
                 for y in 0..height {
                     let row_width = width * 4;
-                    let src_row = &bytes[y * row_width..];
+                    let src_row = &bytes[(height - y - 1) * row_width..];
                     let dest_row = &mut ff_frame.data_mut(0)[y * stride..];
 
                     dest_row[0..row_width].copy_from_slice(&src_row[0..row_width]);
@@ -100,7 +105,7 @@ impl CapturedFrameExt for CapturedFrame {
 
                 for y in 0..height {
                     let row_width = width * 4;
-                    let src_row = &bytes[y * row_width..];
+                    let src_row = &bytes[(height - y - 1) * row_width..];
                     let dest_row = &mut ff_frame.data_mut(0)[y * stride..];
 
                     dest_row[0..row_width].copy_from_slice(&src_row[0..row_width]);
@@ -115,7 +120,7 @@ impl CapturedFrameExt for CapturedFrame {
 
                 for y in 0..height {
                     let row_width = width * 4;
-                    let src_row = &bytes[y * row_width..];
+                    let src_row = &bytes[(height - y - 1) * row_width..];
                     let dest_row = &mut ff_frame.data_mut(0)[y * stride..];
 
                     dest_row[0..row_width].copy_from_slice(&src_row[0..row_width]);

--- a/crates/recording/Cargo.toml
+++ b/crates/recording/Cargo.toml
@@ -61,6 +61,7 @@ cap-enc-avfoundation = { path = "../enc-avfoundation" }
 cap-enc-mediafoundation = { path = "../enc-mediafoundation" }
 cap-mediafoundation-ffmpeg = { path = "../mediafoundation-ffmpeg" }
 cap-mediafoundation-utils = { path = "../mediafoundation-utils" }
+cap-camera-windows = { path = "../camera-windows" }
 windows = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",

--- a/packages/ui-solid/src/auto-imports.d.ts
+++ b/packages/ui-solid/src/auto-imports.d.ts
@@ -53,7 +53,7 @@ declare global {
   const IconCapSettings: typeof import('~icons/cap/settings.jsx')['default']
   const IconCapShadow: typeof import('~icons/cap/shadow.jsx')['default']
   const IconCapSquare: typeof import('~icons/cap/square.jsx')['default']
-  const IconCapStopCircle: typeof import("~icons/cap/stop-circle.jsx")["default"]
+  const IconCapStopCircle: typeof import('~icons/cap/stop-circle.jsx')['default']
   const IconCapTrash: typeof import('~icons/cap/trash.jsx')['default']
   const IconCapUndo: typeof import('~icons/cap/undo.jsx')['default']
   const IconCapUpload: typeof import("~icons/cap/upload.jsx")["default"]


### PR DESCRIPTION
According to Chromium, rgb32 formats on Windows need their y axis inverted:
<img width="496" height="125" alt="image" src="https://github.com/user-attachments/assets/34da5fb4-333e-45b6-9269-c77a73670cbd" />
Additionally, ARGB is technically represented as BGRA - at least when using NVIDIA Broadcast. Maybe this needs to be more finetuned.