### PR TITLE
Add native 48kHz support and input resampling to audio mixer

### DIFF
--- a/crates/recording/src/feeds/microphone.rs
+++ b/crates/recording/src/feeds/microphone.rs
@@ -129,6 +129,8 @@ impl MicrophoneFeed {
 fn get_usable_device(device: Device) -> Option<(String, Device, SupportedStreamConfig)> {
     let device_name_for_logging = device.name().ok();
 
+    let preferred_rate = cpal::SampleRate(48_000);
+
     let result = device
         .supported_input_configs()
         .map_err(|error| {
@@ -148,6 +150,16 @@ fn get_usable_device(device: Device) -> Option<(String, Device, SupportedStreamC
                     .cmp(&a.sample_format().sample_size())
                     .then(b.max_sample_rate().cmp(&a.max_sample_rate()))
             });
+
+            // First try to find a config that natively supports 48 kHz so we
+            // don't have to rely on resampling later.
+            if let Some(config) = configs.iter().find(|config| {
+                ffmpeg_sample_format_for(config.sample_format()).is_some()
+                    && config.min_sample_rate().0 <= preferred_rate.0
+                    && config.max_sample_rate().0 >= preferred_rate.0
+            }) {
+                return Some(config.clone().with_sample_rate(preferred_rate));
+            }
 
             configs.into_iter().find_map(|config| {
                 ffmpeg_sample_format_for(config.sample_format())


### PR DESCRIPTION
Microphone device selection now prefers native 48kHz configs to avoid unnecessary resampling. The audio mixer pipeline has been refactored to insert aresample filters for each input, ensuring all sources are resampled to the target format before mixing, improving compatibility and audio quality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Microphone audio sampling now intelligently detects and uses native 48 kHz sampling rates when available, eliminating unnecessary resampling
  * Audio mixer enhanced with per-source resampling, allowing each input source to be independently resampled for more robust multi-source audio processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->