### PR TITLE
Recording semi-recovery

### DIFF
--- a/apps/desktop/src/routes/(window-chrome)/settings/recordings.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/recordings.tsx
@@ -7,11 +7,10 @@ import {
 	useQueryClient,
 } from "@tanstack/solid-query";
 import { Channel, convertFileSrc } from "@tauri-apps/api/core";
-import { ask } from "@tauri-apps/plugin-dialog";
+import { ask, confirm } from "@tauri-apps/plugin-dialog";
 import { remove } from "@tauri-apps/plugin-fs";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import * as shell from "@tauri-apps/plugin-shell";
-import { confirm } from "@tauri-apps/plugin-dialog";
 import { cx } from "cva";
 import {
 	createMemo,


### PR DESCRIPTION
Allow opening potentially corrupted recordings to give user's the ability to *try* and recover it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added a confirmation dialog when opening recordings that may be corrupted or failed.
  * Edit is now disabled only for in-progress recordings; completed and failed recordings can be opened for editing (confirmation shown if corruption is suspected).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->