### PR TITLE
Fix Rive crashes in New Folder/Subfolder dialogs and shared folder components (#1409)

### DIFF
--- a/apps/web/app/(org)/dashboard/caps/components/Folders.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/Folders.tsx
@@ -29,11 +29,19 @@ export const NormalFolder = React.forwardRef<
 		() => ({
 			play: (animationName: string) => {
 				if (!rive) return;
-				rive.play(animationName);
+				try {
+					rive.play(animationName);
+				} catch (error) {
+					console.warn("Failed to play folder animation", error);
+				}
 			},
 			stop: () => {
 				if (!rive) return;
-				rive.stop();
+				try {
+					rive.stop();
+				} catch (error) {
+					console.warn("Failed to stop folder animation", error);
+				}
 			},
 		}),
 		[rive],
@@ -66,11 +74,19 @@ export const BlueFolder = React.forwardRef<
 		() => ({
 			play: (animationName: string) => {
 				if (!rive) return;
-				rive.play(animationName);
+				try {
+					rive.play(animationName);
+				} catch (error) {
+					console.warn("Failed to play folder animation", error);
+				}
 			},
 			stop: () => {
 				if (!rive) return;
-				rive.stop();
+				try {
+					rive.stop();
+				} catch (error) {
+					console.warn("Failed to stop folder animation", error);
+				}
 			},
 		}),
 		[rive],
@@ -98,11 +114,19 @@ export const RedFolder = React.forwardRef<
 		() => ({
 			play: (animationName: string) => {
 				if (!rive) return;
-				rive.play(animationName);
+				try {
+					rive.play(animationName);
+				} catch (error) {
+					console.warn("Failed to play folder animation", error);
+				}
 			},
 			stop: () => {
 				if (!rive) return;
-				rive.stop();
+				try {
+					rive.stop();
+				} catch (error) {
+					console.warn("Failed to stop folder animation", error);
+				}
 			},
 		}),
 		[rive],
@@ -130,11 +154,19 @@ export const YellowFolder = React.forwardRef<
 		() => ({
 			play: (animationName: string) => {
 				if (!rive) return;
-				rive.play(animationName);
+				try {
+					rive.play(animationName);
+				} catch (error) {
+					console.warn("Failed to play folder animation", error);
+				}
 			},
 			stop: () => {
 				if (!rive) return;
-				rive.stop();
+				try {
+					rive.stop();
+				} catch (error) {
+					console.warn("Failed to stop folder animation", error);
+				}
 			},
 		}),
 		[rive],
@@ -177,11 +209,19 @@ export const AllFolders = React.forwardRef<FolderHandle, AllFoldersProps>(
 			() => ({
 				play: (animationName: string) => {
 					if (!rive) return;
-					rive.play(animationName);
+					try {
+						rive.play(animationName);
+					} catch (error) {
+						console.warn("Failed to play folder animation", error);
+					}
 				},
 				stop: () => {
 					if (!rive) return;
-					rive.stop();
+					try {
+						rive.stop();
+					} catch (error) {
+						console.warn("Failed to stop folder animation", error);
+					}
 				},
 			}),
 			[rive],

--- a/apps/web/app/(org)/dashboard/caps/components/NewFolderDialog.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/NewFolderDialog.tsx
@@ -83,8 +83,14 @@ export const NewFolderDialog: React.FC<Props> = ({
 		src: "/rive/dashboard.riv",
 	});
 
-	useEffect(() => {
-		if (!open) setSelectedColor(null);
+	useEffect(() => { 
+			if (!open) {
+			setSelectedColor(null);
+			// Stop all animations when dialog closes
+			Object.values(folderRefs.current).forEach((ref) => {
+				ref.current?.stop();
+			});
+		}
 	}, [open]);
 
 	const folderRefs = useRef(
@@ -156,21 +162,26 @@ export const NewFolderDialog: React.FC<Props> = ({
 										setSelectedColor(option.value);
 									}}
 									onMouseEnter={() => {
+										if (!riveFile) return;
 										const folderRef = folderRefs.current[option.value]?.current;
 										if (!folderRef) return;
 										folderRef.stop();
 										folderRef.play("folder-open");
 									}}
 									onMouseLeave={() => {
+										if (!riveFile) return;
 										const folderRef = folderRefs.current[option.value]?.current;
 										if (!folderRef) return;
 										folderRef.stop();
 										folderRef.play("folder-close");
 									}}
 								>
-									{option.component(
+									{riveFile && option.component(
 										riveFile as RiveFile,
 										folderRefs.current[option.value],
+									)}
+									{!riveFile && (
+										<div className="w-[50px] h-[50px] bg-gray-4 rounded animate-pulse" />
 									)}
 									<p className="text-xs text-gray-10">{option.label}</p>
 								</div>

--- a/apps/web/app/(org)/dashboard/caps/components/NewFolderDialog.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/NewFolderDialog.tsx
@@ -86,7 +86,6 @@ export const NewFolderDialog: React.FC<Props> = ({
 	useEffect(() => {
 		if (!open) {
 			setSelectedColor(null);
-			// Stop all animations when dialog closes
 			Object.values(folderRefs.current).forEach((ref) => {
 				ref.current?.stop();
 			});

--- a/apps/web/app/(org)/dashboard/caps/components/NewFolderDialog.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/NewFolderDialog.tsx
@@ -83,8 +83,8 @@ export const NewFolderDialog: React.FC<Props> = ({
 		src: "/rive/dashboard.riv",
 	});
 
-	useEffect(() => { 
-			if (!open) {
+	useEffect(() => {
+		if (!open) {
 			setSelectedColor(null);
 			// Stop all animations when dialog closes
 			Object.values(folderRefs.current).forEach((ref) => {
@@ -176,10 +176,11 @@ export const NewFolderDialog: React.FC<Props> = ({
 										folderRef.play("folder-close");
 									}}
 								>
-									{riveFile && option.component(
-										riveFile as RiveFile,
-										folderRefs.current[option.value],
-									)}
+									{riveFile &&
+										option.component(
+											riveFile as RiveFile,
+											folderRefs.current[option.value],
+										)}
 									{!riveFile && (
 										<div className="w-[50px] h-[50px] bg-gray-4 rounded animate-pulse" />
 									)}

--- a/apps/web/app/(org)/dashboard/folder/[id]/components/SubfolderDialog.tsx
+++ b/apps/web/app/(org)/dashboard/folder/[id]/components/SubfolderDialog.tsx
@@ -91,7 +91,6 @@ export const SubfolderDialog: React.FC<Props> = ({
 		if (!open) {
 			setSelectedColor(null);
 			setFolderName("");
-			// Stop any running animations when the dialog closes
 			Object.values(folderRefs.current).forEach((ref) => {
 				ref.current?.stop();
 			});

--- a/apps/web/app/(org)/dashboard/folder/[id]/components/SubfolderDialog.tsx
+++ b/apps/web/app/(org)/dashboard/folder/[id]/components/SubfolderDialog.tsx
@@ -91,6 +91,10 @@ export const SubfolderDialog: React.FC<Props> = ({
 		if (!open) {
 			setSelectedColor(null);
 			setFolderName("");
+			// Stop any running animations when the dialog closes
+			Object.values(folderRefs.current).forEach((ref) => {
+				ref.current?.stop();
+			});
 		}
 	}, [open]);
 
@@ -163,21 +167,26 @@ export const SubfolderDialog: React.FC<Props> = ({
 										setSelectedColor(option.value);
 									}}
 									onMouseEnter={() => {
+										if (!riveFile) return;
 										const folderRef = folderRefs.current[option.value]?.current;
 										if (!folderRef) return;
 										folderRef.stop();
 										folderRef.play("folder-open");
 									}}
 									onMouseLeave={() => {
+										if (!riveFile) return;
 										const folderRef = folderRefs.current[option.value]?.current;
 										if (!folderRef) return;
 										folderRef.stop();
 										folderRef.play("folder-close");
 									}}
 								>
-									{option.component(
+									{riveFile && option.component(
 										riveFile as RiveFile,
 										folderRefs.current[option.value],
+										)}
+									{!riveFile && (
+										<div className="w-[50px] h-[50px] rounded bg-gray-4 animate-pulse" />
 									)}
 									<p className="text-xs text-gray-10">{option.label}</p>
 								</div>

--- a/apps/web/app/(org)/dashboard/folder/[id]/components/SubfolderDialog.tsx
+++ b/apps/web/app/(org)/dashboard/folder/[id]/components/SubfolderDialog.tsx
@@ -181,9 +181,10 @@ export const SubfolderDialog: React.FC<Props> = ({
 										folderRef.play("folder-close");
 									}}
 								>
-									{riveFile && option.component(
-										riveFile as RiveFile,
-										folderRefs.current[option.value],
+									{riveFile &&
+										option.component(
+											riveFile as RiveFile,
+											folderRefs.current[option.value],
 										)}
 									{!riveFile && (
 										<div className="w-[50px] h-[50px] rounded bg-gray-4 animate-pulse" />


### PR DESCRIPTION
## Description
Fixes #1409 - The "New Folder" and "New Subfolder" dialogs occasionally crashed with "Cannot read properties of undefined (reading 'isPlaying/stateMachines')" when opened or hovered too quickly.

## Root Cause
Rive animations load asynchronously, but the dialogs rendered folder components and attached hover handlers before the animation file finished loading, causing calls to undefined Rive objects.

## Changes
- **NewFolderDialog.tsx & SubfolderDialog.tsx**: Guard hover handlers with `if (!riveFile) return`, render folders only once file is loaded, show skeleton placeholder while loading, stop animations on dialog close
- **Folders.tsx**: Wrap all `rive.play/stop` calls in try/catch to prevent uncaught errors

## Testing
- Opened/closed dialogs repeatedly with DevTools open → no client-side exceptions
- Hovered folder tiles aggressively during load → no crashes
- Created folders/subfolders successfully → RPC path verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Animation runtime errors are now caught and logged across folder items and dialogs to keep the UI stable.
  * Closing dialogs stops any running folder animations to prevent lingering activity or resource use.
  * When animation assets aren’t available, the UI shows placeholder/skeleton content and hover interactions are guarded to avoid crashes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->