### PR TITLE
Fix: Add Tinybird default env values in env-setup script

### DIFF
--- a/scripts/env-cli.js
+++ b/scripts/env-cli.js
@@ -137,6 +137,17 @@ async function main() {
 		}
 
 		envs.NEXT_PUBLIC_WEB_URL = envs.WEB_URL;
+
+		// Set Tinybird defaults (no prompts needed)
+		if (!allEnvs.TINYBIRD_HOST) {
+			allEnvs.TINYBIRD_HOST = "https://api.tinybird.co";
+		}
+		envs.TINYBIRD_HOST = allEnvs.TINYBIRD_HOST;
+		
+		if (!allEnvs.TINYBIRD_TOKEN) {
+			allEnvs.TINYBIRD_TOKEN = "";
+		}
+		envs.TINYBIRD_TOKEN = allEnvs.TINYBIRD_TOKEN;
 	}
 
 	if (hasDesktop) {

--- a/scripts/env-cli.js
+++ b/scripts/env-cli.js
@@ -138,7 +138,6 @@ async function main() {
 
 		envs.NEXT_PUBLIC_WEB_URL = envs.WEB_URL;
 
-		// Set Tinybird defaults (no prompts needed)
 		if (!allEnvs.TINYBIRD_HOST) {
 			allEnvs.TINYBIRD_HOST = "https://api.tinybird.co";
 		}


### PR DESCRIPTION
## What
This PR ensures that running pnpm env-setup automatically includes default Tinybird env variables in the generated .env file:
```
TINYBIRD_HOST=https://api.tinybird.co
TINYBIRD_TOKEN=
```

## Why
- Missing Tinybird env variables caused Tinybird initialization to fail during startup.
- This failed silently inside Effect, resulting in cryptic fiber Die/defect errors and GET / 500.\
- Adding sane defaults prevents the crash and makes local development work out-of-the-box. 

## What changed
Added automatic Tinybird configuration to env-setup matching existing patterns for other environment variables.


## Testing
- Run `pnpm env-setup`
- Select "Web"
- Verify .env includes TINYBIRD_HOST and TINYBIRD_TOKEN
- Run `pnpm dev:web` - should work without errors

## Result
New contributors get a complete .env automatically, Tinybird is disabled locally unless a token is provided, and the “fiber crash” goes away.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced environment configuration setup with sensible defaults for backend service integration, streamlining the initial setup process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->