### PR TITLE
Use Rec709 color space in cap_enc_avfoundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,10 +1432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cap-multi-recorder"
-version = "0.1.0"
-
-[[package]]
 name = "cap-project"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["apps/cli", "apps/desktop/src-tauri", "apps/multi-recorder", "crates/*"]
+members = ["apps/cli", "apps/desktop/src-tauri", "crates/*"]
 
 [workspace.dependencies]
 anyhow = { version = "1.0.86" }

--- a/crates/enc-avfoundation/Cargo.toml
+++ b/crates/enc-avfoundation/Cargo.toml
@@ -11,7 +11,7 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cidre = { workspace = true, features = ["vt"] }
+cidre = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - MP4 exports on macOS now embed Rec.709 color profiles (transfer function, primaries, YCbCr matrix) for more accurate, consistent colors across players.
- Refactor
  - Recording startup errors now use clearer, structured formatting, improving readability of error messages without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->