### PR TITLE
chore: remove solid motion one

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -59,7 +59,6 @@
 		"posthog-js": "^1.215.3",
 		"solid-js": "^1.9.3",
 		"solid-markdown": "^2.0.13",
-		"solid-motionone": "^1.0.4",
 		"solid-presence": "^0.1.8",
 		"solid-toast": "^0.5.0",
 		"solid-transition-group": "^0.2.3",

--- a/apps/desktop/src/routes/(window-chrome)/new-main/TargetMenuGrid.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/TargetMenuGrid.tsx
@@ -1,6 +1,6 @@
 import { cx } from "cva";
 import { createMemo, For, Match, Switch } from "solid-js";
-import { Motion } from "solid-motionone";
+import { Transition } from "solid-transition-group";
 import type {
 	CaptureDisplayWithThumbnail,
 	CaptureWindowWithThumbnail,
@@ -134,23 +134,30 @@ export default function TargetMenuGrid(props: TargetMenuGridProps) {
 								return (
 									<For each={items() as CaptureDisplayWithThumbnail[]}>
 										{(item, index) => (
-											<Motion.div
-												initial={{ scale: 0.95, opacity: 0 }}
-												animate={{ scale: 1, opacity: 1 }}
-												exit={{ scale: 0.95 }}
-												transition={{ duration: 0.2, delay: index() * 0.1 }}
+											<Transition
+												appear
+												enterActiveClass="transition duration-200"
+												enterClass="scale-95 opacity-0"
+												enterToClass="scale-100 opacity-100"
+												exitActiveClass="transition duration-200"
+												exitClass="scale-100"
+												exitToClass="scale-95"
 											>
-												<TargetCard
-													variant="display"
-													target={item}
-													onClick={() => displayProps.onSelect?.(item)}
-													disabled={displayProps.disabled}
-													onKeyDown={handleKeyDown}
-													class="w-full"
-													data-target-menu-card="true"
-													highlightQuery={displayProps.highlightQuery}
-												/>
-											</Motion.div>
+												<div
+													style={{ "transition-delay": `${index() * 100}ms` }}
+												>
+													<TargetCard
+														variant="display"
+														target={item}
+														onClick={() => displayProps.onSelect?.(item)}
+														disabled={displayProps.disabled}
+														onKeyDown={handleKeyDown}
+														class="w-full"
+														data-target-menu-card="true"
+														highlightQuery={displayProps.highlightQuery}
+													/>
+												</div>
+											</Transition>
 										)}
 									</For>
 								);
@@ -162,23 +169,30 @@ export default function TargetMenuGrid(props: TargetMenuGridProps) {
 								return (
 									<For each={items() as CaptureWindowWithThumbnail[]}>
 										{(item, index) => (
-											<Motion.div
-												initial={{ scale: 0.95, opacity: 0 }}
-												animate={{ scale: 1, opacity: 1 }}
-												exit={{ scale: 0.95 }}
-												transition={{ duration: 0.2, delay: index() * 0.1 }}
+											<Transition
+												appear
+												enterActiveClass="transition duration-200"
+												enterClass="scale-95 opacity-0"
+												enterToClass="scale-100 opacity-100"
+												exitActiveClass="transition duration-200"
+												exitClass="scale-100"
+												exitToClass="scale-95"
 											>
-												<TargetCard
-													variant="window"
-													target={item}
-													onClick={() => windowProps.onSelect?.(item)}
-													disabled={windowProps.disabled}
-													onKeyDown={handleKeyDown}
-													class="w-full"
-													data-target-menu-card="true"
-													highlightQuery={windowProps.highlightQuery}
-												/>
-											</Motion.div>
+												<div
+													style={{ "transition-delay": `${index() * 100}ms` }}
+												>
+													<TargetCard
+														variant="window"
+														target={item}
+														onClick={() => windowProps.onSelect?.(item)}
+														disabled={windowProps.disabled}
+														onKeyDown={handleKeyDown}
+														class="w-full"
+														data-target-menu-card="true"
+														highlightQuery={windowProps.highlightQuery}
+													/>
+												</div>
+											</Transition>
 										)}
 									</For>
 								);

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -27,7 +27,7 @@ import {
 	Suspense,
 } from "solid-js";
 import { reconcile } from "solid-js/store";
-import { Motion, Presence } from "solid-motionone";
+// Removed solid-motionone in favor of solid-transition-group
 import { Transition } from "solid-transition-group";
 import Tooltip from "~/components/Tooltip";
 import { Input } from "~/routes/editor/ui";
@@ -622,111 +622,115 @@ function Page() {
 	);
 
 	const TargetSelectionHome = () => (
-		<Motion.div
-			initial={{ scale: 0.95 }}
-			animate={{ scale: 1 }}
-			exit={{ scale: 0.95 }}
-			transition={{ duration: 0.2 }}
-			class="flex flex-col gap-2 w-full"
+		<Transition
+			appear
+			enterActiveClass="transition-transform duration-200"
+			enterClass="scale-95"
+			enterToClass="scale-100"
+			exitActiveClass="transition-transform duration-200"
+			exitClass="scale-100"
+			exitToClass="scale-95"
 		>
-			<div class="flex flex-row gap-2 items-stretch w-full text-xs text-gray-11">
-				<div
-					class={cx(
-						"flex flex-1 overflow-hidden rounded-lg bg-gray-3 ring-1 ring-transparent ring-offset-2 ring-offset-gray-1 transition focus-within:ring-blue-9 focus-within:ring-offset-2 focus-within:ring-offset-gray-1",
-						(rawOptions.targetMode === "display" || displayMenuOpen()) &&
-							"ring-blue-9",
-					)}
-				>
+			<div class="flex flex-col gap-2 w-full">
+				<div class="flex flex-row gap-2 items-stretch w-full text-xs text-gray-11">
+					<div
+						class={cx(
+							"flex flex-1 overflow-hidden rounded-lg bg-gray-3 ring-1 ring-transparent ring-offset-2 ring-offset-gray-1 transition focus-within:ring-blue-9 focus-within:ring-offset-2 focus-within:ring-offset-gray-1",
+							(rawOptions.targetMode === "display" || displayMenuOpen()) &&
+								"ring-blue-9",
+						)}
+					>
+						<TargetTypeButton
+							selected={rawOptions.targetMode === "display"}
+							Component={IconMdiMonitor}
+							disabled={isRecording()}
+							onClick={() => {
+								if (isRecording()) return;
+								setOptions("targetMode", (v) =>
+									v === "display" ? null : "display",
+								);
+							}}
+							name="Display"
+							class="flex-1 rounded-none focus-visible:ring-0 focus-visible:ring-offset-0"
+						/>
+						<TargetDropdownButton
+							class={cx(
+								"rounded-none border-l border-gray-6 focus-visible:ring-0 focus-visible:ring-offset-0",
+								displayMenuOpen() && "bg-gray-5",
+							)}
+							ref={(el) => (displayTriggerRef = el)}
+							disabled={isRecording()}
+							expanded={displayMenuOpen()}
+							onClick={() => {
+								setDisplayMenuOpen((prev) => {
+									const next = !prev;
+									if (next) {
+										setWindowMenuOpen(false);
+										setHasOpenedDisplayMenu(true);
+									}
+									return next;
+								});
+							}}
+							aria-haspopup="menu"
+							aria-label="Choose display"
+						/>
+					</div>
+					<div
+						class={cx(
+							"flex flex-1 overflow-hidden rounded-lg bg-gray-3 ring-1 ring-transparent ring-offset-2 ring-offset-gray-1 transition focus-within:ring-blue-9 focus-within:ring-offset-2 focus-within:ring-offset-gray-1",
+							(rawOptions.targetMode === "window" || windowMenuOpen()) &&
+								"ring-blue-9",
+						)}
+					>
+						<TargetTypeButton
+							selected={rawOptions.targetMode === "window"}
+							Component={IconLucideAppWindowMac}
+							disabled={isRecording()}
+							onClick={() => {
+								if (isRecording()) return;
+								setOptions("targetMode", (v) =>
+									v === "window" ? null : "window",
+								);
+							}}
+							name="Window"
+							class="flex-1 rounded-none focus-visible:ring-0 focus-visible:ring-offset-0"
+						/>
+						<TargetDropdownButton
+							class={cx(
+								"rounded-none border-l border-gray-6 focus-visible:ring-0 focus-visible:ring-offset-0",
+								windowMenuOpen() && "bg-gray-5",
+							)}
+							ref={(el) => (windowTriggerRef = el)}
+							disabled={isRecording()}
+							expanded={windowMenuOpen()}
+							onClick={() => {
+								setWindowMenuOpen((prev) => {
+									const next = !prev;
+									if (next) {
+										setDisplayMenuOpen(false);
+										setHasOpenedWindowMenu(true);
+									}
+									return next;
+								});
+							}}
+							aria-haspopup="menu"
+							aria-label="Choose window"
+						/>
+					</div>
 					<TargetTypeButton
-						selected={rawOptions.targetMode === "display"}
-						Component={IconMdiMonitor}
+						selected={rawOptions.targetMode === "area"}
+						Component={IconMaterialSymbolsScreenshotFrame2Rounded}
 						disabled={isRecording()}
 						onClick={() => {
 							if (isRecording()) return;
-							setOptions("targetMode", (v) =>
-								v === "display" ? null : "display",
-							);
+							setOptions("targetMode", (v) => (v === "area" ? null : "area"));
 						}}
-						name="Display"
-						class="flex-1 rounded-none focus-visible:ring-0 focus-visible:ring-offset-0"
-					/>
-					<TargetDropdownButton
-						class={cx(
-							"rounded-none border-l border-gray-6 focus-visible:ring-0 focus-visible:ring-offset-0",
-							displayMenuOpen() && "bg-gray-5",
-						)}
-						ref={(el) => (displayTriggerRef = el)}
-						disabled={isRecording()}
-						expanded={displayMenuOpen()}
-						onClick={() => {
-							setDisplayMenuOpen((prev) => {
-								const next = !prev;
-								if (next) {
-									setWindowMenuOpen(false);
-									setHasOpenedDisplayMenu(true);
-								}
-								return next;
-							});
-						}}
-						aria-haspopup="menu"
-						aria-label="Choose display"
+						name="Area"
 					/>
 				</div>
-				<div
-					class={cx(
-						"flex flex-1 overflow-hidden rounded-lg bg-gray-3 ring-1 ring-transparent ring-offset-2 ring-offset-gray-1 transition focus-within:ring-blue-9 focus-within:ring-offset-2 focus-within:ring-offset-gray-1",
-						(rawOptions.targetMode === "window" || windowMenuOpen()) &&
-							"ring-blue-9",
-					)}
-				>
-					<TargetTypeButton
-						selected={rawOptions.targetMode === "window"}
-						Component={IconLucideAppWindowMac}
-						disabled={isRecording()}
-						onClick={() => {
-							if (isRecording()) return;
-							setOptions("targetMode", (v) =>
-								v === "window" ? null : "window",
-							);
-						}}
-						name="Window"
-						class="flex-1 rounded-none focus-visible:ring-0 focus-visible:ring-offset-0"
-					/>
-					<TargetDropdownButton
-						class={cx(
-							"rounded-none border-l border-gray-6 focus-visible:ring-0 focus-visible:ring-offset-0",
-							windowMenuOpen() && "bg-gray-5",
-						)}
-						ref={(el) => (windowTriggerRef = el)}
-						disabled={isRecording()}
-						expanded={windowMenuOpen()}
-						onClick={() => {
-							setWindowMenuOpen((prev) => {
-								const next = !prev;
-								if (next) {
-									setDisplayMenuOpen(false);
-									setHasOpenedWindowMenu(true);
-								}
-								return next;
-							});
-						}}
-						aria-haspopup="menu"
-						aria-label="Choose window"
-					/>
-				</div>
-				<TargetTypeButton
-					selected={rawOptions.targetMode === "area"}
-					Component={IconMaterialSymbolsScreenshotFrame2Rounded}
-					disabled={isRecording()}
-					onClick={() => {
-						if (isRecording()) return;
-						setOptions("targetMode", (v) => (v === "area" ? null : "area"));
-					}}
-					name="Area"
-				/>
+				<BaseControls />
 			</div>
-			<BaseControls />
-		</Motion.div>
+		</Transition>
 	);
 
 	const startSignInCleanup = listen("start-sign-in", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,9 +182,6 @@ importers:
       solid-markdown:
         specifier: ^2.0.13
         version: 2.0.14(solid-js@1.9.6)
-      solid-motionone:
-        specifier: ^1.0.4
-        version: 1.0.4(solid-js@1.9.6)
       solid-presence:
         specifier: ^0.1.8
         version: 0.1.8(solid-js@1.9.6)
@@ -3750,24 +3747,6 @@ packages:
   '@modelcontextprotocol/sdk@1.6.1':
     resolution: {integrity: sha512-oxzMzYCkZHMntzuyerehK3fV6A2Kwh5BD6CGEJSVDU2QNEhfLOptf2X7esQgaHZXHZY0oHmMsOtIDLP71UJXgA==}
     engines: {node: '>=18'}
-
-  '@motionone/animation@10.18.0':
-    resolution: {integrity: sha512-9z2p5GFGCm0gBsZbi8rVMOAJCtw1WqBTIPw3ozk06gDvZInBPIsQcHgYogEJ4yuHJ+akuW8g1SEIOpTOvYs8hw==}
-
-  '@motionone/dom@10.18.0':
-    resolution: {integrity: sha512-bKLP7E0eyO4B2UaHBBN55tnppwRnaE3KFfh3Ps9HhnAkar3Cb69kUCJY9as8LrccVYKgHA+JY5dOQqJLOPhF5A==}
-
-  '@motionone/easing@10.18.0':
-    resolution: {integrity: sha512-VcjByo7XpdLS4o9T8t99JtgxkdMcNWD3yHU/n6CLEz3bkmKDRZyYQ/wmSf6daum8ZXqfUAgFeCZSpJZIMxaCzg==}
-
-  '@motionone/generators@10.18.0':
-    resolution: {integrity: sha512-+qfkC2DtkDj4tHPu+AFKVfR/C30O1vYdvsGYaR13W/1cczPrrcjdvYCj0VLFuRMN+lP1xvpNZHCRNM4fBzn1jg==}
-
-  '@motionone/types@10.17.1':
-    resolution: {integrity: sha512-KaC4kgiODDz8hswCrS0btrVrzyU2CSQKO7Ps90ibBVSQmjkrt2teqta6/sOG59v7+dPnKMAg13jyqtMKV2yJ7A==}
-
-  '@motionone/utils@10.18.0':
-    resolution: {integrity: sha512-3XVF7sgyTSI2KWvTf6uLlBJ5iAgRgmvp3bpuOiQJvInd4nZ19ET8lX5unn30SlmRH7hXbBbH+Gxd0m0klJ3Xtw==}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -9635,9 +9614,6 @@ packages:
     resolution: {integrity: sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==}
     engines: {node: '>=16.0.0'}
 
-  hey-listen@1.0.8:
-    resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
-
   hls.js@0.14.17:
     resolution: {integrity: sha512-25A7+m6qqp6UVkuzUQ//VVh2EEOPYlOBg32ypr34bcPO7liBMOkKFvbjbCBfiPAOTA/7BSx1Dujft3Th57WyFg==}
 
@@ -12579,11 +12555,6 @@ packages:
     engines: {node: '>=18', pnpm: '>=8.6.0'}
     peerDependencies:
       solid-js: ^1.6.0
-
-  solid-motionone@1.0.4:
-    resolution: {integrity: sha512-aqEjgecoO9raDFznu/dEci7ORSmA26Kjj9J4Cn1Gyr0GZuOVdvsNxdxClTL9J40Aq/uYFx4GLwC8n70fMLHiuA==}
-    peerDependencies:
-      solid-js: ^1.8.0
 
   solid-presence@0.1.8:
     resolution: {integrity: sha512-pWGtXUFWYYUZNbg5YpG5vkQJyOtzn2KXhxYaMx/4I+lylTLYkITOLevaCwMRN+liCVk0pqB6EayLWojNqBFECA==}
@@ -16928,41 +16899,6 @@ snapshots:
       zod-to-json-schema: 3.24.3(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
-
-  '@motionone/animation@10.18.0':
-    dependencies:
-      '@motionone/easing': 10.18.0
-      '@motionone/types': 10.17.1
-      '@motionone/utils': 10.18.0
-      tslib: 2.8.1
-
-  '@motionone/dom@10.18.0':
-    dependencies:
-      '@motionone/animation': 10.18.0
-      '@motionone/generators': 10.18.0
-      '@motionone/types': 10.17.1
-      '@motionone/utils': 10.18.0
-      hey-listen: 1.0.8
-      tslib: 2.8.1
-
-  '@motionone/easing@10.18.0':
-    dependencies:
-      '@motionone/utils': 10.18.0
-      tslib: 2.8.1
-
-  '@motionone/generators@10.18.0':
-    dependencies:
-      '@motionone/types': 10.17.1
-      '@motionone/utils': 10.18.0
-      tslib: 2.8.1
-
-  '@motionone/types@10.17.1': {}
-
-  '@motionone/utils@10.18.0':
-    dependencies:
-      '@motionone/types': 10.17.1
-      hey-listen: 1.0.8
-      tslib: 2.8.1
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
@@ -22124,6 +22060,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.0(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -24118,8 +24058,6 @@ snapshots:
 
   helmet@7.2.0: {}
 
-  hey-listen@1.0.8: {}
-
   hls.js@0.14.17:
     dependencies:
       eventemitter3: 4.0.7
@@ -24988,7 +24926,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.18.2
+      ws: 8.18.3
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -27843,16 +27781,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  solid-motionone@1.0.4(solid-js@1.9.6):
-    dependencies:
-      '@motionone/dom': 10.18.0
-      '@motionone/utils': 10.18.0
-      '@solid-primitives/props': 3.2.1(solid-js@1.9.6)
-      '@solid-primitives/refs': 1.1.1(solid-js@1.9.6)
-      '@solid-primitives/transition-group': 1.1.1(solid-js@1.9.6)
-      csstype: 3.1.3
-      solid-js: 1.9.6
-
   solid-presence@0.1.8(solid-js@1.9.6):
     dependencies:
       '@corvu/utils': 0.4.2(solid-js@1.9.6)
@@ -28917,7 +28845,7 @@ snapshots:
       '@antfu/install-pkg': 0.4.1
       '@antfu/utils': 0.7.10
       '@iconify/utils': 2.3.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       kolorist: 1.8.0
       local-pkg: 0.5.1
       unplugin: 1.16.1
@@ -29257,7 +29185,7 @@ snapshots:
 
   vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.17)(jiti@2.4.2)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.8.3)
     optionalDependencies:
@@ -29332,7 +29260,7 @@ snapshots:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.2.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 1.1.2


### PR DESCRIPTION
Replace motion one with css transitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated UI animations for target selection and grid items to a unified transition approach, delivering smoother, consistent enter/exit effects with subtle staggered delays. Interactive behavior remains unchanged.

- Chores
  - Removed an unused animation dependency from the desktop app to simplify the build and slightly reduce the application footprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->