### PR TITLE
Use check not build for rust release cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,4 +265,4 @@ jobs:
         run: cargo build --all
 
       - name: Build release
-        run: cargo build --all --release
+        run: cargo check --all --release


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build process for improved efficiency during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->