### PR TITLE
fix: prevent panic in AudioInfo::channel_layout() for unsupported channel counts

### DIFF
--- a/crates/editor/src/audio.rs
+++ b/crates/editor/src/audio.rs
@@ -264,6 +264,9 @@ impl<T: FromSampleBytes> AudioPlaybackBuffer<T> {
     const PROCESSING_SAMPLES_COUNT: u32 = 1024;
 
     pub fn new(data: Vec<AudioSegment>, output_info: AudioInfo) -> Self {
+        // Clamp output info for FFmpeg compatibility (max 8 channels)
+        let output_info = output_info.for_ffmpeg_output();
+
         info!(
             sample_rate = output_info.sample_rate,
             channels = output_info.channels,
@@ -391,6 +394,9 @@ pub struct AudioResampler {
 
 impl AudioResampler {
     pub fn new(output_info: AudioInfo) -> Result<Self, MediaError> {
+        // Clamp output info for FFmpeg compatibility (max 8 channels)
+        let output_info = output_info.for_ffmpeg_output();
+
         let mut options = Dictionary::new();
         options.set("filter_size", "128");
         options.set("cutoff", "0.97");
@@ -460,6 +466,10 @@ impl<T: FromSampleBytes> PrerenderedAudioBuffer<T> {
         output_info: AudioInfo,
         duration_secs: f64,
     ) -> Self {
+        // Clamp output info for FFmpeg compatibility (max 8 channels)
+        // The resampler will produce audio with this channel count
+        let output_info = output_info.for_ffmpeg_output();
+
         info!(
             duration_secs = duration_secs,
             sample_rate = output_info.sample_rate,


### PR DESCRIPTION
## Summary

Fixes crash and chipmunk audio on systems with professional audio interfaces that report high channel counts (e.g., RME Digiface with 34 outputs).

### The Problem

When using Cap with a multi-channel audio interface, users experienced:
1. **Crashes** - App panicked with "called `Option::unwrap()` on a `None` value" in `channel_layout()`
2. **Chipmunk audio** - Playback was ~4x faster than normal, making voices sound like chipmunks

### Root Cause

FFmpeg only supports channel layouts up to 8 channels (7.1 surround). When a device reported more channels (like 34), several things broke:

1. `channel_layout()` called `.unwrap()` on `None` because there's no FFmpeg layout for 34 channels
2. Audio buffers were sized for 34 channels but only 8 channels of data were produced
3. The output audio stream expected 34 channels of interleaved samples, but received only 8 - causing playback at 34/8 ≈ 4.25x speed

### The Fix

- Store the **actual** device channel count to correctly parse interleaved audio data
- Clamp to **8 channels max** when interfacing with FFmpeg (resampling, encoding)
- Configure the **output audio stream** to match the clamped channel count
- Add `for_ffmpeg_output()` helper for consistent clamping across the codebase
- Make `channel_layout()` gracefully handle any channel count

### Files Changed

- `crates/media-info/src/lib.rs` - Core AudioInfo fixes and helper method
- `crates/editor/src/audio.rs` - AudioResampler and buffer fixes
- `crates/editor/src/playback.rs` - Stream configuration fixes

### Testing

Tested on Mac with RME Digiface (34 output channels) + RØDE NT-USB Mini microphone:
- ✅ No crash on playback
- ✅ Audio plays at correct speed
- ✅ Recording works correctly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes crashes and chipmunk audio playback on systems with professional audio interfaces reporting more than 8 channels (e.g., RME Digiface with 34 outputs).

**Key Changes:**
- `AudioInfo` now stores the actual device channel count for correct audio data parsing, while clamping to 8 channels when interfacing with FFmpeg (which only supports up to 7.1 surround)
- Added `for_ffmpeg_output()` helper method for consistent channel clamping across the codebase
- Updated `channel_layout()` to gracefully handle 0-channel and excessive channel counts instead of panicking
- Modified `wrap_frame_with_max_channels()` to use actual channel count for input parsing while limiting output to FFmpeg-compatible layouts
- Applied clamping in all audio processing pipelines (AudioResampler, AudioPlaybackBuffer, PrerenderedAudioBuffer) and stream creation
- Updated audio output stream configuration to match clamped channel counts, preventing speed issues
- Added comprehensive tests for edge cases (0 channels, 9-64 channels)

**Impact:**
The fix properly separates the concern of parsing device audio data (which needs the real channel count) from FFmpeg encoding constraints (max 8 channels), eliminating both the panic and the playback speed issue.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The fix is well-designed with clear separation of concerns between device channel parsing and FFmpeg encoding limits. All edge cases (0 channels, excessive channels) are handled with proper clamping and fallbacks. The implementation includes comprehensive unit tests covering the edge cases. Changes are consistently applied across all audio processing paths. The approach preserves correct audio data parsing while preventing FFmpeg-related panics and playback speed issues.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/media-info/src/lib.rs | Core fix: stores actual device channel count, clamps to 8 for FFmpeg, adds `for_ffmpeg_output()` helper, prevents panics in `channel_layout()`, handles 0-channel and 34+ channel edge cases correctly, includes comprehensive tests |
| crates/editor/src/audio.rs | Applies channel clamping via `for_ffmpeg_output()` in AudioPlaybackBuffer, AudioResampler, and PrerenderedAudioBuffer constructors to ensure consistent FFmpeg compatibility across all audio processing pipelines |
| crates/editor/src/playback.rs | Updates audio stream creation to clamp output info and sync stream config channels with clamped values in both `create_stream()` and `create_stream_prerendered()`, preventing channel count mismatches during playback |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Device as Audio Device<br/>(34 channels)
    participant AudioInfo as AudioInfo
    participant Resampler as AudioResampler
    participant FFmpeg as FFmpeg<br/>(max 8 channels)
    participant Output as Audio Output Stream

    Note over Device,Output: Recording/Playback Initialization

    Device->>AudioInfo: from_stream_config(34 channels)
    activate AudioInfo
    Note over AudioInfo: Store actual channel count (34)<br/>for correct data parsing
    AudioInfo-->>Device: AudioInfo { channels: 34 }
    deactivate AudioInfo

    Note over Device,Output: Audio Processing Pipeline

    Device->>AudioInfo: wrap_frame_with_max_channels(data, 8)
    activate AudioInfo
    Note over AudioInfo: Use 34 channels to parse input<br/>Extract only first 8 channels<br/>Avoid div-by-zero with max(1)
    AudioInfo->>FFmpeg: Create frame with 8 channels
    activate FFmpeg
    FFmpeg-->>AudioInfo: Audio frame (8 channels)
    deactivate FFmpeg
    AudioInfo-->>Device: Properly formatted frame
    deactivate AudioInfo

    Device->>Resampler: new(output_info)
    activate Resampler
    Note over Resampler: Call for_ffmpeg_output()<br/>Clamp to 8 channels
    Resampler->>AudioInfo: for_ffmpeg_output()
    activate AudioInfo
    Note over AudioInfo: Return AudioInfo { channels: 8 }
    AudioInfo-->>Resampler: Clamped AudioInfo
    deactivate AudioInfo
    Resampler->>FFmpeg: Create resampler context (8 channels)
    FFmpeg-->>Resampler: Resampler ready
    deactivate Resampler

    Device->>Output: Configure stream
    activate Output
    Note over Output: Set config.channels = 8<br/>(matches clamped AudioInfo)
    Output-->>Device: Stream configured
    deactivate Output

    Note over Device,Output: Result: No panic, correct playback speed
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->