### PR TITLE
use isOwner as part of SpacesPolicy.isMember

### DIFF
--- a/packages/web-backend/src/Spaces/SpacesPolicy.ts
+++ b/packages/web-backend/src/Spaces/SpacesPolicy.ts
@@ -22,11 +22,7 @@ export class SpacesPolicy extends Effect.Service<SpacesPolicy>()(
 				Policy.policy(
 					Effect.fn(function* (user) {
 						const space = yield* repo.getById(spaceId);
-
-						if (Option.isNone(space)) {
-							yield* Effect.log("Space not found. Access granted.");
-							return true;
-						}
+						if (Option.isNone(space)) return false;
 
 						return space.value.createdById === user.id;
 					}),

--- a/packages/web-backend/src/Spaces/SpacesRepo.ts
+++ b/packages/web-backend/src/Spaces/SpacesRepo.ts
@@ -45,6 +45,12 @@ export class SpacesRepo extends Effect.Service<SpacesRepo>()("SpacesRepo", {
 							),
 					)
 					.pipe(Effect.map(Array.get(0))),
+			getById: (spaceId: string) =>
+				db
+					.execute((db) =>
+						db.select().from(Db.spaces).where(Dz.eq(Db.spaces.id, spaceId)),
+					)
+					.pipe(Effect.map(Array.get(0))),
 		};
 	}),
 	dependencies: [Database.Default],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Owners now have explicit access checks in spaces alongside members.
  - New combinators allow composing permission rules (AND/OR) for clearer access outcomes.
- Refactor
  - Permission system streamlined for consistency and future extensibility.
- Backend
  - Improved space lookup to support ownership checks and more reliable permission evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->