### PR TITLE
Enable new uploader in desktop

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -111,7 +111,7 @@ fn default_enable_new_recording_flow() -> bool {
 }
 
 fn default_enable_new_uploader() -> bool {
-    cfg!(debug_assertions)
+    true
 }
 
 fn no(_: &bool) -> bool {


### PR DESCRIPTION
This *should* enable the feature flag in production buildes by default instead of us needing to ask the user to enable it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The new uploader is now enabled by default across all builds, delivering the updated upload experience out of the box.
  * New installations and profiles without a prior preference will start with the new uploader enabled; existing user selections remain unchanged.
  * This ensures a consistent experience across environments and makes it easier for users to access the latest uploading flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->