### PR TITLE
Implement m4s recording with recovery

### DIFF
--- a/crates/enc-ffmpeg/src/mux/fragmented_mp4.rs
+++ b/crates/enc-ffmpeg/src/mux/fragmented_mp4.rs
@@ -1,0 +1,169 @@
+use cap_media_info::RawVideoFormat;
+use ffmpeg::{format, frame};
+use std::{path::PathBuf, time::Duration};
+use tracing::*;
+
+use crate::{
+    audio::AudioEncoder,
+    h264,
+    video::h264::{H264Encoder, H264EncoderError},
+};
+
+pub struct FragmentedMP4File {
+    #[allow(unused)]
+    tag: &'static str,
+    output: format::context::Output,
+    video: H264Encoder,
+    audio: Option<Box<dyn AudioEncoder + Send>>,
+    is_finished: bool,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum InitError {
+    #[error("{0:?}")]
+    Ffmpeg(ffmpeg::Error),
+    #[error("Video/{0}")]
+    VideoInit(H264EncoderError),
+    #[error("Audio/{0}")]
+    AudioInit(Box<dyn std::error::Error>),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum FinishError {
+    #[error("Already finished")]
+    AlreadyFinished,
+    #[error("{0}")]
+    WriteTrailerFailed(ffmpeg::Error),
+}
+
+pub struct FinishResult {
+    pub video_finish: Result<(), ffmpeg::Error>,
+    pub audio_finish: Result<(), ffmpeg::Error>,
+}
+
+impl FragmentedMP4File {
+    pub fn init(
+        tag: &'static str,
+        mut output_path: PathBuf,
+        video: impl FnOnce(&mut format::context::Output) -> Result<H264Encoder, H264EncoderError>,
+        audio: impl FnOnce(
+            &mut format::context::Output,
+        )
+            -> Option<Result<Box<dyn AudioEncoder + Send>, Box<dyn std::error::Error>>>,
+    ) -> Result<Self, InitError> {
+        output_path.set_extension("mp4");
+
+        if let Some(parent) = output_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+
+        let mut output = format::output(&output_path).map_err(InitError::Ffmpeg)?;
+
+        trace!("Preparing encoders for fragmented mp4 file");
+
+        let video = video(&mut output).map_err(InitError::VideoInit)?;
+        let audio = audio(&mut output)
+            .transpose()
+            .map_err(InitError::AudioInit)?;
+
+        info!("Prepared encoders for fragmented mp4 file");
+
+        let mut opts = ffmpeg::Dictionary::new();
+        opts.set("movflags", "frag_keyframe+empty_moov+default_base_moof");
+        opts.set("frag_duration", "1000000");
+
+        output.write_header_with(opts).map_err(InitError::Ffmpeg)?;
+
+        Ok(Self {
+            tag,
+            output,
+            video,
+            audio,
+            is_finished: false,
+        })
+    }
+
+    pub fn video_format() -> RawVideoFormat {
+        RawVideoFormat::YUYV420
+    }
+
+    pub fn queue_video_frame(
+        &mut self,
+        frame: frame::Video,
+        timestamp: Duration,
+    ) -> Result<(), h264::QueueFrameError> {
+        if self.is_finished {
+            return Ok(());
+        }
+
+        self.video.queue_frame(frame, timestamp, &mut self.output)
+    }
+
+    pub fn queue_audio_frame(&mut self, frame: frame::Audio) {
+        if self.is_finished {
+            return;
+        }
+
+        let Some(audio) = &mut self.audio else {
+            return;
+        };
+
+        audio.send_frame(frame, &mut self.output);
+    }
+
+    pub fn finish(&mut self) -> Result<FinishResult, FinishError> {
+        if self.is_finished {
+            return Err(FinishError::AlreadyFinished);
+        }
+
+        self.is_finished = true;
+
+        tracing::info!("FragmentedMP4Encoder: Finishing encoding");
+
+        let video_finish = self.video.flush(&mut self.output).inspect_err(|e| {
+            error!("Failed to finish video encoder: {e:#}");
+        });
+
+        let audio_finish = self
+            .audio
+            .as_mut()
+            .map(|enc| {
+                tracing::info!("FragmentedMP4Encoder: Flushing audio encoder");
+                enc.flush(&mut self.output).inspect_err(|e| {
+                    error!("Failed to finish audio encoder: {e:#}");
+                })
+            })
+            .unwrap_or(Ok(()));
+
+        tracing::info!("FragmentedMP4Encoder: Writing trailer");
+        self.output
+            .write_trailer()
+            .map_err(FinishError::WriteTrailerFailed)?;
+
+        Ok(FinishResult {
+            video_finish,
+            audio_finish,
+        })
+    }
+
+    pub fn video(&self) -> &H264Encoder {
+        &self.video
+    }
+
+    pub fn video_mut(&mut self) -> &mut H264Encoder {
+        &mut self.video
+    }
+}
+
+impl Drop for FragmentedMP4File {
+    fn drop(&mut self) {
+        let _ = self.finish();
+    }
+}
+
+pub struct FragmentedMP4Input {
+    pub video: frame::Video,
+    pub audio: Option<frame::Audio>,
+}
+
+unsafe impl Send for FragmentedMP4File {}

--- a/crates/enc-ffmpeg/src/mux/mod.rs
+++ b/crates/enc-ffmpeg/src/mux/mod.rs
@@ -1,2 +1,3 @@
+pub mod fragmented_mp4;
 pub mod mp4;
 pub mod ogg;

--- a/crates/recording/src/capture_pipeline.rs
+++ b/crates/recording/src/capture_pipeline.rs
@@ -8,6 +8,9 @@ use anyhow::anyhow;
 use cap_timestamp::Timestamps;
 use std::{path::PathBuf, sync::Arc};
 
+#[cfg(target_os = "macos")]
+use crate::output_pipeline::FragmentedMp4MuxerMacOS;
+
 #[cfg(windows)]
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -68,7 +71,7 @@ impl MakeCapturePipeline for screen_capture::CMSampleBufferCapture {
         OutputPipeline::builder(output_path.clone())
             .with_video::<screen_capture::VideoSource>(screen_capture)
             .with_timestamps(start_time)
-            .build::<AVFoundationMp4Muxer>(Default::default())
+            .build::<FragmentedMp4MuxerMacOS>(())
             .await
     }
 

--- a/crates/recording/src/output_pipeline/macos.rs
+++ b/crates/recording/src/output_pipeline/macos.rs
@@ -2,9 +2,11 @@ use crate::{
     output_pipeline::{AudioFrame, AudioMuxer, Muxer, TaskPool, VideoMuxer},
     sources::screen_capture,
 };
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 use cap_enc_avfoundation::QueueFrameError;
+use cap_enc_ffmpeg::{aac::AACEncoder, h264::H264Encoder};
 use cap_media_info::{AudioInfo, VideoInfo};
+use cidre::cv::{self, pixel_buffer::LockFlags};
 use std::{
     path::PathBuf,
     sync::{Arc, Mutex, atomic::AtomicBool},
@@ -116,6 +118,190 @@ impl AudioMuxer for AVFoundationMp4Muxer {
                 }
                 Err(e) => return Err(anyhow!("send_audio_frame/{e}")),
             }
+        }
+
+        Ok(())
+    }
+}
+
+pub struct FragmentedMp4MuxerMacOS {
+    output: ffmpeg::format::context::Output,
+    video_encoder: Option<H264Encoder>,
+    audio_encoder: Option<AACEncoder>,
+}
+
+impl Muxer for FragmentedMp4MuxerMacOS {
+    type Config = ();
+
+    async fn setup(
+        _: Self::Config,
+        output_path: PathBuf,
+        video_config: Option<VideoInfo>,
+        audio_config: Option<AudioInfo>,
+        _pause_flag: Arc<AtomicBool>,
+        _tasks: &mut TaskPool,
+    ) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        let mut output = ffmpeg::format::output(&output_path)?;
+
+        let video_encoder = video_config
+            .map(|video_config| H264Encoder::builder(video_config).build(&mut output))
+            .transpose()
+            .context("video encoder")?;
+
+        let audio_encoder = audio_config
+            .map(|config| AACEncoder::init(config, &mut output))
+            .transpose()
+            .context("audio encoder")?;
+
+        let mut opts = ffmpeg::Dictionary::new();
+        opts.set("movflags", "frag_keyframe+empty_moov+default_base_moof");
+        opts.set("frag_duration", "1000000");
+
+        output.write_header_with(opts)?;
+
+        Ok(Self {
+            output,
+            video_encoder,
+            audio_encoder,
+        })
+    }
+
+    fn finish(&mut self, _: Duration) -> anyhow::Result<anyhow::Result<()>> {
+        let video_result = self
+            .video_encoder
+            .as_mut()
+            .map(|enc| enc.flush(&mut self.output))
+            .unwrap_or(Ok(()));
+
+        let audio_result = self
+            .audio_encoder
+            .as_mut()
+            .map(|enc| enc.flush(&mut self.output))
+            .unwrap_or(Ok(()));
+
+        self.output.write_trailer().context("write_trailer")?;
+
+        if video_result.is_ok() && audio_result.is_ok() {
+            return Ok(Ok(()));
+        }
+
+        Ok(Err(anyhow!(
+            "Video: {video_result:#?}, Audio: {audio_result:#?}"
+        )))
+    }
+}
+
+fn sample_buf_to_ffmpeg(sample_buf: &cidre::cm::SampleBuf) -> anyhow::Result<ffmpeg::frame::Video> {
+    let image_buf = sample_buf
+        .image_buf()
+        .ok_or_else(|| anyhow!("No image buffer in sample"))?;
+
+    let width = image_buf.width();
+    let height = image_buf.height();
+
+    let mut image_buf_mut = image_buf.retained();
+    unsafe { image_buf_mut.lock_base_addr(LockFlags::READ_ONLY) }
+        .result()
+        .map_err(|e| anyhow!("Failed to lock base addr: {e:?}"))?;
+
+    let result = match image_buf.pixel_format() {
+        cv::PixelFormat::_420V => {
+            let mut ff_frame =
+                ffmpeg::frame::Video::new(ffmpeg::format::Pixel::NV12, width as u32, height as u32);
+
+            let src_stride = image_buf.plane_bytes_per_row(0);
+            let dest_stride = ff_frame.stride(0);
+            let src_bytes = unsafe {
+                std::slice::from_raw_parts(
+                    image_buf.plane_base_address(0),
+                    src_stride * image_buf.plane_height(0),
+                )
+            };
+            let dest_bytes = ff_frame.data_mut(0);
+
+            for y in 0..height {
+                let row_width = width;
+                let src_row = &src_bytes[y * src_stride..y * src_stride + row_width];
+                let dest_row = &mut dest_bytes[y * dest_stride..y * dest_stride + row_width];
+                dest_row.copy_from_slice(src_row);
+            }
+
+            let src_stride = image_buf.plane_bytes_per_row(1);
+            let dest_stride = ff_frame.stride(1);
+            let src_bytes = unsafe {
+                std::slice::from_raw_parts(
+                    image_buf.plane_base_address(1),
+                    src_stride * image_buf.plane_height(1),
+                )
+            };
+            let dest_bytes = ff_frame.data_mut(1);
+
+            for y in 0..height / 2 {
+                let row_width = width;
+                let src_row = &src_bytes[y * src_stride..y * src_stride + row_width];
+                let dest_row = &mut dest_bytes[y * dest_stride..y * dest_stride + row_width];
+                dest_row.copy_from_slice(src_row);
+            }
+
+            Ok(ff_frame)
+        }
+        cv::PixelFormat::_32_BGRA => {
+            let mut ff_frame =
+                ffmpeg::frame::Video::new(ffmpeg::format::Pixel::BGRA, width as u32, height as u32);
+
+            let src_stride = image_buf.plane_bytes_per_row(0);
+            let dest_stride = ff_frame.stride(0);
+            let src_bytes = unsafe {
+                std::slice::from_raw_parts(
+                    image_buf.plane_base_address(0),
+                    src_stride * image_buf.plane_height(0),
+                )
+            };
+            let dest_bytes = ff_frame.data_mut(0);
+
+            for y in 0..height {
+                let row_width = width * 4;
+                let src_row = &src_bytes[y * src_stride..y * src_stride + row_width];
+                let dest_row = &mut dest_bytes[y * dest_stride..y * dest_stride + row_width];
+                dest_row.copy_from_slice(src_row);
+            }
+
+            Ok(ff_frame)
+        }
+        format => Err(anyhow!("Unsupported pixel format: {:?}", format)),
+    };
+
+    unsafe { image_buf_mut.unlock_lock_base_addr(LockFlags::READ_ONLY) }
+        .result()
+        .ok();
+
+    result
+}
+
+impl VideoMuxer for FragmentedMp4MuxerMacOS {
+    type VideoFrame = screen_capture::VideoFrame;
+
+    fn send_video_frame(
+        &mut self,
+        frame: Self::VideoFrame,
+        timestamp: Duration,
+    ) -> anyhow::Result<()> {
+        if let Some(video_encoder) = self.video_encoder.as_mut() {
+            let ff_frame = sample_buf_to_ffmpeg(&frame.sample_buf)?;
+            video_encoder.queue_frame(ff_frame, timestamp, &mut self.output)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl AudioMuxer for FragmentedMp4MuxerMacOS {
+    fn send_audio_frame(&mut self, frame: AudioFrame, timestamp: Duration) -> anyhow::Result<()> {
+        if let Some(audio_encoder) = self.audio_encoder.as_mut() {
+            audio_encoder.send_frame(frame.inner, timestamp, &mut self.output)?;
         }
 
         Ok(())

--- a/crates/recording/src/output_pipeline/win.rs
+++ b/crates/recording/src/output_pipeline/win.rs
@@ -305,7 +305,13 @@ impl Muxer for WindowsMuxer {
             .await
             .map_err(|_| anyhow!("Encoder thread ended unexpectedly"))??;
 
-        output.lock().unwrap().write_header()?;
+        {
+            let mut output_guard = output.lock().unwrap();
+            let mut opts = ffmpeg::Dictionary::new();
+            opts.set("movflags", "frag_keyframe+empty_moov+default_base_moof");
+            opts.set("frag_duration", "1000000");
+            output_guard.write_header_with(opts)?;
+        }
 
         Ok(Self {
             video_tx,

--- a/crates/recording/src/studio_recording.rs
+++ b/crates/recording/src/studio_recording.rs
@@ -381,6 +381,7 @@ impl Pipeline {
 
 struct CursorPipeline {
     output_path: PathBuf,
+    stream_path: PathBuf,
     actor: CursorActor,
 }
 
@@ -891,6 +892,7 @@ async fn create_segment_pipeline(
                 cursor_crop_bounds,
                 display,
                 cursors_dir.to_path_buf(),
+                dir.join("cursor-stream.jsonl"),
                 prev_cursors,
                 next_cursors_id,
                 start_time,
@@ -898,6 +900,7 @@ async fn create_segment_pipeline(
 
             Ok::<_, CreateSegmentPipelineError>(CursorPipeline {
                 output_path: dir.join("cursor.json"),
+                stream_path: dir.join("cursor-stream.jsonl"),
                 actor: cursor,
             })
         })


### PR DESCRIPTION
Implement fragmented MP4 (M4S) recording for studio mode to enable recovery of incomplete recordings.

The previous recording method could lead to lost recordings if the application crashed mid-recording. By using fragmented MP4, video data is written incrementally, allowing the recovery mechanism to reconstruct a playable recording from the last successfully written fragment, even if the recording process is interrupted. This PR introduces a new fragmented MP4 muxer, integrates it into the recording pipeline for both Windows and macOS, and adds metadata tracking and editor-side recovery logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7f8e086-f1c8-43fe-bf84-bfe3fc0cef54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7f8e086-f1c8-43fe-bf84-bfe3fc0cef54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

