### PR TITLE
feat: Various misc UX stuff, including fix for macOS virtual screens

### DIFF
--- a/apps/desktop/src-tauri/src/platform/macos/mod.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/mod.rs
@@ -26,6 +26,25 @@ pub fn set_window_level(window: tauri::Window, level: objc2_app_kit::NSWindowLev
     });
 }
 
+pub fn set_window_visible_on_all_workspaces(window: tauri::Window) {
+    use objc2_app_kit::NSWindowCollectionBehavior;
+
+    let c_window = window.clone();
+    _ = window.run_on_main_thread(move || unsafe {
+        let ns_win = c_window
+            .ns_window()
+            .expect("Failed to get native window handle")
+            as *const objc2_app_kit::NSWindow;
+        let current_behavior = (*ns_win).collectionBehavior();
+        (*ns_win).setCollectionBehavior(
+            current_behavior
+                | NSWindowCollectionBehavior::CanJoinAllSpaces
+                | NSWindowCollectionBehavior::FullScreenAuxiliary
+                | NSWindowCollectionBehavior::Stationary,
+        );
+    });
+}
+
 // pub fn get_ns_window_number(ns_window: *mut c_void) -> isize {
 //     let ns_window = ns_window as *const objc2_app_kit::NSWindow;
 

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -185,7 +185,7 @@ impl CapWindowId {
             Self::Main => (300.0, 360.0),
             Self::Editor { .. } => (1275.0, 800.0),
             Self::ScreenshotEditor { .. } => (800.0, 600.0),
-            Self::Settings => (600.0, 450.0),
+            Self::Settings => (600.0, 470.0),
             Self::Camera => (200.0, 200.0),
             Self::Upgrade => (950.0, 850.0),
             Self::ModeSelect => (900.0, 500.0),
@@ -317,7 +317,12 @@ impl ShowCapWindow {
 
                 if new_recording_flow {
                     #[cfg(target_os = "macos")]
-                    crate::platform::set_window_level(window.as_ref().window(), 50);
+                    {
+                        crate::platform::set_window_level(window.as_ref().window(), 50);
+                        crate::platform::set_window_visible_on_all_workspaces(
+                            window.as_ref().window(),
+                        );
+                    }
                 }
 
                 #[cfg(target_os = "macos")]
@@ -412,6 +417,7 @@ impl ShowCapWindow {
                 #[cfg(target_os = "macos")]
                 {
                     crate::platform::set_window_level(window.as_ref().window(), 45);
+                    crate::platform::set_window_visible_on_all_workspaces(window.as_ref().window());
                 }
 
                 window
@@ -585,16 +591,9 @@ impl ShowCapWindow {
                     #[cfg(target_os = "macos")]
                     {
                         crate::platform::set_window_level(window.as_ref().window(), 60);
-
-                        _ = window.run_on_main_thread({
-                            let window = window.as_ref().window();
-                            move || unsafe {
-                                let win = window.ns_window().unwrap() as *const objc2_app_kit::NSWindow;
-                                (*win).setCollectionBehavior(
-                                		(*win).collectionBehavior() | objc2_app_kit::NSWindowCollectionBehavior::FullScreenAuxiliary,
-                                );
-                            }
-                        });
+                        crate::platform::set_window_visible_on_all_workspaces(
+                            window.as_ref().window(),
+                        );
                     }
 
                     window
@@ -640,6 +639,7 @@ impl ShowCapWindow {
                 #[cfg(target_os = "macos")]
                 {
                     crate::platform::set_window_level(window.as_ref().window(), 900);
+                    crate::platform::set_window_visible_on_all_workspaces(window.as_ref().window());
                 }
 
                 window
@@ -655,6 +655,7 @@ impl ShowCapWindow {
                     .shadow(false)
                     .resizable(false)
                     .always_on_top(true)
+                    .visible_on_all_workspaces(true)
                     .content_protected(should_protect)
                     .skip_taskbar(true)
                     .closable(true)
@@ -682,10 +683,13 @@ impl ShowCapWindow {
                 let window = window_builder.build()?;
 
                 #[cfg(target_os = "macos")]
-                crate::platform::set_window_level(
-                    window.as_ref().window(),
-                    objc2_app_kit::NSPopUpMenuWindowLevel,
-                );
+                {
+                    crate::platform::set_window_level(
+                        window.as_ref().window(),
+                        objc2_app_kit::NSPopUpMenuWindowLevel,
+                    );
+                    crate::platform::set_window_visible_on_all_workspaces(window.as_ref().window());
+                }
 
                 // Hide the main window if the target monitor is the same
                 if let Some(main_window) = CapWindowId::Main.get(app)
@@ -731,6 +735,7 @@ impl ShowCapWindow {
                 #[cfg(target_os = "macos")]
                 {
                     crate::platform::set_window_level(window.as_ref().window(), 1000);
+                    crate::platform::set_window_visible_on_all_workspaces(window.as_ref().window());
                 }
 
                 fake_window::spawn_fake_window_listener(app.clone(), window.clone());

--- a/apps/desktop/src/routes/(window-chrome)/(main).tsx
+++ b/apps/desktop/src/routes/(window-chrome)/(main).tsx
@@ -59,10 +59,12 @@ function Page() {
 	const currentRecording = createCurrentRecordingQuery();
 	const generalSettings = generalSettingsStore.createQuery();
 
-	// We do this on focus so the window doesn't get revealed when toggling the setting
 	const navigate = useNavigate();
 	createEventListener(window, "focus", () => {
-		if (generalSettings.data?.enableNewRecordingFlow === true)
+		if (
+			window.location.pathname === "/" &&
+			generalSettings.data?.enableNewRecordingFlow === true
+		)
 			navigate("/new-main");
 	});
 

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -343,7 +343,11 @@ export default function () {
 
 	const navigate = useNavigate();
 	createEventListener(window, "focus", () => {
-		if (generalSettings.data?.enableNewRecordingFlow === false) navigate("/");
+		if (
+			window.location.pathname === "/new-main" &&
+			generalSettings.data?.enableNewRecordingFlow === false
+		)
+			navigate("/");
 	});
 
 	return (

--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -153,9 +153,9 @@ function AppearanceSection(props: {
 	return (
 		<div class="flex flex-col gap-4">
 			<div class="flex flex-col pb-4 border-b border-gray-2">
-				<h2 class="text-lg font-medium text-gray-12">General</h2>
+				<h2 class="text-lg font-medium text-gray-12">General Settings</h2>
 				<p class="text-sm text-gray-10">
-					General settings of your Cap application.
+					Customize how Cap looks, feels, and behaves.
 				</p>
 			</div>
 			<div
@@ -419,18 +419,6 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 					}}
 				/>
 
-				<SettingGroup
-					title="Cap Pro"
-					titleStyling="bg-blue-500 py-1.5 mb-4 text-white text-xs px-2 rounded-lg"
-				>
-					<ToggleSettingItem
-						label="Automatically open shareable links"
-						description="Whether Cap should automatically open instant recordings in your browser"
-						value={!settings.disableAutoOpenLinks}
-						onChange={(v) => handleChange("disableAutoOpenLinks", !v)}
-					/>
-				</SettingGroup>
-
 				{ostype === "macos" && (
 					<SettingGroup title="App">
 						<ToggleSettingItem
@@ -571,6 +559,18 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 						onChange={(v) =>
 							handleChange("deleteInstantRecordingsAfterUpload", v)
 						}
+					/>
+				</SettingGroup>
+
+				<SettingGroup
+					title="Cap Pro Specific"
+					titleStyling="bg-blue-500 py-1.5 mb-4 text-white text-xs px-2 rounded-lg"
+				>
+					<ToggleSettingItem
+						label="Automatically open shareable links"
+						description="Whether Cap should automatically open instant recordings in your browser"
+						value={!settings.disableAutoOpenLinks}
+						onChange={(v) => handleChange("disableAutoOpenLinks", !v)}
 					/>
 				</SettingGroup>
 

--- a/apps/desktop/src/routes/in-progress-recording.tsx
+++ b/apps/desktop/src/routes/in-progress-recording.tsx
@@ -527,7 +527,10 @@ export default function () {
 	};
 
 	return (
-		<div class="flex h-full w-full flex-col justify-end px-3 pb-3">
+		<div
+			class="flex h-full w-full flex-col justify-end px-3 pb-3"
+			onContextMenu={(e) => e.preventDefault()}
+		>
 			<div ref={setInteractiveAreaRef} class="flex w-full flex-col gap-2">
 				<Show when={hasRecordingIssue() && issuePanelVisible()}>
 					<div class="flex w-full flex-row items-start gap-3 rounded-2xl border border-red-8 bg-gray-1 px-4 py-3 text-[12px] leading-snug text-red-11 shadow-lg">


### PR DESCRIPTION
Improvements to window management on macOS, refines user interface text, and adjusts navigation logic in the desktop app. The most significant changes are the addition of a helper for making windows visible on all workspaces, consistent application of this behaviour across window types, and minor UI and logic tweaks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS windows now remain visible across all workspaces during recording and capture operations.

* **Bug Fixes**
  * Refined navigation logic to prevent unintended route switching when toggling recording modes.
  * Disabled right-click context menu during active recording sessions.

* **UI/UX**
  * Updated Settings panel text and reorganized Cap Pro-specific options.
  * Adjusted Settings window size for improved layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->