### PR TITLE
resolve checkbox appearing over selected cap bar

### DIFF
--- a/apps/web/app/(org)/dashboard/caps/components/CapCard/CapCard.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/CapCard/CapCard.tsx
@@ -472,7 +472,7 @@ export const CapCard = ({
 				{!sharedCapCard && onSelectToggle && (
 					<div
 						className={clsx(
-							"absolute top-2 left-2 z-[51] duration-200",
+							"absolute top-2 left-2 z-[49] duration-200",
 							isSelected || anyCapSelected || isDropdownOpen
 								? "opacity-100"
 								: "group-hover:opacity-100 opacity-0",


### PR DESCRIPTION
## Description
Fixed the issue where the video selection checkbox was displaying on top of the Selected Caps Bar.

## Changes Made
Adjusted z-index values for checkbox elements

## Testing
- [x] Tested locally
- [x] Verified checkbox no longer overlaps Selected Caps Bar

Fixes #1122
## Video

https://github.com/user-attachments/assets/dd6a955e-5e86-42d8-bb82-18361d0eb930



