### PR TITLE
Normalize audio frame rate in AudioMixer output

### DIFF
--- a/crates/recording/src/sources/audio_mixer.rs
+++ b/crates/recording/src/sources/audio_mixer.rs
@@ -322,7 +322,7 @@ impl AudioMixer {
 
                 source.buffer_last = Some((
                     timestamp,
-                    Duration::from_secs_f64(frame.samples() as f64 / frame.rate() as f64),
+                    Duration::from_secs_f64(frame.samples() as f64 / rate as f64),
                 ));
                 source.buffer.push_back(AudioFrame::new(frame, timestamp));
             }


### PR DESCRIPTION
Ensures that the audio frames output by AudioMixer have their rate set to AudioMixer::INFO.rate(), preventing downstream encoders from inheriting incorrect rates from upstream sources such as CoreAudio devices. This change also updates the elapsed time calculation to use the normalized output rate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized audio timing to use the mixer's fixed output rate for buffering and downstream frames, improving timestamp alignment.
  * Reduces timing drift and increases stability when combining sources that report varying sample rates, improving compatibility with external encoders and players.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->