### PR TITLE
Simplify system stop error check in macOS screen capture

### DIFF
--- a/crates/recording/src/sources/screen_capture/macos.rs
+++ b/crates/recording/src/sources/screen_capture/macos.rs
@@ -460,12 +460,6 @@ impl output_pipeline::VideoSource for VideoSource {
 }
 
 fn is_system_stop_error(err: &ns::Error) -> bool {
-    const SCK_ERROR_DOMAIN: &str = "com.apple.ScreenCaptureKit.error";
-
-    if err.domain().to_string() != SCK_ERROR_DOMAIN {
-        return false;
-    }
-
     err.localized_description().to_string() == "Stream was stopped by the system"
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen recording error handling on macOS to more reliably detect and recover from system-initiated stream interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->