### PR TITLE
Fix Target Select Overlay window bounds on multimonitor setups

### DIFF
--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -218,12 +218,10 @@ function Inner() {
 			<Match
 				when={
 					rawOptions.targetMode === "window" &&
-					(targetUnderCursor.display_id === params.displayId ||
-						(rawOptions.captureTarget.variant === "window" &&
-							selectedWindow.data))
+					targetUnderCursor.display_id === params.displayId
 				}
 			>
-				<Show when={windowToShow()} keyed>
+				<Show when={targetUnderCursor.window} keyed>
 					{(windowUnderCursor) => (
 						<div
 							data-over={targetUnderCursor.display_id === params.displayId}


### PR DESCRIPTION
Reverts some changes introduced in https://github.com/CapSoftware/Cap/pull/1104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined window overlay targeting logic to improve accuracy and reliability when selecting windows across multiple displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->