### PR TITLE
hide organisation picker if <= 1 organisation

### DIFF
--- a/apps/desktop/src/routes/editor/ExportDialog.tsx
+++ b/apps/desktop/src/routes/editor/ExportDialog.tsx
@@ -532,7 +532,7 @@ export function ExportDialog() {
 										<Show
 											when={
 												settings.exportTo === "link" &&
-												organisations().length > 0
+												organisations().length > 1
 											}
 										>
 											<div


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Organization selector visibility in the Export dialog header and "Export to" section to display only when multiple organizations are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->