### PR TITLE
Increase SCK queue depth to avoid timeouts

### DIFF
--- a/crates/recording/src/sources/screen_capture/macos.rs
+++ b/crates/recording/src/sources/screen_capture/macos.rs
@@ -129,10 +129,7 @@ impl ScreenCaptureConfig<CMSampleBufferCapture> {
 
         debug!("size: {:?}", size);
 
-        // Calculate queue depth based on FPS to provide adequate buffering
-        // Formula: (fps / 30.0 * 10.0).ceil() gives ~10 frames at 30fps, scaling with higher fps
-        // Minimum of 8, maximum of 16 to balance memory usage and tolerance for processing delays
-        let queue_depth = ((self.config.fps as f32 / 30.0 * 10.0).ceil() as isize).clamp(8, 16);
+        let queue_depth = ((self.config.fps as f32 / 30.0 * 5.0).ceil() as isize).clamp(3, 8);
         debug!("Using queue depth: {}", queue_depth);
 
         let mut settings = scap_screencapturekit::StreamCfgBuilder::default()

--- a/crates/scap-screencapturekit/src/config.rs
+++ b/crates/scap-screencapturekit/src/config.rs
@@ -37,9 +37,9 @@ impl StreamCfgBuilder {
 
     /// Sets the queue depth (number of frames to buffer).
     /// Higher values provide more tolerance for processing delays but use more memory.
-    /// Apple's default is 3. Recommended: 8-12 for 30fps, 12-16 for 60fps.
+    /// Apple's default is 3. Maximum is 8.
     pub fn set_queue_depth(&mut self, depth: isize) {
-        self.0.set_queue_depth(depth);
+        self.0.set_queue_depth(depth.min(8));
     }
 
     /// Logical width of the capture area


### PR DESCRIPTION
This will hopefully mitigate some of the 'Stream was stopped by the system' SCK errors, though due to the lack of information in those errors it could have no effect at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Increased video buffer capacity to improve tolerance for frame processing delays, reducing stutter during screen capture.
  * Added frame-rate–adaptive queue depth that auto-adjusts capture buffering based on FPS (with sensible clamping) for more consistent, reliable recordings across varying system conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->