### PR TITLE
Enable upload progress in web

### DIFF
--- a/apps/web/app/(org)/dashboard/caps/components/CapCard/CapCard.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/CapCard/CapCard.tsx
@@ -196,7 +196,6 @@ export const CapCard = ({
 		cap.id,
 		cap.hasActiveUpload || false,
 	);
-	const enableBetaUploadProgress = useFeatureFlag("enableUploadProgress");
 	const [imageStatus, setImageStatus] = useState<ImageLoadingStatus>("loading");
 
 	// Helper function to create a drag preview element
@@ -462,10 +461,7 @@ export const CapCard = ({
 											error: "Failed to duplicate cap",
 										});
 									}}
-									disabled={
-										duplicateMutation.isPending ||
-										(enableBetaUploadProgress && cap.hasActiveUpload)
-									}
+									disabled={duplicateMutation.isPending || cap.hasActiveUpload}
 									className="flex gap-2 items-center rounded-lg"
 								>
 									<FontAwesomeIcon className="size-3" icon={faCopy} />

--- a/apps/web/app/Layout/features.ts
+++ b/apps/web/app/Layout/features.ts
@@ -1,8 +1,6 @@
 import { Effect, Store, useStore } from "@tanstack/react-store";
 
-const defaultFeatureFlags = {
-	enableUploadProgress: false,
-};
+const defaultFeatureFlags = {};
 
 type FeatureFlags = typeof defaultFeatureFlags;
 

--- a/apps/web/app/Layout/providers.tsx
+++ b/apps/web/app/Layout/providers.tsx
@@ -107,7 +107,7 @@ function CapDevtools() {
 	return (
 		<div className="flex flex-col space-y-4 p-4">
 			<h1 className="text-2xl font-semibold">Cap Devtools</h1>
-			<div className="space-y-2">
+			{/*<div className="space-y-2">
 				<h1 className="text-lg font-semibold">Features</h1>
 				<label className="flex items-center space-x-2">
 					<input
@@ -122,7 +122,7 @@ function CapDevtools() {
 					/>
 					<span>Enable Upload Progress UI</span>
 				</label>
-			</div>
+			</div>*/}
 			<div className="space-y-2">
 				<h1 className="text-lg font-semibold">Cap Pro</h1>
 				<p className="text-xs text-muted-foreground">

--- a/apps/web/app/s/[videoId]/_components/ProgressCircle.tsx
+++ b/apps/web/app/s/[videoId]/_components/ProgressCircle.tsx
@@ -23,10 +23,7 @@ const MINUTE = 60 * SECOND;
 const HOUR = 60 * 60 * SECOND;
 const DAY = 24 * HOUR;
 
-export function useUploadProgress(videoId: Video.VideoId, enabledRaw: boolean) {
-	const enableBetaUploadProgress = useFeatureFlag("enableUploadProgress");
-	const enabled = enableBetaUploadProgress ? enabledRaw : false;
-
+export function useUploadProgress(videoId: Video.VideoId, enabled: boolean) {
 	const query = useEffectQuery({
 		queryKey: ["getUploadProgress", videoId],
 		queryFn: () =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Duplicate Cap action is now correctly disabled while a duplicate is in progress or when the cap has an active upload, preventing unintended actions.

- Refactor
  - Removed the beta toggle for upload progress; behavior is now consistent for all users.
  - Simplified upload progress handling to rely on explicit enablement where displayed, with no visual changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->