### PR TITLE
fix: copy link

### DIFF
--- a/apps/web/app/(org)/dashboard/caps/components/CapCard/CapCard.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/CapCard/CapCard.tsx
@@ -1,4 +1,5 @@
 import type { VideoMetadata } from "@cap/database/types";
+import { buildEnv, NODE_ENV } from "@cap/env";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -320,7 +321,11 @@ export const CapCard = ({
 						tooltipContent="Copy link"
 						onClick={(e) => {
 							e.stopPropagation();
-							handleCopy(cap.id);
+							handleCopy(
+								buildEnv.NEXT_PUBLIC_IS_CAP && NODE_ENV === "production"
+									? `https://cap.link/${cap.id}`
+									: `${location.origin}/s/${cap.id}`,
+							);
 						}}
 						className="delay-0"
 						icon={() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Copy Link button on Cap cards now generates environment-aware share URLs. In production on CAP, it copies a short cap.link/{id} link; in other environments, it copies a full link based on the current site origin. Existing copy interaction and UI feedback remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->