### PR TITLE
Reorganize invite quotas and billing to organization level

### DIFF
--- a/apps/web/app/(org)/dashboard/settings/organization/components/MembersCard.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/MembersCard.tsx
@@ -25,7 +25,6 @@ import { removeOrganizationMember } from "@/actions/organization/remove-member";
 import { ConfirmationDialog } from "@/app/(org)/dashboard/_components/ConfirmationDialog";
 import { useDashboardContext } from "@/app/(org)/dashboard/Contexts";
 import { Tooltip } from "@/components/Tooltip";
-import { calculateSeats } from "@/utils/organization";
 
 interface MembersCardProps {
 	isOwner: boolean;
@@ -44,7 +43,6 @@ export const MembersCard = ({
 }: MembersCardProps) => {
 	const router = useRouter();
 	const { activeOrganization } = useDashboardContext();
-	const { remainingSeats } = calculateSeats(activeOrganization || {});
 
 	const handleDeleteInvite = async (inviteId: string) => {
 		if (!isOwner) {
@@ -173,10 +171,6 @@ export const MembersCard = ({
 							onClick={() => {
 								if (!isOwner) {
 									showOwnerToast();
-								} else if (remainingSeats <= 0) {
-									toast.error(
-										"Invite limit reached, please purchase more seats",
-									);
 								} else {
 									setIsInviteDialogOpen(true);
 								}

--- a/apps/web/app/(org)/dashboard/settings/organization/components/SeatsInfoCards.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/SeatsInfoCards.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { Card } from "@cap/ui";
-import { faChair, faUserGroup } from "@fortawesome/free-solid-svg-icons";
+import {
+	faChair,
+	faCrown,
+	faUserGroup,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { calculateSeats } from "@/utils/organization";
 
@@ -9,23 +13,11 @@ import { useDashboardContext } from "../../../Contexts";
 
 export const SeatsInfoCards = () => {
 	const { activeOrganization } = useDashboardContext();
-	const { inviteQuota, remainingSeats } = calculateSeats(
-		activeOrganization || {},
-	);
+	const { paidSeats, memberCount, paidMemberCount, remainingPaidSeats } =
+		calculateSeats(activeOrganization || {});
 
 	return (
 		<div className="flex flex-col flex-1 gap-6 justify-center lg:flex-row">
-			<Card className="flex flex-col flex-1 gap-3 justify-center items-center">
-				<div className="flex justify-center items-center p-3 rounded-full border bg-gray-4 border-gray-5">
-					<FontAwesomeIcon className="text-gray-12 size-3.5" icon={faChair} />
-				</div>
-				<p className="text-gray-11">
-					Seats Remaining
-					<span className="ml-2 font-medium text-gray-12">
-						{remainingSeats}
-					</span>
-				</p>
-			</Card>
 			<Card className="flex flex-col flex-1 gap-3 justify-center items-center">
 				<div className="flex justify-center items-center p-3 rounded-full border bg-gray-4 border-gray-5">
 					<FontAwesomeIcon
@@ -34,8 +26,30 @@ export const SeatsInfoCards = () => {
 					/>
 				</div>
 				<p className="text-gray-11">
-					Seats Capacity
-					<span className="ml-2 font-medium text-gray-12">{inviteQuota}</span>
+					Total Members
+					<span className="ml-2 font-medium text-gray-12">{memberCount}</span>
+				</p>
+			</Card>
+			<Card className="flex flex-col flex-1 gap-3 justify-center items-center">
+				<div className="flex justify-center items-center p-3 rounded-full border bg-gray-4 border-gray-5">
+					<FontAwesomeIcon className="text-gray-12 size-3.5" icon={faCrown} />
+				</div>
+				<p className="text-gray-11">
+					Paid Seats
+					<span className="ml-2 font-medium text-gray-12">
+						{paidMemberCount} / {paidSeats}
+					</span>
+				</p>
+			</Card>
+			<Card className="flex flex-col flex-1 gap-3 justify-center items-center">
+				<div className="flex justify-center items-center p-3 rounded-full border bg-gray-4 border-gray-5">
+					<FontAwesomeIcon className="text-gray-12 size-3.5" icon={faChair} />
+				</div>
+				<p className="text-gray-11">
+					Available Paid Seats
+					<span className="ml-2 font-medium text-gray-12">
+						{remainingPaidSeats}
+					</span>
 				</p>
 			</Card>
 		</div>

--- a/apps/web/app/api/settings/billing/subscribe/route.ts
+++ b/apps/web/app/api/settings/billing/subscribe/route.ts
@@ -11,7 +11,8 @@ import type Stripe from "stripe";
 export async function POST(request: NextRequest) {
 	const user = await getCurrentUser();
 	let customerId = user?.stripeCustomerId;
-	const { priceId, quantity, isOnBoarding } = await request.json();
+	const { priceId, quantity, isOnBoarding, organizationId } =
+		await request.json();
 
 	if (!priceId) {
 		console.error("Price ID not found");
@@ -63,6 +64,8 @@ export async function POST(request: NextRequest) {
 			customerId = customer.id;
 		}
 
+		const targetOrgId = organizationId || user.activeOrganizationId;
+
 		const checkoutSession = await stripe().checkout.sessions.create({
 			customer: customerId as string,
 			line_items: [{ price: priceId, quantity: quantity }],
@@ -78,6 +81,7 @@ export async function POST(request: NextRequest) {
 				platform: "web",
 				dubCustomerId: user.id,
 				isOnBoarding: isOnBoarding ? "true" : "false",
+				organizationId: targetOrgId || "",
 			},
 		});
 

--- a/apps/web/utils/organization.ts
+++ b/apps/web/utils/organization.ts
@@ -1,26 +1,28 @@
+import type { OrganisationMemberSeatType } from "@cap/database/schema";
 import { buildEnv } from "@cap/env";
 
-/**
- * Calculate organization seats information
- */
 export function calculateSeats(organization: {
-	inviteQuota?: number;
-	members?: { id: string }[];
+	paidSeats?: number;
+	members?: { id: string; seatType?: OrganisationMemberSeatType }[];
 	invites?: { id: string }[];
 }) {
-	const inviteQuota = organization?.inviteQuota ?? 1;
+	const paidSeats = organization?.paidSeats ?? 0;
 	const memberCount = organization?.members?.length ?? 0;
 	const pendingInvitesCount = organization?.invites?.length ?? 0;
-	const totalUsedSeats = memberCount + pendingInvitesCount;
-	const remainingSeats = buildEnv.NEXT_PUBLIC_IS_CAP
-		? Math.max(0, inviteQuota - totalUsedSeats)
+	const paidMemberCount =
+		organization?.members?.filter((m) => m.seatType === "paid").length ?? 0;
+	const usedPaidSeats = paidMemberCount;
+	const remainingPaidSeats = buildEnv.NEXT_PUBLIC_IS_CAP
+		? Math.max(0, paidSeats - usedPaidSeats)
 		: Number.MAX_SAFE_INTEGER;
 
 	return {
-		inviteQuota,
+		paidSeats,
 		memberCount,
 		pendingInvitesCount,
-		totalUsedSeats,
-		remainingSeats,
+		paidMemberCount,
+		usedPaidSeats,
+		remainingPaidSeats,
+		canInviteUnlimited: true,
 	};
 }

--- a/packages/database/migrations/0009_org_billing.sql
+++ b/packages/database/migrations/0009_org_billing.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `organizations` ADD `stripeCustomerId` varchar(255);--> statement-breakpoint
+ALTER TABLE `organizations` ADD `stripeSubscriptionId` varchar(255);--> statement-breakpoint
+ALTER TABLE `organizations` ADD `stripeSubscriptionStatus` varchar(255);--> statement-breakpoint
+ALTER TABLE `organizations` ADD `stripeSubscriptionPriceId` varchar(255);--> statement-breakpoint
+ALTER TABLE `organizations` ADD `paidSeats` int NOT NULL DEFAULT 0;--> statement-breakpoint
+ALTER TABLE `organization_members` ADD `seatType` varchar(255) NOT NULL DEFAULT 'free';

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
 			"when": 1762428905323,
 			"tag": "0008_fat_ender_wiggin",
 			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "5",
+			"when": 1764619200000,
+			"tag": "0009_org_billing",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/database/migrations/org_billing_backfill.ts
+++ b/packages/database/migrations/org_billing_backfill.ts
@@ -1,0 +1,226 @@
+import { db } from "@cap/database";
+import {
+	organizationMembers,
+	organizations,
+	sharedVideos,
+	users,
+} from "@cap/database/schema";
+import { Organisation, User } from "@cap/web-domain";
+import { and, count, eq, isNotNull, isNull, sql } from "drizzle-orm";
+
+const CHUNK_SIZE = 100;
+
+interface UserWithBilling {
+	id: User.UserId;
+	stripeCustomerId: string | null;
+	stripeSubscriptionId: string | null;
+	stripeSubscriptionStatus: string | null;
+	stripeSubscriptionPriceId: string | null;
+	inviteQuota: number;
+}
+
+interface OrgWithStats {
+	id: Organisation.OrganisationId;
+	ownerId: User.UserId;
+	memberCount: number;
+	sharedVideoCount: number;
+}
+
+async function findBestOrgForUser(userId: User.UserId): Promise<Organisation.OrganisationId | null> {
+	const orgsOwned = await db()
+		.select({
+			id: organizations.id,
+			ownerId: organizations.ownerId,
+		})
+		.from(organizations)
+		.where(
+			and(eq(organizations.ownerId, userId), isNull(organizations.tombstoneAt)),
+		);
+
+	if (orgsOwned.length === 0) {
+		return null;
+	}
+
+	const orgStats: OrgWithStats[] = [];
+
+	for (const org of orgsOwned) {
+		const memberCountResult = await db()
+			.select({ value: count(organizationMembers.id) })
+			.from(organizationMembers)
+			.where(eq(organizationMembers.organizationId, org.id));
+
+		const sharedVideoCountResult = await db()
+			.select({ value: count(sharedVideos.id) })
+			.from(sharedVideos)
+			.where(eq(sharedVideos.organizationId, org.id));
+
+		orgStats.push({
+			id: org.id,
+			ownerId: org.ownerId,
+			memberCount: memberCountResult[0]?.value || 0,
+			sharedVideoCount: sharedVideoCountResult[0]?.value || 0,
+		});
+	}
+
+	orgStats.sort((a, b) => {
+		if (a.memberCount !== b.memberCount) {
+			return b.memberCount - a.memberCount;
+		}
+		return b.sharedVideoCount - a.sharedVideoCount;
+	});
+
+	return orgStats[0]?.id || null;
+}
+
+async function migrateUserBillingToOrg(user: UserWithBilling): Promise<void> {
+	const targetOrgId = await findBestOrgForUser(user.id);
+
+	if (!targetOrgId) {
+		console.log(`  ⚠️ No organizations found for user ${user.id}, skipping`);
+		return;
+	}
+
+	const paidSeats = user.inviteQuota || 0;
+
+	await db()
+		.update(organizations)
+		.set({
+			stripeCustomerId: user.stripeCustomerId,
+			stripeSubscriptionId: user.stripeSubscriptionId,
+			stripeSubscriptionStatus: user.stripeSubscriptionStatus,
+			stripeSubscriptionPriceId: user.stripeSubscriptionPriceId,
+			paidSeats: paidSeats,
+		})
+		.where(eq(organizations.id, targetOrgId));
+
+	console.log(
+		`  ✅ Migrated billing to org ${targetOrgId} with ${paidSeats} paid seats`,
+	);
+
+	const membersInOrg = await db()
+		.select({
+			id: organizationMembers.id,
+			userId: organizationMembers.userId,
+		})
+		.from(organizationMembers)
+		.where(eq(organizationMembers.organizationId, targetOrgId))
+		.limit(paidSeats > 0 ? paidSeats : 1);
+
+	if (membersInOrg.length > 0 && paidSeats > 0) {
+		const memberIdsToUpgrade = membersInOrg
+			.slice(0, paidSeats)
+			.map((m) => m.id);
+
+		await db()
+			.update(organizationMembers)
+			.set({ seatType: "paid" })
+			.where(
+				sql`${organizationMembers.id} IN (${sql.join(
+					memberIdsToUpgrade.map((id) => sql`${id}`),
+					sql`, `,
+				)})`,
+			);
+
+		console.log(
+			`  ✅ Upgraded ${memberIdsToUpgrade.length} members to paid seats`,
+		);
+	}
+}
+
+async function getInitialStats(): Promise<void> {
+	console.log("📈 Getting initial stats...");
+
+	const usersWithBilling = await db()
+		.select({ count: sql<number>`count(*)` })
+		.from(users)
+		.where(isNotNull(users.stripeSubscriptionId));
+
+	const orgsWithBilling = await db()
+		.select({ count: sql<number>`count(*)` })
+		.from(organizations)
+		.where(isNotNull(organizations.stripeSubscriptionId));
+
+	const totalOrgs = await db()
+		.select({ count: sql<number>`count(*)` })
+		.from(organizations)
+		.where(isNull(organizations.tombstoneAt));
+
+	console.log("📊 Initial stats:");
+	console.log(`  Users with billing: ${usersWithBilling[0]?.count || 0}`);
+	console.log(`  Orgs with billing: ${orgsWithBilling[0]?.count || 0}`);
+	console.log(`  Total active orgs: ${totalOrgs[0]?.count || 0}`);
+	console.log("");
+}
+
+async function backfillOrgBilling(): Promise<void> {
+	console.log("💳 Starting org billing backfill...");
+
+	let processed = 0;
+	let offset = 0;
+
+	while (true) {
+		const usersWithBilling = await db()
+			.select({
+				id: users.id,
+				stripeCustomerId: users.stripeCustomerId,
+				stripeSubscriptionId: users.stripeSubscriptionId,
+				stripeSubscriptionStatus: users.stripeSubscriptionStatus,
+				stripeSubscriptionPriceId: users.stripeSubscriptionPriceId,
+				inviteQuota: users.inviteQuota,
+			})
+			.from(users)
+			.where(isNotNull(users.stripeSubscriptionId))
+			.limit(CHUNK_SIZE)
+			.offset(offset);
+
+		if (usersWithBilling.length === 0) break;
+
+		for (const user of usersWithBilling) {
+			console.log(`\n👤 Processing user ${user.id}...`);
+			await migrateUserBillingToOrg(user);
+			processed++;
+		}
+
+		offset += CHUNK_SIZE;
+		console.log(`\n📝 Processed ${processed} users so far...`);
+	}
+
+	console.log(
+		`\n✅ Org billing backfill complete. Processed ${processed} users.`,
+	);
+}
+
+async function validateBackfill(): Promise<void> {
+	console.log("\n🔍 Validating backfill results...");
+
+	const orgsWithBilling = await db()
+		.select({ count: sql<number>`count(*)` })
+		.from(organizations)
+		.where(isNotNull(organizations.stripeSubscriptionId));
+
+	const paidMembers = await db()
+		.select({ count: sql<number>`count(*)` })
+		.from(organizationMembers)
+		.where(eq(organizationMembers.seatType, "paid"));
+
+	const freeMembers = await db()
+		.select({ count: sql<number>`count(*)` })
+		.from(organizationMembers)
+		.where(eq(organizationMembers.seatType, "free"));
+
+	console.log("📊 Validation results:");
+	console.log(`  Orgs with billing: ${orgsWithBilling[0]?.count || 0}`);
+	console.log(`  Paid seat members: ${paidMembers[0]?.count || 0}`);
+	console.log(`  Free seat members: ${freeMembers[0]?.count || 0}`);
+}
+
+export async function runOrgBillingBackfill(): Promise<void> {
+	console.log("🚀 Starting org billing backfill script");
+	console.log(`📦 Processing in chunks of ${CHUNK_SIZE} users\n`);
+
+	await getInitialStats();
+	await backfillOrgBilling();
+	await validateBackfill();
+
+	console.log("\n🎉 Migration complete!");
+}

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -199,6 +199,15 @@ export const organizations = mysqlTable(
 		updatedAt: timestamp("updatedAt").notNull().defaultNow().onUpdateNow(),
 		workosOrganizationId: varchar("workosOrganizationId", { length: 255 }),
 		workosConnectionId: varchar("workosConnectionId", { length: 255 }),
+		stripeCustomerId: varchar("stripeCustomerId", { length: 255 }),
+		stripeSubscriptionId: varchar("stripeSubscriptionId", { length: 255 }),
+		stripeSubscriptionStatus: varchar("stripeSubscriptionStatus", {
+			length: 255,
+		}),
+		stripeSubscriptionPriceId: varchar("stripeSubscriptionPriceId", {
+			length: 255,
+		}),
+		paidSeats: int("paidSeats").notNull().default(0),
 	},
 	(table) => ({
 		ownerIdTombstoneIndex: index("owner_id_tombstone_idx").on(
@@ -210,6 +219,7 @@ export const organizations = mysqlTable(
 );
 
 export type OrganisationMemberRole = "owner" | "member";
+export type OrganisationMemberSeatType = "free" | "paid";
 export const organizationMembers = mysqlTable(
 	"organization_members",
 	{
@@ -221,6 +231,10 @@ export const organizationMembers = mysqlTable(
 		role: varchar("role", { length: 255 })
 			.notNull()
 			.$type<OrganisationMemberRole>(),
+		seatType: varchar("seatType", { length: 255 })
+			.notNull()
+			.default("free")
+			.$type<OrganisationMemberSeatType>(),
 		createdAt: timestamp("createdAt").notNull().defaultNow(),
 		updatedAt: timestamp("updatedAt").notNull().defaultNow().onUpdateNow(),
 	},

--- a/packages/utils/src/constants/plans.ts
+++ b/packages/utils/src/constants/plans.ts
@@ -11,6 +11,15 @@ export const STRIPE_PLAN_IDS = {
 	},
 };
 
+export const isActiveSubscription = (status?: string | null): boolean => {
+	return (
+		status === "active" ||
+		status === "trialing" ||
+		status === "complete" ||
+		status === "paid"
+	);
+};
+
 export const userIsPro = (
 	user?: {
 		stripeSubscriptionStatus?: string | null;
@@ -23,16 +32,40 @@ export const userIsPro = (
 
 	const { stripeSubscriptionStatus, thirdPartyStripeSubscriptionId } = user;
 
-	// Check for third-party subscription first
 	if (thirdPartyStripeSubscriptionId) {
 		return true;
 	}
 
-	// Then check regular subscription status
+	return isActiveSubscription(stripeSubscriptionStatus);
+};
+
+export const orgIsPro = (
+	org?: {
+		stripeSubscriptionStatus?: string | null;
+		paidSeats?: number | null;
+	} | null,
+) => {
+	if (!buildEnv.NEXT_PUBLIC_IS_CAP) return true;
+
+	if (!org) return false;
+
+	return isActiveSubscription(org.stripeSubscriptionStatus);
+};
+
+export const memberHasPaidSeat = (
+	member?: {
+		seatType?: string | null;
+	} | null,
+	org?: {
+		stripeSubscriptionStatus?: string | null;
+	} | null,
+) => {
+	if (!buildEnv.NEXT_PUBLIC_IS_CAP) return true;
+
+	if (!member || !org) return false;
+
 	return (
-		stripeSubscriptionStatus === "active" ||
-		stripeSubscriptionStatus === "trialing" ||
-		stripeSubscriptionStatus === "complete" ||
-		stripeSubscriptionStatus === "paid"
+		member.seatType === "paid" &&
+		isActiveSubscription(org.stripeSubscriptionStatus)
 	);
 };


### PR DESCRIPTION
Implement organization-based billing and unlimited free invites to align billing with organizations and provide more flexible invitation options.

Previously, `inviteQuota` and billing were tied to individual users, which was not optimal for organizations with varying seat requirements. This change shifts billing responsibility to the organization, allowing for flexible paid seat management per organization and enabling unlimited free invites for members who will remain on the free plan.

---
<a href="https://cursor.com/background-agent?bcId=bc-c629858e-10e9-44fa-8fc3-e4761da5cca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c629858e-10e9-44fa-8fc3-e4761da5cca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

