### PR TITLE
fix: eliminate “helicopter” mic stutter by aligning mixer timebase

### DIFF
--- a/crates/recording/src/sources/audio_mixer.rs
+++ b/crates/recording/src/sources/audio_mixer.rs
@@ -196,7 +196,8 @@ impl AudioMixerBuilder {
             #[cfg(target_os = "macos")]
             let now = Timestamp::MachAbsoluteTime(cap_timestamp::MachAbsoluteTimestamp::now());
             #[cfg(windows)]
-            let now = Timestamp::PerformanceCounter(cap_timestamp::PerformanceCounterTimestamp::now());
+            let now =
+                Timestamp::PerformanceCounter(cap_timestamp::PerformanceCounterTimestamp::now());
             #[cfg(not(any(target_os = "macos", windows)))]
             let now = Timestamp::Instant(Instant::now());
 


### PR DESCRIPTION
Aligns the audio mixer’s clock with microphone frame timestamps to prevent false gap detection and silence insertion that caused pulsing/stutter on playback.

Root cause: Mic frames are timestamped using OS-native clocks (e.g., Mach absolute time on macOS), but the mixer compared them against `Instant::now()`. The mismatched timebases made the mixer think frames were late, so it periodically inserted silence, heard as a “helicopter” effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Audio tick now uses platform-native time sources (macOS, Windows, others) instead of a single universal clock.
  * The tick invocation was updated to pass the OS-derived timestamp.
  * Existing error handling and control flow around the tick remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->