### PR TITLE
Clippy linter warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ unused_must_use = "deny"
 [workspace.lints.clippy]
 dbg_macro = "deny"
 let_underscore_future = "deny"
-unchecked_duration_subtraction = "deny"
+unchecked_time_subtraction = "deny"
 collapsible_if = "deny"
 clone_on_copy = "deny"
 redundant_closure = "deny"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -124,10 +124,10 @@ impl FinalizingRecordings {
 
     pub fn finish_finalizing(&self, path: &Path) {
         let mut recordings = self.recordings.lock().unwrap();
-        if let Some((tx, _)) = recordings.remove(path) {
-            if tx.send(true).is_err() {
-                debug!("Finalizing receiver dropped for path: {:?}", path);
-            }
+        if let Some((tx, _)) = recordings.remove(path)
+            && tx.send(true).is_err()
+        {
+            debug!("Finalizing receiver dropped for path: {:?}", path);
         }
     }
 

--- a/crates/audio/src/latency.rs
+++ b/crates/audio/src/latency.rs
@@ -615,7 +615,7 @@ mod macos {
 }
 
 #[cfg(test)]
-#[allow(clippy::unchecked_duration_subtraction)]
+#[allow(clippy::unchecked_time_subtraction)]
 mod tests {
     use super::*;
     use std::time::Instant;


### PR DESCRIPTION
Fix clippy errors by updating a renamed lint and collapsing a nested `if` statement.

The `unchecked_duration_subtraction` lint was renamed to `unchecked_time_subtraction`, requiring an update in `Cargo.toml` and the corresponding `#[allow]` attribute. Additionally, a `clippy::collapsible_if` warning was resolved by refactoring a nested `if` condition.

---
<a href="https://cursor.com/background-agent?bcId=bc-10f0ae94-e2f9-4586-b5fb-3172ad6748a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-10f0ae94-e2f9-4586-b5fb-3172ad6748a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

