### PR TITLE
Remove hardcoded dynamic routes

### DIFF
--- a/apps/web/app/(org)/dashboard/caps/page.tsx
+++ b/apps/web/app/(org)/dashboard/caps/page.tsx
@@ -96,19 +96,16 @@ async function getSharedSpacesForVideos(videoIds: Video.VideoId[]) {
 	return sharedSpacesMap;
 }
 
-export const dynamic = "force-dynamic";
-
-export default async function CapsPage({
-	searchParams,
-}: PageProps<"/dashboard/caps">) {
-	const page = Number(await searchParams.then((s) => s.page)) || 1;
-	const limit = Number(await searchParams.then((s) => s.limit)) || 15;
-
+export default async function CapsPage(props: PageProps<"/dashboard/caps">) {
+	const searchParams = await props.searchParams;
 	const user = await getCurrentUser();
 
 	if (!user || !user.id) {
 		redirect("/login");
 	}
+
+	const page = Number(searchParams.page) || 1;
+	const limit = Number(searchParams.limit) || 15;
 
 	const userId = user.id;
 	const offset = (page - 1) * limit;

--- a/apps/web/app/(org)/dashboard/caps/page.tsx
+++ b/apps/web/app/(org)/dashboard/caps/page.tsx
@@ -96,10 +96,14 @@ async function getSharedSpacesForVideos(videoIds: Video.VideoId[]) {
 	return sharedSpacesMap;
 }
 
-export default async function CapsPage(props: {
-	searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
-}) {
-	const searchParams = await props.searchParams;
+export const dynamic = "force-dynamic";
+
+export default async function CapsPage({
+	searchParams,
+}: PageProps<"/dashboard/caps">) {
+	const page = Number(await searchParams.then((s) => s.page)) || 1;
+	const limit = Number(await searchParams.then((s) => s.limit)) || 15;
+
 	const user = await getCurrentUser();
 
 	if (!user || !user.id) {
@@ -107,8 +111,6 @@ export default async function CapsPage(props: {
 	}
 
 	const userId = user.id;
-	const page = Number(searchParams.page) || 1;
-	const limit = Number(searchParams.limit) || 15;
 	const offset = (page - 1) * limit;
 
 	const totalCountResult = await db()

--- a/apps/web/app/(org)/layout.tsx
+++ b/apps/web/app/(org)/layout.tsx
@@ -1,8 +1,6 @@
 import type { PropsWithChildren } from "react";
 import { Intercom } from "../Layout/Intercom";
 
-export const revalidate = 0;
-
 export default function Layout(props: PropsWithChildren) {
 	return (
 		<>

--- a/apps/web/app/(site)/download/[platform]/route.ts
+++ b/apps/web/app/(site)/download/[platform]/route.ts
@@ -2,9 +2,6 @@ import { type NextRequest, NextResponse } from "next/server";
 
 export const runtime = "edge";
 
-// Disable caching to ensure users always get the latest download URL
-export const revalidate = 0;
-
 export async function GET(
 	request: NextRequest,
 	props: { params: Promise<{ platform: string }> },

--- a/apps/web/app/api/changelog/status/route.ts
+++ b/apps/web/app/api/changelog/status/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
 import { getChangelogPosts } from "../../../../utils/changelog";
 
-export const revalidate = 0;
-
 export async function GET(request: Request) {
 	const { searchParams } = new URL(request.url);
 	const version = searchParams.get("version");

--- a/apps/web/app/api/download/route.ts
+++ b/apps/web/app/api/download/route.ts
@@ -1,7 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 
 export const runtime = "edge";
-export const revalidate = 0;
 
 export async function GET(request: NextRequest) {
 	const userAgent = request.headers.get("user-agent") || "";

--- a/apps/web/app/api/releases/tauri/[version]/[target]/[arch]/route.ts
+++ b/apps/web/app/api/releases/tauri/[version]/[target]/[arch]/route.ts
@@ -4,8 +4,6 @@ const octokit = new Octokit();
 
 export const runtime = "edge";
 
-export const revalidate = 0;
-
 export async function GET(
 	req: Request,
 	props: RouteContext<"/api/releases/tauri/[version]/[target]/[arch]">,

--- a/apps/web/app/api/status/route.ts
+++ b/apps/web/app/api/status/route.ts
@@ -1,5 +1,3 @@
-export const revalidate = 0;
-
 export async function GET() {
 	return new Response("OK", {
 		status: 200,

--- a/apps/web/app/api/thumbnail/route.ts
+++ b/apps/web/app/api/thumbnail/route.ts
@@ -8,8 +8,6 @@ import type { NextRequest } from "next/server";
 import { runPromise } from "@/lib/server";
 import { getHeaders } from "@/utils/helpers";
 
-export const revalidate = 0;
-
 export async function GET(request: NextRequest) {
 	const { searchParams } = request.nextUrl;
 	const videoId = searchParams.get("videoId");

--- a/apps/web/app/embed/[videoId]/page.tsx
+++ b/apps/web/app/embed/[videoId]/page.tsx
@@ -23,10 +23,6 @@ import { isAiGenerationEnabled } from "@/utils/flags";
 import { EmbedVideo } from "./_components/EmbedVideo";
 import { PasswordOverlay } from "./_components/PasswordOverlay";
 
-export const dynamic = "auto";
-export const dynamicParams = true;
-export const revalidate = 30;
-
 export async function generateMetadata(
 	props: PageProps<"/embed/[videoId]">,
 ): Promise<Metadata> {

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -2,8 +2,6 @@ import type { MetadataRoute } from "next";
 import { headers, type UnsafeUnwrappedHeaders } from "next/headers";
 import { seoPages } from "@/lib/seo-pages";
 
-export const revalidate = 0;
-
 export default function robots(): MetadataRoute.Robots {
 	const seoPageSlugs = Object.keys(seoPages);
 	const headersList = headers() as unknown as UnsafeUnwrappedHeaders;

--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -34,10 +34,6 @@ import { PasswordOverlay } from "./_components/PasswordOverlay";
 import { ShareHeader } from "./_components/ShareHeader";
 import { Share } from "./Share";
 
-export const dynamic = "auto";
-export const dynamicParams = true;
-export const revalidate = 30;
-
 // Helper function to fetch shared spaces data for a video
 async function getSharedSpacesForVideo(videoId: Video.VideoId) {
 	// Fetch space-level sharing


### PR DESCRIPTION
Next is able to detect which routes are dynamic and static, these annotations aren't needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Behavior
  - Routes and pages now use framework-default caching and rendering. This may adjust content freshness and CDN behavior for embeds, short links, robots, downloads, releases, status, thumbnails, and platform-specific downloads.

- Refactor
  - Updated the dashboard caps page to use standardized page props. No user-facing changes.

- Chores
  - Removed explicit revalidation and dynamic rendering flags across multiple pages and API routes to simplify configuration and align with defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->