### PR TITLE
Closes main window when settings open

### DIFF
--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -380,7 +380,7 @@ impl ShowCapWindow {
                 window
             }
             Self::Settings { page } => {
-                // Hide main window and target select overlays when settings window opens
+                // Close main window and target select overlays when settings window opens
                 for (label, window) in app.webview_windows() {
                     if let Ok(id) = CapWindowId::from_str(&label)
                         && matches!(
@@ -390,7 +390,7 @@ impl ShowCapWindow {
                                 | CapWindowId::Camera
                         )
                     {
-                        let _ = window.hide();
+                        let _ = window.close();
                     }
                 }
 


### PR DESCRIPTION
Ensures that the main window is closed, rather than hidden, when the settings window is opened. This prevents potential issues related to device usage and improves the overall user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Windows are now closed instead of hidden when opening Settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->