### PR TITLE
Update compose template to patch vulnerable minio service and include healthchecks

### DIFF
--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -99,7 +99,7 @@ services:
     #   retries: 5
     #   start_period: 10s
 
-  # Local S3 Strorage
+  # Local S3 Storage
   minio:
     container_name: cap-minio-storage
     image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025 (includes fix for CVE-2025-62506)

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -4,6 +4,29 @@ name: cap-so-docker-template
 # IT IS NOT MEANT FOR PRODUCTION DEPLOYMENT WITHOUT MODIFICATIONS TO ENVIRONMENT VARIABLES
 # IT IS MEANT FOR LOCAL EVALUATION AND DEVELOPMENT PURPOSES ONLY
 
+# Storage Configuration:
+# Option 1: Remote S3-compatible storage (AWS S3, Cloudflare R2, etc.)
+# Set these environment variables:
+# - CAP_AWS_ACCESS_KEY: Your S3/R2 access key
+# - CAP_AWS_SECRET_KEY: Your S3/R2 secret key  
+# - CAP_AWS_BUCKET: Your S3/R2 bucket name
+# - CAP_AWS_REGION: Your S3/R2 region (e.g., us-east-1, auto for R2)
+# - CAP_AWS_ENDPOINT: Your S3/R2 endpoint URL
+# - S3_PUBLIC_ENDPOINT: Public endpoint for your bucket (same as CAP_AWS_ENDPOINT for most cases)
+# - S3_INTERNAL_ENDPOINT: Internal endpoint (same as CAP_AWS_ENDPOINT for most cases)
+# - S3_PATH_STYLE: true for R2/most S3-compatible, false for AWS S3 virtual-hosted style
+#
+# Option 2: Local MinIO storage (included on this compose)
+# Deploy MinIO as a separate service in the same network or and set:
+# - CAP_AWS_ACCESS_KEY: MinIO root user
+# - CAP_AWS_SECRET_KEY: MinIO root password
+# - CAP_AWS_BUCKET: Your bucket name (e.g., capso)
+# - CAP_AWS_REGION: us-east-1 (or any region)
+# - CAP_AWS_ENDPOINT: http://minio:9000 (internal MinIO endpoint)
+# - S3_PUBLIC_ENDPOINT: http://your-minio-domain:9000 (public MinIO endpoint)
+# - S3_INTERNAL_ENDPOINT: http://minio:9000 (internal MinIO endpoint)
+# - S3_PATH_STYLE: true
+
 services:
   cap-web:
     container_name: cap-web
@@ -21,8 +44,8 @@ services:
       CAP_AWS_SECRET_KEY: capS3root
       CAP_AWS_BUCKET: capso
       CAP_AWS_REGION: us-east-1
-      S3_PUBLIC_ENDPOINT: http://localhost:3902
-      S3_INTERNAL_ENDPOINT: http://minio:3902
+      S3_PUBLIC_ENDPOINT: http://localhost:9000
+      S3_INTERNAL_ENDPOINT: http://minio:9000
       MEDIA_SERVER_URL: http://cap-media-server:3456
       # CHANGE THESE TO YOUR OWN VALUES
       MEDIA_SERVER_WEBHOOK_SECRET: fe337b52749070bb7b5d2c78cff9948439ea73cbc1869ba39d350e6c24db53b1
@@ -61,19 +84,18 @@ services:
   # Local S3 Strorage
   minio:
     container_name: cap-minio-storage
-    image: "bitnami/minio:latest"
+    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025 (includes fix for CVE-2025-62506)
     restart: unless-stopped
+    command: 'server /data --console-address ":9001"'
     ports:
-      - "3902:3902"
-      - "3903:3903"
+      - "9000:9000" # API
+      - "9001:9001" # Console
     environment:
-      - MINIO_API_PORT_NUMBER=3902
-      - MINIO_CONSOLE_PORT_NUMBER=3903
       # CHANGE THESE TO YOUR OWN VALUES
       - MINIO_ROOT_USER=capS3root
       - MINIO_ROOT_PASSWORD=capS3root
     volumes:
-      - minio-data:/bitnami/minio/data
+      - minio-data:/data
       - minio-certs:/certs
 volumes:
   ps-mysql:

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -49,9 +49,14 @@ services:
       MEDIA_SERVER_URL: http://cap-media-server:3456
       # CHANGE THESE TO YOUR OWN VALUES
       MEDIA_SERVER_WEBHOOK_SECRET: fe337b52749070bb7b5d2c78cff9948439ea73cbc1869ba39d350e6c24db53b1
-
     ports:
       - 3000:3000
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:3000/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   ps-mysql:
     container_name: cap-primary-db
@@ -69,6 +74,12 @@ services:
       ]
     ports:
       - "3306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     volumes:
       - ps-mysql:/var/lib/mysql
 
@@ -80,6 +91,13 @@ services:
       PORT: 3456
     ports:
       - "3456:3456"
+    # TO DO: Enable healthcheck after media server image is published (wget mostly works but double check if wget is present inside container)
+    # healthcheck:
+    #   test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:3456/ || exit 1"]
+    #   interval: 10s
+    #   timeout: 5s
+    #   retries: 5
+    #   start_period: 10s
 
   # Local S3 Strorage
   minio:
@@ -94,6 +112,12 @@ services:
       # CHANGE THESE TO YOUR OWN VALUES
       - MINIO_ROOT_USER=capS3root
       - MINIO_ROOT_PASSWORD=capS3root
+    healthcheck:
+        test: ["CMD", "mc", "ready", "local"]
+        interval: 10s
+        timeout: 5s
+        retries: 5
+        start_period: 10s
     volumes:
       - minio-data:/data
       - minio-certs:/certs

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -17,7 +17,7 @@ name: cap-so-docker-template
 # - S3_PATH_STYLE: true for R2/most S3-compatible, false for AWS S3 virtual-hosted style
 #
 # Option 2: Local MinIO storage (included on this compose)
-# Deploy MinIO as a separate service in the same network or and set:
+# Deploy MinIO as a separate service in the same network and set:
 # - CAP_AWS_ACCESS_KEY: MinIO root user
 # - CAP_AWS_SECRET_KEY: MinIO root password
 # - CAP_AWS_BUCKET: Your bucket name (e.g., capso)


### PR DESCRIPTION
## Changes
- The image used for minio on docker compose template (`image: "bitnami/minio:latest"`) is unmaintained and vulnerable to CVE-2025-62506 , so we will be using `ghcr.io/coollabsio/minio` which is [Automated docker builds (by Coolify Team)](https://github.com/coollabsio/minio) using official minio source code.

- Added instructions (as comments) for using remote S3-compatible storage 

- Added healthcheck to all services in the compose
<img width="2163" height="283" alt="image" src="https://github.com/user-attachments/assets/d7fcb3a9-578c-49a9-a2e2-44b5fcf5d282" />

---

## Testing
- All service except `media server` are working fine. media server docker image is not published on `ghcr.io` so I couldn't pull the image to test it

---

## Notes
- Official minio doesn't support custom API and Console ports like `3902` and `3903`, so I have set them to default ports
- This PR supersedes #1444 by providing a complete and correct implementation for minio.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR addresses a critical security vulnerability (CVE-2025-62506) by replacing the unmaintained `bitnami/minio:latest` image with `ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z`. The changes also standardize MinIO to use default ports (9000 for API, 9001 for console), add comprehensive healthchecks to all services, and include helpful documentation for both local and remote S3 configuration options.

- Switched from vulnerable bitnami/minio to maintained coollabsio/minio build
- Updated MinIO API/Console ports from custom 3902/3903 to standard 9000/9001
- Added healthchecks to `cap-web`, `ps-mysql`, and `minio` services for better service monitoring
- Added detailed comments explaining S3 configuration for both remote (AWS S3, Cloudflare R2) and local MinIO setups
- Updated internal and public S3 endpoints to reflect new port configuration
- Simplified MinIO volume paths and environment variables to match official MinIO conventions

**Issues identified:**
- Two typos in comments that need correction
- MinIO healthcheck uses `mc ready local` command which may not be available in the specified image (needs verification or alternative HTTP-based healthcheck)

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor corrections needed for typos and potential healthcheck verification
- The PR addresses a critical security vulnerability by replacing an unmaintained vulnerable MinIO image, includes well-designed healthchecks for service monitoring, and provides clear documentation. Two spelling errors and one potential healthcheck command compatibility issue were identified but are easy to fix. The port changes are well-documented and the configuration updates are consistent throughout the file.
- docker-compose.template.yml requires minor typo corrections and verification that the MinIO healthcheck command will work with the chosen image

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docker-compose.template.yml | Replaced vulnerable bitnami/minio with ghcr.io/coollabsio/minio, updated ports from 3902/3903 to standard 9000/9001, added healthchecks to all services, and included S3 configuration documentation; minor typos and potential healthcheck issue identified |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Docker as Docker Engine
    participant Web as cap-web
    participant MySQL as ps-mysql
    participant MinIO as minio
    participant MediaServer as cap-media-server

    Note over Docker,MediaServer: Service Startup & Healthcheck Flow

    Docker->>MySQL: Start MySQL service
    activate MySQL
    MySQL-->>Docker: Service running
    
    loop Every 10s (after 20s start_period)
        Docker->>MySQL: mysqladmin ping -h localhost
        MySQL-->>Docker: pong (healthy)
    end

    Docker->>MinIO: Start MinIO service
    activate MinIO
    MinIO-->>Docker: Service running
    
    loop Every 10s (after 10s start_period)
        Docker->>MinIO: mc ready local
        MinIO-->>Docker: ready (healthy)
    end

    Docker->>Web: Start cap-web service
    activate Web
    Web->>MySQL: Connect to DATABASE_URL
    Web->>MinIO: Connect to S3_INTERNAL_ENDPOINT (http://minio:9000)
    Web-->>Docker: Service running
    
    loop Every 10s (after 10s start_period)
        Docker->>Web: wget --spider -q http://127.0.0.1:3000/
        Web-->>Docker: HTTP 200 (healthy)
    end

    Docker->>MediaServer: Start media-server service
    activate MediaServer
    MediaServer-->>Docker: Service running
    Note over MediaServer: No healthcheck (commented out)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->