### PR TITLE
Delete on backend after closing window

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1688,6 +1688,14 @@ async fn get_system_audio_waveforms(
     Ok(out)
 }
 
+#[tauri::command]
+#[specta::specta]
+async fn editor_delete_project(editor_instance: WindowEditorInstance, window: tauri::Window) {
+    let _ = window.close();
+
+    let _ = tokio::fs::remove_dir_all(&editor_instance.0.project_path).await;
+}
+
 // keep this async otherwise opening windows may hang on windows
 #[tauri::command]
 #[specta::specta]
@@ -1899,6 +1907,7 @@ pub async fn run(recording_logging_handle: LoggingHandle) {
             target_select_overlay::close_target_select_overlays,
             target_select_overlay::display_information,
             target_select_overlay::get_window_icon,
+            editor_delete_project
         ])
         .events(tauri_specta::collect_events![
             RecordingOptionsChanged,

--- a/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
@@ -40,7 +40,7 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 	};
 
 	return (
-		<div class="flex flex-col w-full h-full custom-scroll">
+		<div class="flex flex-col h-full custom-scroll">
 			<div class="p-4 space-y-4">
 				<div class="flex flex-col pb-4 border-b border-gray-2">
 					<h2 class="text-lg font-medium text-gray-12">

--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -372,7 +372,7 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 	};
 
 	return (
-		<div class="flex flex-col w-full h-full custom-scroll">
+		<div class="flex flex-col h-full custom-scroll">
 			<div class="p-4 space-y-6">
 				<AppearanceSection
 					currentTheme={settings.theme ?? "system"}

--- a/apps/desktop/src/routes/(window-chrome)/settings/hotkeys.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/hotkeys.tsx
@@ -94,7 +94,7 @@ function Inner(props: { initialStore: HotkeysStore | null }) {
 		] satisfies Array<keyof typeof ACTION_TEXT>;
 
 	return (
-		<div class="flex flex-col flex-1 p-4 w-full h-full custom-scroll">
+		<div class="flex flex-col flex-1 p-4 h-full custom-scroll">
 			<div class="flex flex-col pb-4 border-b border-gray-2">
 				<h2 class="text-lg font-medium text-gray-12">Shortcuts</h2>
 				<p class="text-sm text-gray-10 w-full max-w-[500px]">

--- a/apps/desktop/src/routes/(window-chrome)/settings/license.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/license.tsx
@@ -23,7 +23,7 @@ export default function Page() {
 	const queryClient = useQueryClient();
 
 	return (
-		<div class="flex overflow-y-auto relative flex-col gap-3 items-center p-4 mx-auto w-full h-full custom-scroll">
+		<div class="flex relative flex-col gap-3 items-center p-4 mx-auto h-full custom-scroll">
 			<Switch fallback={<CommercialLicensePurchase />}>
 				<Match when={license.data?.type === "pro" && license.data}>
 					<div class="flex justify-center items-center w-full h-screen">

--- a/apps/desktop/src/routes/editor/Header.tsx
+++ b/apps/desktop/src/routes/editor/Header.tsx
@@ -72,15 +72,10 @@ export function Header() {
 				{ostype() === "macos" && <div class="h-full w-[4rem]" />}
 				<EditorButton
 					onClick={async () => {
-						const currentWindow = getCurrentWindow();
-						if (!editorInstance.path) return;
 						if (!(await ask("Are you sure you want to delete this recording?")))
 							return;
-						await remove(editorInstance.path, {
-							recursive: true,
-						});
-						events.recordingDeleted.emit({ path: editorInstance.path });
-						await currentWindow.close();
+
+						await commands.editorDeleteProject();
 					}}
 					tooltipText="Delete recording"
 					leftIcon={<IconCapTrash class="w-5" />}

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -262,6 +262,9 @@ async displayInformation(displayId: string) : Promise<DisplayInformation> {
 },
 async getWindowIcon(windowId: string) : Promise<string | null> {
     return await TAURI_INVOKE("get_window_icon", { windowId });
+},
+async editorDeleteProject() : Promise<void> {
+    await TAURI_INVOKE("editor_delete_project");
 }
 }
 


### PR DESCRIPTION
Fixes delete from editor on Windows by doing the delete after closing the window, preventing the 'File is in use' error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a unified delete action that closes an editor and deletes its project from the app.

- Refactor
  - Editor header now delegates project deletion to the centralized backend command after confirmation.

- Bug Fixes
  - More reliable deletion flow and window cleanup to reduce partial deletions or lingering windows.

- Chores
  - Made the new delete command available to the frontend command set.

- Style
  - Adjusted root container width/overflow in several settings pages for cleaner layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->