### PR TITLE
prefer VITE_SERVER_URL env var

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2197,15 +2197,15 @@ pub async fn run(recording_logging_handle: LoggingHandle) {
                     recording_logging_handle,
                     mic_feed,
                     camera_feed,
-                    server_url: GeneralSettingsStore::get(&app)
-                        .ok()
-                        .flatten()
-                        .map(|v| v.server_url.clone())
-                        .unwrap_or_else(|| {
-                            std::option_env!("VITE_SERVER_URL")
-                                .unwrap_or("https://cap.so")
-                                .to_string()
-                        }),
+                    server_url: std::option_env!("VITE_SERVER_URL")
+                        .map(|s| s.to_string())
+                        .or_else(|| {
+                            GeneralSettingsStore::get(&app)
+                                .ok()
+                                .flatten()
+                                .map(|v| v.server_url.clone())
+                        })
+                        .unwrap_or_else(|| "https://cap.so".to_string()),
                 })));
 
                 app.manage(Arc::new(RwLock::new(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop app now prioritizes the environment variable for the server URL over the in-app setting, ensuring environments configured via deployment variables connect to the intended server. If the environment variable is not set, the app falls back to the saved setting, then to a default URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->