### PR TITLE
fix: use `minio/minio` instead of `bitnami/minio`

### DIFF
--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -54,8 +54,6 @@ services:
       - "3902:3902"
       - "3903:3903"
     environment:
-      - MINIO_API_PORT_NUMBER=3902
-      - MINIO_CONSOLE_PORT_NUMBER=3903
       # CHANGE THESE TO YOUR OWN VALUES
       - MINIO_ROOT_USER=capS3root
       - MINIO_ROOT_PASSWORD=capS3root

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -45,10 +45,10 @@ services:
     volumes:
       - ps-mysql:/var/lib/mysql
 
-  # Local S3 Strorage
+  # Local S3 Storage
   minio:
     container_name: cap-minio-storage
-    image: "bitnami/minio:latest"
+    image: "minio/minio:latest"
     restart: unless-stopped
     ports:
       - "3902:3902"
@@ -59,8 +59,9 @@ services:
       # CHANGE THESE TO YOUR OWN VALUES
       - MINIO_ROOT_USER=capS3root
       - MINIO_ROOT_PASSWORD=capS3root
+    command: server /data --address :3902 --console-address :3903
     volumes:
-      - minio-data:/bitnami/minio/data
+      - minio-data:/data
       - minio-certs:/certs
 volumes:
   ps-mysql:


### PR DESCRIPTION
Bitnami [deprecated](https://github.com/bitnami/containers/issues/83267) `bitnami/minio` earlier this year in August. Simply switching to use [`minio/minio`](https://hub.docker.com/r/minio/minio) didn’t work, however. LMK if there’s anything I need to do to get this merged.

---

💖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed typo in local S3 storage comment.

* **Chores**
  * Switched MinIO image and updated container configuration.
  * Enabled MinIO console interface while preserving existing port exposure.
  * Simplified MinIO data volume path and removed redundant environment variables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->