### PR TITLE
Drop "Admin Dev" sidebar option

### DIFF
--- a/apps/web/app/(org)/dashboard/_components/Navbar/Items.tsx
+++ b/apps/web/app/(org)/dashboard/_components/Navbar/Items.tsx
@@ -66,16 +66,6 @@ const AdminNavItems = ({ toggleMobileNav }: Props) => {
 			icon: <CogIcon />,
 			subNav: [],
 		},
-		...(buildEnv.NEXT_PUBLIC_IS_CAP && user.email.endsWith("@cap.so")
-			? [
-					{
-						name: "Admin Dev",
-						href: "/dashboard/admin",
-						icon: <CogIcon />,
-						subNav: [],
-					},
-				]
-			: []),
 	];
 
 	const [dialogOpen, setDialogOpen] = useState(false);


### PR DESCRIPTION
It points to a 404 page now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined dashboard navigation by removing the “Admin Dev” menu item.
  * Users who previously saw this option will now have a simplified, consistent menu across environments.
  * No changes to other navigation items or behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->