### PR TITLE
rendering: turn DecodedFrame into a struct

### DIFF
--- a/crates/rendering/src/decoder/ffmpeg.rs
+++ b/crates/rendering/src/decoder/ffmpeg.rs
@@ -9,12 +9,16 @@ use std::{
 };
 use tokio::sync::oneshot;
 
+use crate::DecodedFrame;
+
 use super::{FRAME_CACHE_SIZE, VideoDecoderMessage, frame_converter::FrameConverter, pts_to_frame};
 
 #[derive(Clone)]
 struct ProcessedFrame {
     number: u32,
     data: Arc<Vec<u8>>,
+    width: u32,
+    height: u32,
 }
 
 impl CachedFrame {
@@ -25,6 +29,8 @@ impl CachedFrame {
                 let data = ProcessedFrame {
                     data: Arc::new(frame_buffer),
                     number: *number,
+                    width: frame.width(),
+                    height: frame.height(),
                 };
 
                 *self = Self::Processed(data.clone());
@@ -99,14 +105,22 @@ impl FfmpegDecoder {
                         let mut sender = if let Some(cached) = cache.get_mut(&requested_frame) {
                             let data = cached.process(&mut converter);
 
-                            sender.send(data.data.clone()).ok();
+                            let _ = sender.send(DecodedFrame {
+                                data: data.data.clone(),
+                                width: data.width,
+                                height: data.height,
+                            });
                             *last_sent_frame.borrow_mut() = Some(data);
                             continue;
                         } else {
                             let last_sent_frame = last_sent_frame.clone();
                             Some(move |data: ProcessedFrame| {
                                 *last_sent_frame.borrow_mut() = Some(data.clone());
-                                let _ = sender.send(data.data);
+                                let _ = sender.send(DecodedFrame {
+                                    data: data.data.clone(),
+                                    width: data.width,
+                                    height: data.height,
+                                });
                             })
                         };
 

--- a/crates/rendering/src/decoder/mod.rs
+++ b/crates/rendering/src/decoder/mod.rs
@@ -10,7 +10,25 @@ mod avassetreader;
 mod ffmpeg;
 mod frame_converter;
 
-pub type DecodedFrame = Arc<Vec<u8>>;
+pub struct DecodedFrame {
+    data: Arc<Vec<u8>>,
+    width: u32,
+    height: u32,
+}
+
+impl DecodedFrame {
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+}
 
 pub enum VideoDecoderMessage {
     GetFrame(f32, tokio::sync::oneshot::Sender<DecodedFrame>),

--- a/crates/rendering/src/layers/camera.rs
+++ b/crates/rendering/src/layers/camera.rs
@@ -76,7 +76,7 @@ impl CameraLayer {
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
             },
-            camera_frame,
+            camera_frame.data(),
             wgpu::TexelCopyBufferLayout {
                 offset: 0,
                 bytes_per_row: Some(frame_size.x * 4),

--- a/crates/rendering/src/layers/display.rs
+++ b/crates/rendering/src/layers/display.rs
@@ -62,7 +62,7 @@ impl DisplayLayer {
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
             },
-            &segment_frames.screen_frame,
+            segment_frames.screen_frame.data(),
             wgpu::TexelCopyBufferLayout {
                 offset: 0,
                 bytes_per_row: Some(frame_size.x * 4),

--- a/turbo.json
+++ b/turbo.json
@@ -35,7 +35,8 @@
 			"cache": false
 		},
 		"db:push": {
-			"cache": false
+			"cache": false,
+			"interactive": true
 		},
 		"dev": {
 			"dependsOn": ["db:push"],


### PR DESCRIPTION
In preparation to use the frame-specific width/height to calculate texture bounds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal frame processing to better track and propagate frame dimension metadata throughout the rendering pipeline.
  * Updated frame data access patterns for consistency.

* **Chores**
  * Enabled interactive mode for database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->