### PR TITLE
fix(input): prevent mobile zoom on input focus.

### DIFF
--- a/packages/ui/src/components/input/Input.tsx
+++ b/packages/ui/src/components/input/Input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			<input
 				type={type}
 				className={classNames(
-					"flex px-4 w-full font-thin transition-all duration-200 text-[13px] text-gray-12 bg-gray-1 border-gray-4 outline-0 focus:bg-gray-2",
+					"flex px-4 w-full font-thin transition-all duration-200 text-[16px] md:text-[13px] text-gray-12 bg-gray-1 border-gray-4 outline-0 focus:bg-gray-2",
 					"rounded-xl hover:bg-gray-2 autofill:bg-gray-1 hover:border-gray-5 h-[44px] placeholder:text-gray-8 border-[1px] focus:border-gray-5",
 					"file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none",
 					"disabled:cursor-not-allowed disabled:bg-gray-2 disabled:text-gray-8 disabled:placeholder:text-gray-8 placeholder:transition-all",


### PR DESCRIPTION
### What:
- Fixed the issue where mobile screen zooms in when clicking on input fields by increasing the font size to 16px for mobile devices.

### Why:
- Mobile browsers zoom in when the input field font size is below 16px, which causes usability issues.
Before:

https://github.com/user-attachments/assets/219e6f2c-07c0-4ea2-ba2b-694ead0413ef

After:

https://github.com/user-attachments/assets/d9494427-53a9-4231-83bb-f49c2b753cee


### How:
- Applied Tailwind's responsive font size utilities: `text-[16px]` for mobile and kept `md:text-[13px]` for medium and larger screens.

### Testing:
- Tested on multiple devices (iOS/Android).
- Verified the fix on both small and large screens.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced input field readability by increasing default text size to 16px with responsive scaling on medium screens and above.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->