### PR TITLE
desktop: set initial zoom level

### DIFF
--- a/apps/desktop/src/routes/editor/Timeline/index.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/index.tsx
@@ -52,6 +52,22 @@ export function Timeline() {
 			});
 			resume();
 		}
+
+		const checkBounds = () => {
+			if (timelineBounds.width && timelineBounds.width > 0) {
+				const minSegmentPixels = 80;
+				const secondsPerPixel = 1 / minSegmentPixels;
+				const desiredZoom = timelineBounds.width * secondsPerPixel;
+
+				if (transform().zoom > desiredZoom) {
+					transform().updateZoom(desiredZoom, 0);
+				}
+			} else {
+				setTimeout(checkBounds, 10);
+			}
+		};
+
+		checkBounds();
 	});
 
 	if (


### PR DESCRIPTION
**This PR**: If you open or record a long or short recording, the zoom level will automatically be set on mount (initially) just enough so you can see your zoom segment well enough, whether adding or already for existing ones. 

**This deals with the pain of having to manually zoom in initially so you can add and control your newly added zoom segment properly or modify existing ones.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timeline editor now automatically adjusts zoom levels on load to enforce a minimum segment width, ensuring timeline segments remain readable. Zoom is intelligently optimized based on timeline dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->