### PR TITLE
fix: clamp instant recording output to even minimum size

### DIFF
--- a/crates/recording/src/instant_recording.rs
+++ b/crates/recording/src/instant_recording.rs
@@ -399,65 +399,46 @@ fn current_time_f64() -> f64 {
         .as_secs_f64()
 }
 
+fn ensure_even(value: u32) -> u32 {
+    let adjusted = value - (value % 2);
+    if adjusted == 0 { 2 } else { adjusted }
+}
+
 fn clamp_size(input: (u32, u32), max: (u32, u32)) -> (u32, u32) {
     // 16/9-ish
     if input.0 >= input.1 && (input.0 as f64 / input.1 as f64) <= 16.0 / 9.0 {
-        let mut width = max.0.min(input.0);
-        if width.is_multiple_of(2) {
-            width -= 1;
-        }
+        let width = ensure_even(max.0.min(input.0));
 
         let height_ratio = input.1 as f64 / input.0 as f64;
-        let mut height = (height_ratio * width as f64).round() as u32;
-        if height.is_multiple_of(2) {
-            height -= 1;
-        }
+        let height = ensure_even((height_ratio * width as f64).round() as u32);
 
         (width, height)
     }
     // 9/16-ish
     else if input.0 <= input.1 && (input.0 as f64 / input.1 as f64) >= 9.0 / 16.0 {
-        let mut height = max.0.min(input.1);
-        if height.is_multiple_of(2) {
-            height -= 1;
-        }
+        let height = ensure_even(max.0.min(input.1));
 
         let width_ratio = input.0 as f64 / input.1 as f64;
-        let mut width = (width_ratio * height as f64).round() as u32;
-        if width.is_multiple_of(2) {
-            width -= 1;
-        }
+        let width = ensure_even((width_ratio * height as f64).round() as u32);
 
         (width, height)
     }
     // ultrawide
     else if input.0 >= input.1 && (input.0 as f64 / input.1 as f64) > 16.0 / 9.0 {
-        let mut height = max.1.min(input.1);
-        if height.is_multiple_of(2) {
-            height -= 1;
-        }
+        let height = ensure_even(max.1.min(input.1));
 
         let width_ratio = input.0 as f64 / input.1 as f64;
-        let mut width = (width_ratio * height as f64).round() as u32;
-        if width.is_multiple_of(2) {
-            width -= 1;
-        }
+        let width = ensure_even((width_ratio * height as f64).round() as u32);
 
         (width, height)
     }
     // ultratall
     else if input.0 < input.1 && (input.0 as f64 / input.1 as f64) <= 9.0 / 16.0 {
         // swapped since max_width/height assume horizontal
-        let mut width = max.1.min(input.0);
-        if width.is_multiple_of(2) {
-            width -= 1;
-        }
+        let width = ensure_even(max.1.min(input.0));
 
         let height_ratio = input.1 as f64 / input.0 as f64;
-        let mut height = (height_ratio * width as f64).round() as u32;
-        if height.is_multiple_of(2) {
-            height -= 1;
-        }
+        let height = ensure_even((height_ratio * width as f64).round() as u32);
 
         (width, height)
     } else {


### PR DESCRIPTION
  - guard the instant recording scaler with an ensure_even helper that forces every computed width/height to the nearest even value, never dropping below 2
  - prevent the Media Foundation software H.264 fallback from receiving odd or zero dimensions, avoiding the “expected non-zero even width and height” dialog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instant recording dimension validation to ensure video dimensions are automatically optimized for encoding compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->