### PR TITLE
fix: text color in download page

### DIFF
--- a/apps/web/app/(org)/dashboard/_components/Navbar/Items.tsx
+++ b/apps/web/app/(org)/dashboard/_components/Navbar/Items.tsx
@@ -491,7 +491,7 @@ const NavItem = ({
 				>
 					{name}
 				</p>
-				{extraText && !sidebarCollapsed && (
+				{extraText !== null && !sidebarCollapsed && (
 					<p className="ml-auto text-xs font-medium text-gray-11">
 						{extraText}
 					</p>

--- a/apps/web/app/(org)/dashboard/layout.tsx
+++ b/apps/web/app/(org)/dashboard/layout.tsx
@@ -33,7 +33,7 @@ export default async function DashboardLayout({
 	}
 
 	let organizationSelect: Organization[] = [];
-	let userCapsCount: number | null = null;
+	let userCapsCount: number | null = 0;
 	let organizationSettings: OrganizationSettings | null = null;
 	let spacesData: Spaces[] = [];
 	let anyNewNotifications = false;
@@ -49,7 +49,7 @@ export default async function DashboardLayout({
 	} catch (error) {
 		console.error("Failed to load dashboard data", error);
 		organizationSelect = [];
-		userCapsCount = null;
+		userCapsCount = 0;
 		organizationSettings = null;
 		spacesData = [];
 		anyNewNotifications = false;

--- a/apps/web/components/pages/DownloadPage.tsx
+++ b/apps/web/components/pages/DownloadPage.tsx
@@ -21,7 +21,7 @@ export const DownloadPage = () => {
 				<h1 className="text-2xl fade-in-down animate-delay-1 md:text-4xl">
 					Download Cap
 				</h1>
-				<p className="px-4 text-sm fade-in-down animate-delay-2 md:text-base md:px-0">
+				<p className="px-4 text-sm fade-in-down text-gray-11 animate-delay-2 md:text-base md:px-0">
 					The quickest way to share your screen. Pin to your dock and record in
 					seconds.
 				</p>
@@ -116,8 +116,8 @@ export const DownloadPage = () => {
 				</div>
 
 				{/* Discreet SEO Links */}
-				<div className="pt-8 mt-32 text-xs border-t border-gray-200 opacity-70 text-gray-1">
-					<div className="flex flex-wrap gap-y-2 gap-x-4 justify-center mx-auto max-w-lg">
+				<div className="pt-8 mt-32 text-xs border-t border-gray-5 text-gray-12">
+					<div className="flex flex-wrap gap-y-2 gap-x-4 justify-center items-center mx-auto max-w-lg">
 						<Link
 							href="/screen-recorder"
 							className="text-xs hover:text-gray-8 hover:underline"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Extra text in the navbar now displays when its value is 0 (when the sidebar is expanded).

- Bug Fixes
  - User caps count consistently initializes to 0, ensuring a visible “0” instead of a blank state, including on errors.

- Style
  - Download page visual refinements: updated subheading text color, improved SEO links block with new border/text colors and centered alignment for a cleaner look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->