### PR TITLE
chore: adjust custom image size of org

### DIFF
--- a/apps/web/app/(org)/dashboard/_components/Navbar/Items.tsx
+++ b/apps/web/app/(org)/dashboard/_components/Navbar/Items.tsx
@@ -130,7 +130,12 @@ const AdminNavItems = ({ toggleMobileNav }: Props) => {
 								>
 									<div className="flex items-center">
 										{activeOrg?.organization.iconUrl ? (
-											<div className="overflow-hidden relative flex-shrink-0 rounded-full size-[18px]">
+											<div
+												className={clsx(
+													"overflow-hidden relative flex-shrink-0 rounded-full",
+													sidebarCollapsed ? "size-6" : "size-7",
+												)}
+											>
 												<Image
 													src={activeOrg.organization.iconUrl}
 													alt={


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - The organization icon in the dashboard navbar now adapts its size based on the sidebar state, appearing slightly smaller when collapsed and larger when expanded.
  - Improves visual balance, alignment, and legibility across layouts, enhancing overall UI consistency without affecting functionality.
  - Provides a more polished appearance in both compact and expanded views of the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->