### PR TITLE
Cleanup after the `orgId` on `videos` backfill

### DIFF
--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -247,8 +247,7 @@ export const videos = mysqlTable(
 	{
 		id: nanoId("id").notNull().primaryKey().unique().$type<Video.VideoId>(),
 		ownerId: nanoId("ownerId").notNull(),
-		// TODO: make this non-null
-		orgId: nanoIdNullable("orgId"),
+		orgId: nanoId("orgId"),
 		name: varchar("name", { length: 255 }).notNull().default("My Video"),
 		bucket: nanoIdNullable("bucket").$type<S3Bucket.S3BucketId>(),
 		// in seconds

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -24,6 +24,9 @@ const nanoId = customType<{ data: string; notNull: true }>({
 		return `varchar(${nanoIdLength})`;
 	},
 });
+// TODO: This will replace `nanoId` in: https://github.com/CapSoftware/Cap/pull/1105
+const nanoIdRequired = (name: string) =>
+	varchar(name, { length: nanoIdLength }).notNull();
 
 const nanoIdNullable = customType<{ data: string; notNull: false }>({
 	dataType() {
@@ -247,7 +250,7 @@ export const videos = mysqlTable(
 	{
 		id: nanoId("id").notNull().primaryKey().unique().$type<Video.VideoId>(),
 		ownerId: nanoId("ownerId").notNull(),
-		orgId: nanoId("orgId"),
+		orgId: nanoIdRequired("orgId"),
 		name: varchar("name", { length: 255 }).notNull().default("My Video"),
 		bucket: nanoIdNullable("bucket").$type<S3Bucket.S3BucketId>(),
 		// in seconds

--- a/packages/web-backend/src/Loom/ImportVideo.ts
+++ b/packages/web-backend/src/Loom/ImportVideo.ts
@@ -70,7 +70,7 @@ export const LoomImportVideoLive = LoomImportVideo.toLayer(
 
 				const videoId = yield* videos.create({
 					ownerId: payload.cap.userId,
-					orgId: Option.some(payload.cap.orgId),
+					orgId: payload.cap.orgId,
 					bucketId: customBucketId,
 					source: { type: "desktopMP4" as const },
 					name: payload.loom.video.name,

--- a/packages/web-backend/src/Videos/VideosRepo.ts
+++ b/packages/web-backend/src/Videos/VideosRepo.ts
@@ -58,7 +58,7 @@ export class VideosRepo extends Effect.Service<VideosRepo>()("VideosRepo", {
 								{
 									...data,
 									id,
-									orgId: Option.getOrNull(data.orgId ?? Option.none()),
+									orgId: data.orgId,
 									bucket: Option.getOrNull(data.bucketId ?? Option.none()),
 									metadata: Option.getOrNull(data.metadata ?? Option.none()),
 									transcriptionStatus: Option.getOrNull(
@@ -72,12 +72,12 @@ export class VideosRepo extends Effect.Service<VideosRepo>()("VideosRepo", {
 							]),
 						];
 
-						if (data.importSource && Option.isSome(data.orgId))
+						if (data.importSource)
 							promises.push(
 								db.insert(Db.importedVideos).values([
 									{
 										id,
-										orgId: data.orgId.value,
+										orgId: data.orgId,
 										source: data.importSource.source,
 										sourceId: data.importSource.id,
 									},

--- a/packages/web-domain/src/Video.ts
+++ b/packages/web-domain/src/Video.ts
@@ -14,7 +14,7 @@ export type VideoId = typeof VideoId.Type;
 export class Video extends Schema.Class<Video>("Video")({
 	id: VideoId,
 	ownerId: Schema.String,
-	orgId: Schema.OptionFromNullOr(Schema.String),
+	orgId: Schema.String,
 	name: Schema.String,
 	public: Schema.Boolean,
 	source: Schema.Struct({


### PR DESCRIPTION
This will be merged once the backfill has been run to make `orgId` required. This should be merged after the backfill and Planetscale PR have been merged.

https://app.planetscale.com/cap/cap-production/deploy-requests/39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents orphaned videos by requiring every video to be linked to an organization, reducing listing and permission issues.

* **Chores**
  * Database and backend now enforce and propagate a required organization ID for videos, tightening validation and surfacing clearer errors during creation or import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->