### PR TITLE
Update UpgradeModal spacing: gap-8 md:gap-4 for better content fit

### DIFF
--- a/apps/web/components/UpgradeModal.tsx
+++ b/apps/web/components/UpgradeModal.tsx
@@ -298,7 +298,7 @@ const UpgradeModalImpl = ({
 							</div>
 
 							<div className="flex flex-1 justify-center items-center self-stretch p-8 bg-transparent md:bg-gray-3">
-								<div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+								<div className="grid grid-cols-1 gap-8 md:gap-4 md:grid-cols-2">
 									{proFeatures.map((feature, index) => (
 										<div
 											key={index.toString()}


### PR DESCRIPTION
Adjusted the spacing in UpgradeModal from gap-8 to gap-8 md:gap-4 to make the content fit better on medium and larger screens.

Before:
<img width="1739" height="964" alt="Screenshot 2025-11-10 143513" src="https://github.com/user-attachments/assets/38b1ced4-dda5-4ff4-a4f9-3195b0523c4b" />

After: 
<img width="1787" height="905" alt="Screenshot 2025-11-10 143643" src="https://github.com/user-attachments/assets/df4479a4-d9a3-4d09-92d5-bddd7169f434" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive spacing in the upgrade modal for medium-sized screens, optimizing the visual layout on tablets and similar devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->