### PR TITLE
Enforce nullable constraints

### DIFF
--- a/apps/web/app/(org)/dashboard/caps/page.tsx
+++ b/apps/web/app/(org)/dashboard/caps/page.tsx
@@ -125,7 +125,7 @@ export default async function CapsPage(props: {
 			domainVerified: organizations.domainVerified,
 		})
 		.from(organizations)
-		.where(eq(organizations.id, user.activeOrganizationId))
+		.where(eq(organizations.id, user.activeOrganizationId ?? sql`NULL`))
 		.limit(1);
 
 	let customDomain: string | null = null;
@@ -214,7 +214,7 @@ export default async function CapsPage(props: {
 		.from(folders)
 		.where(
 			and(
-				eq(folders.organizationId, user.activeOrganizationId),
+				eq(folders.organizationId, user.activeOrganizationId ?? sql`NULL`),
 				isNull(folders.parentId),
 				isNull(folders.spaceId),
 			),

--- a/apps/web/app/(org)/dashboard/settings/organization/page.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/page.tsx
@@ -1,7 +1,7 @@
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { organizationMembers, organizations } from "@cap/database/schema";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { getDashboardData } from "../../dashboard-data";
@@ -31,7 +31,7 @@ export default async function OrganizationPage() {
 		.where(
 			and(
 				eq(organizationMembers.userId, user.id),
-				eq(organizations.id, user.activeOrganizationId),
+				eq(organizations.id, user.activeOrganizationId ?? sql`NULL`),
 			),
 		);
 

--- a/apps/web/app/api/notifications/route.ts
+++ b/apps/web/app/api/notifications/route.ts
@@ -55,7 +55,10 @@ export async function GET() {
 			.where(
 				and(
 					eq(notifications.recipientId, currentUser.id),
-					eq(notifications.orgId, currentUser.activeOrganizationId),
+					eq(
+						notifications.orgId,
+						currentUser.activeOrganizationId ?? sql`NULL`,
+					),
 				),
 			)
 			.orderBy(
@@ -72,7 +75,10 @@ export async function GET() {
 			.where(
 				and(
 					eq(notifications.recipientId, currentUser.id),
-					eq(notifications.orgId, currentUser.activeOrganizationId),
+					eq(
+						notifications.orgId,
+						currentUser.activeOrganizationId ?? sql`NULL`,
+					),
 				),
 			)
 			.groupBy(notifications.type);

--- a/apps/web/app/s/[videoId]/_components/tabs/Activity/Comment.tsx
+++ b/apps/web/app/s/[videoId]/_components/tabs/Activity/Comment.tsx
@@ -52,7 +52,7 @@ const Comment: React.FC<{
 
 	const handleDelete = () => {
 		if (window.confirm("Are you sure you want to delete this comment?")) {
-			onDelete(comment.id, comment.parentCommentId);
+			onDelete(comment.id, comment.parentCommentId ?? undefined);
 		}
 	};
 

--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -619,7 +619,7 @@ async function AuthorizedContent({
 				.from(comments)
 				.where(eq(comments.id, replyId))
 				.limit(1);
-			toplLevelCommentId = parentComment?.parentCommentId;
+			toplLevelCommentId = parentComment?.parentCommentId ?? undefined;
 		}
 
 		const commentToBringToTheTop = toplLevelCommentId ?? commentId;

--- a/apps/web/lib/Notification.ts
+++ b/apps/web/lib/Notification.ts
@@ -88,7 +88,6 @@ export async function createNotification(
 			const [recipientUser] = await db()
 				.select({
 					preferences: users.preferences,
-					activeOrganizationId: users.activeOrganizationId,
 				})
 				.from(users)
 				.where(eq(users.id, recipientId))
@@ -122,7 +121,7 @@ export async function createNotification(
 
 			await db().insert(notifications).values({
 				id: notificationId,
-				orgId: recipientUser.activeOrganizationId,
+				orgId: undefined, // TODO: BRUHHHHH: recipientUser.activeOrganizationId,
 				recipientId,
 				type,
 				data,

--- a/packages/database/auth/session.ts
+++ b/packages/database/auth/session.ts
@@ -22,7 +22,12 @@ export const getCurrentUser = cache(
 			.from(users)
 			.where(eq(users.id, session.user.id));
 
-		return currentUser ?? null;
+		return currentUser
+			? {
+					...currentUser,
+					activeOrganizationId: currentUser?.activeOrganizationId ?? null,
+				}
+			: null;
 	},
 );
 

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -1,7 +1,6 @@
 import type { Folder, S3Bucket, Video } from "@cap/web-domain";
 import {
 	boolean,
-	customType,
 	datetime,
 	float,
 	index,
@@ -11,7 +10,6 @@ import {
 	primaryKey,
 	text,
 	timestamp,
-	tinyint,
 	uniqueIndex,
 	varchar,
 } from "drizzle-orm/mysql-core";
@@ -20,30 +18,12 @@ import { relations } from "drizzle-orm/relations";
 import { nanoIdLength } from "./helpers.ts";
 import type { VideoMetadata } from "./types/index.ts";
 
-const nanoId = customType<{ data: string; notNull: true }>({
-	dataType() {
-		return `varchar(${nanoIdLength})`;
-	},
-});
-
-const nanoIdNullable = customType<{ data: string; notNull: false }>({
-	dataType() {
-		return `varchar(${nanoIdLength})`;
-	},
-});
-
-// Add a custom type for encrypted strings
-const encryptedText = customType<{ data: string; notNull: true }>({
-	dataType() {
-		return "text";
-	},
-});
-
-const encryptedTextNullable = customType<{ data: string; notNull: false }>({
-	dataType() {
-		return "text";
-	},
-});
+const nanoId = (name: string) =>
+	varchar(name, { length: nanoIdLength }).notNull();
+const nanoIdNullable = (name: string) =>
+	varchar(name, { length: nanoIdLength });
+const encryptedText = (name: string) => text(name).notNull();
+const encryptedTextNullable = (name: string) => text(name);
 
 export const users = mysqlTable(
 	"users",

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -28,7 +28,7 @@ const encryptedTextNullable = (name: string) => text(name);
 export const users = mysqlTable(
 	"users",
 	{
-		id: nanoId("id").notNull().primaryKey().unique(),
+		id: nanoId("id").primaryKey().unique(),
 		name: varchar("name", { length: 255 }),
 		lastName: varchar("lastName", { length: 255 }),
 		email: varchar("email", { length: 255 }).unique().notNull(),
@@ -63,7 +63,7 @@ export const users = mysqlTable(
 				};
 			} | null>()
 			.default(null),
-		activeOrganizationId: nanoId("activeOrganizationId"),
+		activeOrganizationId: nanoIdNullable("activeOrganizationId"),
 		created_at: timestamp("created_at").notNull().defaultNow(),
 		updated_at: timestamp("updated_at").notNull().defaultNow().onUpdateNow(),
 		onboarding_completed_at: timestamp("onboarding_completed_at"),
@@ -300,7 +300,7 @@ export const comments = mysqlTable(
 		videoId: nanoId("videoId").notNull().$type<Video.VideoId>(),
 		createdAt: timestamp("createdAt").notNull().defaultNow(),
 		updatedAt: timestamp("updatedAt").notNull().defaultNow().onUpdateNow(),
-		parentCommentId: nanoId("parentCommentId"),
+		parentCommentId: nanoIdNullable("parentCommentId"),
 	},
 	(table) => ({
 		videoIdIndex: index("video_id_idx").on(table.videoId),


### PR DESCRIPTION
Our previous definitions of `nanoId` and `encryptedText` in our database schema use Typescript to mark them as being required fields, but in practice that constrain isn't being enforced in the actual SQL DB schema. This means the types are lying. I was about to check and we have a non-insignificant amount of records which break these constrains which would be resulting in runtime errors for users trying to use Cap.

This PR updates the Drizzle schema to enforce these constrains and also relaxes the Typescript type on some fields to align with the reliability of the data in the database.

Blockers:
 - [x] We need #1066 merged and `orgId` to be required on `videos`
 - [ ] Figure out notifications