### PR TITLE
Implement list view in the new recording flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,6 +1188,8 @@ dependencies = [
  "reqwest",
  "rodio",
  "scap",
+ "scap-direct3d",
+ "scap-screencapturekit",
  "scap-targets",
  "sentry",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -89,6 +89,8 @@ cap-flags = { path = "../../../crates/flags" }
 cap-recording = { path = "../../../crates/recording" }
 cap-export = { path = "../../../crates/export" }
 scap-targets = { path = "../../../crates/scap-targets" }
+scap-screencapturekit = { path = "../../../crates/scap-screencapturekit" }
+scap-direct3d = { path = "../../../crates/scap-direct3d" }
 
 flume.workspace = true
 tracing-subscriber = "0.3.19"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1856,6 +1856,8 @@ pub async fn run(recording_logging_handle: LoggingHandle) {
             recording::list_cameras,
             recording::list_capture_windows,
             recording::list_capture_displays,
+            recording::list_displays_with_thumbnails,
+            recording::list_windows_with_thumbnails,
             take_screenshot,
             list_audio_devices,
             close_recordings_overlay_window,
@@ -1922,6 +1924,7 @@ pub async fn run(recording_logging_handle: LoggingHandle) {
             target_select_overlay::close_target_select_overlays,
             target_select_overlay::display_information,
             target_select_overlay::get_window_icon,
+            target_select_overlay::focus_window,
             editor_delete_project
         ])
         .events(tauri_specta::collect_events![

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -13,13 +13,13 @@ use cap_recording::{
 };
 use cap_rendering::ProjectRecordingsMeta;
 use cap_utils::{ensure_dir, spawn_actor};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use specta::Type;
 use std::{path::PathBuf, str::FromStr, sync::Arc, time::Duration};
 use tauri::{AppHandle, Manager};
 use tauri_plugin_dialog::{DialogExt, MessageDialogBuilder};
 use tauri_specta::Event;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     App, CurrentRecordingChanged, MutableState, NewStudioRecordingAdded, RecordingState,
@@ -182,6 +182,667 @@ pub async fn list_capture_windows() -> Vec<CaptureWindow> {
 #[specta::specta]
 pub fn list_cameras() -> Vec<cap_camera::CameraInfo> {
     cap_camera::list_cameras().collect()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct CaptureDisplayWithThumbnail {
+    pub id: scap_targets::DisplayId,
+    pub name: String,
+    pub refresh_rate: u32,
+    pub thumbnail: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct CaptureWindowWithThumbnail {
+    pub id: scap_targets::WindowId,
+    pub owner_name: String,
+    pub name: String,
+    pub bounds: scap_targets::bounds::LogicalBounds,
+    pub refresh_rate: u32,
+    pub thumbnail: Option<String>,
+    pub app_icon: Option<String>,
+}
+
+#[cfg(target_os = "macos")]
+async fn capture_thumbnail_from_filter(filter: &cidre::sc::ContentFilter) -> Option<String> {
+    use cidre::{cv, sc};
+    use image::{ImageEncoder, RgbaImage, codecs::png::PngEncoder};
+    use std::{io::Cursor, slice};
+
+    let mut config = sc::StreamCfg::new();
+    config.set_width(200);
+    config.set_height(112);
+    config.set_shows_cursor(false);
+
+    let sample_buf =
+        match unsafe { sc::ScreenshotManager::capture_sample_buf(filter, &config) }.await {
+            Ok(buf) => buf,
+            Err(err) => {
+                warn!(error = ?err, "Failed to capture sample buffer for thumbnail");
+                return None;
+            }
+        };
+
+    let Some(image_buf) = sample_buf.image_buf() else {
+        warn!("Sample buffer missing image data");
+        return None;
+    };
+    let mut image_buf = image_buf.retained();
+
+    let width = image_buf.width();
+    let height = image_buf.height();
+    if width == 0 || height == 0 {
+        warn!(
+            width = width,
+            height = height,
+            "Captured thumbnail had empty dimensions"
+        );
+        return None;
+    }
+
+    let pixel_format = image_buf.pixel_format();
+
+    let lock =
+        match PixelBufferLock::new(image_buf.as_mut(), cv::pixel_buffer::LockFlags::READ_ONLY) {
+            Ok(lock) => lock,
+            Err(err) => {
+                warn!(error = ?err, "Failed to lock pixel buffer for thumbnail");
+                return None;
+            }
+        };
+
+    let rgba_data = match pixel_format {
+        cv::PixelFormat::_32_BGRA
+        | cv::PixelFormat::_32_RGBA
+        | cv::PixelFormat::_32_ARGB
+        | cv::PixelFormat::_32_ABGR => {
+            convert_32bit_pixel_buffer(&lock, width, height, pixel_format)?
+        }
+        cv::PixelFormat::_420V => {
+            convert_nv12_pixel_buffer(&lock, width, height, Nv12Range::Video)?
+        }
+        other => {
+            warn!(?other, "Unsupported pixel format for thumbnail capture");
+            return None;
+        }
+    };
+
+    let Some(img) = RgbaImage::from_raw(width as u32, height as u32, rgba_data) else {
+        warn!("Failed to construct RGBA image for thumbnail");
+        return None;
+    };
+    let mut png_data = Cursor::new(Vec::new());
+    let encoder = PngEncoder::new(&mut png_data);
+    if let Err(err) = encoder.write_image(
+        img.as_raw(),
+        img.width(),
+        img.height(),
+        image::ColorType::Rgba8.into(),
+    ) {
+        warn!(error = ?err, "Failed to encode thumbnail as PNG");
+        return None;
+    }
+
+    Some(base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        png_data.into_inner(),
+    ))
+}
+
+#[cfg(target_os = "macos")]
+fn convert_32bit_pixel_buffer(
+    lock: &PixelBufferLock<'_>,
+    width: usize,
+    height: usize,
+    pixel_format: cidre::cv::PixelFormat,
+) -> Option<Vec<u8>> {
+    let base_ptr = lock.base_address();
+    if base_ptr.is_null() {
+        warn!("Pixel buffer base address was null");
+        return None;
+    }
+
+    let bytes_per_row = lock.bytes_per_row();
+    let total_len = bytes_per_row.checked_mul(height)?;
+    let raw_data = unsafe { std::slice::from_raw_parts(base_ptr, total_len) };
+
+    let mut rgba_data = Vec::with_capacity(width * height * 4);
+    for y in 0..height {
+        let row_start = y * bytes_per_row;
+        let row_end = row_start + width * 4;
+        if row_end > raw_data.len() {
+            warn!(
+                row_start = row_start,
+                row_end = row_end,
+                raw_len = raw_data.len(),
+                "Row bounds exceeded raw data length during thumbnail capture",
+            );
+            return None;
+        }
+
+        let row = &raw_data[row_start..row_end];
+        for chunk in row.chunks_exact(4) {
+            match pixel_format {
+                cidre::cv::PixelFormat::_32_BGRA => {
+                    rgba_data.extend_from_slice(&[chunk[2], chunk[1], chunk[0], chunk[3]])
+                }
+                cidre::cv::PixelFormat::_32_RGBA => rgba_data.extend_from_slice(chunk),
+                cidre::cv::PixelFormat::_32_ARGB => {
+                    rgba_data.extend_from_slice(&[chunk[1], chunk[2], chunk[3], chunk[0]])
+                }
+                cidre::cv::PixelFormat::_32_ABGR => {
+                    rgba_data.extend_from_slice(&[chunk[3], chunk[2], chunk[1], chunk[0]])
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    Some(rgba_data)
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Copy, Clone)]
+enum Nv12Range {
+    Video,
+    Full,
+}
+
+#[cfg(target_os = "macos")]
+fn convert_nv12_pixel_buffer(
+    lock: &PixelBufferLock<'_>,
+    width: usize,
+    height: usize,
+    range: Nv12Range,
+) -> Option<Vec<u8>> {
+    let y_base = lock.base_address_of_plane(0);
+    let uv_base = lock.base_address_of_plane(1);
+    if y_base.is_null() || uv_base.is_null() {
+        warn!("NV12 plane base address was null");
+        return None;
+    }
+
+    let y_stride = lock.bytes_per_row_of_plane(0);
+    let uv_stride = lock.bytes_per_row_of_plane(1);
+    if y_stride == 0 || uv_stride == 0 {
+        warn!(y_stride, uv_stride, "NV12 plane bytes per row was zero");
+        return None;
+    }
+
+    let y_plane_height = lock.height_of_plane(0);
+    let uv_plane_height = lock.height_of_plane(1);
+    if y_plane_height < height || uv_plane_height < (height + 1) / 2 {
+        warn!(
+            y_plane_height,
+            uv_plane_height,
+            expected_y = height,
+            expected_uv = (height + 1) / 2,
+            "NV12 plane height smaller than expected",
+        );
+        return None;
+    }
+
+    let y_plane = unsafe { std::slice::from_raw_parts(y_base, y_stride * y_plane_height) };
+    let uv_plane = unsafe { std::slice::from_raw_parts(uv_base, uv_stride * uv_plane_height) };
+
+    let mut rgba_data = vec![0u8; width * height * 4];
+
+    for y_idx in 0..height {
+        let y_row_start = y_idx * y_stride;
+        if y_row_start + width > y_plane.len() {
+            warn!(
+                y_row_start,
+                width,
+                y_plane_len = y_plane.len(),
+                "Y row exceeded plane length during conversion",
+            );
+            return None;
+        }
+        let y_row = &y_plane[y_row_start..y_row_start + width];
+
+        let uv_row_start = (y_idx / 2) * uv_stride;
+        if uv_row_start + width > uv_plane.len() {
+            warn!(
+                uv_row_start,
+                width,
+                uv_plane_len = uv_plane.len(),
+                "UV row exceeded plane length during conversion",
+            );
+            return None;
+        }
+        let uv_row = &uv_plane[uv_row_start..uv_row_start + width];
+
+        for x in 0..width {
+            let uv_index = (x / 2) * 2;
+            if uv_index + 1 >= uv_row.len() {
+                warn!(
+                    uv_index,
+                    uv_row_len = uv_row.len(),
+                    "UV index out of bounds during conversion",
+                );
+                return None;
+            }
+
+            let y_val = y_row[x];
+            let cb = uv_row[uv_index];
+            let cr = uv_row[uv_index + 1];
+            let (r, g, b) = ycbcr_to_rgb(y_val, cb, cr, range);
+            let out = (y_idx * width + x) * 4;
+            rgba_data[out] = r;
+            rgba_data[out + 1] = g;
+            rgba_data[out + 2] = b;
+            rgba_data[out + 3] = 255;
+        }
+    }
+
+    Some(rgba_data)
+}
+
+#[cfg(target_os = "macos")]
+fn ycbcr_to_rgb(y: u8, cb: u8, cr: u8, range: Nv12Range) -> (u8, u8, u8) {
+    let y = y as f32;
+    let cb = cb as f32 - 128.0;
+    let cr = cr as f32 - 128.0;
+
+    let (y_value, scale) = match range {
+        Nv12Range::Video => ((y - 16.0).max(0.0), 1.164383_f32),
+        Nv12Range::Full => (y, 1.0_f32),
+    };
+
+    let r = scale * y_value + 1.596027_f32 * cr;
+    let g = scale * y_value - 0.391762_f32 * cb - 0.812968_f32 * cr;
+    let b = scale * y_value + 2.017232_f32 * cb;
+
+    (clamp_channel(r), clamp_channel(g), clamp_channel(b))
+}
+
+#[cfg(target_os = "macos")]
+fn clamp_channel(value: f32) -> u8 {
+    value.max(0.0).min(255.0) as u8
+}
+
+#[cfg(target_os = "macos")]
+struct PixelBufferLock<'a> {
+    buffer: &'a mut cidre::cv::PixelBuf,
+    flags: cidre::cv::pixel_buffer::LockFlags,
+}
+
+#[cfg(target_os = "macos")]
+impl<'a> PixelBufferLock<'a> {
+    fn new(
+        buffer: &'a mut cidre::cv::PixelBuf,
+        flags: cidre::cv::pixel_buffer::LockFlags,
+    ) -> cidre::os::Result<Self> {
+        unsafe { buffer.lock_base_addr(flags) }.result()?;
+        Ok(Self { buffer, flags })
+    }
+
+    fn base_address(&self) -> *const u8 {
+        unsafe { cv_pixel_buffer_get_base_address(self.buffer) as *const u8 }
+    }
+
+    fn bytes_per_row(&self) -> usize {
+        unsafe { cv_pixel_buffer_get_bytes_per_row(self.buffer) }
+    }
+
+    fn base_address_of_plane(&self, plane_index: usize) -> *const u8 {
+        unsafe { cv_pixel_buffer_get_base_address_of_plane(self.buffer, plane_index) as *const u8 }
+    }
+
+    fn bytes_per_row_of_plane(&self, plane_index: usize) -> usize {
+        unsafe { cv_pixel_buffer_get_bytes_per_row_of_plane(self.buffer, plane_index) }
+    }
+
+    fn height_of_plane(&self, plane_index: usize) -> usize {
+        unsafe { cv_pixel_buffer_get_height_of_plane(self.buffer, plane_index) }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for PixelBufferLock<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = self.buffer.unlock_lock_base_addr(self.flags);
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn cv_pixel_buffer_get_base_address(buffer: &cidre::cv::PixelBuf) -> *mut std::ffi::c_void {
+    unsafe extern "C" {
+        fn CVPixelBufferGetBaseAddress(pixel_buffer: &cidre::cv::PixelBuf)
+        -> *mut std::ffi::c_void;
+    }
+
+    unsafe { CVPixelBufferGetBaseAddress(buffer) }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn cv_pixel_buffer_get_bytes_per_row(buffer: &cidre::cv::PixelBuf) -> usize {
+    unsafe extern "C" {
+        fn CVPixelBufferGetBytesPerRow(pixel_buffer: &cidre::cv::PixelBuf) -> usize;
+    }
+
+    unsafe { CVPixelBufferGetBytesPerRow(buffer) }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn cv_pixel_buffer_get_base_address_of_plane(
+    buffer: &cidre::cv::PixelBuf,
+    plane_index: usize,
+) -> *mut std::ffi::c_void {
+    unsafe extern "C" {
+        fn CVPixelBufferGetBaseAddressOfPlane(
+            pixel_buffer: &cidre::cv::PixelBuf,
+            plane_index: usize,
+        ) -> *mut std::ffi::c_void;
+    }
+
+    unsafe { CVPixelBufferGetBaseAddressOfPlane(buffer, plane_index) }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn cv_pixel_buffer_get_bytes_per_row_of_plane(
+    buffer: &cidre::cv::PixelBuf,
+    plane_index: usize,
+) -> usize {
+    unsafe extern "C" {
+        fn CVPixelBufferGetBytesPerRowOfPlane(
+            pixel_buffer: &cidre::cv::PixelBuf,
+            plane_index: usize,
+        ) -> usize;
+    }
+
+    unsafe { CVPixelBufferGetBytesPerRowOfPlane(buffer, plane_index) }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn cv_pixel_buffer_get_height_of_plane(
+    buffer: &cidre::cv::PixelBuf,
+    plane_index: usize,
+) -> usize {
+    unsafe extern "C" {
+        fn CVPixelBufferGetHeightOfPlane(
+            pixel_buffer: &cidre::cv::PixelBuf,
+            plane_index: usize,
+        ) -> usize;
+    }
+
+    unsafe { CVPixelBufferGetHeightOfPlane(buffer, plane_index) }
+}
+
+#[cfg(target_os = "macos")]
+async fn capture_display_thumbnail(display: &scap_targets::Display) -> Option<String> {
+    let filter = display.raw_handle().as_content_filter().await?;
+    capture_thumbnail_from_filter(filter.as_ref()).await
+}
+
+#[cfg(windows)]
+async fn capture_display_thumbnail(display: &scap_targets::Display) -> Option<String> {
+    use image::{ColorType, ImageEncoder, codecs::png::PngEncoder};
+    use scap_direct3d::{Capturer, Settings};
+    use std::io::Cursor;
+
+    let item = display.raw_handle().get_capture_item().ok()?;
+
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    let settings = Settings {
+        is_cursor_capture_enabled: Some(false),
+        pixel_format: scap_direct3d::PixelFormat::R8G8B8A8Unorm,
+        ..Default::default()
+    };
+
+    let capturer = Capturer::new(
+        item,
+        settings.clone(),
+        move |frame| {
+            let _ = tx.send(frame);
+            Ok(())
+        },
+        || Ok(()),
+        None,
+    )
+    .ok()?;
+
+    capturer.start().ok()?;
+
+    let frame = rx.recv_timeout(std::time::Duration::from_secs(2)).ok()?;
+    let _ = capturer.stop();
+
+    let width = frame.width();
+    let height = frame.height();
+
+    if width == 0 || height == 0 {
+        return None;
+    }
+
+    let target_width = 320u32;
+    let target_height = (height as f32 * (target_width as f32 / width as f32)) as u32;
+
+    let frame_buffer = frame.as_buffer().ok()?;
+    let data = frame_buffer.data();
+    let stride = frame_buffer.stride() as usize;
+
+    let mut rgba_data = Vec::with_capacity((width * height * 4) as usize);
+    for y in 0..height as usize {
+        for x in 0..width as usize {
+            let offset = y * stride + x * 4;
+            if offset + 3 < data.len() {
+                rgba_data.push(data[offset]);
+                rgba_data.push(data[offset + 1]);
+                rgba_data.push(data[offset + 2]);
+                rgba_data.push(data[offset + 3]);
+            }
+        }
+    }
+
+    let img = image::RgbaImage::from_raw(width, height, rgba_data)?;
+    let resized = image::imageops::resize(
+        &img,
+        target_width,
+        target_height,
+        image::imageops::FilterType::Lanczos3,
+    );
+
+    let mut png_data = Cursor::new(Vec::new());
+    let encoder = PngEncoder::new(&mut png_data);
+    encoder
+        .write_image(
+            resized.as_raw(),
+            target_width,
+            target_height,
+            ColorType::Rgba8,
+        )
+        .ok()?;
+
+    Some(base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        png_data.into_inner(),
+    ))
+}
+
+#[cfg(target_os = "macos")]
+async fn capture_window_thumbnail(window: &scap_targets::Window) -> Option<String> {
+    let sc_window = window.raw_handle().as_sc().await?;
+    let filter = cidre::sc::ContentFilter::with_desktop_independent_window(&sc_window);
+    capture_thumbnail_from_filter(filter.as_ref()).await
+}
+
+#[cfg(windows)]
+async fn capture_window_thumbnail(window: &scap_targets::Window) -> Option<String> {
+    use image::{ColorType, ImageEncoder, codecs::png::PngEncoder};
+    use scap_direct3d::{Capturer, Settings};
+    use std::io::Cursor;
+
+    let item = window.raw_handle().get_capture_item().ok()?;
+
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    let settings = Settings {
+        is_cursor_capture_enabled: Some(false),
+        pixel_format: scap_direct3d::PixelFormat::R8G8B8A8Unorm,
+        ..Default::default()
+    };
+
+    let capturer = Capturer::new(
+        item,
+        settings.clone(),
+        move |frame| {
+            let _ = tx.send(frame);
+            Ok(())
+        },
+        || Ok(()),
+        None,
+    )
+    .ok()?;
+
+    capturer.start().ok()?;
+
+    let frame = rx.recv_timeout(std::time::Duration::from_secs(2)).ok()?;
+    let _ = capturer.stop();
+
+    let width = frame.width();
+    let height = frame.height();
+
+    if width == 0 || height == 0 {
+        return None;
+    }
+
+    let target_width = 200u32;
+    let target_height = (height as f32 * (target_width as f32 / width as f32)) as u32;
+
+    let frame_buffer = frame.as_buffer().ok()?;
+    let data = frame_buffer.data();
+    let stride = frame_buffer.stride() as usize;
+
+    let mut rgba_data = Vec::with_capacity((width * height * 4) as usize);
+    for y in 0..height as usize {
+        for x in 0..width as usize {
+            let offset = y * stride + x * 4;
+            if offset + 3 < data.len() {
+                rgba_data.push(data[offset]);
+                rgba_data.push(data[offset + 1]);
+                rgba_data.push(data[offset + 2]);
+                rgba_data.push(data[offset + 3]);
+            }
+        }
+    }
+
+    let img = image::RgbaImage::from_raw(width, height, rgba_data)?;
+    let resized = image::imageops::resize(
+        &img,
+        target_width,
+        target_height,
+        image::imageops::FilterType::Lanczos3,
+    );
+
+    let mut png_data = Cursor::new(Vec::new());
+    let encoder = PngEncoder::new(&mut png_data);
+    encoder
+        .write_image(
+            resized.as_raw(),
+            target_width,
+            target_height,
+            ColorType::Rgba8,
+        )
+        .ok()?;
+
+    Some(base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        png_data.into_inner(),
+    ))
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+pub async fn list_displays_with_thumbnails() -> Result<Vec<CaptureDisplayWithThumbnail>, String> {
+    tokio::task::spawn_blocking(|| collect_displays_with_thumbnails())
+        .await
+        .map_err(|err| err.to_string())?
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+pub async fn list_windows_with_thumbnails() -> Result<Vec<CaptureWindowWithThumbnail>, String> {
+    tokio::task::spawn_blocking(|| collect_windows_with_thumbnails())
+        .await
+        .map_err(|err| err.to_string())?
+}
+
+fn collect_displays_with_thumbnails() -> Result<Vec<CaptureDisplayWithThumbnail>, String> {
+    tauri::async_runtime::block_on(async move {
+        let displays = screen_capture::list_displays();
+
+        let mut results = Vec::new();
+        for (capture_display, display) in displays {
+            let thumbnail = capture_display_thumbnail(&display).await;
+            results.push(CaptureDisplayWithThumbnail {
+                id: capture_display.id,
+                name: capture_display.name,
+                refresh_rate: capture_display.refresh_rate,
+                thumbnail,
+            });
+        }
+
+        Ok(results)
+    })
+}
+
+fn collect_windows_with_thumbnails() -> Result<Vec<CaptureWindowWithThumbnail>, String> {
+    tauri::async_runtime::block_on(async move {
+        let windows = screen_capture::list_windows();
+
+        debug!(window_count = windows.len(), "Collecting window thumbnails");
+        let mut results = Vec::new();
+        for (capture_window, window) in windows {
+            let thumbnail = capture_window_thumbnail(&window).await;
+            let app_icon = window
+                .app_icon()
+                .and_then(|bytes| {
+                    if bytes.is_empty() {
+                        None
+                    } else {
+                        Some(
+                            base64::Engine::encode(
+                                &base64::engine::general_purpose::STANDARD,
+                                bytes,
+                            ),
+                        )
+                    }
+                });
+
+            if thumbnail.is_none() {
+                warn!(
+                    window_id = ?capture_window.id,
+                    window_name = %capture_window.name,
+                    owner_name = %capture_window.owner_name,
+                    "Window thumbnail capture returned None",
+                );
+            } else {
+                debug!(
+                    window_id = ?capture_window.id,
+                    window_name = %capture_window.name,
+                    owner_name = %capture_window.owner_name,
+                    "Captured window thumbnail",
+                );
+            }
+
+            results.push(CaptureWindowWithThumbnail {
+                id: capture_window.id,
+                name: capture_window.name,
+                owner_name: capture_window.owner_name,
+                bounds: capture_window.bounds,
+                refresh_rate: capture_window.refresh_rate,
+                thumbnail,
+                app_icon,
+            });
+        }
+
+        info!(windows = results.len(), "Collected window thumbnail data");
+
+        Ok(results)
+    })
 }
 
 #[derive(Deserialize, Type, Clone, Debug)]

--- a/apps/desktop/src/routes/(window-chrome)/new-main/TargetCard.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/TargetCard.tsx
@@ -1,0 +1,217 @@
+import { cx } from "cva";
+import type { ComponentProps } from "solid-js";
+import { createMemo, Show, splitProps } from "solid-js";
+import type {
+	CaptureDisplayWithThumbnail,
+	CaptureWindowWithThumbnail,
+} from "~/utils/tauri";
+import IconLucideAppWindowMac from "~icons/lucide/app-window-mac";
+import IconMdiMonitor from "~icons/mdi/monitor";
+
+function formatResolution(width?: number, height?: number) {
+	if (!width || !height) return undefined;
+
+	const roundedWidth = Math.round(width);
+	const roundedHeight = Math.round(height);
+
+	if (roundedWidth <= 0 || roundedHeight <= 0) return undefined;
+
+	return `${roundedWidth}×${roundedHeight}`;
+}
+
+function formatRefreshRate(refreshRate?: number) {
+	if (!refreshRate) return undefined;
+
+	return `${refreshRate} Hz`;
+}
+
+type TargetCardProps = (
+	| {
+			variant: "display";
+			target: CaptureDisplayWithThumbnail;
+	  }
+	| {
+			variant: "window";
+			target: CaptureWindowWithThumbnail;
+	  }
+) &
+	Omit<ComponentProps<"button">, "children"> & {
+		highlightQuery?: string;
+	};
+
+export default function TargetCard(props: TargetCardProps) {
+	const [local, rest] = splitProps(props, [
+		"variant",
+		"target",
+		"class",
+		"disabled",
+		"highlightQuery",
+	]);
+
+	const displayTarget = createMemo(() => {
+		if (local.variant !== "display") return undefined;
+		return local.target as CaptureDisplayWithThumbnail;
+	});
+
+	const windowTarget = createMemo(() => {
+		if (local.variant !== "window") return undefined;
+		return local.target as CaptureWindowWithThumbnail;
+	});
+
+	const renderIcon = (className: string) =>
+		local.variant === "display" ? (
+			<IconMdiMonitor class={className} />
+		) : (
+			<IconLucideAppWindowMac class={className} />
+		);
+
+	const label = createMemo(() => {
+		const display = displayTarget();
+		if (display) return display.name;
+		const target = windowTarget();
+		return target?.name || target?.owner_name;
+	});
+
+	const subtitle = createMemo(() => windowTarget()?.owner_name);
+
+	const metadata = createMemo(() => {
+		if (local.variant === "window") {
+			const target = windowTarget();
+			if (!target) return undefined;
+			const bounds = target.bounds;
+			const resolution = formatResolution(
+				bounds?.size.width,
+				bounds?.size.height,
+			);
+			const refreshRate = formatRefreshRate(target.refresh_rate);
+
+			if (resolution && refreshRate) return `${resolution} @ ${refreshRate}`;
+			return resolution ?? refreshRate ?? undefined;
+		}
+
+		const target = displayTarget();
+		return target ? formatRefreshRate(target.refresh_rate) : undefined;
+	});
+
+	const thumbnailSrc = createMemo(() => {
+		const target = displayTarget() ?? windowTarget();
+		if (!target?.thumbnail) return undefined;
+		return `data:image/png;base64,${target.thumbnail}`;
+	});
+
+	const appIconSrc = createMemo(() => {
+		const target = windowTarget();
+		if (!target?.app_icon) return undefined;
+		return `data:image/png;base64,${target.app_icon}`;
+	});
+
+	const normalizedQuery = createMemo(() => local.highlightQuery?.trim() ?? "");
+
+	const highlight = (text?: string | null) => {
+		if (!text) return text;
+		const query = normalizedQuery();
+		if (!query) return text;
+
+		const regex = new RegExp(`(${escapeRegExp(query)})`, "ig");
+		const parts = text.split(regex);
+		if (parts.length === 1) return text;
+
+		const lowercaseQuery = query.toLowerCase();
+
+		return parts.map((part) => {
+			if (part.toLowerCase() === lowercaseQuery) {
+				return (
+					<span class="rounded bg-blue-9/20 px-[1px] text-gray-12">{part}</span>
+				);
+			}
+			return part;
+		});
+	};
+
+	return (
+		<button
+			type="button"
+			{...rest}
+			disabled={local.disabled}
+			data-variant={local.variant}
+			class={cx(
+				"group flex flex-col overflow-hidden rounded-lg border border-transparent bg-gray-3 text-left outline-none transition-colors duration-100 hover:bg-gray-4 focus-visible:ring-2 focus-visible:ring-blue-9 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-1",
+				local.disabled && "pointer-events-none opacity-60",
+				local.class,
+			)}
+		>
+			<div class="relative h-[4.75rem] w-full overflow-hidden bg-gray-4/40">
+				<Show
+					when={thumbnailSrc()}
+					fallback={
+						<div class="flex h-full w-full items-center justify-center bg-gray-4">
+							{renderIcon("size-6 text-gray-9 opacity-70")}
+						</div>
+					}
+				>
+					<img
+						src={thumbnailSrc()!}
+						alt={`${
+							local.variant === "display" ? "Display" : "Window"
+						} preview for ${label()}`}
+						class="h-full w-full object-cover"
+						loading="lazy"
+						draggable={false}
+					/>
+				</Show>
+				<Show when={appIconSrc()}>
+					<div class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/45">
+						<img
+							src={appIconSrc()!}
+							alt={`${label()} icon`}
+							class="h-16 w-16 max-h-[55%] max-w-[55%] rounded-lg border border-black/20 object-contain shadow-lg shadow-black/30"
+							draggable={false}
+						/>
+					</div>
+				</Show>
+				<div class="pointer-events-none absolute inset-0 border border-black/5 opacity-60" />
+				<div class="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-black/40 to-transparent" />
+			</div>
+			<div class="flex flex-row items-start gap-2 px-2 py-1.5">
+				<div class="min-w-0 flex-1">
+					<p class="truncate text-[11px] font-medium text-gray-12">
+						{highlight(label())}
+					</p>
+					<Show when={subtitle()}>
+						<p class="truncate text-[11px] text-gray-11">
+							{highlight(subtitle())}
+						</p>
+					</Show>
+					<Show when={metadata()}>
+						<p class="truncate text-[11px] text-gray-10">
+							{highlight(metadata())}
+						</p>
+					</Show>
+				</div>
+			</div>
+		</button>
+	);
+}
+
+function escapeRegExp(value: string) {
+	return value.replace(/[-^$*+?.()|[\]{}]/g, "\\$&");
+}
+export function TargetCardSkeleton(props: { class?: string }) {
+	return (
+		<div
+			class={cx(
+				"flex flex-col overflow-hidden rounded-lg bg-gray-3",
+				props.class,
+			)}
+		>
+			<div class="h-[4.75rem] w-full animate-pulse bg-gray-4" />
+			<div class="flex flex-row items-start gap-2 px-2 py-1.5">
+				<div class="flex-1 space-y-1">
+					<div class="h-3 w-3/4 rounded bg-gray-4" />
+					<div class="h-2.5 w-1/2 rounded bg-gray-4" />
+					<div class="h-2.5 w-2/5 rounded bg-gray-4" />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/routes/(window-chrome)/new-main/TargetDropdownButton.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/TargetDropdownButton.tsx
@@ -1,0 +1,42 @@
+import type { PolymorphicProps } from "@kobalte/core/polymorphic";
+import { Polymorphic } from "@kobalte/core/polymorphic";
+import { cx } from "cva";
+import { splitProps, type ValidComponent } from "solid-js";
+import IconCapChevronDown from "~icons/cap/chevron-down";
+
+type TargetDropdownButtonProps<T extends ValidComponent> = PolymorphicProps<
+	T,
+	{
+		expanded?: boolean;
+	}
+>;
+
+export default function TargetDropdownButton<
+	T extends ValidComponent = "button",
+>(props: TargetDropdownButtonProps<T>) {
+	const [local, rest] = splitProps(props, ["class", "expanded", "disabled"]);
+
+	return (
+		<Polymorphic
+			as="button"
+			type="button"
+			{...rest}
+			disabled={local.disabled}
+			aria-expanded={local.expanded ? "true" : "false"}
+			data-expanded={local.expanded ? "true" : "false"}
+			class={cx(
+				"flex h-[3.75rem] w-5 shrink-0 items-center justify-center rounded-lg bg-gray-4 text-gray-12 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-9 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-1 hover:bg-gray-5",
+				local.expanded && "bg-gray-5",
+				local.disabled && "pointer-events-none opacity-60",
+				local.class,
+			)}
+		>
+			<IconCapChevronDown
+				class={cx(
+					"size-4 text-gray-11 transition-transform duration-150",
+					local.expanded && "rotate-180 text-gray-12",
+				)}
+			/>
+		</Polymorphic>
+	);
+}

--- a/apps/desktop/src/routes/(window-chrome)/new-main/TargetMenuGrid.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/TargetMenuGrid.tsx
@@ -1,0 +1,164 @@
+import { cx } from "cva";
+import { createEffect, createMemo, For, Match, Switch } from "solid-js";
+import type {
+	CaptureDisplayWithThumbnail,
+	CaptureWindowWithThumbnail,
+} from "~/utils/tauri";
+import TargetCard, { TargetCardSkeleton } from "./TargetCard";
+
+const DEFAULT_SKELETON_COUNT = 6;
+
+type BaseProps<T> = {
+	targets?: T[];
+	onSelect?: (target: T) => void;
+	isLoading?: boolean;
+	errorMessage?: string;
+	emptyMessage?: string;
+	disabled?: boolean;
+	skeletonCount?: number;
+	class?: string;
+	highlightQuery?: string;
+};
+
+type DisplayGridProps = BaseProps<CaptureDisplayWithThumbnail> & {
+	variant: "display";
+};
+
+type WindowGridProps = BaseProps<CaptureWindowWithThumbnail> & {
+	variant: "window";
+};
+
+type TargetMenuGridProps = DisplayGridProps | WindowGridProps;
+
+export default function TargetMenuGrid(props: TargetMenuGridProps) {
+	const items = createMemo(() => props.targets ?? []);
+	const skeletonItems = createMemo(() =>
+		Array.from({ length: props.skeletonCount ?? DEFAULT_SKELETON_COUNT }),
+	);
+	const isEmpty = createMemo(
+		() => !props.isLoading && items().length === 0 && !props.errorMessage,
+	);
+
+	let cardRefs: HTMLButtonElement[] = [];
+
+	createEffect(() => {
+		items();
+		cardRefs = [];
+	});
+
+	const registerRef = (index: number) => (el: HTMLButtonElement) => {
+		cardRefs[index] = el;
+	};
+
+	const focusAt = (index: number) => {
+		const target = cardRefs[index];
+		if (target) target.focus();
+	};
+
+	const handleKeyDown = (event: KeyboardEvent, index: number) => {
+		if (!cardRefs.length) return;
+		const columns = 2;
+		let nextIndex = index;
+
+		switch (event.key) {
+			case "ArrowRight":
+				nextIndex = (index + 1) % cardRefs.length;
+				event.preventDefault();
+				break;
+			case "ArrowLeft":
+				nextIndex = (index - 1 + cardRefs.length) % cardRefs.length;
+				event.preventDefault();
+				break;
+			case "ArrowDown":
+				nextIndex = Math.min(index + columns, cardRefs.length - 1);
+				event.preventDefault();
+				break;
+			case "ArrowUp":
+				nextIndex = Math.max(index - columns, 0);
+				event.preventDefault();
+				break;
+			case "Home":
+				nextIndex = 0;
+				event.preventDefault();
+				break;
+			case "End":
+				nextIndex = cardRefs.length - 1;
+				event.preventDefault();
+				break;
+			default:
+				return;
+		}
+
+		focusAt(nextIndex);
+	};
+
+	const defaultEmptyMessage = () =>
+		props.variant === "display" ? "No displays found" : "No windows found";
+
+	return (
+		<div
+			data-variant={props.variant}
+			class={cx(
+				"grid w-full grid-cols-2 content-start items-start justify-items-stretch gap-4",
+				props.class,
+			)}
+			role="listbox"
+		>
+			<Switch>
+				<Match when={props.errorMessage}>
+					<div class="col-span-2 flex flex-col items-center justify-center gap-2 py-6 text-center text-sm text-gray-11">
+						<p>{props.errorMessage}</p>
+					</div>
+				</Match>
+				<Match when={props.isLoading}>
+					<For each={skeletonItems()}>
+						{() => <TargetCardSkeleton class="w-full" />}
+					</For>
+				</Match>
+				<Match when={isEmpty()}>
+					<div class="col-span-2 py-6 text-center text-sm text-gray-11">
+						{props.emptyMessage ?? defaultEmptyMessage()}
+					</div>
+				</Match>
+				<Match when={items().length > 0}>
+					<Switch>
+						<Match when={props.variant === "display"}>
+							<For each={items() as CaptureDisplayWithThumbnail[]}>
+								{(item, index) => (
+									<TargetCard
+										variant="display"
+										target={item}
+										onClick={() => props.onSelect?.(item)}
+										disabled={props.disabled}
+										ref={registerRef(index())}
+										onKeyDown={(event) => handleKeyDown(event, index())}
+										role="option"
+										class="w-full"
+										highlightQuery={props.highlightQuery}
+									/>
+								)}
+							</For>
+						</Match>
+						<Match when={props.variant === "window"}>
+							<For each={items() as CaptureWindowWithThumbnail[]}>
+								{(item, index) => (
+									<TargetCard
+										variant="window"
+										target={item}
+										onClick={() => props.onSelect?.(item)}
+										disabled={props.disabled}
+										ref={registerRef(index())}
+										onKeyDown={(event) => handleKeyDown(event, index())}
+										role="option"
+										class="w-full"
+										highlightQuery={props.highlightQuery}
+									/>
+								)}
+							</For>
+						</Match>
+					</Switch>
+				</Match>
+			</Switch>
+		</div>
+	);
+}

--- a/apps/desktop/src/routes/(window-chrome)/new-main/TargetTypeButton.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/TargetTypeButton.tsx
@@ -1,33 +1,43 @@
 import { cx } from "cva";
-import type { Component, ComponentProps } from "solid-js";
+import { type Component, type ComponentProps, splitProps } from "solid-js";
 
-function TargetTypeButton(
-	props: {
-		selected: boolean;
-		Component: Component<ComponentProps<"svg">>;
-		name: string;
-		disabled?: boolean;
-	} & ComponentProps<"div">,
-) {
+type TargetTypeButtonProps = {
+	selected: boolean;
+	Component: Component<ComponentProps<"svg">>;
+	name: string;
+	disabled?: boolean;
+} & ComponentProps<"button">;
+
+function TargetTypeButton(props: TargetTypeButtonProps) {
+	const [local, rest] = splitProps(props, [
+		"selected",
+		"Component",
+		"name",
+		"disabled",
+		"class",
+	]);
+
 	return (
-		<div
-			{...props}
+		<button
+			{...rest}
+			type="button"
+			disabled={local.disabled}
+			aria-pressed={local.selected ? "true" : "false"}
 			class={cx(
-				"flex-1 text-center hover:bg-gray-4 bg-gray-3 flex flex-col ring-offset-gray-1 ring-offset-2 items-center justify-end gap-2 py-1.5 rounded-lg transition-all",
-				props.selected
-					? "bg-gray-3 text-white ring-blue-9 ring-1"
-					: "ring-transparent ring-0",
-				props.disabled ? "opacity-70 pointer-events-none" : "",
+				"flex flex-1 flex-col items-center justify-end gap-2 rounded-lg bg-gray-3 py-1.5 text-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-9 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-1",
+				local.selected ? "text-gray-12" : "text-gray-12 hover:bg-gray-4",
+				local.disabled && "pointer-events-none opacity-60",
+				local.class,
 			)}
 		>
-			<props.Component
+			<local.Component
 				class={cx(
 					"size-6 transition-colors",
-					props.selected ? "text-gray-12" : "text-gray-9",
+					local.selected ? "text-gray-12" : "text-gray-9",
 				)}
 			/>
-			<p class="text-xs text-gray-12">{props.name}</p>
-		</div>
+			<p class="text-xs">{local.name}</p>
+		</button>
 	);
 }
 

--- a/apps/desktop/src/utils/queries.ts
+++ b/apps/desktop/src/utils/queries.ts
@@ -39,12 +39,36 @@ export const listWindows = queryOptions({
 		return w;
 	},
 	reconcile: "id",
-	refetchInterval: 1000,
+	refetchInterval: false,
 });
 
 export const listScreens = queryOptions({
 	queryKey: ["capture", "displays"] as const,
 	queryFn: () => commands.listCaptureDisplays(),
+	reconcile: "id",
+	refetchInterval: 1000,
+});
+
+export const listWindowsWithThumbnails = queryOptions({
+	queryKey: ["capture", "windows-thumbnails"] as const,
+	queryFn: async () => {
+		const w = await commands.listWindowsWithThumbnails();
+
+		w.sort(
+			(a, b) =>
+				a.owner_name.localeCompare(b.owner_name) ||
+				a.name.localeCompare(b.name),
+		);
+
+		return w;
+	},
+	reconcile: "id",
+	refetchInterval: false,
+});
+
+export const listDisplaysWithThumbnails = queryOptions({
+	queryKey: ["capture", "displays-thumbnails"] as const,
+	queryFn: () => commands.listDisplaysWithThumbnails(),
 	reconcile: "id",
 	refetchInterval: 1000,
 });

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -38,6 +38,12 @@ async listCaptureWindows() : Promise<CaptureWindow[]> {
 async listCaptureDisplays() : Promise<CaptureDisplay[]> {
     return await TAURI_INVOKE("list_capture_displays");
 },
+async listDisplaysWithThumbnails() : Promise<CaptureDisplayWithThumbnail[]> {
+    return await TAURI_INVOKE("list_displays_with_thumbnails");
+},
+async listWindowsWithThumbnails() : Promise<CaptureWindowWithThumbnail[]> {
+    return await TAURI_INVOKE("list_windows_with_thumbnails");
+},
 async takeScreenshot() : Promise<null> {
     return await TAURI_INVOKE("take_screenshot");
 },
@@ -263,6 +269,9 @@ async displayInformation(displayId: string) : Promise<DisplayInformation> {
 async getWindowIcon(windowId: string) : Promise<string | null> {
     return await TAURI_INVOKE("get_window_icon", { windowId });
 },
+async focusWindow(windowId: WindowId) : Promise<null> {
+    return await TAURI_INVOKE("focus_window", { windowId });
+},
 async editorDeleteProject() : Promise<null> {
     return await TAURI_INVOKE("editor_delete_project");
 }
@@ -351,7 +360,9 @@ export type CaptionSegment = { id: string; start: number; end: number; text: str
 export type CaptionSettings = { enabled: boolean; font: string; size: number; color: string; backgroundColor: string; backgroundOpacity: number; position: string; bold: boolean; italic: boolean; outline: boolean; outlineColor: string; exportWithSubtitles: boolean }
 export type CaptionsData = { segments: CaptionSegment[]; settings: CaptionSettings }
 export type CaptureDisplay = { id: DisplayId; name: string; refresh_rate: number }
+export type CaptureDisplayWithThumbnail = { id: DisplayId; name: string; refresh_rate: number; thumbnail: string | null }
 export type CaptureWindow = { id: WindowId; owner_name: string; name: string; bounds: LogicalBounds; refresh_rate: number }
+export type CaptureWindowWithThumbnail = { id: WindowId; owner_name: string; name: string; bounds: LogicalBounds; refresh_rate: number; thumbnail: string | null; app_icon: string | null }
 export type ClipConfiguration = { index: number; offsets: ClipOffsets }
 export type ClipOffsets = { camera?: number; mic?: number; system_audio?: number }
 export type CommercialLicense = { licenseKey: string; expiryDate: number | null; refresh: number; activatedOn: number }

--- a/packages/ui-solid/src/auto-imports.d.ts
+++ b/packages/ui-solid/src/auto-imports.d.ts
@@ -6,6 +6,7 @@
 // biome-ignore lint: disable
 export {}
 declare global {
+  const IconCapArrowLeft: typeof import('~icons/cap/arrow-left.jsx')['default']
   const IconCapArrows: typeof import('~icons/cap/arrows.jsx')['default']
   const IconCapAudioOn: typeof import('~icons/cap/audio-on.jsx')['default']
   const IconCapBgBlur: typeof import('~icons/cap/bg-blur.jsx')['default']


### PR DESCRIPTION
  - Replace the recording flow target selector with new card, grid, and dropdown components that surface thumbnails, search highlighting, and keyboard navigation
  - Extend the backend to stream cursor targets, expose window icons/display metadata, and manage overlay windows/focus across platforms
  - Wire Solid queries and commands to the new overlay/list APIs, cache expensive thumbnails, and keep device/recording option handling aligned

Demo:

https://github.com/user-attachments/assets/4a91376c-d34f-4b2c-b92e-9e003ff0818a

