### PR TITLE
fix: Add whitespace-nowrap to navbar buttons to prevent text wrapping

### DIFF
--- a/apps/web/app/(site)/Navbar.tsx
+++ b/apps/web/app/(site)/Navbar.tsx
@@ -224,7 +224,7 @@ export const Navbar = ({ stars }: NavbarProps) => {
 								target="_blank"
 								href="https://github.com/CapSoftware/Cap"
 								size="sm"
-								className="w-full font-medium sm:w-auto"
+								className="w-full font-medium sm:w-auto whitespace-nowrap"
 							>
 								{`GitHub${stars ? ` (${stars})` : ""}`}
 							</Button>
@@ -310,7 +310,7 @@ function LoginOrDashboard() {
 			variant="dark"
 			href={auth ? "/dashboard" : "/signup"}
 			size="sm"
-			className="w-full font-medium sm:w-auto"
+			className="w-full font-medium sm:w-auto whitespace-nowrap"
 		>
 			{auth ? "Dashboard" : "Sign Up"}
 		</Button>


### PR DESCRIPTION
### Before: 
![Screenshot 2026-01-15 at 4 43 51 PM](https://github.com/user-attachments/assets/b5b0f0e0-420a-4349-bb48-4a4866d246b9)



### After

![Screenshot 2026-01-15 at 4 49 01 PM](https://github.com/user-attachments/assets/0395a968-0460-473c-921b-265a5ba137f1)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added `whitespace-nowrap` Tailwind class to navbar buttons to prevent text wrapping at narrow viewport widths.

- Fixed text wrapping on GitHub button (line 227)
- Fixed text wrapping on Sign Up/Dashboard button (line 313)
- Two similar navbar buttons (Loading fallback and Login) were not updated and may benefit from the same treatment for consistency

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk - it's a simple CSS change
- The change is minimal, focused, and addresses a real UI issue. Score is 4 instead of 5 because two similar buttons in the same component weren't updated, which could lead to inconsistent behavior
- No files require special attention - this is a straightforward CSS improvement

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/(site)/Navbar.tsx | Added `whitespace-nowrap` to GitHub and Sign Up/Dashboard buttons to prevent text wrapping; two similar buttons (Loading, Login) could benefit from the same treatment |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant Navbar
    participant Button

    User->>Browser: Resize window to narrow width
    Browser->>Navbar: Trigger responsive layout
    Navbar->>Button: Apply sm:w-auto class
    Note over Button: Text wraps without whitespace-nowrap
    Button->>Button: Add whitespace-nowrap class
    Note over Button: Text no longer wraps
    Button->>Navbar: Render single-line button
    Navbar->>Browser: Display fixed navbar layout
    Browser->>User: Show properly formatted buttons
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->