### PR TITLE
Local upload tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,6 +1146,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytemuck",
+ "bytes",
  "cap-audio",
  "cap-camera",
  "cap-editor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,6 +1218,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "tauri-specta",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -104,6 +104,7 @@ bytemuck = "1.23.1"
 kameo = "0.17.2"
 tauri-plugin-sentry = "0.5.0"
 thiserror.workspace = true
+bytes = "1.10.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.24.0"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -103,6 +103,7 @@ wgpu.workspace = true
 bytemuck = "1.23.1"
 kameo = "0.17.2"
 tauri-plugin-sentry = "0.5.0"
+thiserror.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.24.0"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1111,9 +1111,9 @@ async fn upload_exported_video(
         &app,
         upload_id.clone(),
         output_path,
-        Some(s3_config),
-        Some(meta.project_path.join("screenshots/display.jpg")),
-        Some(metadata),
+        meta.project_path.join("screenshots/display.jpg"),
+        s3_config,
+        metadata,
         Some(channel.clone()),
     )
     .await

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -30,10 +30,7 @@ use crate::{
     general_settings::{GeneralSettingsStore, PostDeletionBehaviour, PostStudioRecordingBehaviour},
     open_external_link,
     presets::PresetsStore,
-    upload::{
-        InstantMultipartUpload, build_video_meta, create_or_get_video, prepare_screenshot_upload,
-        upload_video,
-    },
+    upload::{InstantMultipartUpload, build_video_meta, create_or_get_video, upload_video},
     web_api::ManagerExt,
     windows::{CapWindowId, ShowCapWindow},
 };
@@ -782,26 +779,27 @@ async fn handle_recording_finish(
                         let _ = screenshot_task.await;
 
                         if video_upload_succeeded {
-                            let resp = prepare_screenshot_upload(
-                                &app,
-                                &video_upload_info.config.clone(),
-                                display_screenshot,
-                            )
-                            .await;
+                            // let resp = prepare_screenshot_upload(
+                            //     &app,
+                            //     &video_upload_info.config.clone(),
+                            //     display_screenshot,
+                            // )
+                            // .await;
 
-                            match resp {
-                                Ok(r)
-                                    if r.status().as_u16() >= 200 && r.status().as_u16() < 300 =>
-                                {
-                                    info!("Screenshot uploaded successfully");
-                                }
-                                Ok(r) => {
-                                    error!("Failed to upload screenshot: {}", r.status());
-                                }
-                                Err(e) => {
-                                    error!("Failed to upload screenshot: {e}");
-                                }
-                            }
+                            // match resp {
+                            //     Ok(r)
+                            //         if r.status().as_u16() >= 200 && r.status().as_u16() < 300 =>
+                            //     {
+                            //         info!("Screenshot uploaded successfully");
+                            //     }
+                            //     Ok(r) => {
+                            //         error!("Failed to upload screenshot: {}", r.status());
+                            //     }
+                            //     Err(e) => {
+                            //         error!("Failed to upload screenshot: {e}");
+                            //     }
+                            // }
+                            todo!();
                         } else {
                             if let Ok(meta) = build_video_meta(&output_path)
                                 .map_err(|err| error!("Error getting video metdata: {}", err))

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -803,26 +803,29 @@ async fn handle_recording_finish(
                                 }
                             }
                         } else {
-                            let meta = build_video_meta(&output_path).ok();
-                            // The upload_video function handles screenshot upload, so we can pass it along
-                            match upload_video(
-                                &app,
-                                video_upload_info.id.clone(),
-                                output_path,
-                                Some(video_upload_info.config.clone()),
-                                Some(display_screenshot.clone()),
-                                meta,
-                                None,
-                            )
-                            .await
+                            if let Ok(meta) = build_video_meta(&output_path)
+                                .map_err(|err| error!("Error getting video metdata: {}", err))
                             {
-                                Ok(_) => {
-                                    info!(
-                                        "Final video upload with screenshot completed successfully"
-                                    )
-                                }
-                                Err(e) => {
-                                    error!("Error in final upload with screenshot: {}", e)
+                                // The upload_video function handles screenshot upload, so we can pass it along
+                                match upload_video(
+                                    &app,
+                                    video_upload_info.id.clone(),
+                                    output_path,
+                                    display_screenshot.clone(),
+                                    video_upload_info.config.clone(),
+                                    meta,
+                                    None,
+                                )
+                                .await
+                                {
+                                    Ok(_) => {
+                                        info!(
+                                            "Final video upload with screenshot completed successfully"
+                                        )
+                                    }
+                                    Err(e) => {
+                                        error!("Error in final upload with screenshot: {}", e)
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
TODO:
 - [ ] `do_presigned_upload` typed error
 - [ ] `do_presigned_upload` reporting progress to frontend
 - [ ] `do_presigned_upload` reporting progress to cloud
 - [ ] Cleanup imports in `upload.rs`
 - [ ] Can we store failed uploads on the project itself so we have it when the app restarts???
 - [ ] `upload_image` needs progress reporting
 - [ ] Is `progressive_upload` optional for instant mode???
 - [ ] Retry and backoff on the `do_presigned_upload` function. I think the multipart upload already has this logic so can we share it?
 - [ ] Progress being reported to the frontend