### PR TITLE
Improve email handling in OTP verification flow (fix for Windows)

### DIFF
--- a/apps/web/app/(org)/verify-otp/page.tsx
+++ b/apps/web/app/(org)/verify-otp/page.tsx
@@ -1,4 +1,3 @@
-import { getSession } from "@cap/database/auth/session";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import { VerifyOTPForm } from "./form";
@@ -11,13 +10,8 @@ export default async function VerifyOTPPage(props: {
 	searchParams: Promise<{ email?: string; next?: string; lastSent?: string }>;
 }) {
 	const searchParams = await props.searchParams;
-	const session = await getSession();
 
-	if (session?.user) {
-		redirect(searchParams.next || "/dashboard");
-	}
-
-	if (!searchParams.email) {
+	if (!searchParams?.email) {
 		redirect("/login");
 	}
 


### PR DESCRIPTION
Refactored OTP verification to retrieve email from URL parameters if not provided, and redirect to login if missing. Updated API calls and UI to use the resolved email. Removed unused session check from the OTP page.

On Windows I was unable to sign in on Chrome. This seems to have done the trick.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Allow authenticated users to access the OTP verification page (previous auto-redirect to dashboard removed).
- Bug Fixes
  - Use the email from the URL if not provided elsewhere during OTP verification.
  - Redirect to the login page when no email is available.
  - Ensure all verification, resend, and UI messages consistently use the resolved email.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->