### PR TITLE
don't abort encoding if capurer stop fails

### DIFF
--- a/crates/recording/src/output_pipeline/core.rs
+++ b/crates/recording/src/output_pipeline/core.rs
@@ -405,12 +405,25 @@ fn spawn_video_encoder<TMutex: VideoMuxer<VideoFrame = TVideo::Frame>, TVideo: V
     muxer: Arc<Mutex<TMutex>>,
     timestamps: Timestamps,
 ) {
+    setup_ctx.tasks().spawn("capture-video", {
+        let stop_token = stop_token.clone();
+        async move {
+            video_source.start().await?;
+
+            stop_token.cancelled().await;
+
+            if let Err(e) = video_source.stop().await {
+                error!("Video source stop failed: {e:#}");
+            };
+
+            Ok(())
+        }
+    });
+
     setup_ctx.tasks().spawn("mux-video", async move {
         use futures::StreamExt;
 
         let mut first_tx = Some(first_tx);
-
-        video_source.start().await?;
 
         stop_token
             .run_until_cancelled(async {
@@ -431,10 +444,6 @@ fn spawn_video_encoder<TMutex: VideoMuxer<VideoFrame = TVideo::Frame>, TVideo: V
                 Ok::<(), anyhow::Error>(())
             })
             .await;
-
-        if let Err(e) = video_source.stop().await {
-            error!("Video source stopped with error: {e:#}");
-        };
 
         muxer.lock().await.stop();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video recording reliability: capture and stop operations are handled separately so muxing no longer forces failures when stopping the video source fails. Recording tasks now complete cleanup more gracefully, reducing aborted recordings.

* **Refactor**
  * Split video capture lifecycle into its own background task for more robust handling of start/stop operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->