### PR TITLE
chore: adjust compare plans text on pricing page

### DIFF
--- a/apps/web/components/FileInput.tsx
+++ b/apps/web/components/FileInput.tsx
@@ -216,7 +216,7 @@ export const FileInput: React.FC<FileInputProps> = ({
 												width: previewIconSize,
 												height: previewIconSize,
 											}}
-											className="flex overflow-hidden relative flex-shrink-0 justify-center items-center rounded-md"
+											className="flex overflow-hidden relative flex-shrink-0 justify-center items-center rounded-full"
 										>
 											{previewUrl && (
 												<Image

--- a/apps/web/components/pages/_components/ComparePlans.tsx
+++ b/apps/web/components/pages/_components/ComparePlans.tsx
@@ -297,7 +297,7 @@ export const ComparePlans = () => {
 	};
 	return (
 		<div className="mx-auto w-full max-w-[1400px]">
-			<h2 className="mb-6 text-center">Compare plans</h2>
+			<h2 className="mb-6 text-4xl text-center text-gray-12">Compare plans</h2>
 			<div className="overflow-x-auto w-full">
 				<div className="overflow-hidden rounded-xl border min-w-fit border-gray-5">
 					<table className="w-full text-left border-separate border-spacing-0 bg-gray-2">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated file upload preview/icon container to a circular shape for a cleaner, modern look.
  * Refined Compare Plans header with larger font and improved text color for better readability and emphasis.
  * No functional behavior changes; drag-and-drop, events, and validation remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->