### PR TITLE
use effect rpc for downloading videos

### DIFF
--- a/apps/web/app/(org)/dashboard/caps/components/CapCard/CapCard.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/CapCard/CapCard.tsx
@@ -7,6 +7,7 @@ import {
 	DropdownMenuTrigger,
 } from "@cap/ui";
 import type { Video } from "@cap/web-domain";
+import { HttpClient } from "@effect/platform";
 import {
 	faCheck,
 	faCopy,
@@ -19,6 +20,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useMutation } from "@tanstack/react-query";
 import clsx from "clsx";
+import { Effect, Option } from "effect";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { type PropsWithChildren, useState } from "react";
@@ -38,8 +40,6 @@ import { SharingDialog } from "../SharingDialog";
 import { CapCardAnalytics } from "./CapCardAnalytics";
 import { CapCardButtons } from "./CapCardButtons";
 import { CapCardContent } from "./CapCardContent";
-import { Effect, Option } from "effect";
-import { HttpClient } from "@effect/platform";
 
 export interface CapCardProps extends PropsWithChildren {
 	cap: {

--- a/apps/web/app/(org)/dashboard/caps/components/CapCard/CapCard.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/CapCard/CapCard.tsx
@@ -38,6 +38,8 @@ import { SharingDialog } from "../SharingDialog";
 import { CapCardAnalytics } from "./CapCardAnalytics";
 import { CapCardButtons } from "./CapCardButtons";
 import { CapCardContent } from "./CapCardContent";
+import { Effect, Option } from "effect";
+import { HttpClient } from "@effect/platform";
 
 export interface CapCardProps extends PropsWithChildren {
 	cap: {
@@ -111,27 +113,29 @@ export const CapCard = ({
 
 	const router = useRouter();
 
-	const downloadMutation = useMutation({
-		mutationFn: async () => {
-			const response = await downloadVideo(cap.id);
-			if (response.success && response.downloadUrl) {
-				const fetchResponse = await fetch(response.downloadUrl);
-				const blob = await fetchResponse.blob();
+	const downloadMutation = useEffectMutation({
+		mutationFn: () =>
+			Effect.gen(function* () {
+				const result = yield* withRpc((r) => r.VideoGetDownloadInfo(cap.id));
+				const httpClient = yield* HttpClient.HttpClient;
+				if (Option.isSome(result)) {
+					const fetchResponse = yield* httpClient.get(result.value.downloadUrl);
+					const blob = yield* fetchResponse.arrayBuffer;
 
-				const blobUrl = window.URL.createObjectURL(blob);
-				const link = document.createElement("a");
-				link.href = blobUrl;
-				link.download = response.filename;
-				link.style.display = "none";
-				document.body.appendChild(link);
-				link.click();
-				document.body.removeChild(link);
+					const blobUrl = window.URL.createObjectURL(new Blob([blob]));
+					const link = document.createElement("a");
+					link.href = blobUrl;
+					link.download = result.value.fileName;
+					link.style.display = "none";
+					document.body.appendChild(link);
+					link.click();
+					document.body.removeChild(link);
 
-				window.URL.revokeObjectURL(blobUrl);
-			} else {
-				throw new Error("Failed to get download URL");
-			}
-		},
+					window.URL.revokeObjectURL(blobUrl);
+				} else {
+					throw new Error("Failed to get download URL");
+				}
+			}),
 	});
 
 	const deleteMutation = useMutation({

--- a/apps/web/lib/EffectRuntime.ts
+++ b/apps/web/lib/EffectRuntime.ts
@@ -1,4 +1,5 @@
 import * as WebSdk from "@effect/opentelemetry/WebSdk";
+import { FetchHttpClient } from "@effect/platform";
 import { Layer, ManagedRuntime } from "effect";
 import {
 	makeUseEffectMutation,
@@ -9,7 +10,11 @@ import { getTracingConfig } from "./tracing";
 
 const TracingLayer = WebSdk.layer(getTracingConfig);
 
-const RuntimeLayer = Layer.mergeAll(Rpc.Default, TracingLayer);
+const RuntimeLayer = Layer.mergeAll(
+	Rpc.Default,
+	TracingLayer,
+	FetchHttpClient.layer,
+);
 
 export type RuntimeLayer = typeof RuntimeLayer;
 

--- a/packages/web-backend/src/Videos/VideosRpcs.ts
+++ b/packages/web-backend/src/Videos/VideosRpcs.ts
@@ -31,6 +31,15 @@ export const VideosRpcsLive = Video.VideoRpcs.toLayer(
 						UnknownException: () => new InternalError({ type: "unknown" }),
 					}),
 				),
+			VideoGetDownloadInfo: (videoId) =>
+				videos.getDownloadInfo(videoId).pipe(
+					provideOptionalAuth,
+					Effect.catchTags({
+						DatabaseError: () => new InternalError({ type: "database" }),
+						UnknownException: () => new InternalError({ type: "unknown" }),
+						S3Error: () => new InternalError({ type: "s3" }),
+					}),
+				),
 		};
 	}),
 );

--- a/packages/web-domain/src/Video.ts
+++ b/packages/web-domain/src/Video.ts
@@ -156,4 +156,16 @@ export class VideoRpcs extends RpcGroup.make(
 			VerifyVideoPasswordError,
 		),
 	}),
+	Rpc.make("VideoGetDownloadInfo", {
+		payload: VideoId,
+		success: Schema.Option(
+			Schema.Struct({ fileName: Schema.String, downloadUrl: Schema.String }),
+		),
+		error: Schema.Union(
+			NotFoundError,
+			InternalError,
+			PolicyDeniedError,
+			VerifyVideoPasswordError,
+		),
+	}),
 ) {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced secure video downloads from dashboard cap cards. Generates a time-limited link and downloads the MP4 with the correct filename.
  - Honors access policies and protected videos; provides a clear message if the download isn’t available.

- Bug Fixes
  - Improved reliability and user feedback for download failures (e.g., not found, access denied, internal errors).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->