### PR TITLE
chore: fix overlay text color

### DIFF
--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -875,7 +875,7 @@ function ShowCapFreeWarning(props: { isInstantMode: boolean }) {
 	return (
 		<Suspense>
 			<Show when={props.isInstantMode && auth.data?.plan?.upgraded === false}>
-				<p class="text-sm text-center max-w-64">
+				<p class="text-sm text-center text-white max-w-64">
 					Instant Mode recordings are limited to 5 mins,{" "}
 					<button
 						class="underline"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved readability of the cap/free usage warning in the target selection overlay by updating its text color to white when Instant Mode is active for non-upgraded users.
  * Ensures the notice remains clearly visible against darker backgrounds in the overlay.
  * No functional changes; interactions and user flow remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->