### PR TITLE
Adds post-settings-close behavior setting

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -31,6 +31,14 @@ pub enum PostDeletionBehaviour {
     ReopenRecordingWindow,
 }
 
+#[derive(Default, Serialize, Deserialize, Type, Debug, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
+pub enum PostSettingsCloseBehaviour {
+    DoNothing,
+    #[default]
+    OpenRecordingWindow,
+}
+
 impl MainWindowRecordingStartBehaviour {
     pub fn perform(&self, window: &tauri::WebviewWindow) -> tauri::Result<()> {
         match self {
@@ -116,6 +124,8 @@ pub struct GeneralSettingsStore {
     pub recording_picker_preference_set: bool,
     #[serde(default)]
     pub post_deletion_behaviour: PostDeletionBehaviour,
+    #[serde(default)]
+    pub post_settings_close_behaviour: PostSettingsCloseBehaviour,
     #[serde(default = "default_excluded_windows")]
     pub excluded_windows: Vec<WindowExclusion>,
     #[serde(default)]
@@ -184,6 +194,7 @@ impl Default for GeneralSettingsStore {
             enable_new_recording_flow: default_enable_new_recording_flow(),
             recording_picker_preference_set: false,
             post_deletion_behaviour: PostDeletionBehaviour::DoNothing,
+            post_settings_close_behaviour: PostSettingsCloseBehaviour::OpenRecordingWindow,
             excluded_windows: default_excluded_windows(),
             delete_instant_recordings_after_upload: false,
             instant_mode_max_resolution: 1920,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -53,7 +53,7 @@ use clipboard_rs::{Clipboard, ClipboardContext};
 use cpal::StreamError;
 use editor_window::{EditorInstances, WindowEditorInstance};
 use ffmpeg::ffi::AV_TIME_BASE;
-use general_settings::GeneralSettingsStore;
+use general_settings::{GeneralSettingsStore, PostSettingsCloseBehaviour};
 use kameo::{Actor, actor::ActorRef};
 use notifications::NotificationType;
 use recording::{InProgressRecording, RecordingEvent, RecordingInputKind};
@@ -2683,6 +2683,16 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
                                 }
                             }
                             CapWindowId::Settings => {
+                                let settings = GeneralSettingsStore::get(&app)
+                                    .ok()
+                                    .flatten()
+                                    .unwrap_or_default();
+
+                                let should_open_main = matches!(
+                                    settings.post_settings_close_behaviour,
+                                    PostSettingsCloseBehaviour::OpenRecordingWindow
+                                );
+
                                 for (label, window) in app.webview_windows() {
                                     if let Ok(id) = CapWindowId::from_str(&label)
                                         && matches!(
@@ -2692,12 +2702,14 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
                                                 | CapWindowId::Camera
                                         )
                                     {
-                                        let _ = window.show();
+                                        if should_open_main {
+                                            let _ = window.show();
+                                        }
                                     }
                                 }
 
                                 #[cfg(target_os = "windows")]
-                                if !has_open_editor_window(&app) {
+                                if should_open_main && !has_open_editor_window(&app) {
                                     reopen_main_window(&app);
                                 }
 

--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -34,6 +34,7 @@ import {
 	type GeneralSettingsStore,
 	type MainWindowRecordingStartBehaviour,
 	type PostDeletionBehaviour,
+	type PostSettingsCloseBehaviour,
 	type PostStudioRecordingBehaviour,
 	type WindowExclusion,
 } from "~/utils/tauri";
@@ -359,6 +360,7 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 			| MainWindowRecordingStartBehaviour
 			| PostStudioRecordingBehaviour
 			| PostDeletionBehaviour
+			| PostSettingsCloseBehaviour
 			| number,
 	>(props: {
 		label: string;
@@ -555,6 +557,21 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 							{
 								text: "Reopen Recording Window",
 								value: "reopenRecordingWindow",
+							},
+						]}
+					/>
+					<SelectSettingItem
+						label="After Closing Settings Window"
+						description="What should Cap do when you close the settings window?"
+						value={settings.postSettingsCloseBehaviour ?? "openRecordingWindow"}
+						onChange={(value) =>
+							handleChange("postSettingsCloseBehaviour", value)
+						}
+						options={[
+							{ text: "Do Nothing", value: "doNothing" },
+							{
+								text: "Open Recording Window",
+								value: "openRecordingWindow",
 							},
 						]}
 					/>

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -404,7 +404,7 @@ export type ExportSettings = ({ format: "Mp4" } & Mp4ExportSettings) | ({ format
 export type FileType = "recording" | "screenshot"
 export type Flags = { captions: boolean }
 export type FramesRendered = { renderedCount: number; totalFrames: number; type: "FramesRendered" }
-export type GeneralSettingsStore = { instanceId?: string; uploadIndividualFiles?: boolean; hideDockIcon?: boolean; autoCreateShareableLink?: boolean; enableNotifications?: boolean; disableAutoOpenLinks?: boolean; hasCompletedStartup?: boolean; theme?: AppTheme; commercialLicense?: CommercialLicense | null; lastVersion?: string | null; windowTransparency?: boolean; postStudioRecordingBehaviour?: PostStudioRecordingBehaviour; mainWindowRecordingStartBehaviour?: MainWindowRecordingStartBehaviour; custom_cursor_capture2?: boolean; serverUrl?: string; recordingCountdown?: number | null; enableNativeCameraPreview: boolean; autoZoomOnClicks?: boolean; enableNewRecordingFlow: boolean; recordingPickerPreferenceSet?: boolean; postDeletionBehaviour?: PostDeletionBehaviour; excludedWindows?: WindowExclusion[]; deleteInstantRecordingsAfterUpload?: boolean; instantModeMaxResolution?: number }
+export type GeneralSettingsStore = { instanceId?: string; uploadIndividualFiles?: boolean; hideDockIcon?: boolean; autoCreateShareableLink?: boolean; enableNotifications?: boolean; disableAutoOpenLinks?: boolean; hasCompletedStartup?: boolean; theme?: AppTheme; commercialLicense?: CommercialLicense | null; lastVersion?: string | null; windowTransparency?: boolean; postStudioRecordingBehaviour?: PostStudioRecordingBehaviour; mainWindowRecordingStartBehaviour?: MainWindowRecordingStartBehaviour; custom_cursor_capture2?: boolean; serverUrl?: string; recordingCountdown?: number | null; enableNativeCameraPreview: boolean; autoZoomOnClicks?: boolean; enableNewRecordingFlow: boolean; recordingPickerPreferenceSet?: boolean; postDeletionBehaviour?: PostDeletionBehaviour; postSettingsCloseBehaviour?: PostSettingsCloseBehaviour; excludedWindows?: WindowExclusion[]; deleteInstantRecordingsAfterUpload?: boolean; instantModeMaxResolution?: number }
 export type GifExportSettings = { fps: number; resolution_base: XY<number>; quality: GifQuality | null }
 export type GifQuality = { 
 /**
@@ -443,6 +443,7 @@ export type PhysicalSize = { width: number; height: number }
 export type Plan = { upgraded: boolean; manual: boolean; last_checked: number }
 export type Platform = "MacOS" | "Windows"
 export type PostDeletionBehaviour = "doNothing" | "reopenRecordingWindow"
+export type PostSettingsCloseBehaviour = "doNothing" | "openRecordingWindow"
 export type PostStudioRecordingBehaviour = "openEditor" | "showOverlay"
 export type Preset = { name: string; config: ProjectConfiguration }
 export type PresetsStore = { presets: Preset[]; default: number | null }


### PR DESCRIPTION
Allows users to configure Cap's behavior after closing the settings window.

The default behavior is to reopen the main recording window, but users can now choose to do nothing.

This setting is added to the general settings store and exposed in the settings UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new settings option to control window behavior after closing the Settings window. Users can now choose between "Do Nothing" or "Open Recording Window" as their preferred post-settings action.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->