### PR TITLE
feat: Ensure monotonic PTS for video and audio frames (fixes instant mode pausing)

### DIFF
--- a/crates/enc-avfoundation/src/mp4.rs
+++ b/crates/enc-avfoundation/src/mp4.rs
@@ -414,7 +414,7 @@ impl MP4Encoder {
     fn audio_frame_duration(frame: &frame::Audio) -> Duration {
         let rate = frame.rate();
 
-        if rate <= 0 {
+        if rate == 0 {
             return Duration::from_millis(1);
         }
 


### PR DESCRIPTION
Adds logic to correct presentation timestamps (PTS) for video and audio frames to guarantee monotonicity, preventing non-increasing PTS values. Introduces tracking of last PTS and timestamp, and helper methods for frame duration calculation. 

This PR fixes pausing when using Instant Mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced monotonic timestamp handling for video and audio encoding to prevent timing regressions during frame processing.
  * Improved frame-timing correction logic to ensure proper playback synchronization.
  * Adjusted timestamp offset management with additional validation for edge cases in frame sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->