### PR TITLE
Add log upload functionality to feedback settings

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -240,6 +240,12 @@ async fn set_mic_input(state: MutableState<'_, App>, label: Option<String>) -> R
 
 #[tauri::command]
 #[specta::specta]
+async fn upload_logs(app_handle: AppHandle) -> Result<(), String> {
+    logging::upload_log_file(&app_handle).await
+}
+
+#[tauri::command]
+#[specta::specta]
 #[instrument(skip(app_handle, state))]
 async fn set_camera_input(
     app_handle: AppHandle,
@@ -1949,6 +1955,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
         .commands(tauri_specta::collect_commands![
             set_mic_input,
             set_camera_input,
+            upload_logs,
             recording::start_recording,
             recording::stop_recording,
             recording::pause_recording,

--- a/apps/desktop/src/routes/(window-chrome)/settings/feedback.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/feedback.tsx
@@ -3,7 +3,9 @@ import { action, useAction, useSubmission } from "@solidjs/router";
 import { getVersion } from "@tauri-apps/api/app";
 import { type as ostype } from "@tauri-apps/plugin-os";
 import { createSignal } from "solid-js";
+import toast from "solid-toast";
 
+import { commands } from "~/utils/tauri";
 import { apiClient, protectedHeaders } from "~/utils/web-api";
 
 const sendFeedbackAction = action(async (feedback: string) => {
@@ -18,9 +20,23 @@ const sendFeedbackAction = action(async (feedback: string) => {
 
 export default function FeedbackTab() {
 	const [feedback, setFeedback] = createSignal("");
+	const [uploadingLogs, setUploadingLogs] = createSignal(false);
 
 	const submission = useSubmission(sendFeedbackAction);
 	const sendFeedback = useAction(sendFeedbackAction);
+
+	const handleUploadLogs = async () => {
+		setUploadingLogs(true);
+		try {
+			await commands.uploadLogs();
+			toast.success("Logs uploaded successfully");
+		} catch (error) {
+			toast.error("Failed to upload logs");
+			console.error("Failed to upload logs:", error);
+		} finally {
+			setUploadingLogs(false);
+		}
+	};
 
 	return (
 		<div class="flex flex-col w-full h-full">
@@ -73,6 +89,21 @@ export default function FeedbackTab() {
 							</Button>
 						</fieldset>
 					</form>
+
+					<div class="pt-6 border-t border-gray-2">
+						<h3 class="text-sm font-medium text-gray-12 mb-2">Debug Information</h3>
+						<p class="text-sm text-gray-10 mb-3">
+							Upload your logs to help us diagnose issues with Cap. No personal information is included.
+						</p>
+						<Button
+							onClick={handleUploadLogs}
+							size="md"
+							variant="gray"
+							disabled={uploadingLogs()}
+						>
+							{uploadingLogs() ? "Uploading..." : "Upload Logs"}
+						</Button>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -11,6 +11,9 @@ async setMicInput(label: string | null) : Promise<null> {
 async setCameraInput(id: DeviceOrModelID | null) : Promise<null> {
     return await TAURI_INVOKE("set_camera_input", { id });
 },
+async uploadLogs() : Promise<null> {
+    return await TAURI_INVOKE("upload_logs");
+},
 async startRecording(inputs: StartRecordingInputs) : Promise<RecordingAction> {
     return await TAURI_INVOKE("start_recording", { inputs });
 },


### PR DESCRIPTION
Introduces a new Tauri command and UI in the feedback settings tab to allow users to upload logs for debugging purposes. Updates the backend, frontend logic, and command utilities to support log uploads, providing user feedback on upload status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added log upload capability in the settings feedback section. Users can now submit debug information via a new "Debug Information" section with an upload button. Uploading state is reflected in the UI, and users receive success or error notifications upon completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->