### PR TITLE
Investigate screen recording edge artifacts

### DIFF
--- a/crates/rendering/src/shaders/composite-video-frame.wgsl
+++ b/crates/rendering/src/shaders/composite-video-frame.wgsl
@@ -270,8 +270,10 @@ fn sample_texture(uv: vec2<f32>, crop_bounds_uv: vec4<f32>) -> vec4<f32> {
 }
 
 fn apply_rounded_corners(current_color: vec4<f32>, target_uv: vec2<f32>) -> vec4<f32> {
-    // Compute the signed distance to the rounded rect in pixel space so we can
-    // blend edges smoothly instead of hard-clipping them (which produced jaggies).
+    if uniforms.rounding_px < 0.5 {
+        return current_color;
+    }
+
     let centered_uv = (target_uv - vec2<f32>(0.5)) * uniforms.target_size;
     let half_size = uniforms.target_size * 0.5;
     let distance = sdf_rounded_rect(centered_uv, half_size, uniforms.rounding_px, uniforms.rounding_type);


### PR DESCRIPTION
Fixes white lines around screen recordings by preventing semi-transparent edges when no rounded corners are applied.

When `rounding_px` was 0, the `apply_rounded_corners` function's smoothstep anti-aliasing produced ~50% coverage at the exact edge pixels, causing background bleed-through. This change ensures straight edges remain fully opaque when no rounding is intended.

---
<a href="https://cursor.com/background-agent?bcId=bc-63f6a450-2f09-479c-a937-e533f7836305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63f6a450-2f09-479c-a937-e533f7836305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

