### PR TITLE
Disable generating Gif sharable links

### DIFF
--- a/apps/desktop/src/routes/editor/ExportDialog.tsx
+++ b/apps/desktop/src/routes/editor/ExportDialog.tsx
@@ -133,9 +133,8 @@ export function ExportDialog() {
 	if (!["Mp4", "Gif"].includes(settings.format)) setSettings("format", "Mp4");
 
 	// Ensure GIF is not selected when exportTo is "link"
-	if (settings.format === "Gif" && settings.exportTo === "link") {
+	if (settings.format === "Gif" && settings.exportTo === "link")
 		setSettings("format", "Mp4");
-	}
 
 	const exportWithSettings = (onProgress: (progress: FramesRendered) => void) =>
 		exportVideo(


### PR DESCRIPTION
The Cap web backend doesn't support these yet so let's just quickly grey out the option until we have the time to implement it.