### PR TITLE
Playback performance and sync

### DIFF
--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -47,6 +47,8 @@ type TransportStats = {
 	renderedFromSharedWindow: number;
 	renderedFromWorkerTotal: number;
 	renderedFromWorkerWindow: number;
+	queuedOutOfOrderDropsTotal: number;
+	queuedOutOfOrderDropsWindow: number;
 	directOutOfOrderDropsTotal: number;
 	directOutOfOrderDropsWindow: number;
 	sabTotalRetryAttempts: number;
@@ -100,6 +102,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		renderedFromSharedWindow: 0,
 		renderedFromWorkerTotal: 0,
 		renderedFromWorkerWindow: 0,
+		queuedOutOfOrderDropsTotal: 0,
+		queuedOutOfOrderDropsWindow: 0,
 		directOutOfOrderDropsTotal: 0,
 		directOutOfOrderDropsWindow: 0,
 		sabTotalRetryAttempts: 0,
@@ -243,6 +247,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			renderedFromSharedWindow: 0,
 			renderedFromWorkerTotal: 0,
 			renderedFromWorkerWindow: 0,
+			queuedOutOfOrderDropsTotal: 0,
+			queuedOutOfOrderDropsWindow: 0,
 			directOutOfOrderDropsTotal: 0,
 			directOutOfOrderDropsWindow: 0,
 			sabTotalRetryAttempts: 0,
@@ -298,6 +304,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 				renderedFromSharedWindow: socketStats.renderedFromSharedWindow,
 				renderedFromWorkerTotal: socketStats.renderedFromWorkerTotal,
 				renderedFromWorkerWindow: socketStats.renderedFromWorkerWindow,
+				queuedOutOfOrderDropsTotal: socketStats.queuedOutOfOrderDropsTotal,
+				queuedOutOfOrderDropsWindow: socketStats.queuedOutOfOrderDropsWindow,
 				directOutOfOrderDropsTotal: socketStats.directOutOfOrderDropsTotal,
 				directOutOfOrderDropsWindow: socketStats.directOutOfOrderDropsWindow,
 				sabTotalRetryAttempts: socketStats.sabTotalRetryAttempts,
@@ -384,6 +392,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`Rendered From Shared (Window): ${t.renderedFromSharedWindow}`,
 			`Rendered From Worker (Total): ${t.renderedFromWorkerTotal}`,
 			`Rendered From Worker (Window): ${t.renderedFromWorkerWindow}`,
+			`Queued Out-Of-Order Drops (Total): ${t.queuedOutOfOrderDropsTotal}`,
+			`Queued Out-Of-Order Drops (Window): ${t.queuedOutOfOrderDropsWindow}`,
 			`Direct Out-Of-Order Drops (Total): ${t.directOutOfOrderDropsTotal}`,
 			`Direct Out-Of-Order Drops (Window): ${t.directOutOfOrderDropsWindow}`,
 			`SAB Retry Attempts: ${t.sabTotalRetryAttempts}`,
@@ -575,6 +585,18 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 									({transportStats().renderedFromSharedTotal} shared /{" "}
 									{transportStats().renderedFromWorkerTotal} worker total)
 								</span>
+							</div>
+						</Show>
+						<Show when={transportStats().queuedOutOfOrderDropsTotal > 0}>
+							<div style={{ color: "#fb923c" }}>
+								Queued out-of-order drops:{" "}
+								{transportStats().queuedOutOfOrderDropsTotal}
+								<Show when={transportStats().queuedOutOfOrderDropsWindow > 0}>
+									<span style={{ color: "rgba(255, 255, 255, 0.6)" }}>
+										{" "}
+										(window {transportStats().queuedOutOfOrderDropsWindow})
+									</span>
+								</Show>
 							</div>
 						</Show>
 						<Show when={transportStats().directOutOfOrderDropsTotal > 0}>

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -38,6 +38,7 @@ type TransportStats = {
 	sabTotalBytes: number;
 	workerFramesInFlight: number;
 	workerInFlightBackpressureHits: number;
+	workerInFlightBackpressureWindowHits: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -80,6 +81,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		sabTotalBytes: 0,
 		workerFramesInFlight: 0,
 		workerInFlightBackpressureHits: 0,
+		workerInFlightBackpressureWindowHits: 0,
 		sabTotalRetryAttempts: 0,
 		sabTotalFramesReceived: 0,
 		sabTotalFramesWrittenToSharedBuffer: 0,
@@ -212,6 +214,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			sabTotalBytes: 0,
 			workerFramesInFlight: 0,
 			workerInFlightBackpressureHits: 0,
+			workerInFlightBackpressureWindowHits: 0,
 			sabTotalRetryAttempts: 0,
 			sabTotalFramesReceived: 0,
 			sabTotalFramesWrittenToSharedBuffer: 0,
@@ -251,6 +254,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 				workerFramesInFlight: socketStats.workerFramesInFlight,
 				workerInFlightBackpressureHits:
 					socketStats.workerInFlightBackpressureHits,
+				workerInFlightBackpressureWindowHits:
+					socketStats.workerInFlightBackpressureWindowHits,
 				sabTotalRetryAttempts: socketStats.sabTotalRetryAttempts,
 				sabTotalFramesReceived: socketStats.sabTotalFramesReceived,
 				sabTotalFramesWrittenToSharedBuffer:
@@ -326,6 +331,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`SAB Total: ${formatSlotMb(t.sabTotalBytes)} MB`,
 			`Worker Frames In Flight: ${t.workerFramesInFlight}`,
 			`Worker In-Flight Cap Hits: ${t.workerInFlightBackpressureHits}`,
+			`Worker In-Flight Cap Hits (Window): ${t.workerInFlightBackpressureWindowHits}`,
 			`SAB Retry Attempts: ${t.sabTotalRetryAttempts}`,
 			`SAB Frames Received: ${t.sabTotalFramesReceived}`,
 			`SAB Frames Written: ${t.sabTotalFramesWrittenToSharedBuffer}`,
@@ -497,6 +503,14 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 							<div style={{ color: "#f59e0b" }}>
 								Worker in-flight cap hits:{" "}
 								{transportStats().workerInFlightBackpressureHits}
+							</div>
+						</Show>
+						<Show
+							when={transportStats().workerInFlightBackpressureWindowHits > 0}
+						>
+							<div style={{ color: "#fbbf24" }}>
+								Worker cap hits (window):{" "}
+								{transportStats().workerInFlightBackpressureWindowHits}
 							</div>
 						</Show>
 						<Show when={stats().droppedFrames > 0}>

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -41,6 +41,8 @@ type TransportStats = {
 	workerInFlightBackpressureWindowHits: number;
 	workerFramesInFlightPeakWindow: number;
 	workerFramesInFlightPeakTotal: number;
+	workerInFlightSupersededDrops: number;
+	workerInFlightSupersededDropsWindow: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -86,6 +88,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		workerInFlightBackpressureWindowHits: 0,
 		workerFramesInFlightPeakWindow: 0,
 		workerFramesInFlightPeakTotal: 0,
+		workerInFlightSupersededDrops: 0,
+		workerInFlightSupersededDropsWindow: 0,
 		sabTotalRetryAttempts: 0,
 		sabTotalFramesReceived: 0,
 		sabTotalFramesWrittenToSharedBuffer: 0,
@@ -221,6 +225,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			workerInFlightBackpressureWindowHits: 0,
 			workerFramesInFlightPeakWindow: 0,
 			workerFramesInFlightPeakTotal: 0,
+			workerInFlightSupersededDrops: 0,
+			workerInFlightSupersededDropsWindow: 0,
 			sabTotalRetryAttempts: 0,
 			sabTotalFramesReceived: 0,
 			sabTotalFramesWrittenToSharedBuffer: 0,
@@ -266,6 +272,10 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 					socketStats.workerFramesInFlightPeakWindow,
 				workerFramesInFlightPeakTotal:
 					socketStats.workerFramesInFlightPeakTotal,
+				workerInFlightSupersededDrops:
+					socketStats.workerInFlightSupersededDrops,
+				workerInFlightSupersededDropsWindow:
+					socketStats.workerInFlightSupersededDropsWindow,
 				sabTotalRetryAttempts: socketStats.sabTotalRetryAttempts,
 				sabTotalFramesReceived: socketStats.sabTotalFramesReceived,
 				sabTotalFramesWrittenToSharedBuffer:
@@ -344,6 +354,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`Worker In-Flight Cap Hits (Window): ${t.workerInFlightBackpressureWindowHits}`,
 			`Worker In-Flight Peak (Window): ${t.workerFramesInFlightPeakWindow}`,
 			`Worker In-Flight Peak (Total): ${t.workerFramesInFlightPeakTotal}`,
+			`Worker In-Flight Superseded Drops: ${t.workerInFlightSupersededDrops}`,
+			`Worker In-Flight Superseded Drops (Window): ${t.workerInFlightSupersededDropsWindow}`,
 			`SAB Retry Attempts: ${t.sabTotalRetryAttempts}`,
 			`SAB Frames Received: ${t.sabTotalFramesReceived}`,
 			`SAB Frames Written: ${t.sabTotalFramesWrittenToSharedBuffer}`,
@@ -530,6 +542,23 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 							<div style={{ color: "#fbbf24" }}>
 								Worker cap hits (window):{" "}
 								{transportStats().workerInFlightBackpressureWindowHits}
+							</div>
+						</Show>
+						<Show when={transportStats().workerInFlightSupersededDrops > 0}>
+							<div style={{ color: "#f97316" }}>
+								Worker in-flight superseded drops:{" "}
+								{transportStats().workerInFlightSupersededDrops}
+								<Show
+									when={
+										transportStats().workerInFlightSupersededDropsWindow > 0
+									}
+								>
+									<span style={{ color: "rgba(255, 255, 255, 0.6)" }}>
+										{" "}
+										(window{" "}
+										{transportStats().workerInFlightSupersededDropsWindow})
+									</span>
+								</Show>
 							</div>
 						</Show>
 						<Show when={stats().droppedFrames > 0}>

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -51,6 +51,10 @@ type TransportStats = {
 	queuedOutOfOrderDropsWindow: number;
 	directOutOfOrderDropsTotal: number;
 	directOutOfOrderDropsWindow: number;
+	directIngressOutOfOrderDropsTotal: number;
+	directIngressOutOfOrderDropsWindow: number;
+	directResponseOutOfOrderDropsTotal: number;
+	directResponseOutOfOrderDropsWindow: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -106,6 +110,10 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		queuedOutOfOrderDropsWindow: 0,
 		directOutOfOrderDropsTotal: 0,
 		directOutOfOrderDropsWindow: 0,
+		directIngressOutOfOrderDropsTotal: 0,
+		directIngressOutOfOrderDropsWindow: 0,
+		directResponseOutOfOrderDropsTotal: 0,
+		directResponseOutOfOrderDropsWindow: 0,
 		sabTotalRetryAttempts: 0,
 		sabTotalFramesReceived: 0,
 		sabTotalFramesWrittenToSharedBuffer: 0,
@@ -251,6 +259,10 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			queuedOutOfOrderDropsWindow: 0,
 			directOutOfOrderDropsTotal: 0,
 			directOutOfOrderDropsWindow: 0,
+			directIngressOutOfOrderDropsTotal: 0,
+			directIngressOutOfOrderDropsWindow: 0,
+			directResponseOutOfOrderDropsTotal: 0,
+			directResponseOutOfOrderDropsWindow: 0,
 			sabTotalRetryAttempts: 0,
 			sabTotalFramesReceived: 0,
 			sabTotalFramesWrittenToSharedBuffer: 0,
@@ -308,6 +320,14 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 				queuedOutOfOrderDropsWindow: socketStats.queuedOutOfOrderDropsWindow,
 				directOutOfOrderDropsTotal: socketStats.directOutOfOrderDropsTotal,
 				directOutOfOrderDropsWindow: socketStats.directOutOfOrderDropsWindow,
+				directIngressOutOfOrderDropsTotal:
+					socketStats.directIngressOutOfOrderDropsTotal,
+				directIngressOutOfOrderDropsWindow:
+					socketStats.directIngressOutOfOrderDropsWindow,
+				directResponseOutOfOrderDropsTotal:
+					socketStats.directResponseOutOfOrderDropsTotal,
+				directResponseOutOfOrderDropsWindow:
+					socketStats.directResponseOutOfOrderDropsWindow,
 				sabTotalRetryAttempts: socketStats.sabTotalRetryAttempts,
 				sabTotalFramesReceived: socketStats.sabTotalFramesReceived,
 				sabTotalFramesWrittenToSharedBuffer:
@@ -396,6 +416,10 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`Queued Out-Of-Order Drops (Window): ${t.queuedOutOfOrderDropsWindow}`,
 			`Direct Out-Of-Order Drops (Total): ${t.directOutOfOrderDropsTotal}`,
 			`Direct Out-Of-Order Drops (Window): ${t.directOutOfOrderDropsWindow}`,
+			`Direct Ingress Out-Of-Order Drops (Total): ${t.directIngressOutOfOrderDropsTotal}`,
+			`Direct Ingress Out-Of-Order Drops (Window): ${t.directIngressOutOfOrderDropsWindow}`,
+			`Direct Response Out-Of-Order Drops (Total): ${t.directResponseOutOfOrderDropsTotal}`,
+			`Direct Response Out-Of-Order Drops (Window): ${t.directResponseOutOfOrderDropsWindow}`,
 			`SAB Retry Attempts: ${t.sabTotalRetryAttempts}`,
 			`SAB Frames Received: ${t.sabTotalFramesReceived}`,
 			`SAB Frames Written: ${t.sabTotalFramesWrittenToSharedBuffer}`,
@@ -607,6 +631,20 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 									<span style={{ color: "rgba(255, 255, 255, 0.6)" }}>
 										{" "}
 										(window {transportStats().directOutOfOrderDropsWindow})
+									</span>
+								</Show>
+								<Show
+									when={
+										transportStats().directIngressOutOfOrderDropsTotal > 0 ||
+										transportStats().directResponseOutOfOrderDropsTotal > 0
+									}
+								>
+									<span style={{ color: "rgba(255, 255, 255, 0.5)" }}>
+										{" "}
+										(ingress{" "}
+										{transportStats().directIngressOutOfOrderDropsTotal} /
+										response{" "}
+										{transportStats().directResponseOutOfOrderDropsTotal})
 									</span>
 								</Show>
 							</div>

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -37,6 +37,7 @@ type TransportStats = {
 	sabSlotCount: number;
 	sabTotalBytes: number;
 	sabTotalFramesReceived: number;
+	sabTotalFramesWrittenToSharedBuffer: number;
 	sabTotalFramesSentToWorker: number;
 	sabTotalSupersededDrops: number;
 };
@@ -74,6 +75,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		sabSlotCount: 0,
 		sabTotalBytes: 0,
 		sabTotalFramesReceived: 0,
+		sabTotalFramesWrittenToSharedBuffer: 0,
 		sabTotalFramesSentToWorker: 0,
 		sabTotalSupersededDrops: 0,
 	});
@@ -201,6 +203,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			sabSlotCount: 0,
 			sabTotalBytes: 0,
 			sabTotalFramesReceived: 0,
+			sabTotalFramesWrittenToSharedBuffer: 0,
 			sabTotalFramesSentToWorker: 0,
 			sabTotalSupersededDrops: 0,
 		});
@@ -234,6 +237,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 				sabSlotCount: socketStats.sabSlotCount,
 				sabTotalBytes: socketStats.sabTotalBytes,
 				sabTotalFramesReceived: socketStats.sabTotalFramesReceived,
+				sabTotalFramesWrittenToSharedBuffer:
+					socketStats.sabTotalFramesWrittenToSharedBuffer,
 				sabTotalFramesSentToWorker: socketStats.sabTotalFramesSentToWorker,
 				sabTotalSupersededDrops: socketStats.sabTotalSupersededDrops,
 			});
@@ -267,6 +272,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`SAB Slot Count: ${t.sabSlotCount}`,
 			`SAB Total: ${formatSlotMb(t.sabTotalBytes)} MB`,
 			`SAB Frames Received: ${t.sabTotalFramesReceived}`,
+			`SAB Frames Written: ${t.sabTotalFramesWrittenToSharedBuffer}`,
 			`SAB Frames Sent to Worker: ${t.sabTotalFramesSentToWorker}`,
 			`SAB Superseded Drops: ${t.sabTotalSupersededDrops}`,
 			`SAB Resizes: ${t.sabResizes}`,
@@ -388,7 +394,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 								</span>
 								<span style={{ color: "rgba(255, 255, 255, 0.4)" }}>
 									{" "}
-									/ {transportStats().sabTotalFramesSentToWorker} worker /{" "}
+									/ {transportStats().sabTotalFramesWrittenToSharedBuffer} sab /{" "}
+									{transportStats().sabTotalFramesSentToWorker} worker /{" "}
 									{transportStats().sabTotalSupersededDrops} superseded
 								</span>
 							</div>

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -36,6 +36,7 @@ type TransportStats = {
 	sabSlotSizeBytes: number;
 	sabSlotCount: number;
 	sabTotalBytes: number;
+	workerFramesInFlight: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -76,6 +77,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		sabSlotSizeBytes: 0,
 		sabSlotCount: 0,
 		sabTotalBytes: 0,
+		workerFramesInFlight: 0,
 		sabTotalRetryAttempts: 0,
 		sabTotalFramesReceived: 0,
 		sabTotalFramesWrittenToSharedBuffer: 0,
@@ -206,6 +208,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			sabSlotSizeBytes: 0,
 			sabSlotCount: 0,
 			sabTotalBytes: 0,
+			workerFramesInFlight: 0,
 			sabTotalRetryAttempts: 0,
 			sabTotalFramesReceived: 0,
 			sabTotalFramesWrittenToSharedBuffer: 0,
@@ -242,6 +245,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 				sabSlotSizeBytes: socketStats.sabSlotSizeBytes,
 				sabSlotCount: socketStats.sabSlotCount,
 				sabTotalBytes: socketStats.sabTotalBytes,
+				workerFramesInFlight: socketStats.workerFramesInFlight,
 				sabTotalRetryAttempts: socketStats.sabTotalRetryAttempts,
 				sabTotalFramesReceived: socketStats.sabTotalFramesReceived,
 				sabTotalFramesWrittenToSharedBuffer:
@@ -315,6 +319,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`SAB Slot: ${formatSlotMb(t.sabSlotSizeBytes)} MB`,
 			`SAB Slot Count: ${t.sabSlotCount}`,
 			`SAB Total: ${formatSlotMb(t.sabTotalBytes)} MB`,
+			`Worker Frames In Flight: ${t.workerFramesInFlight}`,
 			`SAB Retry Attempts: ${t.sabTotalRetryAttempts}`,
 			`SAB Frames Received: ${t.sabTotalFramesReceived}`,
 			`SAB Frames Written: ${t.sabTotalFramesWrittenToSharedBuffer}`,
@@ -475,6 +480,11 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 						<Show when={transportStats().sabRetriesInFlight > 0}>
 							<div style={{ color: "#f59e0b" }}>
 								SAB retries in flight: {transportStats().sabRetriesInFlight}
+							</div>
+						</Show>
+						<Show when={transportStats().workerFramesInFlight > 0}>
+							<div style={{ color: "#fbbf24" }}>
+								Worker frames in flight: {transportStats().workerFramesInFlight}
 							</div>
 						</Show>
 						<Show when={stats().droppedFrames > 0}>

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -40,6 +40,7 @@ type TransportStats = {
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
 	sabTotalFramesSentToWorker: number;
+	sabTotalWorkerFallbackBytes: number;
 	sabTotalSupersededDrops: number;
 };
 
@@ -79,6 +80,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		sabTotalFramesReceived: 0,
 		sabTotalFramesWrittenToSharedBuffer: 0,
 		sabTotalFramesSentToWorker: 0,
+		sabTotalWorkerFallbackBytes: 0,
 		sabTotalSupersededDrops: 0,
 	});
 
@@ -208,6 +210,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			sabTotalFramesReceived: 0,
 			sabTotalFramesWrittenToSharedBuffer: 0,
 			sabTotalFramesSentToWorker: 0,
+			sabTotalWorkerFallbackBytes: 0,
 			sabTotalSupersededDrops: 0,
 		});
 	};
@@ -244,6 +247,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 				sabTotalFramesWrittenToSharedBuffer:
 					socketStats.sabTotalFramesWrittenToSharedBuffer,
 				sabTotalFramesSentToWorker: socketStats.sabTotalFramesSentToWorker,
+				sabTotalWorkerFallbackBytes: socketStats.sabTotalWorkerFallbackBytes,
 				sabTotalSupersededDrops: socketStats.sabTotalSupersededDrops,
 			});
 		};
@@ -279,6 +283,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`SAB Frames Received: ${t.sabTotalFramesReceived}`,
 			`SAB Frames Written: ${t.sabTotalFramesWrittenToSharedBuffer}`,
 			`SAB Frames Sent to Worker: ${t.sabTotalFramesSentToWorker}`,
+			`SAB Fallback Transfer: ${formatSlotMb(t.sabTotalWorkerFallbackBytes)} MB`,
 			`SAB Superseded Drops: ${t.sabTotalSupersededDrops}`,
 			`SAB Resizes: ${t.sabResizes}`,
 			`SAB Fallbacks: ${t.sabFallbacks}`,
@@ -402,7 +407,9 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 									/ {transportStats().sabTotalFramesWrittenToSharedBuffer} sab /{" "}
 									{transportStats().sabTotalFramesSentToWorker} worker /{" "}
 									{transportStats().sabTotalSupersededDrops} superseded /{" "}
-									{transportStats().sabTotalRetryAttempts} retries
+									{transportStats().sabTotalRetryAttempts} retries /{" "}
+									{formatSlotMb(transportStats().sabTotalWorkerFallbackBytes)}MB
+									fallback
 								</span>
 							</div>
 						</Show>

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -47,6 +47,8 @@ type TransportStats = {
 	renderedFromSharedWindow: number;
 	renderedFromWorkerTotal: number;
 	renderedFromWorkerWindow: number;
+	directOutOfOrderDropsTotal: number;
+	directOutOfOrderDropsWindow: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -98,6 +100,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		renderedFromSharedWindow: 0,
 		renderedFromWorkerTotal: 0,
 		renderedFromWorkerWindow: 0,
+		directOutOfOrderDropsTotal: 0,
+		directOutOfOrderDropsWindow: 0,
 		sabTotalRetryAttempts: 0,
 		sabTotalFramesReceived: 0,
 		sabTotalFramesWrittenToSharedBuffer: 0,
@@ -239,6 +243,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			renderedFromSharedWindow: 0,
 			renderedFromWorkerTotal: 0,
 			renderedFromWorkerWindow: 0,
+			directOutOfOrderDropsTotal: 0,
+			directOutOfOrderDropsWindow: 0,
 			sabTotalRetryAttempts: 0,
 			sabTotalFramesReceived: 0,
 			sabTotalFramesWrittenToSharedBuffer: 0,
@@ -292,6 +298,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 				renderedFromSharedWindow: socketStats.renderedFromSharedWindow,
 				renderedFromWorkerTotal: socketStats.renderedFromWorkerTotal,
 				renderedFromWorkerWindow: socketStats.renderedFromWorkerWindow,
+				directOutOfOrderDropsTotal: socketStats.directOutOfOrderDropsTotal,
+				directOutOfOrderDropsWindow: socketStats.directOutOfOrderDropsWindow,
 				sabTotalRetryAttempts: socketStats.sabTotalRetryAttempts,
 				sabTotalFramesReceived: socketStats.sabTotalFramesReceived,
 				sabTotalFramesWrittenToSharedBuffer:
@@ -376,6 +384,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`Rendered From Shared (Window): ${t.renderedFromSharedWindow}`,
 			`Rendered From Worker (Total): ${t.renderedFromWorkerTotal}`,
 			`Rendered From Worker (Window): ${t.renderedFromWorkerWindow}`,
+			`Direct Out-Of-Order Drops (Total): ${t.directOutOfOrderDropsTotal}`,
+			`Direct Out-Of-Order Drops (Window): ${t.directOutOfOrderDropsWindow}`,
 			`SAB Retry Attempts: ${t.sabTotalRetryAttempts}`,
 			`SAB Frames Received: ${t.sabTotalFramesReceived}`,
 			`SAB Frames Written: ${t.sabTotalFramesWrittenToSharedBuffer}`,
@@ -565,6 +575,18 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 									({transportStats().renderedFromSharedTotal} shared /{" "}
 									{transportStats().renderedFromWorkerTotal} worker total)
 								</span>
+							</div>
+						</Show>
+						<Show when={transportStats().directOutOfOrderDropsTotal > 0}>
+							<div style={{ color: "#f97316" }}>
+								Direct out-of-order drops:{" "}
+								{transportStats().directOutOfOrderDropsTotal}
+								<Show when={transportStats().directOutOfOrderDropsWindow > 0}>
+									<span style={{ color: "rgba(255, 255, 255, 0.6)" }}>
+										{" "}
+										(window {transportStats().directOutOfOrderDropsWindow})
+									</span>
+								</Show>
 							</div>
 						</Show>
 						<Show when={transportStats().workerInFlightBackpressureHits > 0}>

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -36,6 +36,7 @@ type TransportStats = {
 	sabSlotSizeBytes: number;
 	sabSlotCount: number;
 	sabTotalBytes: number;
+	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
 	sabTotalFramesSentToWorker: number;
@@ -74,6 +75,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		sabSlotSizeBytes: 0,
 		sabSlotCount: 0,
 		sabTotalBytes: 0,
+		sabTotalRetryAttempts: 0,
 		sabTotalFramesReceived: 0,
 		sabTotalFramesWrittenToSharedBuffer: 0,
 		sabTotalFramesSentToWorker: 0,
@@ -202,6 +204,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			sabSlotSizeBytes: 0,
 			sabSlotCount: 0,
 			sabTotalBytes: 0,
+			sabTotalRetryAttempts: 0,
 			sabTotalFramesReceived: 0,
 			sabTotalFramesWrittenToSharedBuffer: 0,
 			sabTotalFramesSentToWorker: 0,
@@ -236,6 +239,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 				sabSlotSizeBytes: socketStats.sabSlotSizeBytes,
 				sabSlotCount: socketStats.sabSlotCount,
 				sabTotalBytes: socketStats.sabTotalBytes,
+				sabTotalRetryAttempts: socketStats.sabTotalRetryAttempts,
 				sabTotalFramesReceived: socketStats.sabTotalFramesReceived,
 				sabTotalFramesWrittenToSharedBuffer:
 					socketStats.sabTotalFramesWrittenToSharedBuffer,
@@ -271,6 +275,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`SAB Slot: ${formatSlotMb(t.sabSlotSizeBytes)} MB`,
 			`SAB Slot Count: ${t.sabSlotCount}`,
 			`SAB Total: ${formatSlotMb(t.sabTotalBytes)} MB`,
+			`SAB Retry Attempts: ${t.sabTotalRetryAttempts}`,
 			`SAB Frames Received: ${t.sabTotalFramesReceived}`,
 			`SAB Frames Written: ${t.sabTotalFramesWrittenToSharedBuffer}`,
 			`SAB Frames Sent to Worker: ${t.sabTotalFramesSentToWorker}`,
@@ -396,7 +401,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 									{" "}
 									/ {transportStats().sabTotalFramesWrittenToSharedBuffer} sab /{" "}
 									{transportStats().sabTotalFramesSentToWorker} worker /{" "}
-									{transportStats().sabTotalSupersededDrops} superseded
+									{transportStats().sabTotalSupersededDrops} superseded /{" "}
+									{transportStats().sabTotalRetryAttempts} retries
 								</span>
 							</div>
 						</Show>

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -34,6 +34,8 @@ type TransportStats = {
 	sabRetryLimitFallbacks: number;
 	sabRetriesInFlight: number;
 	sabSlotSizeBytes: number;
+	sabSlotCount: number;
+	sabTotalBytes: number;
 };
 
 const STATS_WINDOW_MS = 1000;
@@ -66,6 +68,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		sabRetryLimitFallbacks: 0,
 		sabRetriesInFlight: 0,
 		sabSlotSizeBytes: 0,
+		sabSlotCount: 0,
+		sabTotalBytes: 0,
 	});
 
 	const calculateStats = (): FrameStats => {
@@ -188,6 +192,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			sabRetryLimitFallbacks: 0,
 			sabRetriesInFlight: 0,
 			sabSlotSizeBytes: 0,
+			sabSlotCount: 0,
+			sabTotalBytes: 0,
 		});
 	};
 
@@ -216,6 +222,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 				sabRetryLimitFallbacks: socketStats.sabRetryLimitFallbacks,
 				sabRetriesInFlight: socketStats.sabRetriesInFlight,
 				sabSlotSizeBytes: socketStats.sabSlotSizeBytes,
+				sabSlotCount: socketStats.sabSlotCount,
+				sabTotalBytes: socketStats.sabTotalBytes,
 			});
 		};
 		updateTransportStats();
@@ -244,6 +252,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`Render FPS: ${formatFps(t.renderFps)}`,
 			`Transport: ${formatMb(t.mbPerSec)} MB/s`,
 			`SAB Slot: ${formatSlotMb(t.sabSlotSizeBytes)} MB`,
+			`SAB Slot Count: ${t.sabSlotCount}`,
+			`SAB Total: ${formatSlotMb(t.sabTotalBytes)} MB`,
 			`SAB Resizes: ${t.sabResizes}`,
 			`SAB Fallbacks: ${t.sabFallbacks}`,
 			`SAB Oversize Fallbacks: ${t.sabOversizeFallbacks}`,
@@ -350,7 +360,9 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 							</span>
 							<span style={{ color: "rgba(255, 255, 255, 0.4)" }}>
 								{" "}
-								/ {transportStats().sabResizes} resizes
+								/ {transportStats().sabSlotCount} slots /{" "}
+								{formatSlotMb(transportStats().sabTotalBytes)}MB total /{" "}
+								{transportStats().sabResizes} resizes
 							</span>
 						</div>
 						<Show when={transportStats().sabFallbacks > 0}>

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -37,6 +37,7 @@ type TransportStats = {
 	sabSlotCount: number;
 	sabTotalBytes: number;
 	workerFramesInFlight: number;
+	workerInFlightBackpressureHits: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -78,6 +79,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		sabSlotCount: 0,
 		sabTotalBytes: 0,
 		workerFramesInFlight: 0,
+		workerInFlightBackpressureHits: 0,
 		sabTotalRetryAttempts: 0,
 		sabTotalFramesReceived: 0,
 		sabTotalFramesWrittenToSharedBuffer: 0,
@@ -209,6 +211,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			sabSlotCount: 0,
 			sabTotalBytes: 0,
 			workerFramesInFlight: 0,
+			workerInFlightBackpressureHits: 0,
 			sabTotalRetryAttempts: 0,
 			sabTotalFramesReceived: 0,
 			sabTotalFramesWrittenToSharedBuffer: 0,
@@ -246,6 +249,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 				sabSlotCount: socketStats.sabSlotCount,
 				sabTotalBytes: socketStats.sabTotalBytes,
 				workerFramesInFlight: socketStats.workerFramesInFlight,
+				workerInFlightBackpressureHits:
+					socketStats.workerInFlightBackpressureHits,
 				sabTotalRetryAttempts: socketStats.sabTotalRetryAttempts,
 				sabTotalFramesReceived: socketStats.sabTotalFramesReceived,
 				sabTotalFramesWrittenToSharedBuffer:
@@ -320,6 +325,7 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`SAB Slot Count: ${t.sabSlotCount}`,
 			`SAB Total: ${formatSlotMb(t.sabTotalBytes)} MB`,
 			`Worker Frames In Flight: ${t.workerFramesInFlight}`,
+			`Worker In-Flight Cap Hits: ${t.workerInFlightBackpressureHits}`,
 			`SAB Retry Attempts: ${t.sabTotalRetryAttempts}`,
 			`SAB Frames Received: ${t.sabTotalFramesReceived}`,
 			`SAB Frames Written: ${t.sabTotalFramesWrittenToSharedBuffer}`,
@@ -485,6 +491,12 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 						<Show when={transportStats().workerFramesInFlight > 0}>
 							<div style={{ color: "#fbbf24" }}>
 								Worker frames in flight: {transportStats().workerFramesInFlight}
+							</div>
+						</Show>
+						<Show when={transportStats().workerInFlightBackpressureHits > 0}>
+							<div style={{ color: "#f59e0b" }}>
+								Worker in-flight cap hits:{" "}
+								{transportStats().workerInFlightBackpressureHits}
 							</div>
 						</Show>
 						<Show when={stats().droppedFrames > 0}>

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -36,6 +36,9 @@ type TransportStats = {
 	sabSlotSizeBytes: number;
 	sabSlotCount: number;
 	sabTotalBytes: number;
+	sabTotalFramesReceived: number;
+	sabTotalFramesSentToWorker: number;
+	sabTotalSupersededDrops: number;
 };
 
 const STATS_WINDOW_MS = 1000;
@@ -70,6 +73,9 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		sabSlotSizeBytes: 0,
 		sabSlotCount: 0,
 		sabTotalBytes: 0,
+		sabTotalFramesReceived: 0,
+		sabTotalFramesSentToWorker: 0,
+		sabTotalSupersededDrops: 0,
 	});
 
 	const calculateStats = (): FrameStats => {
@@ -194,6 +200,9 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			sabSlotSizeBytes: 0,
 			sabSlotCount: 0,
 			sabTotalBytes: 0,
+			sabTotalFramesReceived: 0,
+			sabTotalFramesSentToWorker: 0,
+			sabTotalSupersededDrops: 0,
 		});
 	};
 
@@ -224,6 +233,9 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 				sabSlotSizeBytes: socketStats.sabSlotSizeBytes,
 				sabSlotCount: socketStats.sabSlotCount,
 				sabTotalBytes: socketStats.sabTotalBytes,
+				sabTotalFramesReceived: socketStats.sabTotalFramesReceived,
+				sabTotalFramesSentToWorker: socketStats.sabTotalFramesSentToWorker,
+				sabTotalSupersededDrops: socketStats.sabTotalSupersededDrops,
 			});
 		};
 		updateTransportStats();
@@ -254,6 +266,9 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`SAB Slot: ${formatSlotMb(t.sabSlotSizeBytes)} MB`,
 			`SAB Slot Count: ${t.sabSlotCount}`,
 			`SAB Total: ${formatSlotMb(t.sabTotalBytes)} MB`,
+			`SAB Frames Received: ${t.sabTotalFramesReceived}`,
+			`SAB Frames Sent to Worker: ${t.sabTotalFramesSentToWorker}`,
+			`SAB Superseded Drops: ${t.sabTotalSupersededDrops}`,
 			`SAB Resizes: ${t.sabResizes}`,
 			`SAB Fallbacks: ${t.sabFallbacks}`,
 			`SAB Oversize Fallbacks: ${t.sabOversizeFallbacks}`,
@@ -365,6 +380,19 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 								{transportStats().sabResizes} resizes
 							</span>
 						</div>
+						<Show when={transportStats().sabTotalFramesReceived > 0}>
+							<div style={{ color: "rgba(255, 255, 255, 0.7)" }}>
+								<span>SAB totals: </span>
+								<span style={{ color: "#93c5fd" }}>
+									{transportStats().sabTotalFramesReceived} recv
+								</span>
+								<span style={{ color: "rgba(255, 255, 255, 0.4)" }}>
+									{" "}
+									/ {transportStats().sabTotalFramesSentToWorker} worker /{" "}
+									{transportStats().sabTotalSupersededDrops} superseded
+								</span>
+							</div>
+						</Show>
 						<Show when={transportStats().sabFallbacks > 0}>
 							<div style={{ color: "#fbbf24" }}>
 								SAB fallback {transportStats().sabFallbacks} (oversize{" "}

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -43,6 +43,10 @@ type TransportStats = {
 	workerFramesInFlightPeakTotal: number;
 	workerInFlightSupersededDrops: number;
 	workerInFlightSupersededDropsWindow: number;
+	renderedFromSharedTotal: number;
+	renderedFromSharedWindow: number;
+	renderedFromWorkerTotal: number;
+	renderedFromWorkerWindow: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -90,6 +94,10 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		workerFramesInFlightPeakTotal: 0,
 		workerInFlightSupersededDrops: 0,
 		workerInFlightSupersededDropsWindow: 0,
+		renderedFromSharedTotal: 0,
+		renderedFromSharedWindow: 0,
+		renderedFromWorkerTotal: 0,
+		renderedFromWorkerWindow: 0,
 		sabTotalRetryAttempts: 0,
 		sabTotalFramesReceived: 0,
 		sabTotalFramesWrittenToSharedBuffer: 0,
@@ -227,6 +235,10 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			workerFramesInFlightPeakTotal: 0,
 			workerInFlightSupersededDrops: 0,
 			workerInFlightSupersededDropsWindow: 0,
+			renderedFromSharedTotal: 0,
+			renderedFromSharedWindow: 0,
+			renderedFromWorkerTotal: 0,
+			renderedFromWorkerWindow: 0,
 			sabTotalRetryAttempts: 0,
 			sabTotalFramesReceived: 0,
 			sabTotalFramesWrittenToSharedBuffer: 0,
@@ -276,6 +288,10 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 					socketStats.workerInFlightSupersededDrops,
 				workerInFlightSupersededDropsWindow:
 					socketStats.workerInFlightSupersededDropsWindow,
+				renderedFromSharedTotal: socketStats.renderedFromSharedTotal,
+				renderedFromSharedWindow: socketStats.renderedFromSharedWindow,
+				renderedFromWorkerTotal: socketStats.renderedFromWorkerTotal,
+				renderedFromWorkerWindow: socketStats.renderedFromWorkerWindow,
 				sabTotalRetryAttempts: socketStats.sabTotalRetryAttempts,
 				sabTotalFramesReceived: socketStats.sabTotalFramesReceived,
 				sabTotalFramesWrittenToSharedBuffer:
@@ -356,6 +372,10 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`Worker In-Flight Peak (Total): ${t.workerFramesInFlightPeakTotal}`,
 			`Worker In-Flight Superseded Drops: ${t.workerInFlightSupersededDrops}`,
 			`Worker In-Flight Superseded Drops (Window): ${t.workerInFlightSupersededDropsWindow}`,
+			`Rendered From Shared (Total): ${t.renderedFromSharedTotal}`,
+			`Rendered From Shared (Window): ${t.renderedFromSharedWindow}`,
+			`Rendered From Worker (Total): ${t.renderedFromWorkerTotal}`,
+			`Rendered From Worker (Window): ${t.renderedFromWorkerWindow}`,
 			`SAB Retry Attempts: ${t.sabTotalRetryAttempts}`,
 			`SAB Frames Received: ${t.sabTotalFramesReceived}`,
 			`SAB Frames Written: ${t.sabTotalFramesWrittenToSharedBuffer}`,
@@ -528,6 +548,23 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 								Worker in-flight peak:{" "}
 								{transportStats().workerFramesInFlightPeakWindow} window /{" "}
 								{transportStats().workerFramesInFlightPeakTotal} total
+							</div>
+						</Show>
+						<Show
+							when={
+								transportStats().renderedFromSharedTotal > 0 ||
+								transportStats().renderedFromWorkerTotal > 0
+							}
+						>
+							<div style={{ color: "rgba(255, 255, 255, 0.7)" }}>
+								Render source: {transportStats().renderedFromSharedWindow}{" "}
+								shared / {transportStats().renderedFromWorkerWindow} worker
+								window
+								<span style={{ color: "rgba(255, 255, 255, 0.5)" }}>
+									{" "}
+									({transportStats().renderedFromSharedTotal} shared /{" "}
+									{transportStats().renderedFromWorkerTotal} worker total)
+								</span>
 							</div>
 						</Show>
 						<Show when={transportStats().workerInFlightBackpressureHits > 0}>

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -61,6 +61,8 @@ type TransportStats = {
 	strideCorrectionDispatchesWindow: number;
 	strideCorrectionSupersededDropsTotal: number;
 	strideCorrectionSupersededDropsWindow: number;
+	strideCorrectionErrorsTotal: number;
+	strideCorrectionErrorsWindow: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -126,6 +128,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		strideCorrectionDispatchesWindow: 0,
 		strideCorrectionSupersededDropsTotal: 0,
 		strideCorrectionSupersededDropsWindow: 0,
+		strideCorrectionErrorsTotal: 0,
+		strideCorrectionErrorsWindow: 0,
 		sabTotalRetryAttempts: 0,
 		sabTotalFramesReceived: 0,
 		sabTotalFramesWrittenToSharedBuffer: 0,
@@ -281,6 +285,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			strideCorrectionDispatchesWindow: 0,
 			strideCorrectionSupersededDropsTotal: 0,
 			strideCorrectionSupersededDropsWindow: 0,
+			strideCorrectionErrorsTotal: 0,
+			strideCorrectionErrorsWindow: 0,
 			sabTotalRetryAttempts: 0,
 			sabTotalFramesReceived: 0,
 			sabTotalFramesWrittenToSharedBuffer: 0,
@@ -356,6 +362,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 					socketStats.strideCorrectionSupersededDropsTotal,
 				strideCorrectionSupersededDropsWindow:
 					socketStats.strideCorrectionSupersededDropsWindow,
+				strideCorrectionErrorsTotal: socketStats.strideCorrectionErrorsTotal,
+				strideCorrectionErrorsWindow: socketStats.strideCorrectionErrorsWindow,
 				sabTotalRetryAttempts: socketStats.sabTotalRetryAttempts,
 				sabTotalFramesReceived: socketStats.sabTotalFramesReceived,
 				sabTotalFramesWrittenToSharedBuffer:
@@ -454,6 +462,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`Stride Correction Dispatches (Window): ${t.strideCorrectionDispatchesWindow}`,
 			`Stride Correction Superseded Drops (Total): ${t.strideCorrectionSupersededDropsTotal}`,
 			`Stride Correction Superseded Drops (Window): ${t.strideCorrectionSupersededDropsWindow}`,
+			`Stride Correction Errors (Total): ${t.strideCorrectionErrorsTotal}`,
+			`Stride Correction Errors (Window): ${t.strideCorrectionErrorsWindow}`,
 			`SAB Retry Attempts: ${t.sabTotalRetryAttempts}`,
 			`SAB Frames Received: ${t.sabTotalFramesReceived}`,
 			`SAB Frames Written: ${t.sabTotalFramesWrittenToSharedBuffer}`,
@@ -687,7 +697,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 							when={
 								transportStats().strideCorrectionInFlight > 0 ||
 								transportStats().strideCorrectionPending > 0 ||
-								transportStats().strideCorrectionDispatchesTotal > 0
+								transportStats().strideCorrectionDispatchesTotal > 0 ||
+								transportStats().strideCorrectionErrorsTotal > 0
 							}
 						>
 							<div style={{ color: "#f59e0b" }}>
@@ -702,7 +713,9 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 									superseded{" "}
 									{transportStats().strideCorrectionSupersededDropsWindow}{" "}
 									window /{" "}
-									{transportStats().strideCorrectionSupersededDropsTotal} total)
+									{transportStats().strideCorrectionSupersededDropsTotal} total,
+									errors {transportStats().strideCorrectionErrorsWindow} window
+									/ {transportStats().strideCorrectionErrorsTotal} total)
 								</span>
 							</div>
 						</Show>

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -55,6 +55,12 @@ type TransportStats = {
 	directIngressOutOfOrderDropsWindow: number;
 	directResponseOutOfOrderDropsTotal: number;
 	directResponseOutOfOrderDropsWindow: number;
+	strideCorrectionInFlight: number;
+	strideCorrectionPending: number;
+	strideCorrectionDispatchesTotal: number;
+	strideCorrectionDispatchesWindow: number;
+	strideCorrectionSupersededDropsTotal: number;
+	strideCorrectionSupersededDropsWindow: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -114,6 +120,12 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		directIngressOutOfOrderDropsWindow: 0,
 		directResponseOutOfOrderDropsTotal: 0,
 		directResponseOutOfOrderDropsWindow: 0,
+		strideCorrectionInFlight: 0,
+		strideCorrectionPending: 0,
+		strideCorrectionDispatchesTotal: 0,
+		strideCorrectionDispatchesWindow: 0,
+		strideCorrectionSupersededDropsTotal: 0,
+		strideCorrectionSupersededDropsWindow: 0,
 		sabTotalRetryAttempts: 0,
 		sabTotalFramesReceived: 0,
 		sabTotalFramesWrittenToSharedBuffer: 0,
@@ -263,6 +275,12 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			directIngressOutOfOrderDropsWindow: 0,
 			directResponseOutOfOrderDropsTotal: 0,
 			directResponseOutOfOrderDropsWindow: 0,
+			strideCorrectionInFlight: 0,
+			strideCorrectionPending: 0,
+			strideCorrectionDispatchesTotal: 0,
+			strideCorrectionDispatchesWindow: 0,
+			strideCorrectionSupersededDropsTotal: 0,
+			strideCorrectionSupersededDropsWindow: 0,
 			sabTotalRetryAttempts: 0,
 			sabTotalFramesReceived: 0,
 			sabTotalFramesWrittenToSharedBuffer: 0,
@@ -328,6 +346,16 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 					socketStats.directResponseOutOfOrderDropsTotal,
 				directResponseOutOfOrderDropsWindow:
 					socketStats.directResponseOutOfOrderDropsWindow,
+				strideCorrectionInFlight: socketStats.strideCorrectionInFlight,
+				strideCorrectionPending: socketStats.strideCorrectionPending,
+				strideCorrectionDispatchesTotal:
+					socketStats.strideCorrectionDispatchesTotal,
+				strideCorrectionDispatchesWindow:
+					socketStats.strideCorrectionDispatchesWindow,
+				strideCorrectionSupersededDropsTotal:
+					socketStats.strideCorrectionSupersededDropsTotal,
+				strideCorrectionSupersededDropsWindow:
+					socketStats.strideCorrectionSupersededDropsWindow,
 				sabTotalRetryAttempts: socketStats.sabTotalRetryAttempts,
 				sabTotalFramesReceived: socketStats.sabTotalFramesReceived,
 				sabTotalFramesWrittenToSharedBuffer:
@@ -420,6 +448,12 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`Direct Ingress Out-Of-Order Drops (Window): ${t.directIngressOutOfOrderDropsWindow}`,
 			`Direct Response Out-Of-Order Drops (Total): ${t.directResponseOutOfOrderDropsTotal}`,
 			`Direct Response Out-Of-Order Drops (Window): ${t.directResponseOutOfOrderDropsWindow}`,
+			`Stride Correction In Flight: ${t.strideCorrectionInFlight}`,
+			`Stride Correction Pending: ${t.strideCorrectionPending}`,
+			`Stride Correction Dispatches (Total): ${t.strideCorrectionDispatchesTotal}`,
+			`Stride Correction Dispatches (Window): ${t.strideCorrectionDispatchesWindow}`,
+			`Stride Correction Superseded Drops (Total): ${t.strideCorrectionSupersededDropsTotal}`,
+			`Stride Correction Superseded Drops (Window): ${t.strideCorrectionSupersededDropsWindow}`,
 			`SAB Retry Attempts: ${t.sabTotalRetryAttempts}`,
 			`SAB Frames Received: ${t.sabTotalFramesReceived}`,
 			`SAB Frames Written: ${t.sabTotalFramesWrittenToSharedBuffer}`,
@@ -647,6 +681,29 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 										{transportStats().directResponseOutOfOrderDropsTotal})
 									</span>
 								</Show>
+							</div>
+						</Show>
+						<Show
+							when={
+								transportStats().strideCorrectionInFlight > 0 ||
+								transportStats().strideCorrectionPending > 0 ||
+								transportStats().strideCorrectionDispatchesTotal > 0
+							}
+						>
+							<div style={{ color: "#f59e0b" }}>
+								Stride correction: in-flight{" "}
+								{transportStats().strideCorrectionInFlight} / pending{" "}
+								{transportStats().strideCorrectionPending}
+								<span style={{ color: "rgba(255, 255, 255, 0.6)" }}>
+									{" "}
+									(dispatches{" "}
+									{transportStats().strideCorrectionDispatchesWindow} window /{" "}
+									{transportStats().strideCorrectionDispatchesTotal} total,
+									superseded{" "}
+									{transportStats().strideCorrectionSupersededDropsWindow}{" "}
+									window /{" "}
+									{transportStats().strideCorrectionSupersededDropsTotal} total)
+								</span>
 							</div>
 						</Show>
 						<Show when={transportStats().workerInFlightBackpressureHits > 0}>

--- a/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
+++ b/apps/desktop/src/routes/editor/PerformanceOverlay.tsx
@@ -39,6 +39,8 @@ type TransportStats = {
 	workerFramesInFlight: number;
 	workerInFlightBackpressureHits: number;
 	workerInFlightBackpressureWindowHits: number;
+	workerFramesInFlightPeakWindow: number;
+	workerFramesInFlightPeakTotal: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -82,6 +84,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 		workerFramesInFlight: 0,
 		workerInFlightBackpressureHits: 0,
 		workerInFlightBackpressureWindowHits: 0,
+		workerFramesInFlightPeakWindow: 0,
+		workerFramesInFlightPeakTotal: 0,
 		sabTotalRetryAttempts: 0,
 		sabTotalFramesReceived: 0,
 		sabTotalFramesWrittenToSharedBuffer: 0,
@@ -215,6 +219,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			workerFramesInFlight: 0,
 			workerInFlightBackpressureHits: 0,
 			workerInFlightBackpressureWindowHits: 0,
+			workerFramesInFlightPeakWindow: 0,
+			workerFramesInFlightPeakTotal: 0,
 			sabTotalRetryAttempts: 0,
 			sabTotalFramesReceived: 0,
 			sabTotalFramesWrittenToSharedBuffer: 0,
@@ -256,6 +262,10 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 					socketStats.workerInFlightBackpressureHits,
 				workerInFlightBackpressureWindowHits:
 					socketStats.workerInFlightBackpressureWindowHits,
+				workerFramesInFlightPeakWindow:
+					socketStats.workerFramesInFlightPeakWindow,
+				workerFramesInFlightPeakTotal:
+					socketStats.workerFramesInFlightPeakTotal,
 				sabTotalRetryAttempts: socketStats.sabTotalRetryAttempts,
 				sabTotalFramesReceived: socketStats.sabTotalFramesReceived,
 				sabTotalFramesWrittenToSharedBuffer:
@@ -332,6 +342,8 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 			`Worker Frames In Flight: ${t.workerFramesInFlight}`,
 			`Worker In-Flight Cap Hits: ${t.workerInFlightBackpressureHits}`,
 			`Worker In-Flight Cap Hits (Window): ${t.workerInFlightBackpressureWindowHits}`,
+			`Worker In-Flight Peak (Window): ${t.workerFramesInFlightPeakWindow}`,
+			`Worker In-Flight Peak (Total): ${t.workerFramesInFlightPeakTotal}`,
 			`SAB Retry Attempts: ${t.sabTotalRetryAttempts}`,
 			`SAB Frames Received: ${t.sabTotalFramesReceived}`,
 			`SAB Frames Written: ${t.sabTotalFramesWrittenToSharedBuffer}`,
@@ -497,6 +509,13 @@ export function PerformanceOverlay(_props: PerformanceOverlayProps) {
 						<Show when={transportStats().workerFramesInFlight > 0}>
 							<div style={{ color: "#fbbf24" }}>
 								Worker frames in flight: {transportStats().workerFramesInFlight}
+							</div>
+						</Show>
+						<Show when={transportStats().workerFramesInFlightPeakTotal > 0}>
+							<div style={{ color: "#f59e0b" }}>
+								Worker in-flight peak:{" "}
+								{transportStats().workerFramesInFlightPeakWindow} window /{" "}
+								{transportStats().workerFramesInFlightPeakTotal} total
 							</div>
 						</Show>
 						<Show when={transportStats().workerInFlightBackpressureHits > 0}>

--- a/apps/desktop/src/utils/frame-order.test.ts
+++ b/apps/desktop/src/utils/frame-order.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+	frameNumberForwardDelta,
+	isFrameNumberNewer,
+	shouldDropOutOfOrderFrame,
+} from "./frame-order";
+
+describe("frame-order utilities", () => {
+	it("treats positive forward deltas as newer", () => {
+		expect(frameNumberForwardDelta(41, 40)).toBe(1);
+		expect(isFrameNumberNewer(41, 40)).toBe(true);
+	});
+
+	it("treats wraparound forward deltas as newer", () => {
+		expect(frameNumberForwardDelta(2, 0xffffffff)).toBe(3);
+		expect(isFrameNumberNewer(2, 0xffffffff)).toBe(true);
+	});
+
+	it("drops duplicate frame numbers", () => {
+		expect(shouldDropOutOfOrderFrame(120, 120)).toBe(true);
+	});
+
+	it("drops slightly older out-of-order frames inside stale window", () => {
+		expect(shouldDropOutOfOrderFrame(119, 120, 30)).toBe(true);
+		expect(shouldDropOutOfOrderFrame(90, 120, 30)).toBe(true);
+	});
+
+	it("keeps older frames beyond stale window as seek candidates", () => {
+		expect(shouldDropOutOfOrderFrame(89, 120, 30)).toBe(false);
+	});
+
+	it("keeps forward frames", () => {
+		expect(shouldDropOutOfOrderFrame(121, 120, 30)).toBe(false);
+	});
+});

--- a/apps/desktop/src/utils/frame-order.ts
+++ b/apps/desktop/src/utils/frame-order.ts
@@ -1,0 +1,27 @@
+export const FRAME_ORDER_STALE_WINDOW = 30;
+
+export function frameNumberForwardDelta(
+	candidate: number,
+	reference: number,
+): number {
+	return (candidate - reference) >>> 0;
+}
+
+export function isFrameNumberNewer(
+	candidate: number,
+	reference: number,
+): boolean {
+	const delta = frameNumberForwardDelta(candidate, reference);
+	return delta !== 0 && delta < 0x80000000;
+}
+
+export function shouldDropOutOfOrderFrame(
+	candidate: number,
+	reference: number,
+	staleWindow: number = FRAME_ORDER_STALE_WINDOW,
+): boolean {
+	if (candidate === reference) return true;
+	if (isFrameNumberNewer(candidate, reference)) return false;
+	const backwardDelta = frameNumberForwardDelta(reference, candidate);
+	return backwardDelta <= staleWindow;
+}

--- a/apps/desktop/src/utils/frame-transport-config.test.ts
+++ b/apps/desktop/src/utils/frame-transport-config.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_FRAME_BUFFER_CONFIG,
+	FRAME_BUFFER_MAX_SLOT_SIZE,
+	FRAME_BUFFER_MAX_TOTAL_BYTES,
+	computeSharedBufferConfig,
+} from "./frame-transport-config";
+
+describe("frame-transport-config", () => {
+	it("keeps default config for small frames", () => {
+		const config = computeSharedBufferConfig(4 * 1024 * 1024);
+		expect(config.slotSize).toBe(DEFAULT_FRAME_BUFFER_CONFIG.slotSize);
+		expect(config.slotCount).toBe(DEFAULT_FRAME_BUFFER_CONFIG.slotCount);
+	});
+
+	it("increases slot size with aligned headroom", () => {
+		const config = computeSharedBufferConfig(22 * 1024 * 1024);
+		expect(config.slotSize).toBe(28 * 1024 * 1024);
+		expect(config.slotCount).toBe(4);
+	});
+
+	it("caps slot size and total memory budget", () => {
+		const config = computeSharedBufferConfig(80 * 1024 * 1024);
+		expect(config.slotSize).toBe(FRAME_BUFFER_MAX_SLOT_SIZE);
+		expect(config.slotCount).toBe(2);
+		expect(config.slotSize * config.slotCount).toBeLessThanOrEqual(
+			FRAME_BUFFER_MAX_TOTAL_BYTES,
+		);
+	});
+});

--- a/apps/desktop/src/utils/frame-transport-config.ts
+++ b/apps/desktop/src/utils/frame-transport-config.ts
@@ -1,0 +1,37 @@
+import type { SharedFrameBufferConfig } from "./shared-frame-buffer";
+
+export const DEFAULT_FRAME_BUFFER_CONFIG: SharedFrameBufferConfig = {
+	slotCount: 6,
+	slotSize: 16 * 1024 * 1024,
+};
+
+export const FRAME_BUFFER_RESIZE_ALIGNMENT = 2 * 1024 * 1024;
+export const FRAME_BUFFER_MAX_SLOT_SIZE = 64 * 1024 * 1024;
+export const FRAME_BUFFER_MAX_TOTAL_BYTES = 128 * 1024 * 1024;
+export const FRAME_BUFFER_MIN_SLOT_COUNT = 2;
+
+export function alignUp(value: number, alignment: number): number {
+	if (alignment <= 0) return value;
+	return Math.ceil(value / alignment) * alignment;
+}
+
+export function computeSharedBufferConfig(
+	requiredBytes: number,
+	baseConfig: SharedFrameBufferConfig = DEFAULT_FRAME_BUFFER_CONFIG,
+): SharedFrameBufferConfig {
+	const safeRequired = Math.max(requiredBytes, 0);
+	const withHeadroom = Math.ceil(safeRequired * 1.25);
+	const alignedBytes = alignUp(withHeadroom, FRAME_BUFFER_RESIZE_ALIGNMENT);
+	const slotSize = Math.max(
+		baseConfig.slotSize,
+		Math.min(FRAME_BUFFER_MAX_SLOT_SIZE, alignedBytes),
+	);
+
+	const maxSlotsByBudget = Math.max(
+		FRAME_BUFFER_MIN_SLOT_COUNT,
+		Math.floor(FRAME_BUFFER_MAX_TOTAL_BYTES / slotSize),
+	);
+	const slotCount = Math.min(baseConfig.slotCount, maxSlotsByBudget);
+
+	return { slotCount, slotSize };
+}

--- a/apps/desktop/src/utils/frame-transport-inflight.test.ts
+++ b/apps/desktop/src/utils/frame-transport-inflight.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+	decideWorkerInflightDispatch,
+	updateWorkerInflightPeaks,
+} from "./frame-transport-inflight";
+
+describe("frame-transport-inflight", () => {
+	it("dispatches when worker inflight is below limit", () => {
+		expect(decideWorkerInflightDispatch(1, 2, false)).toEqual({
+			action: "dispatch",
+			nextWorkerFramesInFlight: 2,
+			backpressureHitsIncrement: 0,
+			supersededDropsIncrement: 0,
+		});
+	});
+
+	it("returns backpressure without superseded increment when queue empty", () => {
+		expect(decideWorkerInflightDispatch(2, 2, false)).toEqual({
+			action: "backpressure",
+			nextWorkerFramesInFlight: 2,
+			backpressureHitsIncrement: 1,
+			supersededDropsIncrement: 0,
+		});
+	});
+
+	it("returns backpressure with superseded increment when queue occupied", () => {
+		expect(decideWorkerInflightDispatch(4, 2, true)).toEqual({
+			action: "backpressure",
+			nextWorkerFramesInFlight: 4,
+			backpressureHitsIncrement: 1,
+			supersededDropsIncrement: 1,
+		});
+	});
+
+	it("updates worker inflight peaks", () => {
+		expect(updateWorkerInflightPeaks(3, 2, 5)).toEqual({
+			peakWindow: 3,
+			peakTotal: 5,
+		});
+	});
+});

--- a/apps/desktop/src/utils/frame-transport-inflight.ts
+++ b/apps/desktop/src/utils/frame-transport-inflight.ts
@@ -1,0 +1,39 @@
+export type WorkerInflightDispatchDecision = {
+	action: "dispatch" | "backpressure";
+	nextWorkerFramesInFlight: number;
+	backpressureHitsIncrement: number;
+	supersededDropsIncrement: number;
+};
+
+export function decideWorkerInflightDispatch(
+	workerFramesInFlight: number,
+	limit: number,
+	hasQueuedNextFrame: boolean,
+): WorkerInflightDispatchDecision {
+	if (workerFramesInFlight >= limit) {
+		return {
+			action: "backpressure",
+			nextWorkerFramesInFlight: workerFramesInFlight,
+			backpressureHitsIncrement: 1,
+			supersededDropsIncrement: hasQueuedNextFrame ? 1 : 0,
+		};
+	}
+
+	return {
+		action: "dispatch",
+		nextWorkerFramesInFlight: workerFramesInFlight + 1,
+		backpressureHitsIncrement: 0,
+		supersededDropsIncrement: 0,
+	};
+}
+
+export function updateWorkerInflightPeaks(
+	workerFramesInFlight: number,
+	peakWindow: number,
+	peakTotal: number,
+) {
+	return {
+		peakWindow: Math.max(peakWindow, workerFramesInFlight),
+		peakTotal: Math.max(peakTotal, workerFramesInFlight),
+	};
+}

--- a/apps/desktop/src/utils/frame-transport-order.test.ts
+++ b/apps/desktop/src/utils/frame-transport-order.test.ts
@@ -29,6 +29,15 @@ describe("decideFrameOrder", () => {
 		});
 	});
 
+	it("drops duplicate frame numbers", () => {
+		const decision = decideFrameOrder(120, 120, 30);
+		expect(decision).toEqual({
+			action: "drop",
+			nextLatestFrameNumber: 120,
+			dropsIncrement: 1,
+		});
+	});
+
 	it("accepts large backward jumps for seeks", () => {
 		const decision = decideFrameOrder(80, 120, 30);
 		expect(decision).toEqual({
@@ -43,6 +52,15 @@ describe("decideFrameOrder", () => {
 		expect(decision).toEqual({
 			action: "accept",
 			nextLatestFrameNumber: 121,
+			dropsIncrement: 0,
+		});
+	});
+
+	it("accepts wraparound forward progression", () => {
+		const decision = decideFrameOrder(2, 0xffffffff, 30);
+		expect(decision).toEqual({
+			action: "accept",
+			nextLatestFrameNumber: 2,
 			dropsIncrement: 0,
 		});
 	});

--- a/apps/desktop/src/utils/frame-transport-order.test.ts
+++ b/apps/desktop/src/utils/frame-transport-order.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { decideFrameOrder } from "./frame-transport-order";
+
+describe("decideFrameOrder", () => {
+	it("accepts frame when candidate is missing", () => {
+		const decision = decideFrameOrder(null, 120, 30);
+		expect(decision).toEqual({
+			action: "accept",
+			nextLatestFrameNumber: 120,
+			dropsIncrement: 0,
+		});
+	});
+
+	it("accepts first frame and seeds latest", () => {
+		const decision = decideFrameOrder(120, null, 30);
+		expect(decision).toEqual({
+			action: "accept",
+			nextLatestFrameNumber: 120,
+			dropsIncrement: 0,
+		});
+	});
+
+	it("drops short backward stale frames", () => {
+		const decision = decideFrameOrder(119, 120, 30);
+		expect(decision).toEqual({
+			action: "drop",
+			nextLatestFrameNumber: 120,
+			dropsIncrement: 1,
+		});
+	});
+
+	it("accepts large backward jumps for seeks", () => {
+		const decision = decideFrameOrder(80, 120, 30);
+		expect(decision).toEqual({
+			action: "accept",
+			nextLatestFrameNumber: 80,
+			dropsIncrement: 0,
+		});
+	});
+
+	it("accepts forward progression", () => {
+		const decision = decideFrameOrder(121, 120, 30);
+		expect(decision).toEqual({
+			action: "accept",
+			nextLatestFrameNumber: 121,
+			dropsIncrement: 0,
+		});
+	});
+});

--- a/apps/desktop/src/utils/frame-transport-order.ts
+++ b/apps/desktop/src/utils/frame-transport-order.ts
@@ -1,0 +1,49 @@
+import { shouldDropOutOfOrderFrame } from "./frame-order";
+
+export type FrameOrderDecision = {
+	action: "accept" | "drop";
+	nextLatestFrameNumber: number | null;
+	dropsIncrement: number;
+};
+
+export function decideFrameOrder(
+	candidateFrameNumber: number | null,
+	latestFrameNumber: number | null,
+	staleWindow: number,
+): FrameOrderDecision {
+	if (candidateFrameNumber === null) {
+		return {
+			action: "accept",
+			nextLatestFrameNumber: latestFrameNumber,
+			dropsIncrement: 0,
+		};
+	}
+
+	if (latestFrameNumber === null) {
+		return {
+			action: "accept",
+			nextLatestFrameNumber: candidateFrameNumber,
+			dropsIncrement: 0,
+		};
+	}
+
+	if (
+		shouldDropOutOfOrderFrame(
+			candidateFrameNumber,
+			latestFrameNumber,
+			staleWindow,
+		)
+	) {
+		return {
+			action: "drop",
+			nextLatestFrameNumber: latestFrameNumber,
+			dropsIncrement: 1,
+		};
+	}
+
+	return {
+		action: "accept",
+		nextLatestFrameNumber: candidateFrameNumber,
+		dropsIncrement: 0,
+	};
+}

--- a/apps/desktop/src/utils/frame-transport-retry.test.ts
+++ b/apps/desktop/src/utils/frame-transport-retry.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { decideSabWriteFailure } from "./frame-transport-retry";
+
+describe("frame-transport-retry", () => {
+	it("falls back immediately for oversized frames", () => {
+		const decision = decideSabWriteFailure(true, 0, 2);
+		expect(decision).toEqual({
+			action: "fallback_oversize",
+			nextRetryCount: 0,
+		});
+	});
+
+	it("retries while below retry limit", () => {
+		const decision = decideSabWriteFailure(false, 1, 2);
+		expect(decision).toEqual({
+			action: "retry",
+			nextRetryCount: 2,
+		});
+	});
+
+	it("falls back when retry limit is reached", () => {
+		const decision = decideSabWriteFailure(false, 2, 2);
+		expect(decision).toEqual({
+			action: "fallback_retry_limit",
+			nextRetryCount: 0,
+		});
+	});
+});

--- a/apps/desktop/src/utils/frame-transport-retry.ts
+++ b/apps/desktop/src/utils/frame-transport-retry.ts
@@ -1,0 +1,20 @@
+export type SabWriteFailureDecision =
+	| { action: "retry"; nextRetryCount: number }
+	| { action: "fallback_oversize"; nextRetryCount: number }
+	| { action: "fallback_retry_limit"; nextRetryCount: number };
+
+export function decideSabWriteFailure(
+	isOversized: boolean,
+	currentRetryCount: number,
+	retryLimit: number,
+): SabWriteFailureDecision {
+	if (isOversized) {
+		return { action: "fallback_oversize", nextRetryCount: 0 };
+	}
+
+	if (currentRetryCount >= retryLimit) {
+		return { action: "fallback_retry_limit", nextRetryCount: 0 };
+	}
+
+	return { action: "retry", nextRetryCount: currentRetryCount + 1 };
+}

--- a/apps/desktop/src/utils/frame-transport-stride.test.ts
+++ b/apps/desktop/src/utils/frame-transport-stride.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { decideStrideCorrectionDispatch } from "./frame-transport-stride";
+
+describe("decideStrideCorrectionDispatch", () => {
+	it("dispatches immediately when no request is in flight", () => {
+		const decision = decideStrideCorrectionDispatch(false, false);
+		expect(decision).toEqual({
+			action: "dispatch",
+			nextInFlight: true,
+			nextHasPending: false,
+			supersededDropsIncrement: 0,
+			dispatchesIncrement: 1,
+		});
+	});
+
+	it("queues request when worker is in flight without pending", () => {
+		const decision = decideStrideCorrectionDispatch(true, false);
+		expect(decision).toEqual({
+			action: "queue",
+			nextInFlight: true,
+			nextHasPending: true,
+			supersededDropsIncrement: 0,
+			dispatchesIncrement: 0,
+		});
+	});
+
+	it("queues and supersedes older pending request", () => {
+		const decision = decideStrideCorrectionDispatch(true, true);
+		expect(decision).toEqual({
+			action: "queue",
+			nextInFlight: true,
+			nextHasPending: true,
+			supersededDropsIncrement: 1,
+			dispatchesIncrement: 0,
+		});
+	});
+});

--- a/apps/desktop/src/utils/frame-transport-stride.ts
+++ b/apps/desktop/src/utils/frame-transport-stride.ts
@@ -1,0 +1,30 @@
+export type StrideCorrectionDispatchDecision = {
+	action: "dispatch" | "queue";
+	nextInFlight: boolean;
+	nextHasPending: boolean;
+	supersededDropsIncrement: number;
+	dispatchesIncrement: number;
+};
+
+export function decideStrideCorrectionDispatch(
+	inFlight: boolean,
+	hasPending: boolean,
+): StrideCorrectionDispatchDecision {
+	if (!inFlight) {
+		return {
+			action: "dispatch",
+			nextInFlight: true,
+			nextHasPending: hasPending,
+			supersededDropsIncrement: 0,
+			dispatchesIncrement: 1,
+		};
+	}
+
+	return {
+		action: "queue",
+		nextInFlight: true,
+		nextHasPending: true,
+		supersededDropsIncrement: hasPending ? 1 : 0,
+		dispatchesIncrement: 0,
+	};
+}

--- a/apps/desktop/src/utils/frame-worker.ts
+++ b/apps/desktop/src/utils/frame-worker.ts
@@ -51,13 +51,6 @@ interface RendererModeMessage {
 	mode: "webgpu" | "canvas2d";
 }
 
-interface DecodedFrame {
-	type: "decoded";
-	bitmap: ImageBitmap;
-	width: number;
-	height: number;
-}
-
 interface ErrorMessage {
 	type: "error";
 	message: string;
@@ -70,7 +63,6 @@ interface RequestFrameMessage {
 export type {
 	FrameRenderedMessage,
 	RendererModeMessage,
-	DecodedFrame,
 	ErrorMessage,
 	ReadyMessage,
 	RequestFrameMessage,

--- a/apps/desktop/src/utils/frame-worker.ts
+++ b/apps/desktop/src/utils/frame-worker.ts
@@ -930,9 +930,7 @@ self.onmessage = async (e: MessageEvent<IncomingMessage>) => {
 
 	if (e.data.type === "frame") {
 		const result = processFrameBytesSync(new Uint8Array(e.data.buffer));
-		if (result.type === "frame-queued") {
-			self.postMessage(result);
-		} else if (result.type === "error") {
+		if (result.type === "error") {
 			self.postMessage(result);
 		}
 	}

--- a/apps/desktop/src/utils/frame-worker.ts
+++ b/apps/desktop/src/utils/frame-worker.ts
@@ -158,7 +158,7 @@ function tryPollSharedBuffer(): boolean {
 		if (!borrowed) {
 			return false;
 		}
-		queueFrameFromBytes(borrowed.data, borrowed.release);
+		queueFrameFromBytes(borrowed.data, borrowed.release, false);
 		return true;
 	}
 	return false;
@@ -283,6 +283,7 @@ function drainAndRenderLatestSharedWebGPU(maxDrain: number): boolean {
 function queueFrameFromBytes(
 	bytes: Uint8Array,
 	releaseCallback?: () => void,
+	emitQueuedMessage: boolean = true,
 ): void {
 	const meta = parseFrameMetadata(bytes);
 	if (!meta) {
@@ -375,11 +376,13 @@ function queueFrameFromBytes(
 		});
 	}
 
-	self.postMessage({
-		type: "frame-queued",
-		width,
-		height,
-	} satisfies FrameQueuedMessage);
+	if (emitQueuedMessage) {
+		self.postMessage({
+			type: "frame-queued",
+			width,
+			height,
+		} satisfies FrameQueuedMessage);
+	}
 }
 
 function renderLoop() {

--- a/apps/desktop/src/utils/shared-frame-buffer.test.ts
+++ b/apps/desktop/src/utils/shared-frame-buffer.test.ts
@@ -3,6 +3,7 @@ import {
 	createConsumer,
 	createProducer,
 	createSharedFrameBuffer,
+	frameAge,
 } from "./shared-frame-buffer";
 
 function makeFrame(...bytes: number[]): ArrayBuffer {
@@ -17,6 +18,12 @@ function readFirstByte(frame: ArrayBuffer | null): number | null {
 }
 
 describe("shared-frame-buffer", () => {
+	it("computes frame age across u32 wrap", () => {
+		expect(frameAge(1, 0xffffffff)).toBe(2);
+		expect(frameAge(0xffffffff, 0xfffffffe)).toBe(1);
+		expect(frameAge(100, 100)).toBe(0);
+	});
+
 	it("claims alternate writable slot when write index slot is busy", () => {
 		const init = createSharedFrameBuffer({ slotCount: 3, slotSize: 64 });
 		const producer = createProducer(init);

--- a/apps/desktop/src/utils/shared-frame-buffer.test.ts
+++ b/apps/desktop/src/utils/shared-frame-buffer.test.ts
@@ -62,4 +62,23 @@ describe("shared-frame-buffer", () => {
 
 		held?.release();
 	});
+
+	it("readInto consumes sparse-ready slot and returns size", () => {
+		const init = createSharedFrameBuffer({ slotCount: 3, slotSize: 64 });
+		const producer = createProducer(init);
+		const consumer = createConsumer(init.buffer);
+
+		expect(producer.write(makeFrame(21, 22, 23))).toBe(true);
+		expect(producer.write(makeFrame(31, 32))).toBe(true);
+
+		const held = consumer.borrow(0);
+		expect(held?.data[0]).toBe(21);
+
+		const target = new Uint8Array(64);
+		const bytesRead = consumer.readInto(target, 0);
+		expect(bytesRead).toBe(2);
+		expect(Array.from(target.subarray(0, 2))).toEqual([31, 32]);
+
+		held?.release();
+	});
 });

--- a/apps/desktop/src/utils/shared-frame-buffer.test.ts
+++ b/apps/desktop/src/utils/shared-frame-buffer.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+	createConsumer,
+	createProducer,
+	createSharedFrameBuffer,
+} from "./shared-frame-buffer";
+
+function makeFrame(...bytes: number[]): ArrayBuffer {
+	return new Uint8Array(bytes).buffer;
+}
+
+function readFirstByte(frame: ArrayBuffer | null): number | null {
+	if (!frame) return null;
+	const view = new Uint8Array(frame);
+	if (view.byteLength === 0) return null;
+	return view[0];
+}
+
+describe("shared-frame-buffer", () => {
+	it("claims alternate writable slot when write index slot is busy", () => {
+		const init = createSharedFrameBuffer({ slotCount: 3, slotSize: 64 });
+		const producer = createProducer(init);
+		const consumer = createConsumer(init.buffer);
+
+		expect(producer.write(makeFrame(1))).toBe(true);
+		expect(producer.write(makeFrame(2))).toBe(true);
+
+		const held = consumer.borrow(0);
+		expect(held).not.toBeNull();
+		expect(held && held.data[0]).toBe(1);
+
+		const next = consumer.read(0);
+		expect(readFirstByte(next)).toBe(2);
+
+		expect(producer.write(makeFrame(3))).toBe(true);
+		expect(producer.write(makeFrame(4))).toBe(true);
+
+		held?.release();
+
+		const firstRemaining = consumer.read(0);
+		const secondRemaining = consumer.read(0);
+		const remaining = [readFirstByte(firstRemaining), readFirstByte(secondRemaining)]
+			.filter((value): value is number => value !== null)
+			.sort((a, b) => a - b);
+		expect(remaining).toEqual([3, 4]);
+	});
+
+	it("reads ready slot beyond current read index", () => {
+		const init = createSharedFrameBuffer({ slotCount: 3, slotSize: 64 });
+		const producer = createProducer(init);
+		const consumer = createConsumer(init.buffer);
+
+		expect(producer.write(makeFrame(10))).toBe(true);
+		expect(producer.write(makeFrame(11))).toBe(true);
+
+		const held = consumer.borrow(0);
+		expect(held).not.toBeNull();
+		expect(held && held.data[0]).toBe(10);
+
+		const bypassRead = consumer.read(0);
+		expect(readFirstByte(bypassRead)).toBe(11);
+
+		held?.release();
+	});
+});

--- a/apps/desktop/src/utils/shared-frame-buffer.ts
+++ b/apps/desktop/src/utils/shared-frame-buffer.ts
@@ -34,6 +34,15 @@ export interface SharedFrameBufferInit {
 	config: SharedFrameBufferConfig;
 }
 
+export function frameAge(
+	currentFrameNumber: number,
+	candidateFrameNumber: number,
+): number {
+	const current = currentFrameNumber >>> 0;
+	const candidate = candidateFrameNumber >>> 0;
+	return (current - candidate) >>> 0;
+}
+
 export function isSharedArrayBufferSupported(): boolean {
 	try {
 		return (
@@ -189,9 +198,9 @@ export function createProducer(init: SharedFrameBufferInit): Producer {
 								metadataView,
 								candidateMetaIdx + META_FRAME_NUMBER,
 							) >>> 0;
-						const frameAge = (frameCounter - frameNumber) >>> 0;
-						if (frameAge > oldestFrameAge) {
-							oldestFrameAge = frameAge;
+						const candidateAge = frameAge(frameCounter, frameNumber);
+						if (candidateAge > oldestFrameAge) {
+							oldestFrameAge = candidateAge;
 							oldestIdx = candidateIdx;
 							oldestMetaIdx = candidateMetaIdx;
 						}

--- a/apps/desktop/src/utils/shared-frame-buffer.ts
+++ b/apps/desktop/src/utils/shared-frame-buffer.ts
@@ -277,6 +277,7 @@ export function createProducer(init: SharedFrameBufferInit): Producer {
 						SLOT_STATE.READY,
 					);
 					Atomics.notify(metadataView, slotMetaIdx + META_SLOT_STATE, 1);
+					Atomics.notify(metadataView, CONTROL_WRITE_INDEX, 1);
 					return true;
 				}
 
@@ -399,16 +400,14 @@ export function createConsumer(buffer: SharedArrayBuffer): Consumer {
 				const baseReadIdx = Atomics.load(controlView, CONTROL_READ_INDEX);
 				const claimed = claimReadySlot(baseReadIdx);
 				if (!claimed) {
-					const waitSlotMetaIdx =
-						(metadataOffset + baseReadIdx * METADATA_ENTRY_SIZE) / 4;
-					const waitState = Atomics.load(
-						metadataView,
-						waitSlotMetaIdx + META_SLOT_STATE,
+					const observedWriteIdx = Atomics.load(
+						controlView,
+						CONTROL_WRITE_INDEX,
 					);
 					const waitResult = Atomics.wait(
 						metadataView,
-						waitSlotMetaIdx + META_SLOT_STATE,
-						waitState,
+						CONTROL_WRITE_INDEX,
+						observedWriteIdx,
 						timeoutMs,
 					);
 					if (waitResult === "timed-out") {
@@ -478,16 +477,14 @@ export function createConsumer(buffer: SharedArrayBuffer): Consumer {
 				const baseReadIdx = Atomics.load(controlView, CONTROL_READ_INDEX);
 				const claimed = claimReadySlot(baseReadIdx);
 				if (!claimed) {
-					const waitSlotMetaIdx =
-						(metadataOffset + baseReadIdx * METADATA_ENTRY_SIZE) / 4;
-					const waitState = Atomics.load(
-						metadataView,
-						waitSlotMetaIdx + META_SLOT_STATE,
+					const observedWriteIdx = Atomics.load(
+						controlView,
+						CONTROL_WRITE_INDEX,
 					);
 					const waitResult = Atomics.wait(
 						metadataView,
-						waitSlotMetaIdx + META_SLOT_STATE,
-						waitState,
+						CONTROL_WRITE_INDEX,
+						observedWriteIdx,
 						timeoutMs,
 					);
 					if (waitResult === "timed-out") {
@@ -555,16 +552,14 @@ export function createConsumer(buffer: SharedArrayBuffer): Consumer {
 				const baseReadIdx = Atomics.load(controlView, CONTROL_READ_INDEX);
 				const claimed = claimReadySlot(baseReadIdx);
 				if (!claimed) {
-					const waitSlotMetaIdx =
-						(metadataOffset + baseReadIdx * METADATA_ENTRY_SIZE) / 4;
-					const waitState = Atomics.load(
-						metadataView,
-						waitSlotMetaIdx + META_SLOT_STATE,
+					const observedWriteIdx = Atomics.load(
+						controlView,
+						CONTROL_WRITE_INDEX,
 					);
 					const waitResult = Atomics.wait(
 						metadataView,
-						waitSlotMetaIdx + META_SLOT_STATE,
-						waitState,
+						CONTROL_WRITE_INDEX,
+						observedWriteIdx,
 						timeoutMs,
 					);
 					if (waitResult === "timed-out") {

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -63,6 +63,10 @@ export type FpsStats = {
 	queuedOutOfOrderDropsWindow: number;
 	directOutOfOrderDropsTotal: number;
 	directOutOfOrderDropsWindow: number;
+	directIngressOutOfOrderDropsTotal: number;
+	directIngressOutOfOrderDropsWindow: number;
+	directResponseOutOfOrderDropsTotal: number;
+	directResponseOutOfOrderDropsWindow: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -287,6 +291,8 @@ export function createImageDataWS(
 		renderedFromWorkerWindow = 0;
 		queuedOutOfOrderDropsWindow = 0;
 		directOutOfOrderDropsWindow = 0;
+		directIngressOutOfOrderDropsWindow = 0;
+		directResponseOutOfOrderDropsWindow = 0;
 		latestQueuedFrameNumber = null;
 		latestDirectAcceptedFrameNumber = null;
 		lastDirectRenderedFrameNumber = null;
@@ -372,6 +378,10 @@ export function createImageDataWS(
 				if (responseOrderDecision.action === "drop") {
 					directOutOfOrderDropsTotal += responseOrderDecision.dropsIncrement;
 					directOutOfOrderDropsWindow += responseOrderDecision.dropsIncrement;
+					directResponseOutOfOrderDropsTotal +=
+						responseOrderDecision.dropsIncrement;
+					directResponseOutOfOrderDropsWindow +=
+						responseOrderDecision.dropsIncrement;
 					return;
 				}
 				lastDirectRenderedFrameNumber =
@@ -676,6 +686,10 @@ export function createImageDataWS(
 	let queuedOutOfOrderDropsWindow = 0;
 	let directOutOfOrderDropsTotal = 0;
 	let directOutOfOrderDropsWindow = 0;
+	let directIngressOutOfOrderDropsTotal = 0;
+	let directIngressOutOfOrderDropsWindow = 0;
+	let directResponseOutOfOrderDropsTotal = 0;
+	let directResponseOutOfOrderDropsWindow = 0;
 	let totalSupersededDrops = 0;
 	let lastLogTime = 0;
 	let framesReceived = 0;
@@ -721,6 +735,10 @@ export function createImageDataWS(
 		queuedOutOfOrderDropsWindow,
 		directOutOfOrderDropsTotal,
 		directOutOfOrderDropsWindow,
+		directIngressOutOfOrderDropsTotal,
+		directIngressOutOfOrderDropsWindow,
+		directResponseOutOfOrderDropsTotal,
+		directResponseOutOfOrderDropsWindow,
 		sabTotalRetryAttempts: totalSabRetryAttempts,
 		sabTotalFramesReceived: totalFramesReceived,
 		sabTotalFramesWrittenToSharedBuffer: totalFramesWrittenToSharedBuffer,
@@ -758,7 +776,7 @@ export function createImageDataWS(
 					framesReceived > 0 ? (framesDropped / framesReceived) * 100 : 0;
 
 				console.log(
-					`[Frame] recv: ${recvFps.toFixed(1)}/s, sent: ${sentFps.toFixed(1)}/s, ACTUAL: ${actualFps.toFixed(1)}/s, dropped: ${dropRate.toFixed(0)}%, delta: ${avgDelta.toFixed(1)}ms, ${mbPerSec.toFixed(1)} MB/s, RGBA, sab_resizes: ${sharedBufferResizeCount}, sab_fallbacks_window: ${sabFallbackWindowCount}, sab_fallbacks_total: ${sabFallbackCount}, sab_oversize_fallbacks_window: ${sabOversizeFallbackWindowCount}, sab_oversize_fallbacks_total: ${sabOversizeFallbackCount}, sab_retry_limit_fallbacks_window: ${sabRetryLimitFallbackWindowCount}, sab_retry_limit_fallbacks_total: ${sabRetryLimitFallbackCount}, sab_retries: ${sabWriteRetryCount}, worker_inflight: ${workerFramesInFlight}, worker_inflight_peak_window: ${workerFramesInFlightPeakWindow}, worker_inflight_peak_total: ${workerFramesInFlightPeakTotal}, worker_cap_hits_window: ${workerInFlightBackpressureWindowHits}, worker_cap_hits_total: ${totalWorkerInFlightBackpressureHits}, worker_superseded_window: ${workerInFlightSupersededDropsWindow}, worker_superseded_total: ${totalWorkerInFlightSupersededDrops}, rendered_shared_window: ${renderedFromSharedWindow}, rendered_shared_total: ${renderedFromSharedTotal}, rendered_worker_window: ${renderedFromWorkerWindow}, rendered_worker_total: ${renderedFromWorkerTotal}, queued_ooo_window: ${queuedOutOfOrderDropsWindow}, queued_ooo_total: ${queuedOutOfOrderDropsTotal}, direct_ooo_window: ${directOutOfOrderDropsWindow}, direct_ooo_total: ${directOutOfOrderDropsTotal}`,
+					`[Frame] recv: ${recvFps.toFixed(1)}/s, sent: ${sentFps.toFixed(1)}/s, ACTUAL: ${actualFps.toFixed(1)}/s, dropped: ${dropRate.toFixed(0)}%, delta: ${avgDelta.toFixed(1)}ms, ${mbPerSec.toFixed(1)} MB/s, RGBA, sab_resizes: ${sharedBufferResizeCount}, sab_fallbacks_window: ${sabFallbackWindowCount}, sab_fallbacks_total: ${sabFallbackCount}, sab_oversize_fallbacks_window: ${sabOversizeFallbackWindowCount}, sab_oversize_fallbacks_total: ${sabOversizeFallbackCount}, sab_retry_limit_fallbacks_window: ${sabRetryLimitFallbackWindowCount}, sab_retry_limit_fallbacks_total: ${sabRetryLimitFallbackCount}, sab_retries: ${sabWriteRetryCount}, worker_inflight: ${workerFramesInFlight}, worker_inflight_peak_window: ${workerFramesInFlightPeakWindow}, worker_inflight_peak_total: ${workerFramesInFlightPeakTotal}, worker_cap_hits_window: ${workerInFlightBackpressureWindowHits}, worker_cap_hits_total: ${totalWorkerInFlightBackpressureHits}, worker_superseded_window: ${workerInFlightSupersededDropsWindow}, worker_superseded_total: ${totalWorkerInFlightSupersededDrops}, rendered_shared_window: ${renderedFromSharedWindow}, rendered_shared_total: ${renderedFromSharedTotal}, rendered_worker_window: ${renderedFromWorkerWindow}, rendered_worker_total: ${renderedFromWorkerTotal}, queued_ooo_window: ${queuedOutOfOrderDropsWindow}, queued_ooo_total: ${queuedOutOfOrderDropsTotal}, direct_ooo_window: ${directOutOfOrderDropsWindow}, direct_ooo_total: ${directOutOfOrderDropsTotal}, direct_ingress_ooo_window: ${directIngressOutOfOrderDropsWindow}, direct_ingress_ooo_total: ${directIngressOutOfOrderDropsTotal}, direct_response_ooo_window: ${directResponseOutOfOrderDropsWindow}, direct_response_ooo_total: ${directResponseOutOfOrderDropsTotal}`,
 				);
 
 				frameCount = 0;
@@ -779,6 +797,8 @@ export function createImageDataWS(
 				renderedFromWorkerWindow = 0;
 				queuedOutOfOrderDropsWindow = 0;
 				directOutOfOrderDropsWindow = 0;
+				directIngressOutOfOrderDropsWindow = 0;
+				directResponseOutOfOrderDropsWindow = 0;
 				sabWriteRetryCount = 0;
 				minFrameTime = Number.MAX_VALUE;
 				maxFrameTime = 0;
@@ -830,6 +850,8 @@ export function createImageDataWS(
 		if (directOrderDecision.action === "drop") {
 			directOutOfOrderDropsTotal += directOrderDecision.dropsIncrement;
 			directOutOfOrderDropsWindow += directOrderDecision.dropsIncrement;
+			directIngressOutOfOrderDropsTotal += directOrderDecision.dropsIncrement;
+			directIngressOutOfOrderDropsWindow += directOrderDecision.dropsIncrement;
 			return;
 		}
 		latestDirectAcceptedFrameNumber = directOrderDecision.nextLatestFrameNumber;

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -77,6 +77,8 @@ export type FpsStats = {
 	strideCorrectionDispatchesWindow: number;
 	strideCorrectionSupersededDropsTotal: number;
 	strideCorrectionSupersededDropsWindow: number;
+	strideCorrectionErrorsTotal: number;
+	strideCorrectionErrorsWindow: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -309,6 +311,7 @@ export function createImageDataWS(
 		directResponseOutOfOrderDropsWindow = 0;
 		strideCorrectionDispatchesWindow = 0;
 		strideCorrectionSupersededDropsWindow = 0;
+		strideCorrectionErrorsWindow = 0;
 		latestQueuedFrameNumber = null;
 		latestDirectAcceptedFrameNumber = null;
 		lastDirectRenderedFrameNumber = null;
@@ -405,6 +408,8 @@ export function createImageDataWS(
 			};
 
 			if (e.data.type === "error") {
+				strideCorrectionErrorsTotal++;
+				strideCorrectionErrorsWindow++;
 				strideWorkerInFlight = false;
 				flushPending();
 				return;
@@ -801,6 +806,8 @@ export function createImageDataWS(
 	let strideCorrectionDispatchesWindow = 0;
 	let strideCorrectionSupersededDropsTotal = 0;
 	let strideCorrectionSupersededDropsWindow = 0;
+	let strideCorrectionErrorsTotal = 0;
+	let strideCorrectionErrorsWindow = 0;
 	let totalSupersededDrops = 0;
 	let lastLogTime = 0;
 	let framesReceived = 0;
@@ -855,6 +862,8 @@ export function createImageDataWS(
 		strideCorrectionDispatchesWindow,
 		strideCorrectionSupersededDropsTotal,
 		strideCorrectionSupersededDropsWindow,
+		strideCorrectionErrorsTotal,
+		strideCorrectionErrorsWindow,
 		sabTotalRetryAttempts: totalSabRetryAttempts,
 		sabTotalFramesReceived: totalFramesReceived,
 		sabTotalFramesWrittenToSharedBuffer: totalFramesWrittenToSharedBuffer,
@@ -892,7 +901,7 @@ export function createImageDataWS(
 					framesReceived > 0 ? (framesDropped / framesReceived) * 100 : 0;
 
 				console.log(
-					`[Frame] recv: ${recvFps.toFixed(1)}/s, sent: ${sentFps.toFixed(1)}/s, ACTUAL: ${actualFps.toFixed(1)}/s, dropped: ${dropRate.toFixed(0)}%, delta: ${avgDelta.toFixed(1)}ms, ${mbPerSec.toFixed(1)} MB/s, RGBA, sab_resizes: ${sharedBufferResizeCount}, sab_fallbacks_window: ${sabFallbackWindowCount}, sab_fallbacks_total: ${sabFallbackCount}, sab_oversize_fallbacks_window: ${sabOversizeFallbackWindowCount}, sab_oversize_fallbacks_total: ${sabOversizeFallbackCount}, sab_retry_limit_fallbacks_window: ${sabRetryLimitFallbackWindowCount}, sab_retry_limit_fallbacks_total: ${sabRetryLimitFallbackCount}, sab_retries: ${sabWriteRetryCount}, worker_inflight: ${workerFramesInFlight}, worker_inflight_peak_window: ${workerFramesInFlightPeakWindow}, worker_inflight_peak_total: ${workerFramesInFlightPeakTotal}, worker_cap_hits_window: ${workerInFlightBackpressureWindowHits}, worker_cap_hits_total: ${totalWorkerInFlightBackpressureHits}, worker_superseded_window: ${workerInFlightSupersededDropsWindow}, worker_superseded_total: ${totalWorkerInFlightSupersededDrops}, rendered_shared_window: ${renderedFromSharedWindow}, rendered_shared_total: ${renderedFromSharedTotal}, rendered_worker_window: ${renderedFromWorkerWindow}, rendered_worker_total: ${renderedFromWorkerTotal}, queued_ooo_window: ${queuedOutOfOrderDropsWindow}, queued_ooo_total: ${queuedOutOfOrderDropsTotal}, direct_ooo_window: ${directOutOfOrderDropsWindow}, direct_ooo_total: ${directOutOfOrderDropsTotal}, direct_ingress_ooo_window: ${directIngressOutOfOrderDropsWindow}, direct_ingress_ooo_total: ${directIngressOutOfOrderDropsTotal}, direct_response_ooo_window: ${directResponseOutOfOrderDropsWindow}, direct_response_ooo_total: ${directResponseOutOfOrderDropsTotal}, stride_corr_inflight: ${strideWorkerInFlight ? 1 : 0}, stride_corr_pending: ${pendingStrideCorrection ? 1 : 0}, stride_corr_dispatches_window: ${strideCorrectionDispatchesWindow}, stride_corr_dispatches_total: ${strideCorrectionDispatchesTotal}, stride_corr_superseded_window: ${strideCorrectionSupersededDropsWindow}, stride_corr_superseded_total: ${strideCorrectionSupersededDropsTotal}`,
+					`[Frame] recv: ${recvFps.toFixed(1)}/s, sent: ${sentFps.toFixed(1)}/s, ACTUAL: ${actualFps.toFixed(1)}/s, dropped: ${dropRate.toFixed(0)}%, delta: ${avgDelta.toFixed(1)}ms, ${mbPerSec.toFixed(1)} MB/s, RGBA, sab_resizes: ${sharedBufferResizeCount}, sab_fallbacks_window: ${sabFallbackWindowCount}, sab_fallbacks_total: ${sabFallbackCount}, sab_oversize_fallbacks_window: ${sabOversizeFallbackWindowCount}, sab_oversize_fallbacks_total: ${sabOversizeFallbackCount}, sab_retry_limit_fallbacks_window: ${sabRetryLimitFallbackWindowCount}, sab_retry_limit_fallbacks_total: ${sabRetryLimitFallbackCount}, sab_retries: ${sabWriteRetryCount}, worker_inflight: ${workerFramesInFlight}, worker_inflight_peak_window: ${workerFramesInFlightPeakWindow}, worker_inflight_peak_total: ${workerFramesInFlightPeakTotal}, worker_cap_hits_window: ${workerInFlightBackpressureWindowHits}, worker_cap_hits_total: ${totalWorkerInFlightBackpressureHits}, worker_superseded_window: ${workerInFlightSupersededDropsWindow}, worker_superseded_total: ${totalWorkerInFlightSupersededDrops}, rendered_shared_window: ${renderedFromSharedWindow}, rendered_shared_total: ${renderedFromSharedTotal}, rendered_worker_window: ${renderedFromWorkerWindow}, rendered_worker_total: ${renderedFromWorkerTotal}, queued_ooo_window: ${queuedOutOfOrderDropsWindow}, queued_ooo_total: ${queuedOutOfOrderDropsTotal}, direct_ooo_window: ${directOutOfOrderDropsWindow}, direct_ooo_total: ${directOutOfOrderDropsTotal}, direct_ingress_ooo_window: ${directIngressOutOfOrderDropsWindow}, direct_ingress_ooo_total: ${directIngressOutOfOrderDropsTotal}, direct_response_ooo_window: ${directResponseOutOfOrderDropsWindow}, direct_response_ooo_total: ${directResponseOutOfOrderDropsTotal}, stride_corr_inflight: ${strideWorkerInFlight ? 1 : 0}, stride_corr_pending: ${pendingStrideCorrection ? 1 : 0}, stride_corr_dispatches_window: ${strideCorrectionDispatchesWindow}, stride_corr_dispatches_total: ${strideCorrectionDispatchesTotal}, stride_corr_superseded_window: ${strideCorrectionSupersededDropsWindow}, stride_corr_superseded_total: ${strideCorrectionSupersededDropsTotal}, stride_corr_errors_window: ${strideCorrectionErrorsWindow}, stride_corr_errors_total: ${strideCorrectionErrorsTotal}`,
 				);
 
 				frameCount = 0;
@@ -917,6 +926,7 @@ export function createImageDataWS(
 				directResponseOutOfOrderDropsWindow = 0;
 				strideCorrectionDispatchesWindow = 0;
 				strideCorrectionSupersededDropsWindow = 0;
+				strideCorrectionErrorsWindow = 0;
 				sabWriteRetryCount = 0;
 				minFrameTime = Number.MAX_VALUE;
 				maxFrameTime = 0;

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -83,13 +83,6 @@ interface FrameRenderedMessage {
 	height: number;
 }
 
-interface DecodedFrame {
-	type: "decoded";
-	bitmap: ImageBitmap;
-	width: number;
-	height: number;
-}
-
 interface ErrorMessage {
 	type: "error";
 	message: string;
@@ -102,7 +95,6 @@ interface RequestFrameMessage {
 type WorkerMessage =
 	| ReadyMessage
 	| FrameRenderedMessage
-	| DecodedFrame
 	| ErrorMessage
 	| RequestFrameMessage;
 
@@ -409,13 +401,6 @@ export function createImageDataWS(
 		if (e.data.type === "request-frame") {
 			onRequestFrame?.();
 			return;
-		}
-
-		if (e.data.type === "decoded") {
-			const { bitmap, width, height } = e.data;
-			onmessage({ width, height, bitmap });
-			isProcessing = false;
-			processNextFrame();
 		}
 	};
 

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -89,6 +89,7 @@ interface FrameRenderedMessage {
 	type: "frame-rendered";
 	width: number;
 	height: number;
+	source: "shared" | "worker";
 }
 
 interface ErrorMessage {
@@ -407,9 +408,9 @@ export function createImageDataWS(
 		}
 
 		if (e.data.type === "frame-rendered") {
-			const { width, height } = e.data;
+			const { width, height, source } = e.data;
 			onmessage({ width, height });
-			if (workerFramesInFlight > 0) {
+			if (source === "worker" && workerFramesInFlight > 0) {
 				workerFramesInFlight--;
 			}
 			actualRendersCount++;

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -501,7 +501,6 @@ export function createImageDataWS(
 						totalSupersededDrops++;
 					}
 					nextFrame = buffer;
-					scheduleProcessNextFrame();
 					return;
 				}
 				framesSentToWorker++;
@@ -532,7 +531,6 @@ export function createImageDataWS(
 					totalSupersededDrops++;
 				}
 				nextFrame = buffer;
-				scheduleProcessNextFrame();
 				return;
 			}
 			framesSentToWorker++;

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -41,6 +41,7 @@ export type FpsStats = {
 	sabSlotSizeBytes: number;
 	sabSlotCount: number;
 	sabTotalBytes: number;
+	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
 	sabTotalFramesSentToWorker: number;
@@ -463,8 +464,10 @@ export function createImageDataWS(
 
 				if (decision.action === "retry") {
 					isProcessing = false;
+					totalSabRetryAttempts++;
 					if (nextFrame) {
 						framesDropped++;
+						totalSupersededDrops++;
 					}
 					nextFrame = buffer;
 					if (!sabRetryScheduled) {
@@ -519,6 +522,7 @@ export function createImageDataWS(
 	let frameCount = 0;
 	let frameTimeSum = 0;
 	let totalBytesReceived = 0;
+	let totalSabRetryAttempts = 0;
 	let totalFramesReceived = 0;
 	let totalFramesWrittenToSharedBuffer = 0;
 	let totalFramesSentToWorker = 0;
@@ -552,6 +556,7 @@ export function createImageDataWS(
 		sabTotalBytes:
 			(sharedBufferConfig?.slotSize ?? 0) *
 			(sharedBufferConfig?.slotCount ?? 0),
+		sabTotalRetryAttempts: totalSabRetryAttempts,
 		sabTotalFramesReceived: totalFramesReceived,
 		sabTotalFramesWrittenToSharedBuffer: totalFramesWrittenToSharedBuffer,
 		sabTotalFramesSentToWorker: totalFramesSentToWorker,

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -83,12 +83,6 @@ interface FrameRenderedMessage {
 	height: number;
 }
 
-interface FrameQueuedMessage {
-	type: "frame-queued";
-	width: number;
-	height: number;
-}
-
 interface DecodedFrame {
 	type: "decoded";
 	bitmap: ImageBitmap;
@@ -108,7 +102,6 @@ interface RequestFrameMessage {
 type WorkerMessage =
 	| ReadyMessage
 	| FrameRenderedMessage
-	| FrameQueuedMessage
 	| DecodedFrame
 	| ErrorMessage
 	| RequestFrameMessage;
@@ -398,12 +391,6 @@ export function createImageDataWS(
 
 		if (e.data.type === "error") {
 			console.error("[FrameWorker]", e.data.message);
-			isProcessing = false;
-			processNextFrame();
-			return;
-		}
-
-		if (e.data.type === "frame-queued") {
 			isProcessing = false;
 			processNextFrame();
 			return;

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -165,22 +165,12 @@ export function createImageDataWS(
 		height: number,
 		strideBytes: number,
 	) {
-		if (
-			lastRenderedFrameData &&
-			lastRenderedFrameData.data.length === frameData.length
-		) {
-			lastRenderedFrameData.data.set(frameData);
-			lastRenderedFrameData.width = width;
-			lastRenderedFrameData.height = height;
-			lastRenderedFrameData.strideBytes = strideBytes;
-		} else {
-			lastRenderedFrameData = {
-				data: new Uint8ClampedArray(frameData),
-				width,
-				height,
-				strideBytes,
-			};
-		}
+		lastRenderedFrameData = {
+			data: frameData,
+			width,
+			height,
+			strideBytes,
+		};
 		if (!hasRenderedFrame()) {
 			setHasRenderedFrame(true);
 		}

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -53,6 +53,10 @@ export type FpsStats = {
 	workerFramesInFlightPeakTotal: number;
 	workerInFlightSupersededDrops: number;
 	workerInFlightSupersededDropsWindow: number;
+	renderedFromSharedTotal: number;
+	renderedFromSharedWindow: number;
+	renderedFromWorkerTotal: number;
+	renderedFromWorkerWindow: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -270,6 +274,8 @@ export function createImageDataWS(
 		workerInFlightBackpressureWindowHits = 0;
 		workerFramesInFlightPeakWindow = 0;
 		workerInFlightSupersededDropsWindow = 0;
+		renderedFromSharedWindow = 0;
+		renderedFromWorkerWindow = 0;
 
 		if (mainThreadWebGPU) {
 			disposeWebGPU(mainThreadWebGPU);
@@ -416,6 +422,13 @@ export function createImageDataWS(
 			onmessage({ width, height });
 			if (source === "worker" && workerFramesInFlight > 0) {
 				workerFramesInFlight--;
+			}
+			if (source === "worker") {
+				renderedFromWorkerTotal++;
+				renderedFromWorkerWindow++;
+			} else {
+				renderedFromSharedTotal++;
+				renderedFromSharedWindow++;
 			}
 			actualRendersCount++;
 			if (!hasRenderedFrame()) {
@@ -600,6 +613,10 @@ export function createImageDataWS(
 	let workerFramesInFlightPeakTotal = 0;
 	let totalWorkerInFlightSupersededDrops = 0;
 	let workerInFlightSupersededDropsWindow = 0;
+	let renderedFromSharedTotal = 0;
+	let renderedFromSharedWindow = 0;
+	let renderedFromWorkerTotal = 0;
+	let renderedFromWorkerWindow = 0;
 	let totalSupersededDrops = 0;
 	let lastLogTime = 0;
 	let framesReceived = 0;
@@ -637,6 +654,10 @@ export function createImageDataWS(
 		workerFramesInFlightPeakTotal,
 		workerInFlightSupersededDrops: totalWorkerInFlightSupersededDrops,
 		workerInFlightSupersededDropsWindow: workerInFlightSupersededDropsWindow,
+		renderedFromSharedTotal,
+		renderedFromSharedWindow,
+		renderedFromWorkerTotal,
+		renderedFromWorkerWindow,
 		sabTotalRetryAttempts: totalSabRetryAttempts,
 		sabTotalFramesReceived: totalFramesReceived,
 		sabTotalFramesWrittenToSharedBuffer: totalFramesWrittenToSharedBuffer,
@@ -674,7 +695,7 @@ export function createImageDataWS(
 					framesReceived > 0 ? (framesDropped / framesReceived) * 100 : 0;
 
 				console.log(
-					`[Frame] recv: ${recvFps.toFixed(1)}/s, sent: ${sentFps.toFixed(1)}/s, ACTUAL: ${actualFps.toFixed(1)}/s, dropped: ${dropRate.toFixed(0)}%, delta: ${avgDelta.toFixed(1)}ms, ${mbPerSec.toFixed(1)} MB/s, RGBA, sab_resizes: ${sharedBufferResizeCount}, sab_fallbacks_window: ${sabFallbackWindowCount}, sab_fallbacks_total: ${sabFallbackCount}, sab_oversize_fallbacks_window: ${sabOversizeFallbackWindowCount}, sab_oversize_fallbacks_total: ${sabOversizeFallbackCount}, sab_retry_limit_fallbacks_window: ${sabRetryLimitFallbackWindowCount}, sab_retry_limit_fallbacks_total: ${sabRetryLimitFallbackCount}, sab_retries: ${sabWriteRetryCount}, worker_inflight: ${workerFramesInFlight}, worker_inflight_peak_window: ${workerFramesInFlightPeakWindow}, worker_inflight_peak_total: ${workerFramesInFlightPeakTotal}, worker_cap_hits_window: ${workerInFlightBackpressureWindowHits}, worker_cap_hits_total: ${totalWorkerInFlightBackpressureHits}, worker_superseded_window: ${workerInFlightSupersededDropsWindow}, worker_superseded_total: ${totalWorkerInFlightSupersededDrops}`,
+					`[Frame] recv: ${recvFps.toFixed(1)}/s, sent: ${sentFps.toFixed(1)}/s, ACTUAL: ${actualFps.toFixed(1)}/s, dropped: ${dropRate.toFixed(0)}%, delta: ${avgDelta.toFixed(1)}ms, ${mbPerSec.toFixed(1)} MB/s, RGBA, sab_resizes: ${sharedBufferResizeCount}, sab_fallbacks_window: ${sabFallbackWindowCount}, sab_fallbacks_total: ${sabFallbackCount}, sab_oversize_fallbacks_window: ${sabOversizeFallbackWindowCount}, sab_oversize_fallbacks_total: ${sabOversizeFallbackCount}, sab_retry_limit_fallbacks_window: ${sabRetryLimitFallbackWindowCount}, sab_retry_limit_fallbacks_total: ${sabRetryLimitFallbackCount}, sab_retries: ${sabWriteRetryCount}, worker_inflight: ${workerFramesInFlight}, worker_inflight_peak_window: ${workerFramesInFlightPeakWindow}, worker_inflight_peak_total: ${workerFramesInFlightPeakTotal}, worker_cap_hits_window: ${workerInFlightBackpressureWindowHits}, worker_cap_hits_total: ${totalWorkerInFlightBackpressureHits}, worker_superseded_window: ${workerInFlightSupersededDropsWindow}, worker_superseded_total: ${totalWorkerInFlightSupersededDrops}, rendered_shared_window: ${renderedFromSharedWindow}, rendered_shared_total: ${renderedFromSharedTotal}, rendered_worker_window: ${renderedFromWorkerWindow}, rendered_worker_total: ${renderedFromWorkerTotal}`,
 				);
 
 				frameCount = 0;
@@ -691,6 +712,8 @@ export function createImageDataWS(
 				workerInFlightBackpressureWindowHits = 0;
 				workerFramesInFlightPeakWindow = workerFramesInFlight;
 				workerInFlightSupersededDropsWindow = 0;
+				renderedFromSharedWindow = 0;
+				renderedFromWorkerWindow = 0;
 				sabWriteRetryCount = 0;
 				minFrameTime = Number.MAX_VALUE;
 				maxFrameTime = 0;

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -47,6 +47,8 @@ export type FpsStats = {
 	workerInFlightBackpressureWindowHits: number;
 	workerFramesInFlightPeakWindow: number;
 	workerFramesInFlightPeakTotal: number;
+	workerInFlightSupersededDrops: number;
+	workerInFlightSupersededDropsWindow: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -262,6 +264,7 @@ export function createImageDataWS(
 		sabRetryLimitFallbackWindowCount = 0;
 		workerInFlightBackpressureWindowHits = 0;
 		workerFramesInFlightPeakWindow = 0;
+		workerInFlightSupersededDropsWindow = 0;
 
 		if (mainThreadWebGPU) {
 			disposeWebGPU(mainThreadWebGPU);
@@ -507,6 +510,8 @@ export function createImageDataWS(
 					if (nextFrame) {
 						framesDropped++;
 						totalSupersededDrops++;
+						totalWorkerInFlightSupersededDrops++;
+						workerInFlightSupersededDropsWindow++;
 					}
 					nextFrame = buffer;
 					return;
@@ -547,6 +552,8 @@ export function createImageDataWS(
 				if (nextFrame) {
 					framesDropped++;
 					totalSupersededDrops++;
+					totalWorkerInFlightSupersededDrops++;
+					workerInFlightSupersededDropsWindow++;
 				}
 				nextFrame = buffer;
 				return;
@@ -597,6 +604,8 @@ export function createImageDataWS(
 	let workerInFlightBackpressureWindowHits = 0;
 	let workerFramesInFlightPeakWindow = 0;
 	let workerFramesInFlightPeakTotal = 0;
+	let totalWorkerInFlightSupersededDrops = 0;
+	let workerInFlightSupersededDropsWindow = 0;
 	let totalSupersededDrops = 0;
 	let lastLogTime = 0;
 	let framesReceived = 0;
@@ -632,6 +641,8 @@ export function createImageDataWS(
 		workerInFlightBackpressureWindowHits,
 		workerFramesInFlightPeakWindow,
 		workerFramesInFlightPeakTotal,
+		workerInFlightSupersededDrops: totalWorkerInFlightSupersededDrops,
+		workerInFlightSupersededDropsWindow: workerInFlightSupersededDropsWindow,
 		sabTotalRetryAttempts: totalSabRetryAttempts,
 		sabTotalFramesReceived: totalFramesReceived,
 		sabTotalFramesWrittenToSharedBuffer: totalFramesWrittenToSharedBuffer,
@@ -669,7 +680,7 @@ export function createImageDataWS(
 					framesReceived > 0 ? (framesDropped / framesReceived) * 100 : 0;
 
 				console.log(
-					`[Frame] recv: ${recvFps.toFixed(1)}/s, sent: ${sentFps.toFixed(1)}/s, ACTUAL: ${actualFps.toFixed(1)}/s, dropped: ${dropRate.toFixed(0)}%, delta: ${avgDelta.toFixed(1)}ms, ${mbPerSec.toFixed(1)} MB/s, RGBA, sab_resizes: ${sharedBufferResizeCount}, sab_fallbacks_window: ${sabFallbackWindowCount}, sab_fallbacks_total: ${sabFallbackCount}, sab_oversize_fallbacks_window: ${sabOversizeFallbackWindowCount}, sab_oversize_fallbacks_total: ${sabOversizeFallbackCount}, sab_retry_limit_fallbacks_window: ${sabRetryLimitFallbackWindowCount}, sab_retry_limit_fallbacks_total: ${sabRetryLimitFallbackCount}, sab_retries: ${sabWriteRetryCount}, worker_inflight: ${workerFramesInFlight}, worker_inflight_peak_window: ${workerFramesInFlightPeakWindow}, worker_inflight_peak_total: ${workerFramesInFlightPeakTotal}, worker_cap_hits_window: ${workerInFlightBackpressureWindowHits}, worker_cap_hits_total: ${totalWorkerInFlightBackpressureHits}`,
+					`[Frame] recv: ${recvFps.toFixed(1)}/s, sent: ${sentFps.toFixed(1)}/s, ACTUAL: ${actualFps.toFixed(1)}/s, dropped: ${dropRate.toFixed(0)}%, delta: ${avgDelta.toFixed(1)}ms, ${mbPerSec.toFixed(1)} MB/s, RGBA, sab_resizes: ${sharedBufferResizeCount}, sab_fallbacks_window: ${sabFallbackWindowCount}, sab_fallbacks_total: ${sabFallbackCount}, sab_oversize_fallbacks_window: ${sabOversizeFallbackWindowCount}, sab_oversize_fallbacks_total: ${sabOversizeFallbackCount}, sab_retry_limit_fallbacks_window: ${sabRetryLimitFallbackWindowCount}, sab_retry_limit_fallbacks_total: ${sabRetryLimitFallbackCount}, sab_retries: ${sabWriteRetryCount}, worker_inflight: ${workerFramesInFlight}, worker_inflight_peak_window: ${workerFramesInFlightPeakWindow}, worker_inflight_peak_total: ${workerFramesInFlightPeakTotal}, worker_cap_hits_window: ${workerInFlightBackpressureWindowHits}, worker_cap_hits_total: ${totalWorkerInFlightBackpressureHits}, worker_superseded_window: ${workerInFlightSupersededDropsWindow}, worker_superseded_total: ${totalWorkerInFlightSupersededDrops}`,
 				);
 
 				frameCount = 0;
@@ -685,6 +696,7 @@ export function createImageDataWS(
 				sabRetryLimitFallbackWindowCount = 0;
 				workerInFlightBackpressureWindowHits = 0;
 				workerFramesInFlightPeakWindow = workerFramesInFlight;
+				workerInFlightSupersededDropsWindow = 0;
 				sabWriteRetryCount = 0;
 				minFrameTime = Number.MAX_VALUE;
 				maxFrameTime = 0;

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -450,6 +450,14 @@ export function createImageDataWS(
 				sabFallbackCount += 1;
 				if (isOversized) {
 					sabOversizeFallbackCount += 1;
+				} else {
+					isProcessing = false;
+					if (nextFrame) {
+						framesDropped++;
+					}
+					nextFrame = buffer;
+					requestAnimationFrame(() => processNextFrame());
+					return;
 				}
 				framesSentToWorker++;
 				worker.postMessage({ type: "frame", buffer }, [buffer]);

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -34,6 +34,12 @@ export type FpsStats = {
 	minFrameMs: number;
 	maxFrameMs: number;
 	mbPerSec: number;
+	sabResizes: number;
+	sabFallbacks: number;
+	sabOversizeFallbacks: number;
+	sabRetryLimitFallbacks: number;
+	sabRetriesInFlight: number;
+	sabSlotSizeBytes: number;
 };
 
 let globalFpsStatsGetter: (() => FpsStats) | null = null;
@@ -523,6 +529,12 @@ export function createImageDataWS(
 		minFrameMs: minFrameTime === Number.MAX_VALUE ? 0 : minFrameTime,
 		maxFrameMs: maxFrameTime,
 		mbPerSec: totalBytesReceived / 1_000_000,
+		sabResizes: sharedBufferResizeCount,
+		sabFallbacks: sabFallbackCount,
+		sabOversizeFallbacks: sabOversizeFallbackCount,
+		sabRetryLimitFallbacks: sabRetryLimitFallbackCount,
+		sabRetriesInFlight: sabWriteRetryCount,
+		sabSlotSizeBytes: sharedBufferConfig?.slotSize ?? 0,
 	});
 
 	globalFpsStatsGetter = getLocalFpsStats;

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -39,6 +39,8 @@ export type FpsStats = {
 	sabRetryLimitFallbacks: number;
 	sabRetriesInFlight: number;
 	sabSlotSizeBytes: number;
+	sabSlotCount: number;
+	sabTotalBytes: number;
 };
 
 let globalFpsStatsGetter: (() => FpsStats) | null = null;
@@ -530,6 +532,10 @@ export function createImageDataWS(
 		sabRetryLimitFallbacks: sabRetryLimitFallbackCount,
 		sabRetriesInFlight: sabWriteRetryCount,
 		sabSlotSizeBytes: sharedBufferConfig?.slotSize ?? 0,
+		sabSlotCount: sharedBufferConfig?.slotCount ?? 0,
+		sabTotalBytes:
+			(sharedBufferConfig?.slotSize ?? 0) *
+			(sharedBufferConfig?.slotCount ?? 0),
 	});
 
 	globalFpsStatsGetter = getLocalFpsStats;

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -43,6 +43,7 @@ export type FpsStats = {
 	sabSlotCount: number;
 	sabTotalBytes: number;
 	workerFramesInFlight: number;
+	workerInFlightBackpressureHits: number;
 	sabTotalRetryAttempts: number;
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
@@ -496,6 +497,7 @@ export function createImageDataWS(
 				}
 				if (workerFramesInFlight >= WORKER_IN_FLIGHT_LIMIT) {
 					isProcessing = false;
+					totalWorkerInFlightBackpressureHits++;
 					if (nextFrame) {
 						framesDropped++;
 						totalSupersededDrops++;
@@ -526,6 +528,7 @@ export function createImageDataWS(
 			sabWriteRetryCount = 0;
 			if (workerFramesInFlight >= WORKER_IN_FLIGHT_LIMIT) {
 				isProcessing = false;
+				totalWorkerInFlightBackpressureHits++;
 				if (nextFrame) {
 					framesDropped++;
 					totalSupersededDrops++;
@@ -567,6 +570,7 @@ export function createImageDataWS(
 	let totalFramesWrittenToSharedBuffer = 0;
 	let totalFramesSentToWorker = 0;
 	let totalWorkerFallbackBytes = 0;
+	let totalWorkerInFlightBackpressureHits = 0;
 	let totalSupersededDrops = 0;
 	let lastLogTime = 0;
 	let framesReceived = 0;
@@ -598,6 +602,7 @@ export function createImageDataWS(
 			(sharedBufferConfig?.slotSize ?? 0) *
 			(sharedBufferConfig?.slotCount ?? 0),
 		workerFramesInFlight,
+		workerInFlightBackpressureHits: totalWorkerInFlightBackpressureHits,
 		sabTotalRetryAttempts: totalSabRetryAttempts,
 		sabTotalFramesReceived: totalFramesReceived,
 		sabTotalFramesWrittenToSharedBuffer: totalFramesWrittenToSharedBuffer,

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -361,7 +361,6 @@ export function createImageDataWS(
 			directCtx.putImageData(cachedStrideImageData, 0, 0);
 
 			actualRendersCount++;
-			renderFrameCount++;
 			storeRenderedFrame(cachedStrideImageData.data, width, height, width * 4);
 			onmessage({ width, height });
 		};
@@ -709,7 +708,6 @@ export function createImageDataWS(
 	let framesDropped = 0;
 	let framesSentToWorker = 0;
 	let actualRendersCount = 0;
-	let renderFrameCount = 0;
 	let minFrameTime = Number.MAX_VALUE;
 	let maxFrameTime = 0;
 
@@ -886,7 +884,6 @@ export function createImageDataWS(
 				strideBytes,
 			);
 			actualRendersCount++;
-			renderFrameCount++;
 			storeRenderedFrame(frameData, width, height, strideBytes);
 			lastDirectRenderedFrameNumber = frameNumber;
 			onmessage({ width, height });
@@ -927,7 +924,6 @@ export function createImageDataWS(
 					width * 4,
 				);
 				actualRendersCount++;
-				renderFrameCount++;
 				lastDirectRenderedFrameNumber = frameNumber;
 				onmessage({ width, height });
 			} else {

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -404,8 +404,6 @@ export function createImageDataWS(
 		}
 
 		if (e.data.type === "frame-queued") {
-			const { width, height } = e.data;
-			onmessage({ width, height });
 			isProcessing = false;
 			processNextFrame();
 			return;

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -330,6 +330,7 @@ export function createImageDataWS(
 				FRAME_ORDER_STALE_WINDOW,
 			);
 			if (responseOrderDecision.action === "drop") {
+				framesDropped += responseOrderDecision.dropsIncrement;
 				directOutOfOrderDropsTotal += responseOrderDecision.dropsIncrement;
 				directOutOfOrderDropsWindow += responseOrderDecision.dropsIncrement;
 				directResponseOutOfOrderDropsTotal +=
@@ -359,6 +360,8 @@ export function createImageDataWS(
 			cachedStrideImageData.data.set(frameData);
 			directCtx.putImageData(cachedStrideImageData, 0, 0);
 
+			actualRendersCount++;
+			renderFrameCount++;
 			storeRenderedFrame(cachedStrideImageData.data, width, height, width * 4);
 			onmessage({ width, height });
 		};
@@ -858,6 +861,7 @@ export function createImageDataWS(
 			FRAME_ORDER_STALE_WINDOW,
 		);
 		if (directOrderDecision.action === "drop") {
+			framesDropped += directOrderDecision.dropsIncrement;
 			directOutOfOrderDropsTotal += directOrderDecision.dropsIncrement;
 			directOutOfOrderDropsWindow += directOrderDecision.dropsIncrement;
 			directIngressOutOfOrderDropsTotal += directOrderDecision.dropsIncrement;

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -45,6 +45,7 @@ export type FpsStats = {
 	sabTotalFramesReceived: number;
 	sabTotalFramesWrittenToSharedBuffer: number;
 	sabTotalFramesSentToWorker: number;
+	sabTotalWorkerFallbackBytes: number;
 	sabTotalSupersededDrops: number;
 };
 
@@ -501,6 +502,7 @@ export function createImageDataWS(
 				}
 				framesSentToWorker++;
 				totalFramesSentToWorker++;
+				totalWorkerFallbackBytes += buffer.byteLength;
 				worker.postMessage({ type: "frame", buffer }, [buffer]);
 			} else {
 				sabWriteRetryCount = 0;
@@ -515,6 +517,7 @@ export function createImageDataWS(
 			sabWriteRetryCount = 0;
 			framesSentToWorker++;
 			totalFramesSentToWorker++;
+			totalWorkerFallbackBytes += buffer.byteLength;
 			worker.postMessage({ type: "frame", buffer }, [buffer]);
 		}
 	}
@@ -539,6 +542,7 @@ export function createImageDataWS(
 	let totalFramesReceived = 0;
 	let totalFramesWrittenToSharedBuffer = 0;
 	let totalFramesSentToWorker = 0;
+	let totalWorkerFallbackBytes = 0;
 	let totalSupersededDrops = 0;
 	let lastLogTime = 0;
 	let framesReceived = 0;
@@ -573,6 +577,7 @@ export function createImageDataWS(
 		sabTotalFramesReceived: totalFramesReceived,
 		sabTotalFramesWrittenToSharedBuffer: totalFramesWrittenToSharedBuffer,
 		sabTotalFramesSentToWorker: totalFramesSentToWorker,
+		sabTotalWorkerFallbackBytes: totalWorkerFallbackBytes,
 		sabTotalSupersededDrops: totalSupersededDrops,
 	});
 

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -42,6 +42,7 @@ export type FpsStats = {
 	sabSlotCount: number;
 	sabTotalBytes: number;
 	sabTotalFramesReceived: number;
+	sabTotalFramesWrittenToSharedBuffer: number;
 	sabTotalFramesSentToWorker: number;
 	sabTotalSupersededDrops: number;
 };
@@ -487,6 +488,12 @@ export function createImageDataWS(
 				worker.postMessage({ type: "frame", buffer }, [buffer]);
 			} else {
 				sabWriteRetryCount = 0;
+				totalFramesWrittenToSharedBuffer++;
+				isProcessing = false;
+				if (nextFrame || pendingFrame) {
+					processNextFrame();
+				}
+				return;
 			}
 		} else {
 			sabWriteRetryCount = 0;
@@ -513,6 +520,7 @@ export function createImageDataWS(
 	let frameTimeSum = 0;
 	let totalBytesReceived = 0;
 	let totalFramesReceived = 0;
+	let totalFramesWrittenToSharedBuffer = 0;
 	let totalFramesSentToWorker = 0;
 	let totalSupersededDrops = 0;
 	let lastLogTime = 0;
@@ -545,6 +553,7 @@ export function createImageDataWS(
 			(sharedBufferConfig?.slotSize ?? 0) *
 			(sharedBufferConfig?.slotCount ?? 0),
 		sabTotalFramesReceived: totalFramesReceived,
+		sabTotalFramesWrittenToSharedBuffer: totalFramesWrittenToSharedBuffer,
 		sabTotalFramesSentToWorker: totalFramesSentToWorker,
 		sabTotalSupersededDrops: totalSupersededDrops,
 	});

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -502,6 +502,11 @@ export function createImageDataWS(
 				totalFramesSentToWorker++;
 				totalWorkerFallbackBytes += buffer.byteLength;
 				worker.postMessage({ type: "frame", buffer }, [buffer]);
+				isProcessing = false;
+				if (nextFrame || pendingFrame) {
+					processNextFrame();
+				}
+				return;
 			} else {
 				sabWriteRetryCount = 0;
 				totalFramesWrittenToSharedBuffer++;
@@ -517,6 +522,11 @@ export function createImageDataWS(
 			totalFramesSentToWorker++;
 			totalWorkerFallbackBytes += buffer.byteLength;
 			worker.postMessage({ type: "frame", buffer }, [buffer]);
+			isProcessing = false;
+			if (nextFrame || pendingFrame) {
+				processNextFrame();
+			}
+			return;
 		}
 	}
 

--- a/apps/desktop/src/utils/stride-correction-worker.ts
+++ b/apps/desktop/src/utils/stride-correction-worker.ts
@@ -26,34 +26,61 @@ let correctionBufferSize = 0;
 self.onmessage = (e: MessageEvent<StrideCorrectionRequest>) => {
 	if (e.data.type !== "correct-stride") return;
 
-	const { buffer, strideBytes, width, height, frameNumber } = e.data;
-	const expectedRowBytes = width * 4;
-	const expectedLength = expectedRowBytes * height;
+	try {
+		const { buffer, strideBytes, width, height, frameNumber } = e.data;
+		const expectedRowBytes = width * 4;
+		const expectedLength = expectedRowBytes * height;
 
-	if (!correctionBuffer || correctionBufferSize < expectedLength) {
-		correctionBuffer = new Uint8ClampedArray(expectedLength);
-		correctionBufferSize = expectedLength;
+		if (width <= 0 || height <= 0 || strideBytes < expectedRowBytes) {
+			const errorResponse: ErrorResponse = {
+				type: "error",
+				message: "Invalid stride correction dimensions",
+			};
+			self.postMessage(errorResponse);
+			return;
+		}
+
+		const srcData = new Uint8ClampedArray(buffer);
+		if (srcData.byteLength < strideBytes * height) {
+			const errorResponse: ErrorResponse = {
+				type: "error",
+				message: "Stride correction buffer too small",
+			};
+			self.postMessage(errorResponse);
+			return;
+		}
+
+		if (!correctionBuffer || correctionBufferSize < expectedLength) {
+			correctionBuffer = new Uint8ClampedArray(expectedLength);
+			correctionBufferSize = expectedLength;
+		}
+
+		for (let row = 0; row < height; row++) {
+			const srcStart = row * strideBytes;
+			const destStart = row * expectedRowBytes;
+			correctionBuffer.set(
+				srcData.subarray(srcStart, srcStart + expectedRowBytes),
+				destStart,
+			);
+		}
+
+		const result = correctionBuffer.slice(0, expectedLength);
+		const response: StrideCorrectionResponse = {
+			type: "corrected",
+			buffer: result.buffer,
+			width,
+			height,
+			frameNumber,
+		};
+		self.postMessage(response, { transfer: [result.buffer] });
+	} catch (error) {
+		const errorResponse: ErrorResponse = {
+			type: "error",
+			message:
+				error instanceof Error ? error.message : "Stride correction failed",
+		};
+		self.postMessage(errorResponse);
 	}
-
-	const srcData = new Uint8ClampedArray(buffer);
-	for (let row = 0; row < height; row++) {
-		const srcStart = row * strideBytes;
-		const destStart = row * expectedRowBytes;
-		correctionBuffer.set(
-			srcData.subarray(srcStart, srcStart + expectedRowBytes),
-			destStart,
-		);
-	}
-
-	const result = correctionBuffer.slice(0, expectedLength);
-	const response: StrideCorrectionResponse = {
-		type: "corrected",
-		buffer: result.buffer,
-		width,
-		height,
-		frameNumber,
-	};
-	self.postMessage(response, { transfer: [result.buffer] });
 };
 
 export type {

--- a/apps/desktop/src/utils/stride-correction-worker.ts
+++ b/apps/desktop/src/utils/stride-correction-worker.ts
@@ -4,6 +4,7 @@ interface StrideCorrectionRequest {
 	strideBytes: number;
 	width: number;
 	height: number;
+	frameNumber: number;
 }
 
 interface StrideCorrectionResponse {
@@ -11,6 +12,7 @@ interface StrideCorrectionResponse {
 	buffer: ArrayBuffer;
 	width: number;
 	height: number;
+	frameNumber: number;
 }
 
 interface ErrorResponse {
@@ -24,7 +26,7 @@ let correctionBufferSize = 0;
 self.onmessage = (e: MessageEvent<StrideCorrectionRequest>) => {
 	if (e.data.type !== "correct-stride") return;
 
-	const { buffer, strideBytes, width, height } = e.data;
+	const { buffer, strideBytes, width, height, frameNumber } = e.data;
 	const expectedRowBytes = width * 4;
 	const expectedLength = expectedRowBytes * height;
 
@@ -49,6 +51,7 @@ self.onmessage = (e: MessageEvent<StrideCorrectionRequest>) => {
 		buffer: result.buffer,
 		width,
 		height,
+		frameNumber,
 	};
 	self.postMessage(response, { transfer: [result.buffer] });
 };

--- a/crates/camera-ffmpeg/src/lib.rs
+++ b/crates/camera-ffmpeg/src/lib.rs
@@ -8,6 +8,11 @@ mod windows;
 #[cfg(windows)]
 pub use windows::*;
 
+#[cfg(not(any(target_os = "macos", windows)))]
+#[derive(Debug, thiserror::Error)]
+#[error("Camera FFmpeg conversion is unsupported on this platform")]
+pub struct AsFFmpegError;
+
 pub trait CapturedFrameExt {
     /// Creates an ffmpeg video frame from the native frame.
     /// Only size, format, and data are set.

--- a/crates/cursor-capture/src/position.rs
+++ b/crates/cursor-capture/src/position.rs
@@ -1,5 +1,7 @@
 use device_query::{DeviceQuery, DeviceState};
-use scap_targets::{Display, bounds::*};
+#[cfg(any(windows, target_os = "macos"))]
+use scap_targets::bounds::*;
+use scap_targets::Display;
 
 // Physical on Windows, Logical on macOS
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -55,6 +57,12 @@ impl RelativeCursorPosition {
                 display,
             })
         }
+
+        #[cfg(not(any(windows, target_os = "macos")))]
+        {
+            let _ = (raw, display);
+            None
+        }
     }
 
     pub fn display(&self) -> &Display {
@@ -96,6 +104,11 @@ impl RelativeCursorPosition {
                 },
                 display: self.display,
             })
+        }
+
+        #[cfg(not(any(windows, target_os = "macos")))]
+        {
+            None
         }
     }
 }

--- a/crates/cursor-capture/src/position.rs
+++ b/crates/cursor-capture/src/position.rs
@@ -1,7 +1,7 @@
 use device_query::{DeviceQuery, DeviceState};
+use scap_targets::Display;
 #[cfg(any(windows, target_os = "macos"))]
 use scap_targets::bounds::*;
-use scap_targets::Display;
 
 // Physical on Windows, Logical on macOS
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -496,6 +496,40 @@ cargo run -p cap-recording --example playback-test-runner -- full
   - `cargo run -p cap-editor --example playback-csv-report -- --csv /tmp/cap-playback-benchmark.csv --baseline-label linux-pass-a --candidate-label linux-pass-b --output-csv /tmp/cap-playback-summary.csv`
 - Unit tests: **5 passed** (`parses_sequential_csv_line`, `parses_seek_csv_line`, `summarizes_sequential_and_seek_medians`, `groups_rows_by_label_and_video`, `writes_summary_and_delta_csv_rows`).
 
+### Benchmark Run: 2026-02-14 00:00:00 UTC (rejected adaptive FFmpeg seek-window scaling)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `decode-benchmark --seek-iterations 10`, `playback-benchmark --seek-iterations 10`  
+**Change under test:** adaptive preferred seek window scaling based on forward seek distance in `cap-video-decode` FFmpeg reset path
+
+#### Decode benchmark results
+- 1080p:
+  - seek avg/p95:
+    - 0.5s: **47.42 / 93.91ms**
+    - 1.0s: **72.91 / 158.23ms**
+    - 2.0s: **163.64 / 370.53ms**
+    - 5.0s: **232.74 / 371.60ms**
+  - random access avg/p95: **115.74 / 343.67ms**
+- 4k:
+  - seek avg/p95:
+    - 0.5s: **191.74 / 382.95ms**
+    - 1.0s: **322.25 / 621.32ms**
+    - 2.0s: **606.82 / 1445.27ms**
+    - 5.0s: **1068.25 / 1734.44ms**
+  - random access avg/p95: **486.56 / 1407.30ms**
+
+#### Playback throughput regression checks
+- 1080p: **60.23 fps**, missed deadlines **0**
+- 4k: **60.15 fps**, missed deadlines **1**
+- 4k seek avg/p95:
+  - 0.5s: **208.79 / 365.07ms**
+  - 1.0s: **362.89 / 734.88ms**
+  - 2.0s: **621.30 / 1482.17ms**
+  - 5.0s: **1007.51 / 1663.69ms**
+
+#### Decision
+- Rejected. While throughput remained ~60fps, long-distance seek tails regressed compared with the current default seek-window profile.
+
 ### Benchmark Run: 2026-02-14 00:00:00 UTC
 
 **Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -171,7 +171,7 @@ cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback
 # List run-id sample counts discovered in startup CSV logs
 cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-runs
 
-# List per-run startup metric summaries (avg/p95 by callback + path-selection events + audio startup mode classification)
+# List per-run startup metric summaries (avg/p95 by callback, effective callback, path-selection events + audio startup mode classification)
 cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-run-metrics
 
 # Export run counts or run metrics to CSV (`run_metric_audio_path` rows include audio startup mode classification)

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -123,6 +123,40 @@ cargo run -p cap-recording --example playback-test-runner -- full
 - Decode: avg **5.54ms**, p95 **8.35ms**, p99 **12.69ms**, max **17.10ms**
 - Seek samples: 0.5s **266.92ms**, 1.0s **306.19ms**, 2.0s **570.41ms**, 5.0s **442.48ms**
 
+### Benchmark Run: 2026-02-14 00:00:00 UTC (FFmpeg seek reset tuning)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `decode-benchmark` and `playback-benchmark`  
+**Change under test:** FFmpeg decoder reset now uses forward seek window before fallback seek
+
+#### Decode Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Decoder init: **6.58ms**
+- Sequential decode: **367.9 fps**, avg **2.72ms**
+- Seek latency: 0.5s **1.88ms**, 1.0s **1.73ms**, 2.0s **5.26ms**, 5.0s **115.42ms**
+- Random access: avg **120.87ms**, p95 **366.01ms**, p99 **391.53ms**
+
+#### Decode Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Decoder init: **32.65ms**
+- Sequential decode: **88.0 fps**, avg **11.36ms**
+- Seek latency: 0.5s **7.52ms**, 1.0s **7.76ms**, 2.0s **12.65ms**, 5.0s **679.52ms**
+- Random access: avg **533.65ms**, p95 **1520.65ms**, p99 **1636.44ms**
+
+#### Playback Throughput Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **480/480**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.11**
+- Decode: avg **1.33ms**, p95 **2.45ms**, p99 **2.51ms**, max **3.99ms**
+- Seek samples: 0.5s **11.89ms**, 1.0s **2.71ms**, 2.0s **2.81ms**, 5.0s **138.26ms**
+
+#### Playback Throughput Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **480/480**, failures **0**
+- Missed deadlines: **1**
+- Effective FPS: **60.11**
+- Decode: avg **5.41ms**, p95 **7.93ms**, p99 **11.18ms**, max **18.70ms**
+- Seek samples: 0.5s **30.06ms**, 1.0s **9.43ms**, 2.0s **9.15ms**, 5.0s **432.97ms**
+
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 
 ---

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -109,6 +109,9 @@ cargo run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-bench
 
 # Compare two run labels directly
 cargo run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-benchmark.csv --baseline-label macos-pass-1 --candidate-label windows-pass-1
+
+# Export scrub summary/delta rows to CSV
+cargo run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-benchmark.csv --baseline-label macos-pass-1 --candidate-label windows-pass-1 --output-csv /tmp/cap-scrub-summary.csv
 ```
 
 #### Playback Startup Latency Report (log analysis)
@@ -416,7 +419,21 @@ cargo run -p cap-recording --example playback-test-runner -- full
     - all_avg **199.01ms**
     - last_avg **213.93ms**
     - successful **144**, failed **0**
-- Unit tests: **4 passed** (`parses_aggregate_csv_line`, `falls_back_to_config_label_when_run_label_missing`, `summarizes_medians`, `groups_rows_by_label_and_video`).
+- Unit tests: **5 passed** (`parses_aggregate_csv_line`, `falls_back_to_config_label_when_run_label_missing`, `summarizes_medians`, `groups_rows_by_label_and_video`, `writes_summary_and_delta_csv_rows`).
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (scrub CSV report export)
+
+**Environment:** Linux runner, scrub CSV analysis utility validation  
+**Commands:** `scrub-csv-report --output-csv`, `cargo test -p cap-editor --example scrub-csv-report`
+
+#### Validation
+- Added `--output-csv` to write summary and delta rows for downstream reporting.
+- Smoke run:
+  - `cargo run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-span-20-22.csv --baseline-label span20 --candidate-label span22 --output-csv /tmp/cap-scrub-summary.csv`
+  - output CSV includes:
+    - summary rows per `(label, video)`
+    - delta rows per overlapping video
+- Utility tests remain green (**5 passed**).
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -316,6 +316,56 @@ cargo run -p cap-recording --example playback-test-runner -- full
   - 2.0s: **589.11 / 1424.54 / 1424.54ms**
   - 5.0s: **926.16 / 1460.47 / 1460.47ms**
 
+### Benchmark Run: 2026-02-14 00:00:00 UTC (Decoder duplicate-request coalescing)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `decode-benchmark` and `playback-benchmark` with `--seek-iterations 10`  
+**Change under test:** FFmpeg decoder request batches now coalesce same-frame requests into a single decode result fan-out
+
+#### Decode Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Decoder init: **6.80ms**
+- Sequential decode: **385.6 fps**, avg **2.59ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **46.92 / 89.95 / 89.95ms**
+  - 1.0s: **70.08 / 147.40 / 147.40ms**
+  - 2.0s: **153.93 / 373.48 / 373.48ms**
+  - 5.0s: **251.75 / 419.44 / 419.44ms**
+- Random access: avg **125.70ms**, p95 **376.36ms**, p99 **426.63ms**
+
+#### Decode Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Decoder init: **30.79ms**
+- Sequential decode: **103.4 fps**, avg **9.67ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **197.39 / 395.30 / 395.30ms**
+  - 1.0s: **351.40 / 730.65 / 730.65ms**
+  - 2.0s: **613.21 / 1398.75 / 1398.75ms**
+  - 5.0s: **900.60 / 1467.33 / 1467.33ms**
+- Random access: avg **517.34ms**, p95 **1493.69ms**, p99 **1622.08ms**
+
+#### Playback Throughput Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **240/240**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.24**
+- Decode: avg **1.21ms**, p95 **2.14ms**, p99 **2.23ms**, max **3.63ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **46.02 / 92.97 / 92.97ms**
+  - 1.0s: **68.15 / 142.22 / 142.22ms**
+  - 2.0s: **146.18 / 356.46 / 356.46ms**
+  - 5.0s: **232.73 / 379.79 / 379.79ms**
+
+#### Playback Throughput Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **240/240**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.20**
+- Decode: avg **4.81ms**, p95 **7.59ms**, p99 **12.31ms**, max **13.54ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **201.18 / 362.15 / 362.15ms**
+  - 1.0s: **332.09 / 662.63 / 662.63ms**
+  - 2.0s: **584.79 / 1411.56 / 1411.56ms**
+  - 5.0s: **1012.17 / 1722.61 / 1722.61ms**
+
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 
 ---

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -10,7 +10,7 @@ This document tracks performance benchmarks for Cap's playback and decoding syst
 |--------|--------|-----------|
 | Decoder Init | <200ms | - |
 | Decode Latency (p95) | <50ms | - |
-| Effective FPS | ≥30 fps | ±2 fps |
+| Effective FPS | ≥60 fps | ±2 fps |
 | Decode Jitter | <10ms | - |
 | A/V Sync (mic↔video) | <100ms | - |
 | A/V Sync (system↔video) | <100ms | - |
@@ -64,6 +64,16 @@ cargo run -p cap-editor --example decode-benchmark -- --video /path/to/video.mp4
 cargo run -p cap-editor --example decode-benchmark -- --video /path/to/video.mp4 --fps 60 --iterations 50
 ```
 
+#### Playback Throughput Benchmark (Linux-compatible)
+
+```bash
+# Simulate real-time playback deadlines from a single video
+cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.mp4 --fps 60 --max-frames 600
+
+# Optional audio duration comparison
+cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.mp4 --audio /path/to/audio.ogg --fps 60
+```
+
 #### Combined Workflow (Recording → Playback)
 
 ```bash
@@ -79,6 +89,39 @@ cargo run -p cap-recording --example playback-test-runner -- full
 ## Benchmark History
 
 <!-- PLAYBACK_BENCHMARK_RESULTS_START -->
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `decode-benchmark` and `playback-benchmark`
+
+#### Decode Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Decoder init: **6.09ms**
+- Sequential decode: **401.9 fps**, avg **2.49ms**, p95 **~2.34ms**
+- Seek latency: 0.5s **1.88ms**, 1.0s **1.83ms**, 2.0s **260.87ms**, 5.0s **102.36ms**
+- Random access: avg **223.27ms**, p95 **398.42ms**, p99 **443.68ms**
+
+#### Decode Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Decoder init: **28.65ms**
+- Sequential decode: **99.4 fps**, avg **10.06ms**, p95 **~8.35ms**
+- Seek latency: 0.5s **6.61ms**, 1.0s **6.73ms**, 2.0s **905.03ms**, 5.0s **442.71ms**
+- Random access: avg **918.05ms**, p95 **1620.94ms**, p99 **2084.36ms**
+
+#### Playback Throughput Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **480/480**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.11**
+- Decode: avg **1.23ms**, p95 **2.34ms**, p99 **2.44ms**, max **4.76ms**
+- Seek samples: 0.5s **104.51ms**, 1.0s **90.83ms**, 2.0s **144.89ms**, 5.0s **98.70ms**
+
+#### Playback Throughput Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **480/480**, failures **0**
+- Missed deadlines: **2**
+- Effective FPS: **60.11**
+- Decode: avg **5.54ms**, p95 **8.35ms**, p99 **12.69ms**, max **17.10ms**
+- Seek samples: 0.5s **266.92ms**, 1.0s **306.19ms**, 2.0s **570.41ms**, 5.0s **442.48ms**
 
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -165,7 +165,7 @@ cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback
 # List run-id sample counts discovered in startup CSV logs
 cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-runs
 
-# List per-run startup metric summaries (avg/p95 by event)
+# List per-run startup metric summaries (avg/p95 by event + audio startup mode classification)
 cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-run-metrics
 
 # Export run counts or run metrics to CSV

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -95,7 +95,7 @@ cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4 
 # Runtime tuning for FFmpeg scrub supersession heuristic
 CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_PIXELS=3686400 \
 CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_REQUESTS=8 \
-CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES=45 \
+CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES=25 \
 cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4
 ```
 
@@ -605,6 +605,57 @@ cargo run -p cap-recording --example playback-test-runner -- full
 - Per-run last-request averages: **963.69ms**, **887.58ms**, **1001.96ms**
 - Median all-request latency: avg **957.47ms**, p95 **2087.13ms**, p99 **2087.15ms**, max **2087.15ms**
 - Median last-request latency: avg **963.69ms**, p95 **2087.13ms**, p99 **2087.13ms**, max **2087.13ms**
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (Supersession default span set to 25)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `scrub-benchmark --runs 3`, `decode-benchmark --seek-iterations 10`, `playback-benchmark --seek-iterations 10`  
+**Change under test:** default supersession span threshold reduced from 45 to 25 frames
+
+#### Scrub Burst Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Runs: **3**, requests: **360 success / 0 failures**
+- Per-run last-request averages: **304.93ms**, **294.07ms**, **293.85ms**
+- Median all-request latency: avg **202.60ms**, p95 **425.68ms**, p99 **450.24ms**, max **455.69ms**
+- Median last-request latency: avg **294.07ms**, p95 **455.69ms**, p99 **455.69ms**, max **455.69ms**
+
+#### Scrub Burst Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Runs: **3**, requests: **360 success / 0 failures**
+- Per-run last-request averages: **1008.68ms**, **808.71ms**, **805.92ms**
+- Median all-request latency: avg **804.50ms**, p95 **1694.01ms**, p99 **1694.02ms**, max **1694.02ms**
+- Median last-request latency: avg **808.71ms**, p95 **1694.01ms**, p99 **1694.01ms**, max **1694.01ms**
+
+#### Decode Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Decoder init: **7.32ms**
+- Sequential decode: **375.7 fps**, avg **2.66ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **47.99 / 96.34 / 96.34ms**
+  - 1.0s: **69.90 / 147.03 / 147.03ms**
+  - 2.0s: **152.95 / 364.03 / 364.03ms**
+  - 5.0s: **236.14 / 385.37 / 385.37ms**
+- Random access: avg **117.85ms**, p95 **367.79ms**, p99 **376.78ms**
+
+#### Decode Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Decoder init: **35.38ms**
+- Sequential decode: **95.5 fps**, avg **10.47ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **201.57 / 395.76 / 395.76ms**
+  - 1.0s: **323.73 / 627.27 / 627.27ms**
+  - 2.0s: **607.72 / 1500.76 / 1500.76ms**
+  - 5.0s: **932.14 / 1463.20 / 1463.20ms**
+- Random access: avg **539.60ms**, p95 **1516.95ms**, p99 **1707.36ms**
+
+#### Playback Throughput Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **240/240**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.22**
+- Decode: avg **1.40ms**, p95 **2.51ms**, p99 **2.89ms**, max **4.27ms**
+
+#### Playback Throughput Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **240/240**, failures **0**
+- Effective FPS: **60.18**
+- Decode: avg **5.02ms**, p95 **7.18ms**, p99 **11.55ms**, max **15.85ms**
 
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -125,6 +125,9 @@ cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4 
 # Aggregate multiple runs (median across runs) for lower-variance comparisons
 cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4 --fps 60 --bursts 10 --burst-size 12 --sweep-seconds 2.0 --runs 3
 
+# For even run counts, aggregate medians now average the two middle runs
+cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4 --fps 60 --bursts 10 --burst-size 12 --sweep-seconds 2.0 --runs 2
+
 # Runtime tuning for FFmpeg scrub supersession heuristic
 CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_PIXELS=2000000 \
 CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_REQUESTS=7 \
@@ -222,6 +225,25 @@ cargo run -p cap-recording --example playback-test-runner -- full
 ## Benchmark History
 
 <!-- PLAYBACK_BENCHMARK_RESULTS_START -->
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (scrub even-run median aggregation fix)
+
+**Environment:** Linux runner, synthetic 1080p60 MP4 asset  
+**Change under test:** scrub benchmark median aggregation now uses true median for even run counts (average of middle two runs)
+
+#### Validation commands
+- `cargo +1.88.0 test -p cap-editor --example scrub-benchmark --example scrub-csv-report`
+- `cargo +1.88.0 run -p cap-editor --example scrub-benchmark -- --video /tmp/cap-bench-1080p60.mp4 --fps 60 --bursts 2 --burst-size 12 --sweep-seconds 2.0 --runs 2 --run-label linux-median-even-check --output-csv /tmp/cap-scrub-median-even.csv`
+
+#### Output validation highlights
+- Per-run last-request averages:
+  - run 1: **172.02ms**
+  - run 2: **173.90ms**
+- Reported aggregate last-request average:
+  - **172.96ms**
+- Check:
+  - `(172.02 + 173.90) / 2 = 172.96`
+- Result confirms even-run aggregation now reflects the midpoint between both runs rather than selecting only one run.
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC (latest-first min-pixels metadata capture)
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -354,6 +354,39 @@ cargo run -p cap-recording --example playback-test-runner -- full
 - Keep `CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES` default at **20**.
 - Candidate spans 15 and 25 were rejected; neither improved both 1080p and 4k tails versus 20 under the new defaults.
 
+### Benchmark Run: 2026-02-14 00:00:00 UTC (fine span sweep 18/20/22, rejected span 22)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `scrub-benchmark --runs 3`, `scrub-csv-report --baseline-label span20 --candidate-label span22`
+
+#### Fine sweep medians (single-pass)
+- 1080p:
+  - **18**: avg **303.40ms**, p95 **665.16ms**
+  - **20**: avg **214.65ms**, p95 **434.74ms**
+  - **22**: avg **210.83ms**, p95 **442.55ms**
+- 4k:
+  - **18**: avg **897.87ms**, p95 **1891.21ms**
+  - **20**: avg **967.04ms**, p95 **1897.05ms**
+  - **22**: avg **829.73ms**, p95 **1714.74ms**
+
+#### Paired span20 vs span22 labeled sweep
+- Using `/tmp/cap-scrub-span-20-22.csv` with run labels:
+  - 1080p delta (22-20): all_avg **-0.34ms**, all_p95 **+24.13ms**, last_avg **-0.15ms**, last_p95 **+24.13ms**
+  - 4k delta (22-20): all_avg **-64.97ms**, all_p95 **-227.95ms**, last_avg **-78.37ms**, last_p95 **-296.82ms**
+
+#### Validation pass on temporary default-22 branch state
+- Scrub medians:
+  - 1080p last-request avg **203.87ms**, p95 **435.18ms**
+  - 4k last-request avg **847.32ms**, p95 **1797.10ms**
+- Playback regression sample:
+  - 4k effective fps **60.14** with missed deadlines **4**
+- Decode regression sample:
+  - 4k random access avg **511.57ms**, p95 **1456.64ms**
+
+#### Decision
+- Rejected promoting span **22** as default due inconsistent 4k tail behavior across repeated runs and a noisier playback regression sample.
+- Keep default `CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES` at **20** for stability.
+
 ### Benchmark Run: 2026-02-14 00:00:00 UTC (scrub CSV report tooling)
 
 **Environment:** Linux runner, CSV analysis utility validation  

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -225,6 +225,28 @@ cargo run -p cap-recording --example playback-test-runner -- full
 - Decode: avg **4.95ms**, p95 **7.57ms**, p99 **10.04ms**, max **14.18ms**
 - Seek samples: 0.5s **30.56ms**, 1.0s **9.45ms**, 2.0s **8.94ms**, 5.0s **430.25ms**
 
+### Benchmark Run: 2026-02-14 00:00:00 UTC (Startup instrumentation pass)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `playback-benchmark`  
+**Change under test:** startup timeline instrumentation for first decoded frame, first rendered frame, and audio callback origin aligned to playback start
+
+#### Playback Throughput Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **480/480**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.11**
+- Decode: avg **1.28ms**, p95 **2.51ms**, p99 **2.63ms**, max **4.70ms**
+- Seek samples: 0.5s **14.63ms**, 1.0s **2.68ms**, 2.0s **2.87ms**, 5.0s **145.33ms**
+
+#### Playback Throughput Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **480/480**, failures **0**
+- Missed deadlines: **1**
+- Effective FPS: **60.11**
+- Decode: avg **5.54ms**, p95 **8.09ms**, p99 **11.25ms**, max **15.17ms**
+- Seek samples: 0.5s **41.73ms**, 1.0s **9.75ms**, 2.0s **8.98ms**, 5.0s **451.74ms**
+
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 
 ---

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -426,6 +426,56 @@ cargo run -p cap-recording --example playback-test-runner -- full
 - All-request latency: avg **1071.64ms**, p95 **2098.98ms**, p99 **2204.29ms**, max **2204.29ms**
 - Last-request-in-burst latency: avg **1524.00ms**, p95 **2116.35ms**, p99 **2204.29ms**, max **2204.29ms**
 
+### Benchmark Run: 2026-02-14 00:00:00 UTC (Scrub supersession heuristic pass)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `scrub-benchmark`, `decode-benchmark`, `playback-benchmark`  
+**Change under test:** decoder batch supersession for large-span burst queues (keeps newest request as primary target)
+
+#### Scrub Burst Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Requests: **240 success / 0 failures**
+- All-request latency: avg **204.53ms**, p95 **452.60ms**, p99 **622.10ms**, max **622.10ms**
+- Last-request-in-burst latency: avg **221.18ms**, p95 **528.20ms**, p99 **622.09ms**, max **622.09ms**
+
+#### Scrub Burst Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Requests: **240 success / 0 failures**
+- All-request latency: avg **833.64ms**, p95 **1888.52ms**, p99 **1941.42ms**, max **1954.14ms**
+- Last-request-in-burst latency: avg **869.99ms**, p95 **1941.42ms**, p99 **1954.14ms**, max **1954.14ms**
+
+#### Decode Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Decoder init: **7.45ms**
+- Sequential decode: **389.5 fps**, avg **2.57ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **47.39 / 87.98 / 87.98ms**
+  - 1.0s: **70.93 / 147.39 / 147.39ms**
+  - 2.0s: **149.20 / 359.46 / 359.46ms**
+  - 5.0s: **238.28 / 400.59 / 400.59ms**
+- Random access: avg **115.15ms**, p95 **355.59ms**, p99 **371.61ms**
+
+#### Decode Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Decoder init: **30.67ms**
+- Sequential decode: **98.4 fps**, avg **10.16ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **191.23 / 344.32 / 344.32ms**
+  - 1.0s: **320.28 / 634.08 / 634.08ms**
+  - 2.0s: **577.92 / 1399.73 / 1399.73ms**
+  - 5.0s: **992.08 / 1635.12 / 1635.12ms**
+- Random access: avg **500.44ms**, p95 **1480.01ms**, p99 **1531.96ms**
+
+#### Playback Throughput Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **240/240**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.23**
+- Decode: avg **1.41ms**, p95 **2.51ms**, p99 **2.57ms**, max **4.27ms**
+
+#### Playback Throughput Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **240/240**, failures **0**
+- Missed deadlines: **1**
+- Effective FPS: **60.16**
+- Decode: avg **6.40ms**, p95 **8.65ms**, p99 **13.10ms**, max **18.91ms**
+
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 
 ---

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -68,6 +68,12 @@ cargo run -p cap-editor --example decode-benchmark -- --video /path/to/video.mp4
 
 # Includes duplicate-request burst stats (burst sizes 4/8/16) by default
 cargo run -p cap-editor --example decode-benchmark -- --video /path/to/video.mp4 --fps 60
+
+# Export decode benchmark rows to CSV for cross-machine analysis
+cargo run -p cap-editor --example decode-benchmark -- --video /path/to/video.mp4 --fps 60 --seek-iterations 20 --output-csv /tmp/cap-decode-benchmark.csv
+
+# Add run labels for baseline/candidate grouping
+cargo run -p cap-editor --example decode-benchmark -- --video /path/to/video.mp4 --fps 60 --output-csv /tmp/cap-decode-benchmark.csv --run-label windows-pass-1
 ```
 
 #### Playback Throughput Benchmark (Linux-compatible)
@@ -1055,6 +1061,33 @@ cargo run -p cap-recording --example playback-test-runner -- full
 - Decoded: **240/240**, failures **0**
 - Effective FPS: **60.18**
 - Decode: avg **5.02ms**, p95 **7.18ms**, p99 **11.55ms**, max **15.85ms**
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (Decode benchmark CSV export validation)
+
+**Environment:** Linux runner with synthetic 1080p60 MP4 asset  
+**Command:** `decode-benchmark --fps 60 --iterations 3 --seek-iterations 2 --output-csv /tmp/cap-decode-benchmark-v2.csv --run-label linux-frame-order-pass-v2`  
+**Change under test:** decode benchmark CSV export + run-label plumbing
+
+#### Decode Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Decoder init: **10.28ms**
+- Sequential decode: **377.11 fps**, avg **2.65ms**, p95 **3.53ms**, p99 **4.85ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **41.52 / 81.16 / 81.16ms**
+  - 1.0s: **16.61 / 29.90 / 29.90ms**
+  - 2.0s: **191.45 / 213.25 / 213.25ms**
+  - 5.0s: **147.94 / 295.55 / 295.55ms**
+- Random access: avg **118.94ms**, p95 **355.69ms**, p99 **376.19ms**
+- Duplicate burst (batch avg / request avg):
+  - 4: **3.68 / 3.66ms**
+  - 8: **4.99 / 4.97ms**
+  - 16: **4.12 / 4.09ms**
+- CSV rows written for modes:
+  - `decoder_creation`
+  - `sequential`
+  - `seek`
+  - `random_access`
+  - `duplicate_batch`
+  - `duplicate_request`
 
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -114,11 +114,17 @@ CAP_PLAYBACK_STARTUP_TRACE_FILE=/tmp/playback-startup.csv CAP_PLAYBACK_STARTUP_T
 # Parse startup timing logs captured from desktop editor sessions
 cargo run -p cap-editor --example playback-startup-report -- --log /path/to/editor.log
 
+# Filter startup CSV events to a specific labeled run id
+cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --run-id macos-pass-1
+
 # Aggregate multiple session logs
 cargo run -p cap-editor --example playback-startup-report -- --log /path/to/macos.log --log /path/to/windows.log
 
 # Compare candidate logs against baseline logs
 cargo run -p cap-editor --example playback-startup-report -- --baseline-log /path/to/baseline.log --candidate-log /path/to/candidate.log
+
+# Compare specific labeled runs inside shared startup CSV traces
+cargo run -p cap-editor --example playback-startup-report -- --baseline-log /tmp/playback-startup.csv --candidate-log /tmp/playback-startup.csv --baseline-run-id macos-pass-1 --candidate-run-id macos-pass-2
 ```
 
 #### Combined Workflow (Recording → Playback)
@@ -158,6 +164,19 @@ cargo run -p cap-recording --example playback-test-runner -- full
   - one row per run (`scope=run`)
   - one aggregate row (`scope=aggregate`)
 - Captures runtime supersession env values alongside scrub latency metrics for easier cross-machine sweeps.
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (startup report run-id filters)
+
+**Environment:** Linux runner, startup report parser validation  
+**Commands:** `playback-startup-report --run-id`, `cargo test -p cap-editor --example playback-startup-report`
+
+#### Startup Report Parser Validation
+- Unit tests: **6 passed**, including:
+  - CSV parse with and without run-id column
+  - run-id filtering of startup metrics from mixed-run CSV lines
+- CLI smoke run:
+  - `cargo run -p cap-editor --example playback-startup-report -- --log crates/editor/PLAYBACK-BENCHMARKS.md --run-id sample-run`
+  - Completed successfully with filtered metric output path active.
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -105,6 +105,9 @@ cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4
 # Capture startup traces from desktop editor playback sessions
 CAP_PLAYBACK_STARTUP_TRACE_FILE=/tmp/playback-startup.csv pnpm dev:desktop
 
+# Optional run label embedded in each CSV line
+CAP_PLAYBACK_STARTUP_TRACE_FILE=/tmp/playback-startup.csv CAP_PLAYBACK_STARTUP_TRACE_RUN_ID=macos-pass-1 pnpm dev:desktop
+
 # Parse startup timing logs captured from desktop editor sessions
 cargo run -p cap-editor --example playback-startup-report -- --log /path/to/editor.log
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -117,6 +117,9 @@ CAP_PLAYBACK_STARTUP_TRACE_FILE=/tmp/playback-startup.csv CAP_PLAYBACK_STARTUP_T
 # Parse startup timing logs captured from desktop editor sessions
 cargo run -p cap-editor --example playback-startup-report -- --log /path/to/editor.log
 
+# Export startup metric summaries to CSV
+cargo run -p cap-editor --example playback-startup-report -- --log /path/to/editor.log --output-csv /tmp/playback-startup-summary.csv
+
 # Filter startup CSV events to a specific labeled run id
 cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --run-id macos-pass-1
 
@@ -131,6 +134,9 @@ cargo run -p cap-editor --example playback-startup-report -- --baseline-log /pat
 
 # Compare specific labeled runs inside shared startup CSV traces
 cargo run -p cap-editor --example playback-startup-report -- --baseline-log /tmp/playback-startup.csv --candidate-log /tmp/playback-startup.csv --baseline-run-id macos-pass-1 --candidate-run-id macos-pass-2
+
+# Export baseline/candidate deltas to CSV
+cargo run -p cap-editor --example playback-startup-report -- --baseline-log /tmp/playback-startup.csv --candidate-log /tmp/playback-startup.csv --baseline-run-id macos-pass-1 --candidate-run-id macos-pass-2 --output-csv /tmp/playback-startup-delta.csv
 ```
 
 #### Combined Workflow (Recording → Playback)
@@ -196,6 +202,20 @@ cargo run -p cap-recording --example playback-test-runner -- full
   - `cargo run -p cap-editor --example playback-startup-report -- --log crates/editor/PLAYBACK-BENCHMARKS.md --list-runs`
   - `cargo run -p cap-editor --example playback-startup-report -- --log crates/editor/PLAYBACK-BENCHMARKS.md --run-id missing-run` (expected non-zero exit)
 - Unit tests remain green: `cargo test -p cap-editor --example playback-startup-report` (**6 passed**).
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (startup report CSV export)
+
+**Environment:** Linux runner, startup report parser validation  
+**Commands:** `playback-startup-report --output-csv`, `cargo test -p cap-editor --example playback-startup-report`
+
+#### Startup Report CSV Validation
+- Added CSV export for:
+  - aggregate startup metrics (`mode=aggregate`)
+  - baseline/candidate deltas (`mode=delta`)
+- Unit tests now cover CSV row emission and delta summarization (**8 passed**).
+- CLI smoke run:
+  - `cargo run -p cap-editor --example playback-startup-report -- --log crates/editor/PLAYBACK-BENCHMARKS.md --output-csv /tmp/playback-startup-summary.csv`
+  - output CSV schema verified with header row.
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC (supersession span retune to 20)
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -168,7 +168,7 @@ cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback
 # List per-run startup metric summaries (avg/p95 by event + audio startup mode classification)
 cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-run-metrics
 
-# Export run counts or run metrics to CSV
+# Export run counts or run metrics to CSV (`run_metric_audio_path` rows include audio startup mode classification)
 cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-runs --output-csv /tmp/playback-startup-run-summary.csv
 cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-run-metrics --output-csv /tmp/playback-startup-run-summary.csv
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -1173,6 +1173,30 @@ cargo run -p cap-recording --example playback-test-runner -- full
   - 2.0s: **557.40 / 1412.22 / 1412.22ms**
   - 5.0s: **1070.92 / 1530.27 / 1530.27ms**
 
+### Benchmark Run: 2026-02-14 00:00:00 UTC (Startup CSV structured audio path columns)
+
+**Environment:** Linux runner, startup report parser validation  
+**Commands:** `playback-startup-report --list-run-metrics --output-csv`, `playback-startup-report --baseline-run-id ... --candidate-run-id ... --output-csv`  
+**Change under test:** startup report CSV now emits structured audio path columns for aggregate/run-metrics/delta outputs
+
+#### Validation Dataset
+- Source log: `/workspace/tmp-startup-sample.csv` (baseline stream callback, candidate prerender callback)
+- Export target: `/tmp/playback-startup-run-export-v2.csv`
+
+#### Results
+- Run metrics output now includes:
+  - `run_metric_audio_path` rows
+  - `audio_path`, `audio_stream_samples`, `audio_prerender_samples` columns
+- Delta output now includes:
+  - `delta_audio_path` rows
+  - baseline + candidate audio path columns:
+    - `audio_path` / `candidate_audio_path`
+    - `audio_stream_samples` / `candidate_audio_stream_samples`
+    - `audio_prerender_samples` / `candidate_audio_prerender_samples`
+- Example delta audio path row:
+  - baseline: `streaming (1 stream / 0 prerender)`
+  - candidate: `prerendered (0 stream / 1 prerender)`
+
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 
 ---

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -103,6 +103,12 @@ cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4 
 
 # Add explicit run label for cross-machine comparisons
 cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4 --runs 3 --output-csv /tmp/cap-scrub-benchmark.csv --run-label windows-pass-1
+
+# Summarize scrub CSV runs grouped by run label
+cargo run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-benchmark.csv
+
+# Compare two run labels directly
+cargo run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-benchmark.csv --baseline-label macos-pass-1 --candidate-label windows-pass-1
 ```
 
 #### Playback Startup Latency Report (log analysis)
@@ -347,6 +353,21 @@ cargo run -p cap-recording --example playback-test-runner -- full
 #### Decision
 - Keep `CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES` default at **20**.
 - Candidate spans 15 and 25 were rejected; neither improved both 1080p and 4k tails versus 20 under the new defaults.
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (scrub CSV report tooling)
+
+**Environment:** Linux runner, CSV analysis utility validation  
+**Commands:** `scrub-csv-report`, `cargo test -p cap-editor --example scrub-csv-report`
+
+#### Validation
+- New utility parses scrub benchmark CSV aggregate rows and reports median summaries by run label.
+- Smoke run against labeled CSV:
+  - `cargo run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-labeled.csv --label linux-pass-a`
+  - output summary:
+    - all_avg **199.01ms**
+    - last_avg **213.93ms**
+    - successful **144**, failed **0**
+- Unit tests: **2 passed** (`parses_aggregate_csv_line`, `summarizes_medians`).
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -156,6 +156,9 @@ CAP_PLAYBACK_STARTUP_TRACE_FILE=/tmp/playback-startup.csv CAP_PLAYBACK_STARTUP_T
 # Force legacy pre-rendered startup path for A/B startup comparisons
 CAP_AUDIO_PRERENDER_ONLY=1 CAP_PLAYBACK_STARTUP_TRACE_FILE=/tmp/playback-startup.csv CAP_PLAYBACK_STARTUP_TRACE_RUN_ID=macos-prerender pnpm dev:desktop
 
+# Force streaming-only startup path (disables pre-render fallback) for startup comparisons
+CAP_AUDIO_STREAMING_ONLY=1 CAP_PLAYBACK_STARTUP_TRACE_FILE=/tmp/playback-startup.csv CAP_PLAYBACK_STARTUP_TRACE_RUN_ID=macos-streaming-only pnpm dev:desktop
+
 # Parse startup timing logs captured from desktop editor sessions
 cargo run -p cap-editor --example playback-startup-report -- --log /path/to/editor.log
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -87,6 +87,15 @@ cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.m
 
 # Add run label for cross-machine baseline/candidate grouping
 cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.mp4 --fps 60 --max-frames 600 --output-csv /tmp/cap-playback-benchmark.csv --run-label windows-pass-1
+
+# Summarize playback CSV rows grouped by run label and video
+cargo run -p cap-editor --example playback-csv-report -- --csv /tmp/cap-playback-benchmark.csv
+
+# Compare baseline/candidate playback labels
+cargo run -p cap-editor --example playback-csv-report -- --csv /tmp/cap-playback-benchmark.csv --baseline-label macos-pass-1 --candidate-label windows-pass-1
+
+# Export playback summary/delta rows to CSV
+cargo run -p cap-editor --example playback-csv-report -- --csv /tmp/cap-playback-benchmark.csv --baseline-label macos-pass-1 --candidate-label windows-pass-1 --output-csv /tmp/cap-playback-summary.csv
 ```
 
 #### Scrub Burst Benchmark (queue stress)
@@ -465,6 +474,27 @@ cargo run -p cap-recording --example playback-test-runner -- full
   - 2.0s avg/p95 **149.21 / 364.12ms**
   - 5.0s avg/p95 **237.82 / 377.19ms**
 - CSV output includes `mode=sequential` and `mode=seek` rows with shared run label for downstream aggregation.
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (playback CSV report tooling)
+
+**Environment:** Linux runner, playback CSV analysis utility validation  
+**Commands:** `playback-csv-report`, `cargo test -p cap-editor --example playback-csv-report`
+
+#### Validation
+- New utility parses playback benchmark CSV sequential + seek rows and groups them by `(run_label, video)`.
+- Reports median sequential metrics:
+  - effective FPS
+  - decode p95
+  - missed deadlines
+- Reports median seek metrics per distance:
+  - seek avg/p95/max
+  - aggregated seek sample/failure counts
+- Supports baseline/candidate run-label deltas across overlapping videos and seek distances.
+- Supports `--output-csv` for summary and delta row export.
+- Smoke runs:
+  - `cargo run -p cap-editor --example playback-csv-report -- --csv /tmp/cap-playback-benchmark.csv --label linux-pass-a`
+  - `cargo run -p cap-editor --example playback-csv-report -- --csv /tmp/cap-playback-benchmark.csv --baseline-label linux-pass-a --candidate-label linux-pass-b --output-csv /tmp/cap-playback-summary.csv`
+- Unit tests: **5 passed** (`parses_sequential_csv_line`, `parses_seek_csv_line`, `summarizes_sequential_and_seek_medians`, `groups_rows_by_label_and_video`, `writes_summary_and_delta_csv_rows`).
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -361,13 +361,14 @@ cargo run -p cap-recording --example playback-test-runner -- full
 
 #### Validation
 - New utility parses scrub benchmark CSV aggregate rows and reports median summaries by run label + video.
+- Empty run labels now automatically fall back to a derived config label (`min_pixels`, `min_requests`, `min_span`, `disabled`) so unlabeled sweeps remain distinguishable.
 - Smoke run against labeled CSV:
   - `cargo run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-labeled.csv --label linux-pass-a`
   - output summary:
     - all_avg **199.01ms**
     - last_avg **213.93ms**
     - successful **144**, failed **0**
-- Unit tests: **3 passed** (`parses_aggregate_csv_line`, `summarizes_medians`, `groups_rows_by_label_and_video`).
+- Unit tests: **4 passed** (`parses_aggregate_csv_line`, `falls_back_to_config_label_when_run_label_missing`, `summarizes_medians`, `groups_rows_by_label_and_video`).
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -191,6 +191,40 @@ cargo run -p cap-recording --example playback-test-runner -- full
 - Decode: avg **4.76ms**, p95 **7.41ms**, p99 **9.82ms**, max **15.94ms**
 - Seek samples: 0.5s **29.80ms**, 1.0s **9.01ms**, 2.0s **8.80ms**, 5.0s **410.35ms**
 
+### Benchmark Run: 2026-02-14 00:00:00 UTC (FFmpeg long-seek tuning pass 3)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `decode-benchmark` and `playback-benchmark`  
+**Change under test:** seek fallback order adjusted (preferred -> legacy backward -> wide window)
+
+#### Decode Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Decoder init: **5.91ms**
+- Sequential decode: **393.7 fps**, avg **2.54ms**
+- Seek latency: 0.5s **2.04ms**, 1.0s **1.71ms**, 2.0s **4.61ms**, 5.0s **110.27ms**
+- Random access: avg **119.53ms**, p95 **364.02ms**, p99 **404.91ms**
+
+#### Decode Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Decoder init: **29.08ms**
+- Sequential decode: **104.1 fps**, avg **9.60ms**
+- Seek latency: 0.5s **6.72ms**, 1.0s **6.76ms**, 2.0s **11.48ms**, 5.0s **569.83ms**
+- Random access: avg **516.48ms**, p95 **1505.44ms**, p99 **1566.39ms**
+
+#### Playback Throughput Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **480/480**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.11**
+- Decode: avg **1.27ms**, p95 **2.33ms**, p99 **2.42ms**, max **3.74ms**
+- Seek samples: 0.5s **12.01ms**, 1.0s **2.68ms**, 2.0s **2.80ms**, 5.0s **144.54ms**
+
+#### Playback Throughput Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **480/480**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.12**
+- Decode: avg **4.95ms**, p95 **7.57ms**, p99 **10.04ms**, max **14.18ms**
+- Seek samples: 0.5s **30.56ms**, 1.0s **9.45ms**, 2.0s **8.94ms**, 5.0s **430.25ms**
+
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 
 ---

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -74,6 +74,15 @@ cargo run -p cap-editor --example decode-benchmark -- --video /path/to/video.mp4
 
 # Add run labels for baseline/candidate grouping
 cargo run -p cap-editor --example decode-benchmark -- --video /path/to/video.mp4 --fps 60 --output-csv /tmp/cap-decode-benchmark.csv --run-label windows-pass-1
+
+# Summarize decode CSV rows grouped by run label and video
+cargo run -p cap-editor --example decode-csv-report -- --csv /tmp/cap-decode-benchmark.csv
+
+# Compare baseline/candidate decode labels
+cargo run -p cap-editor --example decode-csv-report -- --csv /tmp/cap-decode-benchmark.csv --baseline-label macos-pass-1 --candidate-label windows-pass-1
+
+# Export decode summary/delta rows to CSV
+cargo run -p cap-editor --example decode-csv-report -- --csv /tmp/cap-decode-benchmark.csv --baseline-label macos-pass-1 --candidate-label windows-pass-1 --output-csv /tmp/cap-decode-summary.csv
 ```
 
 #### Playback Throughput Benchmark (Linux-compatible)
@@ -1088,6 +1097,48 @@ cargo run -p cap-recording --example playback-test-runner -- full
   - `random_access`
   - `duplicate_batch`
   - `duplicate_request`
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (Decode CSV report baseline/candidate validation)
+
+**Environment:** Linux runner with synthetic 1080p60 MP4 asset  
+**Commands:** `decode-benchmark --output-csv /tmp/cap-decode-benchmark-v2.csv --run-label linux-frame-order-pass-v2`, `decode-benchmark --output-csv /tmp/cap-decode-benchmark-v2.csv --run-label linux-frame-order-pass-v2b`, `decode-csv-report --baseline-label linux-frame-order-pass-v2 --candidate-label linux-frame-order-pass-v2b --output-csv /tmp/cap-decode-summary-v2.csv`  
+**Change under test:** decode CSV reporting utility for grouped summaries and deltas
+
+#### Decode CSV Report — Summary (1080p60)
+- `linux-frame-order-pass-v2`:
+  - Decoder creation: **10.28ms**
+  - Sequential FPS: **377.11**
+  - Sequential decode p95: **3.53ms**
+  - Random access avg/p95: **118.94 / 355.69ms**
+- `linux-frame-order-pass-v2b`:
+  - Decoder creation: **9.18ms**
+  - Sequential FPS: **378.80**
+  - Sequential decode p95: **3.42ms**
+  - Random access avg/p95: **116.85 / 354.24ms**
+
+#### Decode CSV Report — Delta (`v2b - v2`)
+- Core:
+  - Decoder creation: **-1.10ms**
+  - Sequential FPS: **+1.69**
+  - Sequential decode p95: **-0.11ms**
+  - Random access avg: **-2.09ms**
+  - Random access p95: **-1.45ms**
+- Seek deltas (avg / p95 / p99 / max):
+  - 0.5s: **+6.47 / +13.00 / +13.00 / +13.00ms**
+  - 1.0s: **+2.94 / +5.31 / +5.31 / +5.31ms**
+  - 2.0s: **+1.84 / +1.49 / +1.49 / +1.49ms**
+  - 5.0s: **-6.11 / -11.93 / -11.93 / -11.93ms**
+
+#### CSV Artifacts
+- Source decode rows: `/tmp/cap-decode-benchmark-v2.csv`
+- Report summary/delta rows: `/tmp/cap-decode-summary-v2.csv`
+- Report modes emitted:
+  - `summary_core`
+  - `summary_seek`
+  - `summary_duplicate`
+  - `delta_core`
+  - `delta_seek`
+  - `delta_duplicate`
 
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -1140,6 +1140,36 @@ cargo run -p cap-recording --example playback-test-runner -- full
   - `delta_seek`
   - `delta_duplicate`
 
+### Benchmark Run: 2026-02-14 00:00:00 UTC (Audio streaming-first windows path prep)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Command:** `playback-benchmark --fps 60 --max-frames 240 --seek-iterations 8`  
+**Change under test:** audio playback startup path now attempts streaming on all platforms with pre-rendered fallback (`CAP_AUDIO_PRERENDER_ONLY` override)
+
+#### Playback Throughput Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **240/240**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.23**
+- Decode: avg **1.37ms**, p95 **2.52ms**, p99 **2.61ms**, max **4.34ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **42.38 / 94.80 / 94.80ms**
+  - 1.0s: **64.87 / 147.85 / 147.85ms**
+  - 2.0s: **124.91 / 308.52 / 308.52ms**
+  - 5.0s: **223.96 / 354.15 / 354.15ms**
+
+#### Playback Throughput Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **240/240**, failures **0**
+- Missed deadlines: **11**
+- Effective FPS: **60.17**
+- Decode: avg **6.95ms**, p95 **12.62ms**, p99 **23.18ms**, max **31.66ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **177.49 / 356.81 / 356.81ms**
+  - 1.0s: **303.60 / 632.02 / 632.02ms**
+  - 2.0s: **557.40 / 1412.22 / 1412.22ms**
+  - 5.0s: **1070.92 / 1530.27 / 1530.27ms**
+
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 
 ---

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -77,6 +77,9 @@ cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.m
 #### Playback Startup Latency Report (log analysis)
 
 ```bash
+# Capture startup traces from desktop editor playback sessions
+CAP_PLAYBACK_STARTUP_TRACE_FILE=/tmp/playback-startup.csv pnpm dev:desktop
+
 # Parse startup timing logs captured from desktop editor sessions
 cargo run -p cap-editor --example playback-startup-report -- --log /path/to/editor.log
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -138,6 +138,10 @@ cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback
 # List per-run startup metric summaries (avg/p95 by event)
 cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-run-metrics
 
+# Export run counts or run metrics to CSV
+cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-runs --output-csv /tmp/playback-startup-run-summary.csv
+cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-run-metrics --output-csv /tmp/playback-startup-run-summary.csv
+
 # Aggregate multiple session logs
 cargo run -p cap-editor --example playback-startup-report -- --log /path/to/macos.log --log /path/to/windows.log
 
@@ -236,10 +240,14 @@ cargo run -p cap-recording --example playback-test-runner -- full
 
 #### Validation
 - Added `--list-run-metrics` mode to print per-run startup metric summaries (avg/p95/samples per event).
-- Unit tests now include run-metrics aggregation path (**9 passed** total in example target).
+- Added CSV export support for `--list-runs` and `--list-run-metrics` modes.
+- Unit tests now include run-metrics aggregation and run-mode CSV writer paths (**10 passed** total in example target).
 - CLI smoke run:
   - `cargo run -p cap-editor --example playback-startup-report -- --log crates/editor/PLAYBACK-BENCHMARKS.md --list-run-metrics`
   - confirms mode execution path and empty-run handling output.
+  - `cargo run -p cap-editor --example playback-startup-report -- --log crates/editor/PLAYBACK-BENCHMARKS.md --list-runs --output-csv /tmp/playback-startup-run-export.csv`
+  - `cargo run -p cap-editor --example playback-startup-report -- --log crates/editor/PLAYBACK-BENCHMARKS.md --list-run-metrics --output-csv /tmp/playback-startup-run-export.csv`
+  - verified CSV header/output path is produced in no-run scenarios.
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC (supersession span retune to 20)
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -308,6 +308,26 @@ cargo run -p cap-recording --example playback-test-runner -- full
   - 1080p random access avg **115.49ms**, p95 **350.30ms**
   - 4k random access avg **511.55ms**, p95 **1394.69ms**
 
+### Benchmark Run: 2026-02-14 00:00:00 UTC (span threshold recheck after default retunes)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES={15,20,25} scrub-benchmark --runs 3`  
+**Context:** defaults already retuned to `min_requests=7`, `min_pixels=2_000_000`
+
+#### Span sweep medians (last-request latency)
+- 1080p:
+  - **15**: avg **216.43ms**, p95 **457.45ms**
+  - **20**: avg **209.63ms**, p95 **442.04ms**
+  - **25**: avg **213.84ms**, p95 **447.71ms**
+- 4k:
+  - **15**: avg **862.02ms**, p95 **1789.73ms**
+  - **20**: avg **860.43ms**, p95 **1761.25ms**
+  - **25**: avg **866.03ms**, p95 **1781.42ms**
+
+#### Decision
+- Keep `CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES` default at **20**.
+- Candidate spans 15 and 25 were rejected; neither improved both 1080p and 4k tails versus 20 under the new defaults.
+
 ### Benchmark Run: 2026-02-14 00:00:00 UTC
 
 **Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -62,6 +62,9 @@ cargo run -p cap-editor --example decode-benchmark -- --video /path/to/video.mp4
 
 # With custom FPS and iterations
 cargo run -p cap-editor --example decode-benchmark -- --video /path/to/video.mp4 --fps 60 --iterations 50
+
+# Increase seek sampling per distance for more stable tails
+cargo run -p cap-editor --example decode-benchmark -- --video /path/to/video.mp4 --fps 60 --seek-iterations 20
 ```
 
 #### Playback Throughput Benchmark (Linux-compatible)
@@ -72,6 +75,9 @@ cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.m
 
 # Optional audio duration comparison
 cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.mp4 --audio /path/to/audio.ogg --fps 60
+
+# Increase seek sample count for stable p95/max seek stats
+cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.mp4 --fps 60 --max-frames 600 --seek-iterations 20
 ```
 
 #### Playback Startup Latency Report (log analysis)
@@ -259,6 +265,56 @@ cargo run -p cap-recording --example playback-test-runner -- full
 - Effective FPS: **60.11**
 - Decode: avg **5.54ms**, p95 **8.09ms**, p99 **11.25ms**, max **15.17ms**
 - Seek samples: 0.5s **41.73ms**, 1.0s **9.75ms**, 2.0s **8.98ms**, 5.0s **451.74ms**
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (Seek benchmark methodology hardening)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `decode-benchmark` and `playback-benchmark` with `--seek-iterations 10`  
+**Change under test:** benchmark seek sampling now uses varied start positions per iteration and reports avg/p95/max tails
+
+#### Decode Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Decoder init: **6.93ms**
+- Sequential decode: **393.9 fps**, avg **2.54ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **47.25 / 92.23 / 92.23ms**
+  - 1.0s: **69.24 / 144.81 / 144.81ms**
+  - 2.0s: **151.47 / 375.69 / 375.69ms**
+  - 5.0s: **237.30 / 379.66 / 379.66ms**
+- Random access: avg **115.46ms**, p95 **351.75ms**, p99 **386.64ms**
+
+#### Decode Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Decoder init: **30.88ms**
+- Sequential decode: **100.4 fps**, avg **9.96ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **195.41 / 369.35 / 369.35ms**
+  - 1.0s: **333.83 / 671.86 / 671.86ms**
+  - 2.0s: **584.19 / 1421.40 / 1421.40ms**
+  - 5.0s: **925.07 / 1474.59 / 1474.59ms**
+- Random access: avg **539.69ms**, p95 **1467.07ms**, p99 **1667.76ms**
+
+#### Playback Throughput Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **240/240**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.24**
+- Decode: avg **1.17ms**, p95 **2.22ms**, p99 **2.61ms**, max **3.71ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **47.74 / 104.77 / 104.77ms**
+  - 1.0s: **68.99 / 142.64 / 142.64ms**
+  - 2.0s: **155.51 / 367.99 / 367.99ms**
+  - 5.0s: **231.63 / 372.21 / 372.21ms**
+
+#### Playback Throughput Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **240/240**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.13**
+- Decode: avg **5.13ms**, p95 **7.60ms**, p99 **11.15ms**, max **12.78ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **202.75 / 361.23 / 361.23ms**
+  - 1.0s: **320.26 / 617.03 / 617.03ms**
+  - 2.0s: **589.11 / 1424.54 / 1424.54ms**
+  - 5.0s: **926.16 / 1460.47 / 1460.47ms**
 
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -100,6 +100,9 @@ cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4
 
 # Export per-run and aggregate scrub metrics to CSV
 cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4 --runs 3 --output-csv /tmp/cap-scrub-benchmark.csv
+
+# Add explicit run label for cross-machine comparisons
+cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4 --runs 3 --output-csv /tmp/cap-scrub-benchmark.csv --run-label windows-pass-1
 ```
 
 #### Playback Startup Latency Report (log analysis)
@@ -258,6 +261,17 @@ cargo run -p cap-recording --example playback-test-runner -- full
   - 1080p random access avg **116.73ms**, p95 **369.84ms**
   - 4k random access avg **522.27ms**, p95 **1514.02ms**
   - follow-up 4k run: random access avg **537.60ms** and **522.27ms** (variance envelope maintained)
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (scrub CSV run-label tagging)
+
+**Environment:** Linux runner, synthetic 1080p60 MP4  
+**Command:** `scrub-benchmark --runs 2 --output-csv /tmp/cap-scrub-labeled.csv --run-label linux-pass-a`
+
+#### Result
+- Successful requests: **144**, failures: **0**
+- Median all-request latency: avg **199.01ms**, p95 **410.34ms**
+- Median last-request latency: avg **213.93ms**, p95 **410.34ms**
+- CSV output now includes `run_label` column across run and aggregate rows, enabling direct cross-machine merge and grouping.
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -168,7 +168,7 @@ cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback
 # List run-id sample counts discovered in startup CSV logs
 cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-runs
 
-# List per-run startup metric summaries (avg/p95 by event + audio startup mode classification)
+# List per-run startup metric summaries (avg/p95 by callback + path-selection events + audio startup mode classification)
 cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-run-metrics
 
 # Export run counts or run metrics to CSV (`run_metric_audio_path` rows include audio startup mode classification)

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -65,6 +65,9 @@ cargo run -p cap-editor --example decode-benchmark -- --video /path/to/video.mp4
 
 # Increase seek sampling per distance for more stable tails
 cargo run -p cap-editor --example decode-benchmark -- --video /path/to/video.mp4 --fps 60 --seek-iterations 20
+
+# Includes duplicate-request burst stats (burst sizes 4/8/16) by default
+cargo run -p cap-editor --example decode-benchmark -- --video /path/to/video.mp4 --fps 60
 ```
 
 #### Playback Throughput Benchmark (Linux-compatible)
@@ -365,6 +368,40 @@ cargo run -p cap-recording --example playback-test-runner -- full
   - 1.0s: **332.09 / 662.63 / 662.63ms**
   - 2.0s: **584.79 / 1411.56 / 1411.56ms**
   - 5.0s: **1012.17 / 1722.61 / 1722.61ms**
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (Duplicate burst metric stabilization)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `decode-benchmark --seek-iterations 10`  
+**Change under test:** duplicate-request burst benchmark now includes warmup seek to remove first-request cold-start distortion
+
+#### Decode Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Decoder init: **7.31ms**
+- Sequential decode: **392.4 fps**, avg **2.55ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **45.99 / 87.99 / 87.99ms**
+  - 1.0s: **69.52 / 146.76 / 146.76ms**
+  - 2.0s: **148.12 / 359.00 / 359.00ms**
+  - 5.0s: **231.81 / 375.66 / 375.66ms**
+- Random access: avg **115.46ms**, p95 **352.45ms**, p99 **378.86ms**
+- Duplicate burst batch avg / p95:
+  - burst 4: **3.68 / 3.84ms**
+  - burst 8: **3.68 / 3.74ms**
+  - burst 16: **2.33 / 3.69ms**
+
+#### Decode Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Decoder init: **30.03ms**
+- Sequential decode: **94.3 fps**, avg **10.61ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **188.28 / 356.06 / 356.06ms**
+  - 1.0s: **337.66 / 681.87 / 681.87ms**
+  - 2.0s: **635.27 / 1455.41 / 1455.41ms**
+  - 5.0s: **922.75 / 1510.31 / 1510.31ms**
+- Random access: avg **527.08ms**, p95 **1481.91ms**, p99 **1649.11ms**
+- Duplicate burst batch avg / p95:
+  - burst 4: **21.25 / 21.98ms**
+  - burst 8: **21.76 / 21.95ms**
+  - burst 16: **16.89 / 21.72ms**
 
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -81,6 +81,12 @@ cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.m
 
 # Increase seek sample count for stable p95/max seek stats
 cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.mp4 --fps 60 --max-frames 600 --seek-iterations 20
+
+# Export playback throughput + seek samples to CSV
+cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.mp4 --fps 60 --max-frames 600 --seek-iterations 20 --output-csv /tmp/cap-playback-benchmark.csv
+
+# Add run label for cross-machine baseline/candidate grouping
+cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.mp4 --fps 60 --max-frames 600 --output-csv /tmp/cap-playback-benchmark.csv --run-label windows-pass-1
 ```
 
 #### Scrub Burst Benchmark (queue stress)
@@ -442,6 +448,23 @@ cargo run -p cap-recording --example playback-test-runner -- full
     - summary rows per `(label, video)`
     - delta rows per overlapping video
 - Utility tests remain green (**5 passed**).
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (playback benchmark CSV export)
+
+**Environment:** Linux runner, synthetic 1080p60 MP4  
+**Command:** `playback-benchmark --seek-iterations 10 --output-csv /tmp/cap-playback-benchmark.csv --run-label linux-pass-a`
+
+#### Result
+- Sequential row:
+  - effective fps **60.23**
+  - decoded **240**, failed **0**, missed deadlines **0**
+  - decode avg/p95/p99/max: **1.36 / 2.57 / 4.27 / 5.25ms**
+- Seek rows emitted for sampled distances:
+  - 0.5s avg/p95 **48.31 / 97.18ms**
+  - 1.0s avg/p95 **69.16 / 148.41ms**
+  - 2.0s avg/p95 **149.21 / 364.12ms**
+  - 5.0s avg/p95 **237.82 / 377.19ms**
+- CSV output includes `mode=sequential` and `mode=seek` rows with shared run label for downstream aggregation.
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -110,6 +110,9 @@ cargo run -p cap-editor --example playback-startup-report -- --log /path/to/edit
 
 # Aggregate multiple session logs
 cargo run -p cap-editor --example playback-startup-report -- --log /path/to/macos.log --log /path/to/windows.log
+
+# Compare candidate logs against baseline logs
+cargo run -p cap-editor --example playback-startup-report -- --baseline-log /path/to/baseline.log --candidate-log /path/to/candidate.log
 ```
 
 #### Combined Workflow (Recording → Playback)

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -153,6 +153,9 @@ CAP_PLAYBACK_STARTUP_TRACE_FILE=/tmp/playback-startup.csv pnpm dev:desktop
 # Optional run label embedded in each CSV line
 CAP_PLAYBACK_STARTUP_TRACE_FILE=/tmp/playback-startup.csv CAP_PLAYBACK_STARTUP_TRACE_RUN_ID=macos-pass-1 pnpm dev:desktop
 
+# Force legacy pre-rendered startup path for A/B startup comparisons
+CAP_AUDIO_PRERENDER_ONLY=1 CAP_PLAYBACK_STARTUP_TRACE_FILE=/tmp/playback-startup.csv CAP_PLAYBACK_STARTUP_TRACE_RUN_ID=macos-prerender pnpm dev:desktop
+
 # Parse startup timing logs captured from desktop editor sessions
 cargo run -p cap-editor --example playback-startup-report -- --log /path/to/editor.log
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -83,6 +83,13 @@ cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.m
 cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.mp4 --fps 60 --max-frames 600 --seek-iterations 20
 ```
 
+#### Scrub Burst Benchmark (queue stress)
+
+```bash
+# Simulate rapid scrub bursts and track latest-request latency
+cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4 --fps 60 --bursts 20 --burst-size 12 --sweep-seconds 2.0
+```
+
 #### Playback Startup Latency Report (log analysis)
 
 ```bash
@@ -402,6 +409,22 @@ cargo run -p cap-recording --example playback-test-runner -- full
   - burst 4: **21.25 / 21.98ms**
   - burst 8: **21.76 / 21.95ms**
   - burst 16: **16.89 / 21.72ms**
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (Scrub burst queue stress baseline)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Command:** `scrub-benchmark --bursts 20 --burst-size 12 --sweep-seconds 2.0`  
+**Goal:** measure latest-request latency under rapid scrub-like request bursts
+
+#### Scrub Burst Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Requests: **240 success / 0 failures**
+- All-request latency: avg **217.97ms**, p95 **434.83ms**, p99 **455.72ms**, max **461.85ms**
+- Last-request-in-burst latency: avg **312.50ms**, p95 **455.72ms**, p99 **461.85ms**, max **461.85ms**
+
+#### Scrub Burst Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Requests: **240 success / 0 failures**
+- All-request latency: avg **1071.64ms**, p95 **2098.98ms**, p99 **2204.29ms**, max **2204.29ms**
+- Last-request-in-burst latency: avg **1524.00ms**, p95 **2116.35ms**, p99 **2204.29ms**, max **2204.29ms**
 
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -74,6 +74,16 @@ cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.m
 cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.mp4 --audio /path/to/audio.ogg --fps 60
 ```
 
+#### Playback Startup Latency Report (log analysis)
+
+```bash
+# Parse startup timing logs captured from desktop editor sessions
+cargo run -p cap-editor --example playback-startup-report -- --log /path/to/editor.log
+
+# Aggregate multiple session logs
+cargo run -p cap-editor --example playback-startup-report -- --log /path/to/macos.log --log /path/to/windows.log
+```
+
 #### Combined Workflow (Recording → Playback)
 
 ```bash

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -1197,6 +1197,24 @@ cargo run -p cap-recording --example playback-test-runner -- full
   - baseline: `streaming (1 stream / 0 prerender)`
   - candidate: `prerendered (0 stream / 1 prerender)`
 
+### Benchmark Run: 2026-02-14 00:00:00 UTC (Startup path selection events)
+
+**Environment:** Linux runner, startup report parser validation  
+**Commands:** `playback-startup-report --list-run-metrics --output-csv`  
+**Change under test:** startup report now consumes `audio_startup_path_streaming` / `audio_startup_path_prerendered` events even when callback events are missing
+
+#### Validation Dataset
+- Source log: `/workspace/tmp-startup-path-only.csv` (decoded/rendered + `audio_startup_path_prerendered`, no callback rows)
+- Export target: `/tmp/playback-startup-path-only.csv`
+
+#### Results
+- `list-run-metrics` output classified run as:
+  - `audio_path=prerendered stream_samples=0 prerender_samples=1`
+- CSV includes `run_metric_audio_path` row with:
+  - `audio_path=prerendered`
+  - `audio_stream_samples=0`
+  - `audio_prerender_samples=1`
+
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 
 ---

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -360,14 +360,14 @@ cargo run -p cap-recording --example playback-test-runner -- full
 **Commands:** `scrub-csv-report`, `cargo test -p cap-editor --example scrub-csv-report`
 
 #### Validation
-- New utility parses scrub benchmark CSV aggregate rows and reports median summaries by run label.
+- New utility parses scrub benchmark CSV aggregate rows and reports median summaries by run label + video.
 - Smoke run against labeled CSV:
   - `cargo run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-labeled.csv --label linux-pass-a`
   - output summary:
     - all_avg **199.01ms**
     - last_avg **213.93ms**
     - successful **144**, failed **0**
-- Unit tests: **2 passed** (`parses_aggregate_csv_line`, `summarizes_medians`).
+- Unit tests: **3 passed** (`parses_aggregate_csv_line`, `summarizes_medians`, `groups_rows_by_label_and_video`).
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -132,6 +132,9 @@ cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback
 # List run-id sample counts discovered in startup CSV logs
 cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-runs
 
+# List per-run startup metric summaries (avg/p95 by event)
+cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-run-metrics
+
 # Aggregate multiple session logs
 cargo run -p cap-editor --example playback-startup-report -- --log /path/to/macos.log --log /path/to/windows.log
 
@@ -222,6 +225,18 @@ cargo run -p cap-recording --example playback-test-runner -- full
 - CLI smoke run:
   - `cargo run -p cap-editor --example playback-startup-report -- --log crates/editor/PLAYBACK-BENCHMARKS.md --output-csv /tmp/playback-startup-summary.csv`
   - output CSV schema verified with header row.
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (startup run-metrics listing)
+
+**Environment:** Linux runner, startup report parser validation  
+**Commands:** `playback-startup-report --list-run-metrics`, `cargo test -p cap-editor --example playback-startup-report`
+
+#### Validation
+- Added `--list-run-metrics` mode to print per-run startup metric summaries (avg/p95/samples per event).
+- Unit tests now include run-metrics aggregation path (**9 passed** total in example target).
+- CLI smoke run:
+  - `cargo run -p cap-editor --example playback-startup-report -- --log crates/editor/PLAYBACK-BENCHMARKS.md --list-run-metrics`
+  - confirms mode execution path and empty-run handling output.
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC (supersession span retune to 20)
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -97,6 +97,9 @@ CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_PIXELS=3686400 \
 CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_REQUESTS=8 \
 CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES=25 \
 cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4
+
+# Export per-run and aggregate scrub metrics to CSV
+cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4 --runs 3 --output-csv /tmp/cap-scrub-benchmark.csv
 ```
 
 #### Playback Startup Latency Report (log analysis)
@@ -133,6 +136,28 @@ cargo run -p cap-recording --example playback-test-runner -- full
 ## Benchmark History
 
 <!-- PLAYBACK_BENCHMARK_RESULTS_START -->
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (scrub CSV export)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `scrub-benchmark --runs 2 --output-csv /tmp/cap-scrub-benchmark.csv`
+
+#### Scrub Burst Benchmark + CSV — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Successful requests: **192**, failures: **0**
+- Median across 2 runs (all-request): avg **191.35ms**, p95 **430.23ms**, p99 **430.23ms**, max **450.58ms**
+- Median across 2 runs (last-request): avg **290.53ms**, p95 **450.58ms**, p99 **450.58ms**, max **450.58ms**
+
+#### Scrub Burst Benchmark + CSV — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Successful requests: **192**, failures: **0**
+- Median across 2 runs (all-request): avg **740.11ms**, p95 **1712.02ms**, p99 **1712.02ms**, max **1712.03ms**
+- Median across 2 runs (last-request): avg **740.10ms**, p95 **1712.02ms**, p99 **1712.02ms**, max **1712.02ms**
+
+#### CSV Output
+- Output file: `/tmp/cap-scrub-benchmark.csv`
+- Rows emitted per invocation:
+  - one row per run (`scope=run`)
+  - one aggregate row (`scope=aggregate`)
+- Captures runtime supersession env values alongside scrub latency metrics for easier cross-machine sweeps.
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -136,6 +136,10 @@ CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_REQUESTS=3 \
 CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_SPAN_FRAMES=30 \
 cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4
 
+# Optionally gate latest-request-first ordering to higher-resolution streams
+CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_PIXELS=2500000 \
+cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4
+
 # Disable latest-request-first ordering for A/B comparisons
 CAP_FFMPEG_SCRUB_LATEST_FIRST_DISABLED=1 \
 cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4
@@ -218,6 +222,20 @@ cargo run -p cap-recording --example playback-test-runner -- full
 ## Benchmark History
 
 <!-- PLAYBACK_BENCHMARK_RESULTS_START -->
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (latest-first min-pixels metadata capture)
+
+**Environment:** Linux runner, synthetic 1080p60 MP4 asset  
+**Change under test:** scrub CSV metadata now includes `CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_PIXELS` for unlabeled config-derived grouping
+
+#### Validation commands
+- `CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_REQUESTS=3 CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_SPAN_FRAMES=30 CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_PIXELS=2500000 cargo +1.88.0 run -p cap-editor --example scrub-benchmark -- --video /tmp/cap-bench-1080p60.mp4 --fps 60 --bursts 2 --burst-size 12 --sweep-seconds 8.0 --runs 1 --output-csv /tmp/cap-scrub-latest-first-threshold-v2.csv`
+- `cargo +1.88.0 run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-latest-first-threshold-v2.csv`
+
+#### Output validation highlights
+- `scrub-csv-report` config-derived label now includes `latest_first_min_pixels=2500000`:
+  - `cfg(...,latest_first_min_requests=3,latest_first_min_span=30,latest_first_min_pixels=2500000,latest_first=default)`
+- Confirms CSV schema + parser stay aligned for latest-first threshold metadata without requiring explicit run labels.
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC (latest-first threshold metadata capture)
 
@@ -588,7 +606,7 @@ cargo run -p cap-recording --example playback-test-runner -- full
 
 #### Validation
 - New utility parses scrub benchmark CSV aggregate rows and reports median summaries by run label + video.
-- Empty run labels now automatically fall back to a derived config label (`min_pixels`, `min_requests`, `min_span`, `disabled`, `latest_first_min_requests`, `latest_first_min_span`, `latest_first`) so unlabeled sweeps remain distinguishable.
+- Empty run labels now automatically fall back to a derived config label (`min_pixels`, `min_requests`, `min_span`, `disabled`, `latest_first_min_requests`, `latest_first_min_span`, `latest_first_min_pixels`, `latest_first`) so unlabeled sweeps remain distinguishable.
 - Smoke run against labeled CSV:
   - `cargo run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-labeled.csv --label linux-pass-a`
   - output summary:

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -157,6 +157,40 @@ cargo run -p cap-recording --example playback-test-runner -- full
 - Decode: avg **5.41ms**, p95 **7.93ms**, p99 **11.18ms**, max **18.70ms**
 - Seek samples: 0.5s **30.06ms**, 1.0s **9.43ms**, 2.0s **9.15ms**, 5.0s **432.97ms**
 
+### Benchmark Run: 2026-02-14 00:00:00 UTC (FFmpeg long-seek tuning pass 2)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `decode-benchmark` and `playback-benchmark`  
+**Change under test:** narrower backtrack window for forward seeks with near-target keyframe preference
+
+#### Decode Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Decoder init: **6.18ms**
+- Sequential decode: **403.6 fps**, avg **2.48ms**
+- Seek latency: 0.5s **1.78ms**, 1.0s **1.79ms**, 2.0s **7.05ms**, 5.0s **142.01ms**
+- Random access: avg **114.64ms**, p95 **351.09ms**, p99 **378.21ms**
+
+#### Decode Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Decoder init: **29.37ms**
+- Sequential decode: **105.9 fps**, avg **9.44ms**
+- Seek latency: 0.5s **6.50ms**, 1.0s **6.53ms**, 2.0s **11.20ms**, 5.0s **559.44ms**
+- Random access: avg **525.90ms**, p95 **1489.77ms**, p99 **1628.36ms**
+
+#### Playback Throughput Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **480/480**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.11**
+- Decode: avg **1.21ms**, p95 **2.26ms**, p99 **2.35ms**, max **4.11ms**
+- Seek samples: 0.5s **11.39ms**, 1.0s **2.75ms**, 2.0s **2.55ms**, 5.0s **138.90ms**
+
+#### Playback Throughput Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **480/480**, failures **0**
+- Missed deadlines: **1**
+- Effective FPS: **60.11**
+- Decode: avg **4.76ms**, p95 **7.41ms**, p99 **9.82ms**, max **15.94ms**
+- Seek samples: 0.5s **29.80ms**, 1.0s **9.01ms**, 2.0s **8.80ms**, 5.0s **410.35ms**
+
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 
 ---

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -117,6 +117,9 @@ cargo run -p cap-editor --example playback-startup-report -- --log /path/to/edit
 # Filter startup CSV events to a specific labeled run id
 cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --run-id macos-pass-1
 
+# List run-id sample counts discovered in startup CSV logs
+cargo run -p cap-editor --example playback-startup-report -- --log /tmp/playback-startup.csv --list-runs
+
 # Aggregate multiple session logs
 cargo run -p cap-editor --example playback-startup-report -- --log /path/to/macos.log --log /path/to/windows.log
 
@@ -177,6 +180,19 @@ cargo run -p cap-recording --example playback-test-runner -- full
 - CLI smoke run:
   - `cargo run -p cap-editor --example playback-startup-report -- --log crates/editor/PLAYBACK-BENCHMARKS.md --run-id sample-run`
   - Completed successfully with filtered metric output path active.
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (startup report run-id listing + strict filtering)
+
+**Environment:** Linux runner, startup report parser validation  
+**Commands:** `playback-startup-report --list-runs`, `playback-startup-report --run-id ...`
+
+#### Startup Report CLI Validation
+- `--list-runs` mode prints grouped run-id sample counts from CSV traces.
+- Requesting a `--run-id` with zero matched startup samples now exits with an explicit failure.
+- Validation commands:
+  - `cargo run -p cap-editor --example playback-startup-report -- --log crates/editor/PLAYBACK-BENCHMARKS.md --list-runs`
+  - `cargo run -p cap-editor --example playback-startup-report -- --log crates/editor/PLAYBACK-BENCHMARKS.md --run-id missing-run` (expected non-zero exit)
+- Unit tests remain green: `cargo test -p cap-editor --example playback-startup-report` (**6 passed**).
 
 ### Benchmark Run: 2026-02-14 00:00:00 UTC (supersession span retune to 20)
 

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -476,6 +476,56 @@ cargo run -p cap-recording --example playback-test-runner -- full
 - Effective FPS: **60.16**
 - Decode: avg **6.40ms**, p95 **8.65ms**, p99 **13.10ms**, max **18.91ms**
 
+### Benchmark Run: 2026-02-14 00:00:00 UTC (Scrub supersession pass 2: resolution-gated)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Commands:** `scrub-benchmark`, `decode-benchmark`, `playback-benchmark`  
+**Change under test:** supersession heuristic enabled only for higher-resolution streams (`>= 2560x1440`)
+
+#### Scrub Burst Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Requests: **240 success / 0 failures**
+- All-request latency: avg **206.84ms**, p95 **409.20ms**, p99 **424.00ms**, max **436.97ms**
+- Last-request-in-burst latency: avg **297.67ms**, p95 **427.05ms**, p99 **436.97ms**, max **436.97ms**
+
+#### Scrub Burst Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Requests: **240 success / 0 failures**
+- All-request latency: avg **820.24ms**, p95 **1689.13ms**, p99 **1828.91ms**, max **1828.91ms**
+- Last-request-in-burst latency: avg **863.94ms**, p95 **1689.13ms**, p99 **1828.91ms**, max **1828.91ms**
+
+#### Decode Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Decoder init: **6.69ms**
+- Sequential decode: **414.7 fps**, avg **2.41ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **45.48 / 89.37 / 89.37ms**
+  - 1.0s: **69.15 / 144.09 / 144.09ms**
+  - 2.0s: **148.41 / 358.91 / 358.91ms**
+  - 5.0s: **231.79 / 377.04 / 377.04ms**
+- Random access: avg **116.19ms**, p95 **350.22ms**, p99 **379.83ms**
+
+#### Decode Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Decoder init: **29.79ms**
+- Sequential decode: **105.4 fps**, avg **9.49ms**
+- Seek latency (avg / p95 / max):
+  - 0.5s: **189.31 / 354.05 / 354.05ms**
+  - 1.0s: **336.64 / 710.24 / 710.24ms**
+  - 2.0s: **589.34 / 1393.35 / 1393.35ms**
+  - 5.0s: **898.27 / 1479.23 / 1479.23ms**
+- Random access: avg **511.68ms**, p95 **1497.14ms**, p99 **1611.62ms**
+
+#### Playback Throughput Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **240/240**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.23**
+- Decode: avg **1.20ms**, p95 **2.13ms**, p99 **3.09ms**, max **4.08ms**
+
+#### Playback Throughput Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Target: **60 fps**, budget **16.67ms**
+- Decoded: **240/240**, failures **0**
+- Missed deadlines: **0**
+- Effective FPS: **60.19**
+- Decode: avg **4.99ms**, p95 **7.17ms**, p99 **9.64ms**, max **13.37ms**
+
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 
 ---

--- a/crates/editor/PLAYBACK-BENCHMARKS.md
+++ b/crates/editor/PLAYBACK-BENCHMARKS.md
@@ -89,6 +89,9 @@ cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.m
 # Simulate rapid scrub bursts and track latest-request latency
 cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4 --fps 60 --bursts 20 --burst-size 12 --sweep-seconds 2.0
 
+# Aggregate multiple runs (median across runs) for lower-variance comparisons
+cargo run -p cap-editor --example scrub-benchmark -- --video /path/to/video.mp4 --fps 60 --bursts 10 --burst-size 12 --sweep-seconds 2.0 --runs 3
+
 # Runtime tuning for FFmpeg scrub supersession heuristic
 CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_PIXELS=3686400 \
 CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_REQUESTS=8 \
@@ -581,6 +584,24 @@ cargo run -p cap-recording --example playback-test-runner -- full
 - Missed deadlines: **2**
 - Effective FPS: **60.17**
 - Decode: avg **6.43ms**, p95 **8.82ms**, p99 **14.14ms**, max **17.52ms**
+
+### Benchmark Run: 2026-02-14 00:00:00 UTC (Scrub multi-run aggregation support)
+
+**Environment:** Linux runner with synthetic 1080p60 and 4k60 MP4 assets  
+**Command:** `scrub-benchmark --bursts 10 --burst-size 12 --sweep-seconds 2.0 --runs 3`  
+**Change under test:** scrub benchmark now supports repeated runs with median aggregation
+
+#### Scrub Burst Benchmark — 1080p60 (`/tmp/cap-bench-1080p60.mp4`)
+- Runs: **3**, requests: **360 success / 0 failures**
+- Per-run last-request averages: **303.69ms**, **284.95ms**, **310.89ms**
+- Median all-request latency: avg **210.56ms**, p95 **429.62ms**, p99 **442.55ms**, max **457.71ms**
+- Median last-request latency: avg **303.69ms**, p95 **457.71ms**, p99 **457.71ms**, max **457.71ms**
+
+#### Scrub Burst Benchmark — 4k60 (`/tmp/cap-bench-4k60.mp4`)
+- Runs: **3**, requests: **360 success / 0 failures**
+- Per-run last-request averages: **963.69ms**, **887.58ms**, **1001.96ms**
+- Median all-request latency: avg **957.47ms**, p95 **2087.13ms**, p99 **2087.15ms**, max **2087.15ms**
+- Median last-request latency: avg **963.69ms**, p95 **2087.13ms**, p99 **2087.13ms**, max **2087.13ms**
 
 <!-- PLAYBACK_BENCHMARK_RESULTS_END -->
 

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1187,7 +1187,8 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 3. Added `--list-runs` mode to enumerate run-id sample counts from startup CSV traces.
 4. Added strict failures when a requested run-id filter matches zero startup samples.
 5. Added `--output-csv` export for aggregate summaries and baseline/candidate deltas.
-6. Added parser tests that validate run-id filtering behavior on mixed-run CSV traces.
+6. Added `--list-run-metrics` mode to print per-run startup metric summaries.
+7. Added parser tests that validate run-id filtering behavior on mixed-run CSV traces.
 
 **Changes Made**:
 - `crates/editor/examples/playback-startup-report.rs`
@@ -1197,10 +1198,12 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
     - `--baseline-run-id`
     - `--candidate-run-id`
     - `--list-runs`
+    - `--list-run-metrics`
     - `--output-csv`
   - run-id filter now excludes non-matching CSV rows before metric aggregation
   - run-id filtered queries now return explicit non-zero exit on zero matches
   - aggregate and delta modes can append CSV rows for downstream analysis
+  - run-metrics mode now reports per-run decoded/rendered/audio startup summaries
   - added unit test coverage for run-id-filtered parsing
 - `crates/editor/PLAYBACK-BENCHMARKS.md`
   - added command examples for run-id filtering, run listing, CSV export, and same-file baseline/candidate comparisons
@@ -1208,6 +1211,7 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 **Verification**:
 - `cargo +1.88.0 test -p cap-editor --example playback-startup-report`
 - `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --list-runs`
+- `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --list-run-metrics`
 - `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --run-id missing-run` (expected non-zero exit)
 - `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --output-csv /tmp/playback-startup-summary.csv`
 
@@ -1215,8 +1219,9 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 - ✅ Startup parser supports grouped analysis across repeated sessions in one CSV file.
 - ✅ Baseline/candidate deltas can now target specific labeled runs in shared trace files.
 - ✅ Run-id inventory can be listed before comparisons to avoid manual CSV inspection.
+- ✅ Run-metrics listing surfaces avg/p95 startup behavior per run id without manual slicing.
 - ✅ CSV summaries/deltas can now be exported to files for external aggregation.
-- ✅ All startup report example tests passing (8/8).
+- ✅ All startup report example tests passing (9/9).
 
 **Stopping point**: macOS/Windows startup captures can remain in a single trace file while still enabling precise per-run before/after reporting.
 

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -3425,6 +3425,37 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (direct stale-drop accounting + stride render counter fix)
+
+**Goal**: Align transport drop-rate and render FPS diagnostics with direct-path behavior, including stride-corrected direct renders
+
+**What was done**:
+1. Counted direct ingress/response stale drops in overall dropped-frame window counter.
+2. Counted stride-corrected direct renders in actual render FPS counters.
+3. Re-ran desktop typecheck and utility test suite.
+
+**Changes Made**:
+- `apps/desktop/src/utils/socket.ts`
+  - direct ingress stale drops now increment `framesDropped`
+  - direct response stale drops now increment `framesDropped`
+  - stride-correction direct render path now increments:
+    - `actualRendersCount`
+    - `renderFrameCount`
+
+**Verification**:
+- `pnpm --dir apps/desktop exec biome format --write src/utils/socket.ts`
+- `pnpm --dir apps/desktop exec tsc --noEmit`
+- `pnpm --dir apps/desktop exec vitest run src/utils/frame-transport-order.test.ts src/utils/frame-order.test.ts src/utils/frame-transport-inflight.test.ts src/utils/frame-transport-config.test.ts src/utils/frame-transport-retry.test.ts src/utils/shared-frame-buffer.test.ts`
+
+**Results**:
+- ✅ Drop-rate calculations now include direct-path stale drops.
+- ✅ Render FPS counters now include stride-corrected direct frames.
+- ✅ Desktop typecheck and utility tests pass (30/30).
+
+**Stopping point**: Ready for target-machine sessions where drop-rate and render-FPS telemetry should better match direct-path visual behavior.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -777,6 +777,37 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Supersession default span tuning)
+
+**Goal**: Promote a better default supersession span without requiring env overrides
+
+**What was done**:
+1. Benchmarked supersession configs with multi-run scrub reports (`--runs 3`) to reduce noise.
+2. Compared default behavior against candidate span thresholds.
+3. Set default `CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES` fallback to `25`.
+4. Re-ran scrub/decode/playback benchmarks with the new default.
+
+**Changes Made**:
+- `crates/rendering/src/decoder/ffmpeg.rs`
+  - changed default supersession span fallback from `FRAME_CACHE_SIZE / 2` to `25`
+  - kept runtime override support intact
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - added benchmark run section for the new default tuning pass
+
+**Results**:
+- ✅ Scrub median improvements vs previous default:
+  - 1080p last-request avg: **~319.76ms -> ~294.07ms**
+  - 4k last-request avg: **~967.21ms -> ~808.71ms**
+  - 4k last-request p95: **~1881ms -> ~1694ms**
+- ✅ Playback remained 60fps-class in regression runs:
+  - 1080p: **60.22 fps**
+  - 4k: **60.18 fps** (best run in pass)
+- ✅ Decode metrics remained in expected variance envelope after default change.
+
+**Stopping point**: supersession now ships with a stronger default profile while remaining fully runtime-tunable for platform-specific calibration.
+
+---
+
 ### Session 2026-02-14 (Scrub benchmark multi-run aggregation)
 
 **Goal**: Improve scrub benchmark repeatability by reducing single-run noise in comparisons

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1389,6 +1389,40 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (SAB retry decision extraction + test coverage)
+
+**Goal**: Make SAB retry/fallback policy deterministic and test-covered
+
+**What was done**:
+1. Extracted SAB write-failure decision logic into a dedicated helper.
+2. Replaced inline socket retry branch logic with helper-driven decisions.
+3. Added targeted unit tests for oversize fallback, retry progression, and retry-limit fallback.
+
+**Changes Made**:
+- `apps/desktop/src/utils/frame-transport-retry.ts`
+  - added `decideSabWriteFailure`
+  - explicit decision outcomes:
+    - `retry`
+    - `fallback_oversize`
+    - `fallback_retry_limit`
+- `apps/desktop/src/utils/socket.ts`
+  - now consumes `decideSabWriteFailure` for SAB write-failure handling
+- `apps/desktop/src/utils/frame-transport-retry.test.ts`
+  - added 3 tests covering all decision outcomes
+
+**Verification**:
+- `pnpm exec biome format --write apps/desktop/src/utils/socket.ts apps/desktop/src/utils/frame-transport-retry.ts apps/desktop/src/utils/frame-transport-retry.test.ts`
+- `pnpm --dir apps/desktop exec vitest run src/utils/frame-transport-retry.test.ts src/utils/frame-transport-config.test.ts src/utils/shared-frame-buffer.test.ts` (11 passed)
+- `pnpm --dir apps/desktop exec tsc --noEmit`
+
+**Results**:
+- ✅ SAB retry policy behavior is now isolated, testable, and easier to tune.
+- ✅ Desktop tests and TypeScript checks pass.
+
+**Stopping point**: keep using SAB telemetry counters on target machines to tune retry limit and slot sizing defaults from real playback traces.
+
+---
+
 ### Session 2026-02-14 (Rejected superseded-burst cache-window reduction)
 
 **Goal**: Reduce superseded scrub decode work by shrinking decode cache window for superseded requests

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1335,15 +1335,17 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
     - probes EMPTY slots first
     - if none available, probes READY slots and replaces the first claimable READY slot
 - `apps/desktop/src/utils/shared-frame-buffer.test.ts`
-  - added test verifying full-ring overwrite keeps latest frame set (`[2, 3]`) after writing `1,2,3` into 2 slots
+  - added tests verifying:
+    - full-ring overwrite keeps latest frame set (`[2, 3]`) after writing `1,2,3` into 2 slots
+    - READING slots are not overwritten when ring is saturated
 
 **Verification**:
 - `pnpm exec biome format --write apps/desktop/src/utils/shared-frame-buffer.ts apps/desktop/src/utils/shared-frame-buffer.test.ts`
-- `pnpm --dir apps/desktop exec vitest run src/utils/shared-frame-buffer.test.ts` (4 passed)
+- `pnpm --dir apps/desktop exec vitest run src/utils/shared-frame-buffer.test.ts` (5 passed)
 - `pnpm --dir apps/desktop exec tsc --noEmit`
 
 **Results**:
-- ✅ Desktop unit tests pass (4/4) for sparse-slot and overwrite-on-full behaviors.
+- ✅ Desktop unit tests pass (5/5) for sparse-slot, overwrite-on-full, and READING-slot protection behaviors.
 - ✅ Producer now avoids avoidable write failures when buffer is saturated with READY slots and can keep newer frames flowing.
 
 **Stopping point**: validate on macOS/Windows with SAB telemetry to confirm reduced worker fallback rate under sustained high-resolution playback.

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -3361,7 +3361,8 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 **Results**:
 - ✅ Startup report now emits path-selection metric summaries in both console and CSV flows.
-- ✅ Existing startup report tests remain green (11/11).
+- ✅ Added structured-log parsing coverage for path-selection-only lines.
+- ✅ Existing startup report tests remain green (12/12).
 
 **Stopping point**: Ready for real startup traces where path-selection event timing should be compared directly against callback startup timing.
 

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1314,6 +1314,36 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Shared frame buffer overwrite-on-full policy)
+
+**Goal**: Preserve latest-frame delivery under sustained pressure without unnecessary SAB write failures
+
+**What was done**:
+1. Added producer fallback policy to reclaim READY slots when no EMPTY slots are available.
+2. Kept WRITING/READING slots protected; only READY slots are eligible for replacement.
+3. Added unit coverage for overwrite-on-full behavior.
+
+**Changes Made**:
+- `apps/desktop/src/utils/shared-frame-buffer.ts`
+  - producer write now:
+    - probes EMPTY slots first
+    - if none available, probes READY slots and replaces the first claimable READY slot
+- `apps/desktop/src/utils/shared-frame-buffer.test.ts`
+  - added test verifying full-ring overwrite keeps latest frame set (`[2, 3]`) after writing `1,2,3` into 2 slots
+
+**Verification**:
+- `pnpm exec biome format --write apps/desktop/src/utils/shared-frame-buffer.ts apps/desktop/src/utils/shared-frame-buffer.test.ts`
+- `pnpm --dir apps/desktop exec vitest run src/utils/shared-frame-buffer.test.ts` (4 passed)
+- `pnpm --dir apps/desktop exec tsc --noEmit`
+
+**Results**:
+- ✅ Desktop unit tests pass (4/4) for sparse-slot and overwrite-on-full behaviors.
+- ✅ Producer now avoids avoidable write failures when buffer is saturated with READY slots and can keep newer frames flowing.
+
+**Stopping point**: validate on macOS/Windows with SAB telemetry to confirm reduced worker fallback rate under sustained high-resolution playback.
+
+---
+
 ### Session 2026-02-14 (Rejected superseded-burst cache-window reduction)
 
 **Goal**: Reduce superseded scrub decode work by shrinking decode cache window for superseded requests

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1466,7 +1466,7 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 2. Added transport diagnostics to overlay panel:
    - render FPS
    - transport MB/s
-   - SAB slot size and resize count
+   - SAB slot size, slot count, total SAB memory, and resize count
    - SAB fallback counters (oversize vs retry-limit)
    - in-flight SAB retry count
 3. Extended clipboard export payload with the same transport diagnostics.

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -3818,10 +3818,11 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 **What was done**:
 1. Added runtime env controls for latest-first minimum request count and span threshold.
-2. Kept existing default behavior by mapping defaults to current policy (`min_requests=2`, `min_span` inherited from supersession span).
-3. Extended scrub CSV output to persist latest-first threshold env values.
-4. Extended scrub CSV report config-label fallback parsing to include latest-first threshold values.
-5. Added targeted parser/unit test updates for both legacy and extended scrub CSV schemas.
+2. Added runtime env control for latest-first minimum pixel gating.
+3. Kept existing default behavior by mapping defaults to current policy (`min_requests=2`, `min_span` inherited from supersession span).
+4. Extended scrub CSV output to persist latest-first threshold env values.
+5. Extended scrub CSV report config-label fallback parsing to include latest-first threshold values.
+6. Added targeted parser/unit test updates for both legacy and extended scrub CSV schemas.
 
 **Changes Made**:
 - `crates/rendering/src/decoder/ffmpeg.rs`
@@ -3831,12 +3832,14 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
   - new env vars:
     - `CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_REQUESTS`
     - `CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_SPAN_FRAMES`
+    - `CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_PIXELS`
   - latest-first prioritization now gates on those thresholds
   - added request-count threshold unit test for prioritization guard
 - `crates/editor/examples/scrub-benchmark.rs`
   - CSV output now includes:
     - `latest_first_min_requests`
     - `latest_first_min_span_frames`
+    - `latest_first_min_pixels`
     - `latest_first_disabled`
 - `crates/editor/examples/scrub-csv-report.rs`
   - parser now supports both previous and extended CSV schemas using index fallbacks
@@ -3853,11 +3856,14 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 - `CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_REQUESTS=3 CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_SPAN_FRAMES=30 cargo +1.88.0 run -p cap-editor --example scrub-benchmark -- --video /tmp/cap-bench-1080p60.mp4 --fps 60 --bursts 3 --burst-size 12 --sweep-seconds 8.0 --runs 2 --output-csv /tmp/cap-scrub-latest-first-threshold.csv`
 - `CAP_FFMPEG_SCRUB_LATEST_FIRST_DISABLED=1 CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_REQUESTS=3 CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_SPAN_FRAMES=30 cargo +1.88.0 run -p cap-editor --example scrub-benchmark -- --video /tmp/cap-bench-1080p60.mp4 --fps 60 --bursts 3 --burst-size 12 --sweep-seconds 8.0 --runs 2 --output-csv /tmp/cap-scrub-latest-first-threshold.csv`
 - `cargo +1.88.0 run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-latest-first-threshold.csv`
+- `CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_REQUESTS=3 CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_SPAN_FRAMES=30 CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_PIXELS=2500000 cargo +1.88.0 run -p cap-editor --example scrub-benchmark -- --video /tmp/cap-bench-1080p60.mp4 --fps 60 --bursts 2 --burst-size 12 --sweep-seconds 8.0 --runs 1 --output-csv /tmp/cap-scrub-latest-first-threshold-v2.csv`
+- `cargo +1.88.0 run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-latest-first-threshold-v2.csv`
 
 **Results**:
 - ✅ Latest-first activation policy is now fully runtime-tunable without recompiling.
 - ✅ Scrub CSV pipelines remain backward-compatible with old row schema while emitting richer threshold metadata for new runs.
 - ✅ Unlabeled scrub rows now carry config-derived labels with `latest_first_min_requests` and `latest_first_min_span`, enabling grouped analysis without manual run labels.
+- ✅ Unlabeled scrub rows now also carry `latest_first_min_pixels`, enabling resolution-gating comparisons via config-derived grouping.
 - ✅ Decoder and scrub parser tests pass with expanded coverage.
 
 **Stopping point**: Use new latest-first threshold env knobs in macOS/Windows labeled sweeps to tune medium/long scrub tails per hardware profile.

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1009,7 +1009,9 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 **What was done**:
 1. Extended startup report parser to read optional CSV run-id column.
 2. Added run-id filters for aggregate mode and baseline/candidate comparison mode.
-3. Added parser tests that validate run-id filtering behavior on mixed-run CSV traces.
+3. Added `--list-runs` mode to enumerate run-id sample counts from startup CSV traces.
+4. Added strict failures when a requested run-id filter matches zero startup samples.
+5. Added parser tests that validate run-id filtering behavior on mixed-run CSV traces.
 
 **Changes Made**:
 - `crates/editor/examples/playback-startup-report.rs`
@@ -1018,18 +1020,22 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
     - `--run-id`
     - `--baseline-run-id`
     - `--candidate-run-id`
+    - `--list-runs`
   - run-id filter now excludes non-matching CSV rows before metric aggregation
+  - run-id filtered queries now return explicit non-zero exit on zero matches
   - added unit test coverage for run-id-filtered parsing
 - `crates/editor/PLAYBACK-BENCHMARKS.md`
-  - added command examples for run-id filtering and same-file baseline/candidate comparisons
+  - added command examples for run-id filtering, run listing, and same-file baseline/candidate comparisons
 
 **Verification**:
 - `cargo +1.88.0 test -p cap-editor --example playback-startup-report`
-- `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --run-id sample-run`
+- `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --list-runs`
+- `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --run-id missing-run` (expected non-zero exit)
 
 **Results**:
 - ✅ Startup parser supports grouped analysis across repeated sessions in one CSV file.
 - ✅ Baseline/candidate deltas can now target specific labeled runs in shared trace files.
+- ✅ Run-id inventory can be listed before comparisons to avoid manual CSV inspection.
 - ✅ All startup report example tests passing (6/6).
 
 **Stopping point**: macOS/Windows startup captures can remain in a single trace file while still enabling precise per-run before/after reporting.

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1120,7 +1120,8 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 2. Added run-id filters for aggregate mode and baseline/candidate comparison mode.
 3. Added `--list-runs` mode to enumerate run-id sample counts from startup CSV traces.
 4. Added strict failures when a requested run-id filter matches zero startup samples.
-5. Added parser tests that validate run-id filtering behavior on mixed-run CSV traces.
+5. Added `--output-csv` export for aggregate summaries and baseline/candidate deltas.
+6. Added parser tests that validate run-id filtering behavior on mixed-run CSV traces.
 
 **Changes Made**:
 - `crates/editor/examples/playback-startup-report.rs`
@@ -1130,22 +1131,26 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
     - `--baseline-run-id`
     - `--candidate-run-id`
     - `--list-runs`
+    - `--output-csv`
   - run-id filter now excludes non-matching CSV rows before metric aggregation
   - run-id filtered queries now return explicit non-zero exit on zero matches
+  - aggregate and delta modes can append CSV rows for downstream analysis
   - added unit test coverage for run-id-filtered parsing
 - `crates/editor/PLAYBACK-BENCHMARKS.md`
-  - added command examples for run-id filtering, run listing, and same-file baseline/candidate comparisons
+  - added command examples for run-id filtering, run listing, CSV export, and same-file baseline/candidate comparisons
 
 **Verification**:
 - `cargo +1.88.0 test -p cap-editor --example playback-startup-report`
 - `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --list-runs`
 - `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --run-id missing-run` (expected non-zero exit)
+- `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --output-csv /tmp/playback-startup-summary.csv`
 
 **Results**:
 - ✅ Startup parser supports grouped analysis across repeated sessions in one CSV file.
 - ✅ Baseline/candidate deltas can now target specific labeled runs in shared trace files.
 - ✅ Run-id inventory can be listed before comparisons to avoid manual CSV inspection.
-- ✅ All startup report example tests passing (6/6).
+- ✅ CSV summaries/deltas can now be exported to files for external aggregation.
+- ✅ All startup report example tests passing (8/8).
 
 **Stopping point**: macOS/Windows startup captures can remain in a single trace file while still enabling precise per-run before/after reporting.
 

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -3076,6 +3076,7 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 - ✅ Stride-correction responses now honor frame-order stale gating before main-thread render.
 - ✅ Direct-path ordering state now distinguishes accepted ingress ordering from completed render ordering.
 - ✅ Desktop typecheck and transport utility tests pass (28/28).
+- ✅ Transport order helper coverage now includes duplicate-frame and wraparound-forward decision cases (30/30 utility tests).
 
 **Stopping point**: Ready for target-machine sessions to validate reduced direct-path visual regressions under stride-correction-heavy clips.
 

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -3456,6 +3456,33 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (socket dead render counter cleanup)
+
+**Goal**: Remove unused render counter state from socket transport hot paths to reduce bookkeeping overhead
+
+**What was done**:
+1. Removed unused `renderFrameCount` state from socket transport.
+2. Removed associated increments from direct render branches.
+3. Re-ran desktop typecheck and utility tests.
+
+**Changes Made**:
+- `apps/desktop/src/utils/socket.ts`
+  - removed `renderFrameCount` declaration
+  - removed direct-path increment sites that did not feed any stats output
+
+**Verification**:
+- `pnpm --dir apps/desktop exec biome format --write src/utils/socket.ts`
+- `pnpm --dir apps/desktop exec tsc --noEmit`
+- `pnpm --dir apps/desktop exec vitest run src/utils/frame-transport-order.test.ts src/utils/frame-order.test.ts src/utils/frame-transport-inflight.test.ts src/utils/frame-transport-config.test.ts src/utils/frame-transport-retry.test.ts src/utils/shared-frame-buffer.test.ts`
+
+**Results**:
+- ✅ Socket hot path no longer updates unused render counter state.
+- ✅ Desktop typecheck and utility tests pass (30/30).
+
+**Stopping point**: Ready for continued direct-path tuning with leaner per-frame bookkeeping.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -982,7 +982,8 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 1. Added a new CSV report example for scrub benchmarks.
 2. Implemented aggregate-row parsing with run-label and video grouping.
 3. Added baseline/candidate label delta reporting per overlapping video.
-4. Added unit tests for CSV parsing, median summarization, and grouping behavior.
+4. Added derived config-label fallback for rows without explicit run labels.
+5. Added unit tests for CSV parsing, config-label fallback, median summarization, and grouping behavior.
 
 **Changes Made**:
 - `crates/editor/examples/scrub-csv-report.rs`
@@ -992,18 +993,20 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
     - `--baseline-label <run-label>`
     - `--candidate-label <run-label>`
   - reports median summaries per run label from aggregate rows
+  - auto-labels unlabeled rows with config-derived keys
   - computes candidate-minus-baseline deltas for all/last request avg and p95 per video
 - `crates/editor/PLAYBACK-BENCHMARKS.md`
   - added command usage and validation run output for the new utility
 
 **Verification**:
 - `cargo +1.88.0 check -p cap-editor --example scrub-csv-report`
-- `cargo +1.88.0 test -p cap-editor --example scrub-csv-report` (3 tests)
+- `cargo +1.88.0 test -p cap-editor --example scrub-csv-report` (4 tests)
 - `cargo +1.88.0 run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-labeled.csv --label linux-pass-a`
 
 **Results**:
 - ✅ Cross-machine scrub CSVs can now be summarized and compared without manual spreadsheet work.
-- ✅ Utility test suite passing (3/3).
+- ✅ Unlabeled sweeps now group correctly by supersession config defaults/overrides.
+- ✅ Utility test suite passing (4/4).
 
 **Stopping point**: startup and scrub evidence collection on macOS/Windows now has matching run-label analysis tools on Linux for post-capture evaluation.
 

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -471,6 +471,33 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Playback startup instrumentation alignment)
+
+**Goal**: Make startup latency logs directly comparable across decode, render, and audio callback milestones
+
+**What was done**:
+1. Added playback startup origin timestamp at playback start.
+2. Logged first decoded frame availability in prefetch pipeline against that origin.
+3. Logged first rendered frame against the same origin.
+4. Switched audio callback startup logging to use the same playback origin timestamp.
+
+**Changes Made**:
+- `crates/editor/src/playback.rs`
+  - added startup timeline logs:
+    - `Playback first decoded frame ready`
+    - `Playback first frame rendered`
+  - added `startup_instant` to `AudioPlayback` and wired callback logs to playback start origin
+
+**Results**:
+- Playback throughput remains at ~60fps in synthetic benchmark after instrumentation:
+  - 1080p: **60.11 fps**, missed deadlines **0**
+  - 4k: **60.11 fps**, missed deadlines **1**
+- No functional playback regression observed in benchmark pass.
+
+**Stopping point**: startup timing evidence can now be captured in real editor sessions and compared directly; next required step is collecting macOS and Windows session logs with the new unified timing markers.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -3162,6 +3162,45 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (startup report audio-path classification)
+
+**Goal**: Improve startup trace readability by explicitly classifying audio startup mode per run (streaming/prerendered/mixed/none)
+
+**What was done**:
+1. Added audio-path classification helpers to startup report parser.
+2. Extended `--list-run-metrics` output with audio path labels and sample counts.
+3. Extended aggregate and delta modes with explicit audio path summary lines.
+4. Added unit tests covering all audio-path classification modes.
+
+**Changes Made**:
+- `crates/editor/examples/playback-startup-report.rs`
+  - added:
+    - `AudioStartupPath` enum
+    - `detect_audio_startup_path`
+    - `audio_startup_path_label`
+  - `--list-run-metrics` now prints audio path classification per run id
+  - aggregate mode prints:
+    - `audio startup path: <mode> (stream_samples=<n> prerender_samples=<n>)`
+  - delta mode prints:
+    - baseline and candidate audio path classification + counts
+  - tests now include `detects_audio_startup_path_modes`
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - startup report command docs now mention audio-path classification in run-metrics output
+
+**Verification**:
+- `cargo +1.88.0 fmt --all`
+- `cargo +1.88.0 test -p cap-editor --example playback-startup-report`
+- `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --list-run-metrics`
+
+**Results**:
+- ✅ Startup report now surfaces whether runs used streaming, pre-rendered, mixed, or no audio callback samples.
+- ✅ Unit tests pass with new audio-path mode coverage (11/11).
+- ✅ CLI run succeeds with updated run-metrics output path.
+
+**Stopping point**: Ready for macOS/Windows startup traces where audio path classification can quickly verify whether streaming-first startup engaged.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1010,7 +1010,8 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 2. Implemented aggregate-row parsing with run-label and video grouping.
 3. Added baseline/candidate label delta reporting per overlapping video.
 4. Added derived config-label fallback for rows without explicit run labels.
-5. Added unit tests for CSV parsing, config-label fallback, median summarization, and grouping behavior.
+5. Added `--output-csv` to persist summary and delta rows.
+6. Added unit tests for CSV parsing, config-label fallback, median summarization, grouping, and CSV writing.
 
 **Changes Made**:
 - `crates/editor/examples/scrub-csv-report.rs`
@@ -1019,21 +1020,25 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
     - `--label <run-label>`
     - `--baseline-label <run-label>`
     - `--candidate-label <run-label>`
+    - `--output-csv <path>`
   - reports median summaries per run label from aggregate rows
   - auto-labels unlabeled rows with config-derived keys
   - computes candidate-minus-baseline deltas for all/last request avg and p95 per video
+  - writes summary/delta rows for downstream reporting when output path is provided
 - `crates/editor/PLAYBACK-BENCHMARKS.md`
   - added command usage and validation run output for the new utility
 
 **Verification**:
 - `cargo +1.88.0 check -p cap-editor --example scrub-csv-report`
-- `cargo +1.88.0 test -p cap-editor --example scrub-csv-report` (4 tests)
+- `cargo +1.88.0 test -p cap-editor --example scrub-csv-report` (5 tests)
 - `cargo +1.88.0 run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-labeled.csv --label linux-pass-a`
+- `cargo +1.88.0 run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-span-20-22.csv --baseline-label span20 --candidate-label span22 --output-csv /tmp/cap-scrub-summary.csv`
 
 **Results**:
 - ✅ Cross-machine scrub CSVs can now be summarized and compared without manual spreadsheet work.
 - ✅ Unlabeled sweeps now group correctly by supersession config defaults/overrides.
-- ✅ Utility test suite passing (4/4).
+- ✅ Summary/delta exports can now be archived as machine-readable artifacts.
+- ✅ Utility test suite passing (5/5).
 
 **Stopping point**: startup and scrub evidence collection on macOS/Windows now has matching run-label analysis tools on Linux for post-capture evaluation.
 

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -850,6 +850,25 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Startup trace run labeling)
+
+**Goal**: Improve startup trace collection hygiene across repeated platform sessions
+
+**What was done**:
+1. Added optional startup trace run label sourced from `CAP_PLAYBACK_STARTUP_TRACE_RUN_ID`.
+2. Startup CSV rows now include a fifth `run_id` column.
+3. Updated benchmark docs with labeled trace capture example.
+
+**Changes Made**:
+- `crates/editor/src/playback.rs`
+  - added run-id capture for startup trace rows
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - documented labeled startup trace collection command
+
+**Stopping point**: startup traces from macOS/Windows can now carry explicit run labels for easier before/after grouping.
+
+---
+
 ### Session 2026-02-14 (Scrub benchmark multi-run aggregation)
 
 **Goal**: Improve scrub benchmark repeatability by reducing single-run noise in comparisons

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1882,6 +1882,40 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (transport split percentage diagnostics)
+
+**Goal**: Make long-session transport attribution easier by surfacing SAB-vs-worker share percentages directly in overlay and clipboard output
+
+**What was done**:
+1. Added derived transport split metrics for SAB and worker frame share.
+2. Added derived superseded-drop percentage relative to total received frames.
+3. Extended clipboard export and overlay rows with these percentages.
+4. Re-ran desktop typecheck and targeted transport tests.
+
+**Changes Made**:
+- `apps/desktop/src/routes/editor/PerformanceOverlay.tsx`
+  - added derived helpers:
+    - total transported frame count
+    - SAB frame share percent
+    - worker frame share percent
+    - superseded-drop percent
+  - clipboard export now includes all three percentages
+  - new overlay row displays transport split percentages during active sessions
+
+**Verification**:
+- `pnpm --dir apps/desktop exec tsc --noEmit`
+- `pnpm --dir apps/desktop exec vitest run src/utils/frame-transport-config.test.ts src/utils/frame-transport-retry.test.ts src/utils/shared-frame-buffer.test.ts`
+- `pnpm --dir apps/desktop exec biome format --write src/routes/editor/PerformanceOverlay.tsx`
+
+**Results**:
+- ✅ Overlay now provides immediate percentage-level attribution for SAB vs worker transport usage.
+- ✅ Clipboard exports include normalized split metrics for easier cross-machine comparison.
+- ✅ Desktop typecheck and targeted transport tests pass.
+
+**Stopping point**: Ready for macOS/Windows diagnostics runs where percentage splits can be compared alongside fallback byte totals and startup timing traces.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1193,7 +1193,8 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 4. Added strict failures when a requested run-id filter matches zero startup samples.
 5. Added `--output-csv` export for aggregate summaries and baseline/candidate deltas.
 6. Added `--list-run-metrics` mode to print per-run startup metric summaries.
-7. Added parser tests that validate run-id filtering behavior on mixed-run CSV traces.
+7. Added CSV export support for `--list-runs` and `--list-run-metrics` modes.
+8. Added parser tests that validate run-id filtering behavior on mixed-run CSV traces.
 
 **Changes Made**:
 - `crates/editor/examples/playback-startup-report.rs`
@@ -1209,6 +1210,7 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
   - run-id filtered queries now return explicit non-zero exit on zero matches
   - aggregate and delta modes can append CSV rows for downstream analysis
   - run-metrics mode now reports per-run decoded/rendered/audio startup summaries
+  - list-runs and list-run-metrics modes can export rows via shared CSV output path
   - added unit test coverage for run-id-filtered parsing
 - `crates/editor/PLAYBACK-BENCHMARKS.md`
   - added command examples for run-id filtering, run listing, CSV export, and same-file baseline/candidate comparisons
@@ -1217,6 +1219,8 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 - `cargo +1.88.0 test -p cap-editor --example playback-startup-report`
 - `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --list-runs`
 - `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --list-run-metrics`
+- `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --list-runs --output-csv /tmp/playback-startup-run-export.csv`
+- `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --list-run-metrics --output-csv /tmp/playback-startup-run-export.csv`
 - `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --run-id missing-run` (expected non-zero exit)
 - `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --output-csv /tmp/playback-startup-summary.csv`
 
@@ -1226,7 +1230,8 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 - ✅ Run-id inventory can be listed before comparisons to avoid manual CSV inspection.
 - ✅ Run-metrics listing surfaces avg/p95 startup behavior per run id without manual slicing.
 - ✅ CSV summaries/deltas can now be exported to files for external aggregation.
-- ✅ All startup report example tests passing (9/9).
+- ✅ List-run and run-metrics modes can now emit CSV artifacts for CI/report pipelines.
+- ✅ All startup report example tests passing (10/10).
 
 **Stopping point**: macOS/Windows startup captures can remain in a single trace file while still enabling precise per-run before/after reporting.
 

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -131,6 +131,7 @@ cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.m
 | `crates/recording/examples/playback-test-runner.rs` | Playback benchmark runner |
 | `crates/editor/examples/playback-benchmark.rs` | Linux-compatible playback throughput benchmark |
 | `crates/editor/examples/scrub-benchmark.rs` | Scrub burst latency benchmark |
+| `crates/editor/examples/scrub-csv-report.rs` | Scrub CSV summary and label-delta analysis |
 
 ---
 
@@ -970,6 +971,41 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 **Decision**: keep `min_span_frames=20`; candidates 15 and 25 were rejected.
 
 **Stopping point**: supersession defaults remain `min_requests=7`, `min_span_frames=20`, `min_pixels=2_000_000`.
+
+---
+
+### Session 2026-02-14 (Scrub CSV report utility)
+
+**Goal**: Provide a lightweight analysis tool for cross-machine scrub CSV comparisons
+
+**What was done**:
+1. Added a new CSV report example for scrub benchmarks.
+2. Implemented aggregate-row parsing with run-label grouping.
+3. Added baseline/candidate label delta reporting for quick comparisons.
+4. Added unit tests for CSV parsing and median summarization.
+
+**Changes Made**:
+- `crates/editor/examples/scrub-csv-report.rs`
+  - new CLI args:
+    - `--csv <path>` (repeatable)
+    - `--label <run-label>`
+    - `--baseline-label <run-label>`
+    - `--candidate-label <run-label>`
+  - reports median summaries per run label from aggregate rows
+  - computes candidate-minus-baseline deltas for all/last request avg and p95
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - added command usage and validation run output for the new utility
+
+**Verification**:
+- `cargo +1.88.0 check -p cap-editor --example scrub-csv-report`
+- `cargo +1.88.0 test -p cap-editor --example scrub-csv-report`
+- `cargo +1.88.0 run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-labeled.csv --label linux-pass-a`
+
+**Results**:
+- ✅ Cross-machine scrub CSVs can now be summarized and compared without manual spreadsheet work.
+- ✅ Utility test suite passing (2/2).
+
+**Stopping point**: startup and scrub evidence collection on macOS/Windows now has matching run-label analysis tools on Linux for post-capture evaluation.
 
 ---
 

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1211,6 +1211,10 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
    - retry-limit-triggered fallbacks
 9. Added SAB retry scheduling guard:
    - retry requeue now uses a single pending animation-frame callback to avoid stacking duplicate retry callbacks under burst pressure
+10. Expanded exported FPS stats payload to include SAB transport diagnostics:
+    - resize/fallback counters
+    - in-flight retry count
+    - current SAB slot size
 
 **Changes Made**:
 - `apps/desktop/src/utils/socket.ts`

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -501,6 +501,35 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Startup trace export for cross-platform sessions)
+
+**Goal**: Make macOS/Windows startup latency collection deterministic and parseable
+
+**What was done**:
+1. Added optional startup trace CSV export from desktop playback path via environment variable.
+2. Emitted trace rows for first decoded frame, first rendered frame, and first audio callback milestones.
+3. Updated startup report example to parse both tracing logs and CSV trace lines.
+
+**Changes Made**:
+- `crates/editor/src/playback.rs`
+  - added `CAP_PLAYBACK_STARTUP_TRACE_FILE` writer
+  - startup milestones now append CSV rows:
+    - `first_decoded_frame`
+    - `first_rendered_frame`
+    - `audio_streaming_callback`
+    - `audio_prerender_callback`
+- `crates/editor/examples/playback-startup-report.rs`
+  - added CSV event parser support
+
+**Verification**:
+- `cargo +1.88.0 check -p cap-editor`
+- `cargo +1.88.0 check -p cap-editor --example playback-startup-report`
+- `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log crates/editor/PLAYBACK-BENCHMARKS.md`
+
+**Stopping point**: next actionable step is running desktop playback sessions on macOS and Windows with `CAP_PLAYBACK_STARTUP_TRACE_FILE` enabled and feeding the resulting logs into `playback-startup-report`.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1044,6 +1044,41 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Playback benchmark CSV export)
+
+**Goal**: Persist playback throughput benchmark outputs in machine-readable format for cross-platform comparisons
+
+**What was done**:
+1. Added optional CSV export to `playback-benchmark`.
+2. Added optional run labeling for exported playback benchmark rows.
+3. Emitted sequential and per-seek rows in a single CSV schema.
+
+**Changes Made**:
+- `crates/editor/examples/playback-benchmark.rs`
+  - new CLI args:
+    - `--output-csv <path>`
+    - `--run-label <label>`
+  - new env fallback:
+    - `CAP_PLAYBACK_BENCHMARK_RUN_LABEL`
+  - CSV rows:
+    - `mode=sequential` for throughput/decode summary
+    - `mode=seek` for each seek distance sample summary
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - added command usage and validation benchmark sample for CSV mode
+
+**Verification**:
+- `cargo +1.88.0 check -p cap-editor --example playback-benchmark`
+- `cargo +1.88.0 run -p cap-editor --example playback-benchmark -- --video /tmp/cap-bench-1080p60.mp4 --fps 60 --max-frames 240 --seek-iterations 10 --output-csv /tmp/cap-playback-benchmark.csv --run-label linux-pass-a`
+- inspected `/tmp/cap-playback-benchmark.csv` and confirmed sequential + seek rows with populated metrics.
+
+**Results**:
+- ✅ Playback benchmark outputs can now be aggregated across machines/runs without manual copy-paste.
+- ✅ CSV schema captures both real-time throughput and seek behavior under one run label.
+
+**Stopping point**: startup + scrub + playback benchmark tooling now all support labeled CSV exports, enabling cleaner macOS/Windows evidence ingestion once traces are collected.
+
+---
+
 ### Session 2026-02-14 (Rejected superseded-burst cache-window reduction)
 
 **Goal**: Reduce superseded scrub decode work by shrinking decode cache window for superseded requests

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -3246,11 +3246,20 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 1. Extended aggregate CSV export with `aggregate_audio_path` rows.
 2. Extended delta CSV export with `delta_audio_path` rows.
 3. Extended run-metrics CSV export with `run_metric_audio_path` rows.
-4. Added tests validating new audio-path CSV rows.
-5. Updated benchmark docs to note audio-path run-metric CSV mode.
+4. Added structured audio-path columns in CSV schema for machine-readable parsing.
+5. Added tests validating new audio-path CSV rows.
+6. Updated benchmark docs to note audio-path run-metric CSV mode.
+7. Validated with synthetic baseline/candidate startup trace export.
 
 **Changes Made**:
 - `crates/editor/examples/playback-startup-report.rs`
+  - CSV header now includes:
+    - `audio_path`
+    - `audio_stream_samples`
+    - `audio_prerender_samples`
+    - `candidate_audio_path`
+    - `candidate_audio_stream_samples`
+    - `candidate_audio_prerender_samples`
   - `append_aggregate_csv` now appends `aggregate_audio_path` row with:
     - audio path label
     - stream callback sample count
@@ -3266,9 +3275,12 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 - `cargo +1.88.0 fmt --all`
 - `cargo +1.88.0 test -p cap-editor --example playback-startup-report`
 - `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --list-run-metrics --output-csv /tmp/playback-startup-run-export.csv`
+- `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/tmp-startup-sample.csv --list-run-metrics --output-csv /tmp/playback-startup-run-export-v2.csv`
+- `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --baseline-log /workspace/tmp-startup-sample.csv --candidate-log /workspace/tmp-startup-sample.csv --baseline-run-id baseline --candidate-run-id candidate --output-csv /tmp/playback-startup-run-export-v2.csv`
 
 **Results**:
 - ✅ Startup report CSV outputs now carry explicit audio startup mode rows for aggregate, delta, and run-metrics exports.
+- ✅ Audio path rows now populate structured columns for direct CSV querying.
 - ✅ Updated startup report tests pass with new row modes (11/11).
 
 **Stopping point**: Ready to ingest macOS/Windows startup trace CSVs and query audio startup mode directly from exported rows.

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -808,6 +808,28 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Supersession min-request threshold sweep)
+
+**Goal**: Validate whether lowering supersession queue threshold improves scrub latency further
+
+**What was done**:
+1. Ran 3-run scrub benchmarks for candidate `min_requests=6`, `min_span_frames=25`.
+2. Compared medians against current default (`min_requests=8`, `min_span_frames=25`).
+
+**Results**:
+- 1080p improved with threshold 6:
+  - median last-request avg: **~294ms -> ~286ms**
+  - median last-request p95: **~456ms -> ~428ms**
+- 4k regressed vs threshold 8:
+  - median last-request avg: **~809ms -> ~842ms**
+  - median last-request p95: **~1694ms -> ~1744ms**
+
+**Decision**: keep default `min_requests=8` because it gives better 4k scrub responsiveness while still materially improving 1080p over the original baseline.
+
+**Stopping point**: defaults remain `min_requests=8`, `min_span_frames=25`, with runtime overrides available for platform-specific tuning.
+
+---
+
 ### Session 2026-02-14 (Scrub benchmark multi-run aggregation)
 
 **Goal**: Improve scrub benchmark repeatability by reducing single-run noise in comparisons

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -72,7 +72,7 @@
 ### Active Work Items
 *(Update this section as you work)*
 
-- [ ] **Capture audio startup latency before/after** - Validate streaming audio path startup behavior against prior path
+- [ ] **Capture audio startup latency before/after** - Use new playback log metrics (`Audio streaming callback started`) to validate startup on macOS/Windows
 - [ ] **Tune medium/long seek latency** - Reduce 2s+ seek spikes visible in decode and playback benchmarks
 - [ ] **Run full desktop editor validation on macOS + Windows** - Confirm in-app FPS and A/V behavior on target platforms
 
@@ -387,6 +387,30 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 - Long 5.0s seek latency is still elevated on 4k and remains an active tuning target
 
 **Stopping point**: Keep current seek tuning; next focus is long-seek (5s+) latency and real desktop A/V startup measurements.
+
+---
+
+### Session 2026-02-14 (Audio startup instrumentation)
+
+**Goal**: Add measurable startup telemetry for audio output callback timing
+
+**What was done**:
+1. Instrumented audio output callback startup in both streaming and pre-rendered playback paths
+2. Added one-time startup latency logs from playback start thread spawn to first output callback invocation
+
+**Changes Made**:
+- `crates/editor/src/playback.rs`
+  - Added startup timing capture in `AudioPlayback::spawn`
+  - Logs:
+    - `Audio streaming callback started`
+    - `Audio pre-rendered callback started`
+  - Includes startup latency in milliseconds
+
+**Results**:
+- No compile regressions in `cap-editor`
+- Playback now has explicit, low-overhead startup latency telemetry for validating user-reported delayed audio start
+
+**Stopping point**: Run this instrumentation on macOS and Windows editor sessions to collect before/after startup latency evidence.
 
 ---
 

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -3643,6 +3643,39 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (startup report effective audio callback metric)
+
+**Goal**: Make startup latency comparisons resilient when runs switch between streaming and pre-rendered audio paths
+
+**What was done**:
+1. Added a shared helper that merges streaming and pre-render callback startup samples into one effective callback series.
+2. Surfaced effective callback summaries in run-metric console output.
+3. Added effective callback metric rows to run-metrics CSV output.
+4. Added effective callback metric output to aggregate and baseline-vs-candidate delta displays.
+5. Added effective callback metric rows to aggregate/delta CSV exports.
+6. Re-ran startup report example tests with Rust 1.88 toolchain.
+
+**Changes Made**:
+- `crates/editor/examples/playback-startup-report.rs`
+  - added `audio_callback_startup_values(&EventStats) -> Vec<f64>`
+  - `--list-run-metrics` output now includes `audio_callback_effective[...]`
+  - `append_run_metrics_csv` now writes `audio callback effective`
+  - aggregate display/CSV now include `audio callback effective`
+  - delta display/CSV now include `audio callback effective`
+
+**Verification**:
+- `rustfmt crates/editor/examples/playback-startup-report.rs`
+- `cargo +1.88.0 test -p cap-editor --example playback-startup-report`
+
+**Results**:
+- ✅ Startup reports now provide a single callback-startup metric that remains comparable across mixed path-selection runs.
+- ✅ Structured CSV exports now include effective callback rows for downstream analysis tooling.
+- ✅ Example test suite passes (12/12) with the updated metric outputs.
+
+**Stopping point**: Ready to collect macOS/Windows startup traces and compare baseline/candidate runs with the new effective audio callback metric.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -622,6 +622,33 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Duplicate burst benchmark signal hardening)
+
+**Goal**: Stabilize duplicate-request benchmark signal for evaluating coalescing behavior
+
+**What was done**:
+1. Extended `decode-benchmark` with an explicit duplicate-request burst section (burst sizes 4/8/16).
+2. Added warmup frame fetch before burst sampling to remove cold-start outlier distortion.
+3. Re-ran 1080p and 4k decode benchmarks with hardened seek sampling and burst metrics.
+
+**Changes Made**:
+- `crates/editor/examples/decode-benchmark.rs`
+  - added duplicate burst metric table output
+  - added burst warmup call prior to timing iterations
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - recorded stabilized duplicate burst metrics and updated decode-benchmark command notes
+
+**Results**:
+- ✅ Duplicate burst metrics now stable and interpretable:
+  - 1080p burst batch p95: **~3.7–3.8ms**
+  - 4k burst batch p95: **~21.7–22.0ms**
+- ✅ No failures in duplicate burst requests across tested burst sizes.
+- ✅ Existing throughput and seek-tail profile remained consistent with recent runs.
+
+**Stopping point**: duplicate burst metric is now productionized for ongoing coalescing validation; remaining performance gap is still long-distance 4k seek tails.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -3238,6 +3238,43 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (startup report CSV audio-path rows)
+
+**Goal**: Persist audio startup mode classification into startup report CSV outputs for downstream baseline/candidate analysis
+
+**What was done**:
+1. Extended aggregate CSV export with `aggregate_audio_path` rows.
+2. Extended delta CSV export with `delta_audio_path` rows.
+3. Extended run-metrics CSV export with `run_metric_audio_path` rows.
+4. Added tests validating new audio-path CSV rows.
+5. Updated benchmark docs to note audio-path run-metric CSV mode.
+
+**Changes Made**:
+- `crates/editor/examples/playback-startup-report.rs`
+  - `append_aggregate_csv` now appends `aggregate_audio_path` row with:
+    - audio path label
+    - stream callback sample count
+    - prerender callback sample count
+  - `append_delta_csv` now appends `delta_audio_path` row with baseline/candidate audio path summary
+  - `append_run_metrics_csv` now appends `run_metric_audio_path` row per run id
+  - aggregate/delta call sites now pass audio-path summaries
+  - tests updated to assert new row modes
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - startup report CSV command note updated to mention `run_metric_audio_path` row mode
+
+**Verification**:
+- `cargo +1.88.0 fmt --all`
+- `cargo +1.88.0 test -p cap-editor --example playback-startup-report`
+- `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --list-run-metrics --output-csv /tmp/playback-startup-run-export.csv`
+
+**Results**:
+- ✅ Startup report CSV outputs now carry explicit audio startup mode rows for aggregate, delta, and run-metrics exports.
+- ✅ Updated startup report tests pass with new row modes (11/11).
+
+**Stopping point**: Ready to ingest macOS/Windows startup trace CSVs and query audio startup mode directly from exported rows.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1202,6 +1202,8 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
    - SAB resize count
    - SAB fallback count
    - oversize-triggered SAB fallback count
+6. Added SAB backpressure retry path:
+   - when SAB write fails due slot contention (non-oversize), frame is re-queued for next animation frame instead of immediately transferring via worker message copy
 
 **Changes Made**:
 - `apps/desktop/src/utils/socket.ts`

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1013,17 +1013,20 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 1. Extended `scrub-benchmark` with `--output-csv <path>`.
 2. Added CSV row emission for each run and one aggregate row.
 3. Embedded supersession runtime env values in each CSV row for threshold traceability.
-4. Validated export flow with 2-run 1080p and 4k benchmark passes.
+4. Added optional run labeling (`--run-label` / `CAP_SCRUB_BENCHMARK_RUN_LABEL`) in CSV output.
+5. Validated export flow with labeled and unlabeled benchmark passes.
 
 **Changes Made**:
 - `crates/editor/examples/scrub-benchmark.rs`
   - added `output_csv` config field and CLI parsing
+  - added `run_label` config field and CLI/env wiring
   - writes append-only CSV rows with run and aggregate metrics
   - includes current supersession env vars:
     - `CAP_FFMPEG_SCRUB_SUPERSEDE_DISABLED`
     - `CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_PIXELS`
     - `CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_REQUESTS`
     - `CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES`
+    - `CAP_SCRUB_BENCHMARK_RUN_LABEL`
 - `crates/editor/PLAYBACK-BENCHMARKS.md`
   - documented CSV export usage and recorded validation benchmark sample
 
@@ -1031,10 +1034,12 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 - `cargo +1.88.0 check -p cap-editor --example scrub-benchmark`
 - `cargo +1.88.0 run -p cap-editor --example scrub-benchmark -- --video /tmp/cap-bench-1080p60.mp4 --fps 60 --bursts 8 --burst-size 12 --sweep-seconds 2.0 --runs 2 --output-csv /tmp/cap-scrub-benchmark.csv`
 - `cargo +1.88.0 run -p cap-editor --example scrub-benchmark -- --video /tmp/cap-bench-4k60.mp4 --fps 60 --bursts 8 --burst-size 12 --sweep-seconds 2.0 --runs 2 --output-csv /tmp/cap-scrub-benchmark.csv`
+- `cargo +1.88.0 run -p cap-editor --example scrub-benchmark -- --video /tmp/cap-bench-1080p60.mp4 --fps 60 --bursts 6 --burst-size 12 --sweep-seconds 2.0 --runs 2 --output-csv /tmp/cap-scrub-labeled.csv --run-label linux-pass-a`
 
 **Results**:
 - ✅ CSV output captured run-level and aggregate metrics for both test clips.
 - ✅ Export includes supersession env values, enabling apples-to-apples threshold sweeps across machines.
+- ✅ Labeled CSV rows now support explicit machine/pass grouping without separate files.
 - ✅ No request failures in validation passes.
 
 **Stopping point**: macOS and Windows scrub passes can now produce directly comparable CSV artifacts without manual copy/paste from terminal output.

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -2308,6 +2308,36 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (decoded transport branch cleanup)
+
+**Goal**: Remove stale worker/socket transport branch handling that was no longer emitted after queue-ack path removal
+
+**What was done**:
+1. Removed unused `DecodedFrame` message type from worker utilities.
+2. Removed `decoded` branch handling from socket worker message dispatcher.
+3. Re-ran desktop typecheck and targeted transport tests.
+
+**Changes Made**:
+- `apps/desktop/src/utils/frame-worker.ts`
+  - removed `DecodedFrame` interface/export
+- `apps/desktop/src/utils/socket.ts`
+  - removed `DecodedFrame` interface and worker message union entry
+  - removed dead `if (e.data.type === "decoded")` handling block
+
+**Verification**:
+- `pnpm --dir apps/desktop exec tsc --noEmit`
+- `pnpm --dir apps/desktop exec vitest run src/utils/frame-transport-config.test.ts src/utils/frame-transport-retry.test.ts src/utils/shared-frame-buffer.test.ts`
+- `pnpm --dir apps/desktop exec biome format --write src/utils/frame-worker.ts src/utils/socket.ts`
+
+**Results**:
+- ✅ Worker/socket message surface now matches currently emitted runtime events.
+- ✅ Removed dead branch logic from socket worker dispatcher.
+- ✅ Desktop typecheck and targeted transport tests pass.
+
+**Stopping point**: Ready for continued transport tuning with reduced message-schema complexity.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -964,6 +964,40 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Startup report run-id filtering)
+
+**Goal**: Allow startup latency comparisons from shared CSV logs without manual file splitting
+
+**What was done**:
+1. Extended startup report parser to read optional CSV run-id column.
+2. Added run-id filters for aggregate mode and baseline/candidate comparison mode.
+3. Added parser tests that validate run-id filtering behavior on mixed-run CSV traces.
+
+**Changes Made**:
+- `crates/editor/examples/playback-startup-report.rs`
+  - CSV parser now returns optional run-id field
+  - new CLI args:
+    - `--run-id`
+    - `--baseline-run-id`
+    - `--candidate-run-id`
+  - run-id filter now excludes non-matching CSV rows before metric aggregation
+  - added unit test coverage for run-id-filtered parsing
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - added command examples for run-id filtering and same-file baseline/candidate comparisons
+
+**Verification**:
+- `cargo +1.88.0 test -p cap-editor --example playback-startup-report`
+- `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --run-id sample-run`
+
+**Results**:
+- ✅ Startup parser supports grouped analysis across repeated sessions in one CSV file.
+- ✅ Baseline/candidate deltas can now target specific labeled runs in shared trace files.
+- ✅ All startup report example tests passing (6/6).
+
+**Stopping point**: macOS/Windows startup captures can remain in a single trace file while still enabling precise per-run before/after reporting.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1457,6 +1457,38 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Performance overlay transport diagnostics)
+
+**Goal**: Surface SAB transport telemetry directly in overlay UI for faster cross-platform validation
+
+**What was done**:
+1. Wired overlay to read live socket transport stats via `getFpsStats`.
+2. Added transport diagnostics to overlay panel:
+   - render FPS
+   - transport MB/s
+   - SAB slot size and resize count
+   - SAB fallback counters (oversize vs retry-limit)
+   - in-flight SAB retry count
+3. Extended clipboard export payload with the same transport diagnostics.
+
+**Changes Made**:
+- `apps/desktop/src/routes/editor/PerformanceOverlay.tsx`
+  - added transport stats polling and reset behavior
+  - added transport diagnostics rows to overlay UI
+  - added transport fields to copied stats text
+
+**Verification**:
+- `pnpm exec biome format --write apps/desktop/src/routes/editor/PerformanceOverlay.tsx`
+- `pnpm --dir apps/desktop exec tsc --noEmit`
+
+**Results**:
+- ✅ Desktop TypeScript checks pass.
+- ✅ Overlay now exposes SAB transport metrics needed for target-machine playback tuning sessions.
+
+**Stopping point**: use this diagnostics panel in upcoming macOS/Windows runs to collect evidence for fallback-rate and transport-throughput behavior.
+
+---
+
 ### Session 2026-02-14 (Rejected superseded-burst cache-window reduction)
 
 **Goal**: Reduce superseded scrub decode work by shrinking decode cache window for superseded requests

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -948,6 +948,31 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Rejected span threshold changes after default retunes)
+
+**Goal**: Verify whether span threshold should move again after adopting `min_requests=7` and `min_pixels=2_000_000`
+
+**What was done**:
+1. Re-ran span sweep with `CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES={15,20,25}`.
+2. Executed 1080p and 4k scrub benchmarks (`--runs 3`) for each span candidate.
+3. Compared median last-request averages and p95 tails.
+
+**Results**:
+- 1080p (avg / p95):
+  - span 15: **216.43ms / 457.45ms**
+  - span 20: **209.63ms / 442.04ms**
+  - span 25: **213.84ms / 447.71ms**
+- 4k (avg / p95):
+  - span 15: **862.02ms / 1789.73ms**
+  - span 20: **860.43ms / 1761.25ms**
+  - span 25: **866.03ms / 1781.42ms**
+
+**Decision**: keep `min_span_frames=20`; candidates 15 and 25 were rejected.
+
+**Stopping point**: supersession defaults remain `min_requests=7`, `min_span_frames=20`, `min_pixels=2_000_000`.
+
+---
+
 ### Session 2026-02-14 (Rejected superseded-burst cache-window reduction)
 
 **Goal**: Reduce superseded scrub decode work by shrinking decode cache window for superseded requests

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -980,9 +980,9 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 **What was done**:
 1. Added a new CSV report example for scrub benchmarks.
-2. Implemented aggregate-row parsing with run-label grouping.
-3. Added baseline/candidate label delta reporting for quick comparisons.
-4. Added unit tests for CSV parsing and median summarization.
+2. Implemented aggregate-row parsing with run-label and video grouping.
+3. Added baseline/candidate label delta reporting per overlapping video.
+4. Added unit tests for CSV parsing, median summarization, and grouping behavior.
 
 **Changes Made**:
 - `crates/editor/examples/scrub-csv-report.rs`
@@ -992,18 +992,18 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
     - `--baseline-label <run-label>`
     - `--candidate-label <run-label>`
   - reports median summaries per run label from aggregate rows
-  - computes candidate-minus-baseline deltas for all/last request avg and p95
+  - computes candidate-minus-baseline deltas for all/last request avg and p95 per video
 - `crates/editor/PLAYBACK-BENCHMARKS.md`
   - added command usage and validation run output for the new utility
 
 **Verification**:
 - `cargo +1.88.0 check -p cap-editor --example scrub-csv-report`
-- `cargo +1.88.0 test -p cap-editor --example scrub-csv-report`
+- `cargo +1.88.0 test -p cap-editor --example scrub-csv-report` (3 tests)
 - `cargo +1.88.0 run -p cap-editor --example scrub-csv-report -- --csv /tmp/cap-scrub-labeled.csv --label linux-pass-a`
 
 **Results**:
 - ✅ Cross-machine scrub CSVs can now be summarized and compared without manual spreadsheet work.
-- ✅ Utility test suite passing (2/2).
+- ✅ Utility test suite passing (3/3).
 
 **Stopping point**: startup and scrub evidence collection on macOS/Windows now has matching run-label analysis tools on Linux for post-capture evaluation.
 

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -3275,6 +3275,29 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (startup capture docs for pre-render override)
+
+**Goal**: Make A/B startup capture workflow explicit for streaming-first vs forced pre-render audio startup comparisons
+
+**What was done**:
+1. Added startup capture command showing `CAP_AUDIO_PRERENDER_ONLY=1` usage.
+2. Included run-id labeling in the same command for direct baseline/candidate grouping.
+
+**Changes Made**:
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - startup latency section now includes:
+    - `CAP_AUDIO_PRERENDER_ONLY=1`
+    - `CAP_PLAYBACK_STARTUP_TRACE_FILE`
+    - `CAP_PLAYBACK_STARTUP_TRACE_RUN_ID`
+  - command demonstrates forced pre-render run labeling for startup deltas
+
+**Results**:
+- ✅ Startup trace capture docs now include explicit forced pre-render comparison path for audio startup A/B runs.
+
+**Stopping point**: Ready for macOS/Windows startup capture passes with matched streaming/pre-render run labels.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -3870,6 +3870,40 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (scrub even-run median aggregation correction)
+
+**Goal**: Improve benchmark evidence quality by fixing even-run median aggregation bias in scrub benchmark summaries
+
+**What was done**:
+1. Updated scrub benchmark median helper to return the midpoint of the two middle values for even sample counts.
+2. Added unit tests for even-sample median behavior.
+3. Added aggregate-summaries test to verify even-run last-request median calculation.
+4. Re-ran scrub example test suite and a 2-run scrub benchmark command to validate runtime output.
+
+**Changes Made**:
+- `crates/editor/examples/scrub-benchmark.rs`
+  - `median_of(...)` now averages middle two values for even-length input
+  - added tests:
+    - `median_of_even_samples_averages_middle_values`
+    - `aggregate_summaries_uses_even_median_for_last_request_average`
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - documented even-run median behavior in command guidance
+  - added benchmark history entry proving runtime aggregate equals average of two run values
+
+**Verification**:
+- `rustfmt --edition 2024 crates/editor/examples/scrub-benchmark.rs`
+- `cargo +1.88.0 test -p cap-editor --example scrub-benchmark --example scrub-csv-report`
+- `cargo +1.88.0 run -p cap-editor --example scrub-benchmark -- --video /tmp/cap-bench-1080p60.mp4 --fps 60 --bursts 2 --burst-size 12 --sweep-seconds 2.0 --runs 2 --run-label linux-median-even-check --output-csv /tmp/cap-scrub-median-even.csv`
+
+**Results**:
+- ✅ Even-run scrub medians now represent true midpoint values instead of upper-middle selection.
+- ✅ Runtime output validated with concrete 2-run sample where aggregate matches exact average of both run values.
+- ✅ Example tests pass (`scrub-benchmark` 2/2, `scrub-csv-report` 6/6).
+
+**Stopping point**: Continue macOS/Windows scrub threshold sweeps with corrected even-run aggregation for lower-bias comparisons.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1489,6 +1489,36 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Cumulative SAB fallback counters for diagnostics stability)
+
+**Goal**: Keep overlay diagnostics stable across sampling windows by preserving cumulative fallback counters
+
+**What was done**:
+1. Split SAB fallback counters into:
+   - cumulative totals (for exported FPS stats / overlay)
+   - window counters (for per-log-frame console snapshots)
+2. Updated websocket frame log output to include both window and total fallback counters.
+3. Stopped resetting cumulative fallback counters in the periodic logging reset path.
+
+**Changes Made**:
+- `apps/desktop/src/utils/socket.ts`
+  - added window counter variables for SAB fallback classes
+  - log output now prints `*_window` and `*_total` values
+  - `getFpsStats()` now remains backed by cumulative fallback counters
+
+**Verification**:
+- `pnpm exec biome format --write apps/desktop/src/utils/socket.ts`
+- `pnpm --dir apps/desktop exec tsc --noEmit`
+- `pnpm --dir apps/desktop exec vitest run src/utils/frame-transport-retry.test.ts src/utils/frame-transport-config.test.ts src/utils/shared-frame-buffer.test.ts` (13 passed)
+
+**Results**:
+- ✅ Overlay/clipboard transport diagnostics now remain monotonic across log windows.
+- ✅ Console output still includes short-window fallback visibility for burst debugging.
+
+**Stopping point**: ready for target-machine playback sessions where cumulative fallback totals are needed across longer runs.
+
+---
+
 ### Session 2026-02-14 (Rejected superseded-burst cache-window reduction)
 
 **Goal**: Reduce superseded scrub decode work by shrinking decode cache window for superseded requests

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1204,6 +1204,11 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
    - oversize-triggered SAB fallback count
 6. Added SAB backpressure retry path:
    - when SAB write fails due slot contention (non-oversize), frame is re-queued for next animation frame instead of immediately transferring via worker message copy
+7. Added retry-limit fallback guard:
+   - after bounded SAB retry attempts, transport falls back to worker transfer to avoid indefinite retry loops
+8. Expanded SAB telemetry to separate:
+   - oversize-triggered fallbacks
+   - retry-limit-triggered fallbacks
 
 **Changes Made**:
 - `apps/desktop/src/utils/socket.ts`

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1302,10 +1302,11 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 **Verification**:
 - `pnpm exec biome format --write apps/desktop/src/utils/shared-frame-buffer.ts`
+- `pnpm --dir apps/desktop exec vitest run src/utils/shared-frame-buffer.test.ts`
 - `pnpm --dir apps/desktop exec tsc --noEmit`
 
 **Results**:
-- ✅ Desktop unit tests pass (2/2) for writer-slot probing and consumer sparse-ready-slot reads.
+- ✅ Desktop unit tests pass (3/3) for writer-slot probing and sparse-ready `read`/`readInto` paths.
 - ✅ Desktop TypeScript checks pass.
 - ✅ Consumer path now remains compatible with producer-side sparse slot selection and avoids avoidable waits on empty read-index slots.
 

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -804,6 +804,37 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Startup report baseline/candidate deltas)
+
+**Goal**: Improve startup-latency evidence workflow for before/after validation
+
+**What was done**:
+1. Extended startup report tool with paired baseline/candidate log support.
+2. Added delta output for avg and p95 startup latency per event.
+3. Added tests for metric summarization path.
+
+**Changes Made**:
+- `crates/editor/examples/playback-startup-report.rs`
+  - new args:
+    - `--baseline-log <path>`
+    - `--candidate-log <path>`
+  - prints candidate-minus-baseline deltas for:
+    - first decoded frame
+    - first rendered frame
+    - audio streaming callback
+    - audio pre-rendered callback
+  - kept existing `--log` aggregate mode
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - documented baseline/candidate comparison command
+
+**Verification**:
+- `cargo +1.88.0 test -p cap-editor --example playback-startup-report`
+- `cargo +1.88.0 check -p cap-editor --example playback-startup-report`
+
+**Stopping point**: startup instrumentation evidence can now be reported as explicit before/after deltas once macOS and Windows traces are collected.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1331,6 +1331,7 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 4. Added unit coverage for overwrite-on-full behavior.
 5. Made oldest-slot selection wrap-safe by comparing frame age in unsigned 32-bit space.
 6. Added explicit `frameAge` helper and unit coverage for u32 wrap semantics.
+7. Updated consumer wait strategy to wait on write-index updates, preventing missed wakeups when READY frames appear in non-read-index slots.
 
 **Changes Made**:
 - `apps/desktop/src/utils/shared-frame-buffer.ts`

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1128,8 +1128,9 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 **What was done**:
 1. Simplified desktop websocket frame handling in `socket.ts` to operate on RGBA payloads only.
 2. Simplified worker decode/render path in `frame-worker.ts` to parse and process only RGBA transport metadata.
-3. Removed NV12 detection, conversion, deferred NV12 frame buffering, and NV12 render branches from main-thread and worker hot paths.
-4. Kept stride-correction and worker fallback paths for RGBA frames intact.
+3. Removed unused NV12 shader/pipeline allocation path from `webgpu-renderer.ts` so renderer initialization only builds the active RGBA pipeline.
+4. Removed NV12 detection, conversion, deferred NV12 frame buffering, and NV12 render branches from main-thread and worker hot paths.
+5. Kept stride-correction and worker fallback paths for RGBA frames intact.
 
 **Changes Made**:
 - `apps/desktop/src/utils/socket.ts`
@@ -1141,6 +1142,10 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
   - removed NV12 parsing and conversion branches
   - removed NV12 WebGPU render dispatch paths
   - simplified queued-frame and metadata types to RGBA-only transport
+- `apps/desktop/src/utils/webgpu-renderer.ts`
+  - removed NV12 fragment shader, pipeline, bind-group layout, and texture/bind group cache state
+  - removed unused `renderNv12FrameWebGPU` export
+  - simplified renderer initialization and disposal to RGBA-only resources
 
 **Verification**:
 - `pnpm install --filter @cap/desktop...`

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -649,6 +649,36 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Scrub burst benchmark baseline)
+
+**Goal**: Add direct scrub-queue stress evidence for latest-request latency
+
+**What was done**:
+1. Added `scrub-benchmark` example that issues bursty decoder requests over a configurable sweep window.
+2. Captured two key metrics:
+   - all-request latency distribution
+   - last-request-in-burst latency distribution
+3. Ran 1080p and 4k baseline passes with 20 bursts × 12 requests.
+
+**Changes Made**:
+- `crates/editor/examples/scrub-benchmark.rs`
+  - new benchmark for scrub queue stress behavior
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - added command usage and baseline results for scrub burst runs
+
+**Results**:
+- 1080p scrub burst:
+  - all-request avg **217.97ms**, p95 **434.83ms**
+  - last-request avg **312.50ms**, p95 **455.72ms**
+- 4k scrub burst:
+  - all-request avg **1071.64ms**, p95 **2098.98ms**
+  - last-request avg **1524.00ms**, p95 **2116.35ms**
+- ✅ Benchmark now exposes scrub-specific latency that decode/playback sequential tests do not capture.
+
+**Stopping point**: next optimization pass should target reducing last-request-in-burst latency (especially 4k) and use scrub-benchmark plus seek-iteration benchmarks as acceptance gates.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -414,6 +414,34 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (FFmpeg long-seek tuning pass 2)
+
+**Goal**: Improve long forward seek latency while preserving medium seek gains
+
+**What was done**:
+1. Adjusted FFmpeg forward-seek behavior to prefer keyframes closer to target time
+2. Re-ran decode and playback throughput benchmarks
+
+**Changes Made**:
+- `crates/video-decode/src/ffmpeg.rs`
+  - forward seek now first tries:
+    - small backtrack window (0.5s)
+    - larger forward allowance (2.0s)
+  - then falls back to wider symmetric window and legacy seek behavior
+
+**Results**:
+- 1080p60:
+  - random access avg: **120.87ms -> 114.64ms**
+  - playback 5s seek sample: **138.26ms -> 138.90ms** (flat)
+- 4k60:
+  - random access avg: **533.65ms -> 525.90ms**
+  - playback 5s seek sample: **432.97ms -> 410.35ms**
+- Playback throughput still meets 60fps target in synthetic real-time simulation
+
+**Stopping point**: Long-seek behavior improved but still high on 4k; next progress requires richer keyframe-aware seek strategy or decoder-pool approach for FFmpeg path.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1209,6 +1209,8 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 8. Expanded SAB telemetry to separate:
    - oversize-triggered fallbacks
    - retry-limit-triggered fallbacks
+9. Added SAB retry scheduling guard:
+   - retry requeue now uses a single pending animation-frame callback to avoid stacking duplicate retry callbacks under burst pressure
 
 **Changes Made**:
 - `apps/desktop/src/utils/socket.ts`

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -777,6 +777,33 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Scrub benchmark multi-run aggregation)
+
+**Goal**: Improve scrub benchmark repeatability by reducing single-run noise in comparisons
+
+**What was done**:
+1. Extended `scrub-benchmark` with `--runs <n>` support.
+2. Added per-run summaries and median-across-runs aggregate reporting.
+3. Validated on 1080p and 4k with 3-run aggregated passes.
+
+**Changes Made**:
+- `crates/editor/examples/scrub-benchmark.rs`
+  - added `--runs` option (default 1)
+  - added `ScrubSummary` and median aggregation across runs
+  - output now includes per-run last-request averages when runs > 1
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - added command usage and benchmark data for multi-run aggregation mode
+
+**Results**:
+- ✅ Benchmark output now exposes run-to-run variance directly and provides median summary.
+- ✅ 1080p (3 runs) median last-request avg: **303.69ms**.
+- ✅ 4k (3 runs) median last-request avg: **963.69ms**.
+- ✅ No failures in aggregated scrub runs.
+
+**Stopping point**: scrub tuning can now use multi-run medians as acceptance criteria, reducing false positives from one-off noisy runs.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -2810,6 +2810,53 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (decode benchmark CSV export + run labels)
+
+**Goal**: Improve decode benchmark evidence portability for cross-machine baseline/candidate comparisons
+
+**What was done**:
+1. Extended decode benchmark CLI with CSV output path support.
+2. Added optional run-label support via CLI/env for grouped analysis.
+3. Added structured CSV rows for decoder creation, sequential decode, seek distances, random access, and duplicate burst metrics.
+4. Validated CSV generation with a full benchmark run on 1080p60.
+
+**Changes Made**:
+- `crates/editor/examples/decode-benchmark.rs`
+  - added config fields:
+    - `output_csv: Option<PathBuf>`
+    - `run_label: Option<String>`
+  - added CSV writer with append-header behavior
+  - added run-label resolver from:
+    - `--run-label`
+    - `CAP_DECODE_BENCHMARK_RUN_LABEL`
+  - exports row modes:
+    - `decoder_creation`
+    - `sequential`
+    - `seek`
+    - `random_access`
+    - `duplicate_batch`
+    - `duplicate_request`
+  - wired CLI args:
+    - `--output-csv <path>`
+    - `--run-label <label>`
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - added decode CSV export command examples
+  - added validation benchmark run summary for CSV mode
+
+**Verification**:
+- `cargo +1.88.0 fmt --all`
+- `cargo +1.88.0 check -p cap-editor --example decode-benchmark`
+- `cargo +1.88.0 run -p cap-editor --example decode-benchmark -- --video /tmp/cap-bench-1080p60.mp4 --fps 60 --iterations 3 --seek-iterations 2 --output-csv /tmp/cap-decode-benchmark-v2.csv --run-label linux-frame-order-pass-v2`
+
+**Results**:
+- ✅ Decode benchmark now emits structured CSV suitable for aggregated multi-machine analysis.
+- ✅ Run labels allow baseline/candidate grouping in a shared CSV artifact.
+- ✅ Validation run completed and appended expected row modes to `/tmp/cap-decode-benchmark-v2.csv`.
+
+**Stopping point**: Ready to collect decode CSV artifacts from macOS and Windows with consistent labels alongside existing scrub/playback CSV workflows.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -3332,6 +3332,41 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (startup report path-selection metric summaries)
+
+**Goal**: Surface explicit startup path-selection timing metrics alongside callback metrics in startup report outputs
+
+**What was done**:
+1. Added path-selection metric rows to run-metrics CSV export.
+2. Added path-selection metric printing in list-run-metrics output.
+3. Added path-selection metric printing in aggregate and delta modes.
+4. Added path-selection metric participation in aggregate/delta CSV metric arrays.
+
+**Changes Made**:
+- `crates/editor/examples/playback-startup-report.rs`
+  - run metrics now include:
+    - `audio startup path streaming`
+    - `audio startup path prerendered`
+  - list-run-metrics console output now prints metric briefs for selected-path events
+  - aggregate mode now prints selected-path metric summaries
+  - delta mode now prints selected-path metric deltas
+  - aggregate/delta CSV exports now receive selected-path metric slices
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - startup report command description updated to include path-selection event summaries
+
+**Verification**:
+- `cargo +1.88.0 fmt --all`
+- `cargo +1.88.0 test -p cap-editor --example playback-startup-report`
+- `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log /workspace/crates/editor/PLAYBACK-BENCHMARKS.md --list-run-metrics`
+
+**Results**:
+- ✅ Startup report now emits path-selection metric summaries in both console and CSV flows.
+- ✅ Existing startup report tests remain green (11/11).
+
+**Stopping point**: Ready for real startup traces where path-selection event timing should be compared directly against callback startup timing.
+
+---
+
 ### Session 2026-02-14 (startup capture docs for pre-render override)
 
 **Goal**: Make A/B startup capture workflow explicit for streaming-first vs forced pre-render audio startup comparisons

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -487,6 +487,9 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
     - `Playback first decoded frame ready`
     - `Playback first frame rendered`
   - added `startup_instant` to `AudioPlayback` and wired callback logs to playback start origin
+- `crates/editor/examples/playback-startup-report.rs`
+  - added log analysis utility for startup timing markers
+  - reports avg/p50/p95/min/max for decoded, rendered, and audio callback startup milestones
 
 **Results**:
 - Playback throughput remains at ~60fps in synthetic benchmark after instrumentation:

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -743,6 +743,40 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Supersession runtime configurability)
+
+**Goal**: Enable faster cross-platform tuning of scrub supersession without code edits
+
+**What was done**:
+1. Added environment-driven controls for FFmpeg scrub supersession behavior:
+   - `CAP_FFMPEG_SCRUB_SUPERSEDE_DISABLED`
+   - `CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_PIXELS`
+   - `CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_REQUESTS`
+   - `CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES`
+2. Kept default behavior equivalent to current tuned path.
+3. Re-ran scrub, decode, and playback benchmarks with defaults to verify no functional regressions.
+
+**Changes Made**:
+- `crates/rendering/src/decoder/ffmpeg.rs`
+  - added `ScrubSupersessionConfig` with `OnceLock` initialization
+  - replaced hard-coded supersession thresholds with config values
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - added command examples for runtime supersession tuning
+  - added validation benchmark run for the configurable defaults
+
+**Results**:
+- ✅ Scrub supersession behavior preserved with defaults:
+  - 4k last-request avg **~821ms**, p95 **~1768ms**
+  - 1080p last-request avg **~304ms**, p95 **~435ms**
+- ✅ Playback throughput remains at 60fps-class:
+  - 1080p: **60.22 fps**
+  - 4k: **60.17 fps**
+- ✅ Decode benchmark metrics remain in expected variance envelope after config refactor.
+
+**Stopping point**: supersession tuning is now runtime-configurable, enabling platform-specific calibration runs (especially macOS/Windows) without recompiling.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -974,6 +974,33 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Rejected fine span retune to 22)
+
+**Goal**: Validate whether a finer span adjustment (`22`) outperforms the current default (`20`)
+
+**What was done**:
+1. Ran fine span sweep (`18`, `20`, `22`) on 1080p and 4k with `--runs 3`.
+2. Ran paired span20/span22 sweeps with explicit run labels and compared via `scrub-csv-report`.
+3. Temporarily switched default span to `22` and executed scrub/playback/decode regression checks.
+
+**Results**:
+- Fine sweep signal:
+  - 1080p favored `20` on tails (span 22 raised p95 vs span 20 in sampled runs).
+  - 4k often favored `22` in paired delta comparisons.
+- Paired labeled deltas (`span22 - span20`):
+  - 1080p: p95 worsened by about **+24ms**
+  - 4k: avg and p95 improved materially in that paired sample
+- Temporary default-22 regressions:
+  - 4k scrub sample still showed heavy tails (**~1797ms p95**)
+  - playback regression sample had higher missed deadlines (**4**)
+  - decode remained in variance envelope but with no clear stability gain
+
+**Decision**: rejected promoting `min_span_frames=22` due inconsistent tail behavior across reruns.
+
+**Stopping point**: keep defaults at `min_requests=7`, `min_span_frames=20`, `min_pixels=2_000_000`.
+
+---
+
 ### Session 2026-02-14 (Scrub CSV report utility)
 
 **Goal**: Provide a lightweight analysis tool for cross-machine scrub CSV comparisons

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -129,10 +129,14 @@ cargo run -p cap-editor --example playback-benchmark -- --video /path/to/video.m
 | `crates/video-decode/src/ffmpeg.rs` | FFmpeg software fallback |
 | `crates/audio/src/lib.rs` | AudioData loading and sync analysis |
 | `crates/recording/examples/playback-test-runner.rs` | Playback benchmark runner |
+| `crates/editor/examples/decode-benchmark.rs` | Decode benchmark + CSV export |
+| `crates/editor/examples/decode-csv-report.rs` | Decode CSV summary + label-delta analysis |
 | `crates/editor/examples/playback-benchmark.rs` | Linux-compatible playback throughput benchmark |
 | `crates/editor/examples/playback-csv-report.rs` | Playback CSV summary and label-delta analysis |
 | `crates/editor/examples/scrub-benchmark.rs` | Scrub burst latency benchmark |
 | `crates/editor/examples/scrub-csv-report.rs` | Scrub CSV summary and label-delta analysis |
+| `apps/desktop/src/utils/frame-order.ts` | Wrap-safe frame-order comparisons |
+| `apps/desktop/src/utils/frame-transport-order.ts` | Shared transport stale-order decision helper |
 
 ---
 

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -442,6 +442,35 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (FFmpeg long-seek tuning pass 3)
+
+**Goal**: Improve long-seek behavior by changing seek fallback ordering
+
+**What was done**:
+1. Changed forward seek fallback order in FFmpeg reset path:
+   - preferred bounded seek
+   - legacy backward seek
+   - wide bounded seek
+2. Re-ran decode and playback throughput benchmarks
+
+**Changes Made**:
+- `crates/video-decode/src/ffmpeg.rs`
+  - reordered fallback sequence in forward seek reset path
+
+**Results**:
+- 1080p:
+  - 5s decode seek: **142.01ms -> 110.27ms** (improved)
+  - random access avg: **114.64ms -> 119.53ms** (slight regression/noise)
+- 4k:
+  - random access avg: **525.90ms -> 516.48ms** (small improvement)
+  - 5s decode seek: **559.44ms -> 569.83ms** (flat/slightly worse)
+  - 5s playback seek sample: **410.35ms -> 430.25ms** (slight regression)
+- Throughput remains ~60fps in playback benchmark for both synthetic clips
+
+**Stopping point**: pass 3 did not materially improve long 4k seeks; code was reverted to pass 2 strategy and further gains will need a deeper keyframe-aware approach.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1127,8 +1127,9 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 **What was done**:
 1. Simplified desktop websocket frame handling in `socket.ts` to operate on RGBA payloads only.
-2. Removed NV12 detection, conversion, deferred NV12 frame buffering, and NV12 capture conversion branches from the main message loop and capture path.
-3. Kept stride-correction and worker fallback paths for RGBA frames intact.
+2. Simplified worker decode/render path in `frame-worker.ts` to parse and process only RGBA transport metadata.
+3. Removed NV12 detection, conversion, deferred NV12 frame buffering, and NV12 render branches from main-thread and worker hot paths.
+4. Kept stride-correction and worker fallback paths for RGBA frames intact.
 
 **Changes Made**:
 - `apps/desktop/src/utils/socket.ts`
@@ -1136,6 +1137,10 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
   - removed NV12 render paths for main-thread WebGPU and 2D fallback
   - simplified frame metadata parsing to RGBA 24-byte trailer handling
   - simplified stored-frame capture path to direct RGBA image data
+- `apps/desktop/src/utils/frame-worker.ts`
+  - removed NV12 parsing and conversion branches
+  - removed NV12 WebGPU render dispatch paths
+  - simplified queued-frame and metadata types to RGBA-only transport
 
 **Verification**:
 - `pnpm install --filter @cap/desktop...`

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -830,6 +830,26 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (Rejected superseded-burst cache-window reduction)
+
+**Goal**: Reduce superseded scrub decode work by shrinking decode cache window for superseded requests
+
+**What was done**:
+1. Implemented a reduced cache window path for requests marked as superseded bursts.
+2. Ran scrub, decode, and playback regression benchmarks on 1080p and 4k.
+3. Compared multi-run scrub medians and tail behavior to current default.
+
+**Results**:
+- 4k scrub median last-request average improved (roughly **809ms -> 782ms**), but p95 tail worsened materially in sampled runs (up to **~1952ms**).
+- 1080p scrub average regressed vs current default (roughly **294ms -> 313ms**).
+- Decode/playback regressions remained generally stable, but scrub-tail tradeoff was unfavorable.
+
+**Decision**: reverted the cache-window reduction experiment; keep current supersession behavior unchanged.
+
+**Stopping point**: continue tuning through runtime thresholds and benchmark methodology rather than superseded-request decode-window specialization.
+
+---
+
 ### Session 2026-02-14 (Scrub benchmark multi-run aggregation)
 
 **Goal**: Improve scrub benchmark repeatability by reducing single-run noise in comparisons

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1198,6 +1198,10 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 4. Restored worker transport stats accounting for:
    - frames sent via worker fallback
    - dropped queued frames when newer frames supersede pending ones
+5. Added SAB telemetry counters to frame stats logs:
+   - SAB resize count
+   - SAB fallback count
+   - oversize-triggered SAB fallback count
 
 **Changes Made**:
 - `apps/desktop/src/utils/socket.ts`

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1270,6 +1270,7 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 **Verification**:
 - `pnpm exec biome format --write apps/desktop/src/utils/shared-frame-buffer.ts`
+- `pnpm --dir apps/desktop exec vitest run src/utils/shared-frame-buffer.test.ts`
 - `pnpm --dir apps/desktop exec tsc --noEmit`
 
 **Results**:
@@ -1299,6 +1300,7 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 - `pnpm --dir apps/desktop exec tsc --noEmit`
 
 **Results**:
+- ✅ Desktop unit tests pass (2/2) for writer-slot probing and consumer sparse-ready-slot reads.
 - ✅ Desktop TypeScript checks pass.
 - ✅ Consumer path now remains compatible with producer-side sparse slot selection and avoids avoidable waits on empty read-index slots.
 

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -524,6 +524,7 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 **Verification**:
 - `cargo +1.88.0 check -p cap-editor`
 - `cargo +1.88.0 check -p cap-editor --example playback-startup-report`
+- `cargo +1.88.0 test -p cap-editor --example playback-startup-report`
 - `cargo +1.88.0 run -p cap-editor --example playback-startup-report -- --log crates/editor/PLAYBACK-BENCHMARKS.md`
 
 **Stopping point**: next actionable step is running desktop playback sessions on macOS and Windows with `CAP_PLAYBACK_STARTUP_TRACE_FILE` enabled and feeding the resulting logs into `playback-startup-report`.

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -1329,6 +1329,7 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 2. Prioritized reclaiming the oldest READY slot under full-buffer pressure.
 3. Kept WRITING/READING slots protected; only READY slots are eligible for replacement.
 4. Added unit coverage for overwrite-on-full behavior.
+5. Made oldest-slot selection wrap-safe by comparing frame age in unsigned 32-bit space.
 
 **Changes Made**:
 - `apps/desktop/src/utils/shared-frame-buffer.ts`

--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -3367,6 +3367,40 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-02-14 (audio startup mode env override expansion)
+
+**Goal**: Improve startup A/B experimentation by adding an explicit streaming-only override in addition to the existing pre-render-only override
+
+**What was done**:
+1. Added `CAP_AUDIO_STREAMING_ONLY` override handling in playback audio startup selection.
+2. Preserved `CAP_AUDIO_PRERENDER_ONLY` precedence when both overrides are set.
+3. Updated startup capture docs with streaming-only command variant.
+
+**Changes Made**:
+- `crates/editor/src/playback.rs`
+  - reads `CAP_AUDIO_STREAMING_ONLY` via `env_flag_enabled`
+  - stream selection logic now supports:
+    - pre-render-only override
+    - streaming-only override
+    - default streaming with pre-render fallback
+  - logs warning when both pre-render-only and streaming-only flags are set
+- `crates/editor/PLAYBACK-BENCHMARKS.md`
+  - startup trace capture commands now include `CAP_AUDIO_STREAMING_ONLY=1` variant
+
+**Verification**:
+- `cargo +1.88.0 fmt --all`
+- `cargo +1.88.0 check -p cap-editor`
+- `cargo +1.88.0 run -p cap-editor --example playback-benchmark -- --video /tmp/cap-bench-1080p60.mp4 --fps 60 --max-frames 120 --seek-iterations 4`
+
+**Results**:
+- ✅ Startup mode overrides now support explicit streaming-only and pre-render-only A/B captures.
+- ✅ Override conflict behavior is deterministic (`CAP_AUDIO_PRERENDER_ONLY` wins).
+- ✅ Editor crate compiles and playback benchmark smoke run remains healthy.
+
+**Stopping point**: Ready for macOS/Windows startup trace capture sweeps using labeled streaming-only vs pre-render-only runs.
+
+---
+
 ### Session 2026-02-14 (startup capture docs for pre-render override)
 
 **Goal**: Make A/B startup capture workflow explicit for streaming-first vs forced pre-render audio startup comparisons

--- a/crates/editor/examples/decode-csv-report.rs
+++ b/crates/editor/examples/decode-csv-report.rs
@@ -1,0 +1,977 @@
+use std::collections::BTreeMap;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+
+#[derive(Clone)]
+struct DecodeCsvRow {
+    mode: String,
+    run_label: String,
+    video: String,
+    distance_s: Option<f64>,
+    burst_size: Option<usize>,
+    samples: usize,
+    failures: usize,
+    avg_ms: f64,
+    p95_ms: f64,
+    p99_ms: f64,
+    max_ms: f64,
+    sequential_fps: Option<f64>,
+}
+
+#[derive(Clone, Copy)]
+struct CoreSummary {
+    decoder_creation_ms: f64,
+    sequential_fps: f64,
+    sequential_decode_p95_ms: f64,
+    random_access_avg_ms: f64,
+    random_access_p95_ms: f64,
+}
+
+#[derive(Clone, Copy)]
+struct SeekSummary {
+    distance_millis: i64,
+    rows: usize,
+    samples: usize,
+    failures: usize,
+    avg_ms: f64,
+    p95_ms: f64,
+    p99_ms: f64,
+    max_ms: f64,
+}
+
+#[derive(Clone)]
+struct DuplicateSummary {
+    mode: String,
+    burst_size: usize,
+    rows: usize,
+    samples: usize,
+    failures: usize,
+    avg_ms: f64,
+    p95_ms: f64,
+    p99_ms: f64,
+    max_ms: f64,
+}
+
+#[derive(Clone)]
+struct SummaryEntry {
+    label: String,
+    video: String,
+    core: CoreSummary,
+    seeks: Vec<SeekSummary>,
+    duplicates: Vec<DuplicateSummary>,
+}
+
+fn median_f64(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let index = sorted.len() / 2;
+    if sorted.len().is_multiple_of(2) {
+        (sorted[index - 1] + sorted[index]) / 2.0
+    } else {
+        sorted[index]
+    }
+}
+
+fn parse_optional_f64(field: &str) -> Option<f64> {
+    let value = field.trim_matches('"');
+    if value.is_empty() {
+        None
+    } else {
+        value.parse::<f64>().ok()
+    }
+}
+
+fn parse_optional_usize(field: &str) -> Option<usize> {
+    let value = field.trim_matches('"');
+    if value.is_empty() {
+        None
+    } else {
+        value.parse::<usize>().ok()
+    }
+}
+
+fn parse_csv_line(line: &str) -> Option<DecodeCsvRow> {
+    let fields = line.split(',').collect::<Vec<_>>();
+    if fields.len() < 19 {
+        return None;
+    }
+    if fields.first().copied() == Some("timestamp_ms") {
+        return None;
+    }
+
+    let mode = fields[1].trim_matches('"').to_string();
+    if mode != "decoder_creation"
+        && mode != "sequential"
+        && mode != "seek"
+        && mode != "random_access"
+        && mode != "duplicate_batch"
+        && mode != "duplicate_request"
+    {
+        return None;
+    }
+
+    let run_label = fields[2].trim_matches('"');
+
+    Some(DecodeCsvRow {
+        mode,
+        run_label: if run_label.is_empty() {
+            "unlabeled".to_string()
+        } else {
+            run_label.to_string()
+        },
+        video: fields[3].trim_matches('"').to_string(),
+        distance_s: parse_optional_f64(fields[7]),
+        burst_size: parse_optional_usize(fields[8]),
+        samples: fields[9].parse::<usize>().ok()?,
+        failures: fields[10].parse::<usize>().ok()?,
+        avg_ms: fields[11].parse::<f64>().ok()?,
+        p95_ms: fields[12].parse::<f64>().ok()?,
+        p99_ms: fields[13].parse::<f64>().ok()?,
+        max_ms: fields[14].parse::<f64>().ok()?,
+        sequential_fps: parse_optional_f64(fields[15]),
+    })
+}
+
+fn parse_csv_file(path: &PathBuf) -> Result<Vec<DecodeCsvRow>, String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|error| format!("read {} / {error}", path.display()))?;
+    Ok(contents.lines().filter_map(parse_csv_line).collect())
+}
+
+fn summarize(
+    rows: &[DecodeCsvRow],
+) -> Option<(CoreSummary, Vec<SeekSummary>, Vec<DuplicateSummary>)> {
+    let sequential_rows = rows
+        .iter()
+        .filter(|row| row.mode == "sequential")
+        .collect::<Vec<_>>();
+    if sequential_rows.is_empty() {
+        return None;
+    }
+
+    let decoder_rows = rows
+        .iter()
+        .filter(|row| row.mode == "decoder_creation")
+        .collect::<Vec<_>>();
+    let random_rows = rows
+        .iter()
+        .filter(|row| row.mode == "random_access")
+        .collect::<Vec<_>>();
+
+    let core = CoreSummary {
+        decoder_creation_ms: median_f64(
+            &decoder_rows
+                .iter()
+                .map(|row| row.avg_ms)
+                .collect::<Vec<_>>(),
+        ),
+        sequential_fps: median_f64(
+            &sequential_rows
+                .iter()
+                .filter_map(|row| row.sequential_fps)
+                .collect::<Vec<_>>(),
+        ),
+        sequential_decode_p95_ms: median_f64(
+            &sequential_rows
+                .iter()
+                .map(|row| row.p95_ms)
+                .collect::<Vec<_>>(),
+        ),
+        random_access_avg_ms: median_f64(
+            &random_rows.iter().map(|row| row.avg_ms).collect::<Vec<_>>(),
+        ),
+        random_access_p95_ms: median_f64(
+            &random_rows.iter().map(|row| row.p95_ms).collect::<Vec<_>>(),
+        ),
+    };
+
+    let mut seek_groups = BTreeMap::<i64, Vec<&DecodeCsvRow>>::new();
+    for row in rows.iter().filter(|row| row.mode == "seek") {
+        let Some(distance) = row.distance_s else {
+            continue;
+        };
+        let distance_millis = (distance * 1000.0).round() as i64;
+        seek_groups.entry(distance_millis).or_default().push(row);
+    }
+    let seeks = seek_groups
+        .into_iter()
+        .map(|(distance_millis, rows)| SeekSummary {
+            distance_millis,
+            rows: rows.len(),
+            samples: rows.iter().map(|row| row.samples).sum(),
+            failures: rows.iter().map(|row| row.failures).sum(),
+            avg_ms: median_f64(&rows.iter().map(|row| row.avg_ms).collect::<Vec<_>>()),
+            p95_ms: median_f64(&rows.iter().map(|row| row.p95_ms).collect::<Vec<_>>()),
+            p99_ms: median_f64(&rows.iter().map(|row| row.p99_ms).collect::<Vec<_>>()),
+            max_ms: median_f64(&rows.iter().map(|row| row.max_ms).collect::<Vec<_>>()),
+        })
+        .collect::<Vec<_>>();
+
+    let mut duplicate_groups = BTreeMap::<(String, usize), Vec<&DecodeCsvRow>>::new();
+    for row in rows
+        .iter()
+        .filter(|row| row.mode == "duplicate_batch" || row.mode == "duplicate_request")
+    {
+        let Some(burst_size) = row.burst_size else {
+            continue;
+        };
+        duplicate_groups
+            .entry((row.mode.clone(), burst_size))
+            .or_default()
+            .push(row);
+    }
+    let duplicates = duplicate_groups
+        .into_iter()
+        .map(|((mode, burst_size), rows)| DuplicateSummary {
+            mode,
+            burst_size,
+            rows: rows.len(),
+            samples: rows.iter().map(|row| row.samples).sum(),
+            failures: rows.iter().map(|row| row.failures).sum(),
+            avg_ms: median_f64(&rows.iter().map(|row| row.avg_ms).collect::<Vec<_>>()),
+            p95_ms: median_f64(&rows.iter().map(|row| row.p95_ms).collect::<Vec<_>>()),
+            p99_ms: median_f64(&rows.iter().map(|row| row.p99_ms).collect::<Vec<_>>()),
+            max_ms: median_f64(&rows.iter().map(|row| row.max_ms).collect::<Vec<_>>()),
+        })
+        .collect::<Vec<_>>();
+
+    Some((core, seeks, duplicates))
+}
+
+fn group_by_label_and_video(
+    rows: &[DecodeCsvRow],
+) -> BTreeMap<(String, String), Vec<DecodeCsvRow>> {
+    rows.iter().fold(
+        BTreeMap::<(String, String), Vec<DecodeCsvRow>>::new(),
+        |mut acc, row| {
+            acc.entry((row.run_label.clone(), row.video.clone()))
+                .or_default()
+                .push(row.clone());
+            acc
+        },
+    )
+}
+
+fn format_distance(distance_millis: i64) -> String {
+    format!("{:.3}", distance_millis as f64 / 1000.0)
+}
+
+fn print_summary(entry: &SummaryEntry) {
+    println!(
+        "{} video={}: decoder_creation={:.2}ms sequential_fps={:.2} sequential_decode_p95={:.2}ms random_access_avg={:.2}ms random_access_p95={:.2}ms",
+        entry.label,
+        entry.video,
+        entry.core.decoder_creation_ms,
+        entry.core.sequential_fps,
+        entry.core.sequential_decode_p95_ms,
+        entry.core.random_access_avg_ms,
+        entry.core.random_access_p95_ms
+    );
+    for seek in &entry.seeks {
+        println!(
+            "{} video={} seek_distance={}s: rows={} samples={} failures={} avg={:.2}ms p95={:.2}ms p99={:.2}ms max={:.2}ms",
+            entry.label,
+            entry.video,
+            format_distance(seek.distance_millis),
+            seek.rows,
+            seek.samples,
+            seek.failures,
+            seek.avg_ms,
+            seek.p95_ms,
+            seek.p99_ms,
+            seek.max_ms
+        );
+    }
+    for duplicate in &entry.duplicates {
+        println!(
+            "{} video={} {} burst={}: rows={} samples={} failures={} avg={:.2}ms p95={:.2}ms p99={:.2}ms max={:.2}ms",
+            entry.label,
+            entry.video,
+            duplicate.mode,
+            duplicate.burst_size,
+            duplicate.rows,
+            duplicate.samples,
+            duplicate.failures,
+            duplicate.avg_ms,
+            duplicate.p95_ms,
+            duplicate.p99_ms,
+            duplicate.max_ms
+        );
+    }
+}
+
+fn print_delta(
+    baseline_label: &str,
+    candidate_label: &str,
+    video: &str,
+    baseline: CoreSummary,
+    candidate: CoreSummary,
+) {
+    println!(
+        "delta({candidate_label}-{baseline_label}) video={video}: decoder_creation={:+.2}ms sequential_fps={:+.2} sequential_decode_p95={:+.2}ms random_access_avg={:+.2}ms random_access_p95={:+.2}ms",
+        candidate.decoder_creation_ms - baseline.decoder_creation_ms,
+        candidate.sequential_fps - baseline.sequential_fps,
+        candidate.sequential_decode_p95_ms - baseline.sequential_decode_p95_ms,
+        candidate.random_access_avg_ms - baseline.random_access_avg_ms,
+        candidate.random_access_p95_ms - baseline.random_access_p95_ms
+    );
+}
+
+fn print_seek_delta(
+    baseline_label: &str,
+    candidate_label: &str,
+    video: &str,
+    distance_millis: i64,
+    baseline: SeekSummary,
+    candidate: SeekSummary,
+) {
+    println!(
+        "delta({candidate_label}-{baseline_label}) video={video} seek_distance={}s: avg={:+.2}ms p95={:+.2}ms p99={:+.2}ms max={:+.2}ms",
+        format_distance(distance_millis),
+        candidate.avg_ms - baseline.avg_ms,
+        candidate.p95_ms - baseline.p95_ms,
+        candidate.p99_ms - baseline.p99_ms,
+        candidate.max_ms - baseline.max_ms
+    );
+}
+
+fn print_duplicate_delta(
+    baseline_label: &str,
+    candidate_label: &str,
+    video: &str,
+    mode: &str,
+    burst_size: usize,
+    baseline: &DuplicateSummary,
+    candidate: &DuplicateSummary,
+) {
+    println!(
+        "delta({candidate_label}-{baseline_label}) video={video} {mode} burst={burst_size}: avg={:+.2}ms p95={:+.2}ms p99={:+.2}ms max={:+.2}ms",
+        candidate.avg_ms - baseline.avg_ms,
+        candidate.p95_ms - baseline.p95_ms,
+        candidate.p99_ms - baseline.p99_ms,
+        candidate.max_ms - baseline.max_ms
+    );
+}
+
+fn write_csv_header(path: &PathBuf, file: &mut std::fs::File) -> Result<(), String> {
+    if path.exists() && path.metadata().map(|meta| meta.len()).unwrap_or(0) > 0 {
+        return Ok(());
+    }
+    let header = [
+        "timestamp_ms",
+        "mode",
+        "label",
+        "video",
+        "distance_s",
+        "duplicate_mode",
+        "burst_size",
+        "rows",
+        "samples",
+        "failures",
+        "decoder_creation_ms",
+        "sequential_fps",
+        "sequential_decode_p95_ms",
+        "random_access_avg_ms",
+        "random_access_p95_ms",
+        "avg_ms",
+        "p95_ms",
+        "p99_ms",
+        "max_ms",
+        "baseline_label",
+        "candidate_label",
+        "delta_decoder_creation_ms",
+        "delta_sequential_fps",
+        "delta_sequential_decode_p95_ms",
+        "delta_random_access_avg_ms",
+        "delta_random_access_p95_ms",
+        "delta_avg_ms",
+        "delta_p95_ms",
+        "delta_p99_ms",
+        "delta_max_ms",
+    ]
+    .join(",");
+    writeln!(file, "{header}").map_err(|error| format!("write {} / {error}", path.display()))
+}
+
+fn append_summary_csv(path: &PathBuf, summaries: &[SummaryEntry]) -> Result<(), String> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|error| format!("open {} / {error}", path.display()))?;
+    write_csv_header(path, &mut file)?;
+    let timestamp_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default();
+
+    for entry in summaries {
+        writeln!(
+            file,
+            "{timestamp_ms},summary_core,\"{}\",\"{}\",\"\",\"\",\"\",\"\",\"\",\"\",{:.3},{:.3},{:.3},{:.3},{:.3},\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\"",
+            entry.label,
+            entry.video,
+            entry.core.decoder_creation_ms,
+            entry.core.sequential_fps,
+            entry.core.sequential_decode_p95_ms,
+            entry.core.random_access_avg_ms,
+            entry.core.random_access_p95_ms
+        )
+        .map_err(|error| format!("write {} / {error}", path.display()))?;
+
+        for seek in &entry.seeks {
+            writeln!(
+                file,
+                "{timestamp_ms},summary_seek,\"{}\",\"{}\",{},\"\",\"\",{},{},{},\"\",\"\",\"\",\"\",\"\",{:.3},{:.3},{:.3},{:.3},\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\"",
+                entry.label,
+                entry.video,
+                format_distance(seek.distance_millis),
+                seek.rows,
+                seek.samples,
+                seek.failures,
+                seek.avg_ms,
+                seek.p95_ms,
+                seek.p99_ms,
+                seek.max_ms
+            )
+            .map_err(|error| format!("write {} / {error}", path.display()))?;
+        }
+
+        for duplicate in &entry.duplicates {
+            writeln!(
+                file,
+                "{timestamp_ms},summary_duplicate,\"{}\",\"{}\",\"\",\"{}\",{},{},{},{},\"\",\"\",\"\",\"\",\"\",{:.3},{:.3},{:.3},{:.3},\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\"",
+                entry.label,
+                entry.video,
+                duplicate.mode,
+                duplicate.burst_size,
+                duplicate.rows,
+                duplicate.samples,
+                duplicate.failures,
+                duplicate.avg_ms,
+                duplicate.p95_ms,
+                duplicate.p99_ms,
+                duplicate.max_ms
+            )
+            .map_err(|error| format!("write {} / {error}", path.display()))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn append_delta_csv(
+    path: &PathBuf,
+    baseline_label: &str,
+    candidate_label: &str,
+    video: &str,
+    baseline: &SummaryEntry,
+    candidate: &SummaryEntry,
+) -> Result<(), String> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|error| format!("open {} / {error}", path.display()))?;
+    write_csv_header(path, &mut file)?;
+    let timestamp_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default();
+
+    writeln!(
+        file,
+        "{timestamp_ms},delta_core,\"\",\"{}\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"{}\",\"{}\",{:.3},{:.3},{:.3},{:.3},{:.3},\"\",\"\",\"\",\"\"",
+        video,
+        baseline_label,
+        candidate_label,
+        candidate.core.decoder_creation_ms - baseline.core.decoder_creation_ms,
+        candidate.core.sequential_fps - baseline.core.sequential_fps,
+        candidate.core.sequential_decode_p95_ms - baseline.core.sequential_decode_p95_ms,
+        candidate.core.random_access_avg_ms - baseline.core.random_access_avg_ms,
+        candidate.core.random_access_p95_ms - baseline.core.random_access_p95_ms
+    )
+    .map_err(|error| format!("write {} / {error}", path.display()))?;
+
+    let baseline_seeks = baseline
+        .seeks
+        .iter()
+        .map(|seek| (seek.distance_millis, *seek))
+        .collect::<BTreeMap<_, _>>();
+    let candidate_seeks = candidate
+        .seeks
+        .iter()
+        .map(|seek| (seek.distance_millis, *seek))
+        .collect::<BTreeMap<_, _>>();
+
+    for (distance_millis, baseline_seek) in baseline_seeks {
+        let Some(candidate_seek) = candidate_seeks.get(&distance_millis) else {
+            continue;
+        };
+        writeln!(
+            file,
+            "{timestamp_ms},delta_seek,\"\",\"{}\",{},\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"{}\",\"{}\",\"\",\"\",\"\",\"\",\"\",{:.3},{:.3},{:.3},{:.3}",
+            video,
+            format_distance(distance_millis),
+            baseline_label,
+            candidate_label,
+            candidate_seek.avg_ms - baseline_seek.avg_ms,
+            candidate_seek.p95_ms - baseline_seek.p95_ms,
+            candidate_seek.p99_ms - baseline_seek.p99_ms,
+            candidate_seek.max_ms - baseline_seek.max_ms
+        )
+        .map_err(|error| format!("write {} / {error}", path.display()))?;
+    }
+
+    let baseline_duplicates = baseline
+        .duplicates
+        .iter()
+        .map(|duplicate| ((duplicate.mode.clone(), duplicate.burst_size), duplicate))
+        .collect::<BTreeMap<_, _>>();
+    let candidate_duplicates = candidate
+        .duplicates
+        .iter()
+        .map(|duplicate| ((duplicate.mode.clone(), duplicate.burst_size), duplicate))
+        .collect::<BTreeMap<_, _>>();
+
+    for ((mode, burst_size), baseline_duplicate) in baseline_duplicates {
+        let Some(candidate_duplicate) = candidate_duplicates.get(&(mode.clone(), burst_size))
+        else {
+            continue;
+        };
+        writeln!(
+            file,
+            "{timestamp_ms},delta_duplicate,\"\",\"{}\",\"\",\"{}\",{},\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"{}\",\"{}\",\"\",\"\",\"\",\"\",\"\",{:.3},{:.3},{:.3},{:.3}",
+            video,
+            mode,
+            burst_size,
+            baseline_label,
+            candidate_label,
+            candidate_duplicate.avg_ms - baseline_duplicate.avg_ms,
+            candidate_duplicate.p95_ms - baseline_duplicate.p95_ms,
+            candidate_duplicate.p99_ms - baseline_duplicate.p99_ms,
+            candidate_duplicate.max_ms - baseline_duplicate.max_ms
+        )
+        .map_err(|error| format!("write {} / {error}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+fn main() {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.is_empty() {
+        eprintln!(
+            "Usage: decode-csv-report --csv <path> [--csv <path> ...] [--label <run-label>] [--baseline-label <run-label> --candidate-label <run-label>] [--output-csv <path>]"
+        );
+        std::process::exit(1);
+    }
+
+    let mut csv_paths = Vec::<PathBuf>::new();
+    let mut label: Option<String> = None;
+    let mut baseline_label: Option<String> = None;
+    let mut candidate_label: Option<String> = None;
+    let mut output_csv: Option<PathBuf> = None;
+
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--csv" => {
+                if let Some(value) = args.get(index + 1) {
+                    csv_paths.push(PathBuf::from(value));
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --csv");
+                std::process::exit(1);
+            }
+            "--label" => {
+                if let Some(value) = args.get(index + 1) {
+                    label = Some(value.clone());
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --label");
+                std::process::exit(1);
+            }
+            "--baseline-label" => {
+                if let Some(value) = args.get(index + 1) {
+                    baseline_label = Some(value.clone());
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --baseline-label");
+                std::process::exit(1);
+            }
+            "--candidate-label" => {
+                if let Some(value) = args.get(index + 1) {
+                    candidate_label = Some(value.clone());
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --candidate-label");
+                std::process::exit(1);
+            }
+            "--output-csv" => {
+                if let Some(value) = args.get(index + 1) {
+                    output_csv = Some(PathBuf::from(value));
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --output-csv");
+                std::process::exit(1);
+            }
+            unknown => {
+                eprintln!("Unknown argument: {unknown}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    if csv_paths.is_empty() {
+        eprintln!("At least one --csv path is required");
+        std::process::exit(1);
+    }
+
+    let mut all_rows = Vec::<DecodeCsvRow>::new();
+    for path in &csv_paths {
+        match parse_csv_file(path) {
+            Ok(mut rows) => all_rows.append(&mut rows),
+            Err(error) => {
+                eprintln!("{error}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    if all_rows.is_empty() {
+        eprintln!("No rows found");
+        std::process::exit(1);
+    }
+
+    let grouped = group_by_label_and_video(&all_rows);
+    let mut summaries = Vec::<SummaryEntry>::new();
+
+    if let Some(label) = label {
+        for ((group_label, video), rows) in grouped.iter() {
+            if group_label != &label {
+                continue;
+            }
+            let Some((core, seeks, duplicates)) = summarize(rows) else {
+                continue;
+            };
+            summaries.push(SummaryEntry {
+                label: group_label.clone(),
+                video: video.clone(),
+                core,
+                seeks,
+                duplicates,
+            });
+        }
+        if summaries.is_empty() {
+            eprintln!("No rows found for label: {label}");
+            std::process::exit(1);
+        }
+    } else {
+        for ((group_label, video), rows) in grouped.iter() {
+            let Some((core, seeks, duplicates)) = summarize(rows) else {
+                continue;
+            };
+            summaries.push(SummaryEntry {
+                label: group_label.clone(),
+                video: video.clone(),
+                core,
+                seeks,
+                duplicates,
+            });
+        }
+    }
+
+    if summaries.is_empty() {
+        eprintln!("No summaries produced");
+        std::process::exit(1);
+    }
+
+    for summary in &summaries {
+        print_summary(summary);
+    }
+
+    if let Some(path) = &output_csv
+        && let Err(error) = append_summary_csv(path, &summaries)
+    {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+
+    if let (Some(baseline_label), Some(candidate_label)) = (baseline_label, candidate_label) {
+        let baseline_by_video = summaries
+            .iter()
+            .filter(|entry| entry.label == baseline_label)
+            .map(|entry| (entry.video.clone(), entry.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let candidate_by_video = summaries
+            .iter()
+            .filter(|entry| entry.label == candidate_label)
+            .map(|entry| (entry.video.clone(), entry.clone()))
+            .collect::<BTreeMap<_, _>>();
+
+        if baseline_by_video.is_empty() {
+            eprintln!("No rows found for baseline label: {baseline_label}");
+            std::process::exit(1);
+        }
+        if candidate_by_video.is_empty() {
+            eprintln!("No rows found for candidate label: {candidate_label}");
+            std::process::exit(1);
+        }
+
+        let mut compared = false;
+        for (video, baseline) in baseline_by_video {
+            let Some(candidate) = candidate_by_video.get(&video) else {
+                continue;
+            };
+            print_delta(
+                &baseline_label,
+                &candidate_label,
+                &video,
+                baseline.core,
+                candidate.core,
+            );
+
+            let baseline_seeks = baseline
+                .seeks
+                .iter()
+                .map(|seek| (seek.distance_millis, *seek))
+                .collect::<BTreeMap<_, _>>();
+            for candidate_seek in &candidate.seeks {
+                let Some(baseline_seek) = baseline_seeks.get(&candidate_seek.distance_millis)
+                else {
+                    continue;
+                };
+                print_seek_delta(
+                    &baseline_label,
+                    &candidate_label,
+                    &video,
+                    candidate_seek.distance_millis,
+                    *baseline_seek,
+                    *candidate_seek,
+                );
+            }
+
+            let baseline_duplicates = baseline
+                .duplicates
+                .iter()
+                .map(|duplicate| ((duplicate.mode.clone(), duplicate.burst_size), duplicate))
+                .collect::<BTreeMap<_, _>>();
+            for candidate_duplicate in &candidate.duplicates {
+                let key = (
+                    candidate_duplicate.mode.clone(),
+                    candidate_duplicate.burst_size,
+                );
+                let Some(baseline_duplicate) = baseline_duplicates.get(&key) else {
+                    continue;
+                };
+                print_duplicate_delta(
+                    &baseline_label,
+                    &candidate_label,
+                    &video,
+                    &candidate_duplicate.mode,
+                    candidate_duplicate.burst_size,
+                    baseline_duplicate,
+                    candidate_duplicate,
+                );
+            }
+
+            if let Some(path) = &output_csv
+                && let Err(error) = append_delta_csv(
+                    path,
+                    &baseline_label,
+                    &candidate_label,
+                    &video,
+                    &baseline,
+                    candidate,
+                )
+            {
+                eprintln!("{error}");
+                std::process::exit(1);
+            }
+            compared = true;
+        }
+
+        if !compared {
+            eprintln!("No overlapping videos found between baseline and candidate labels");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SummaryEntry, append_delta_csv, append_summary_csv, parse_csv_line, summarize};
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn parses_sequential_row() {
+        let line = "1771054846650,sequential,\"linux-pass\",\"/tmp/cap-bench-1080p60.mp4\",60,3,2,\"\",\"\",100,0,2.651,3.532,4.851,5.979,377.112,10.276,0,0";
+        let row = parse_csv_line(line).expect("expected row");
+        assert_eq!(row.mode, "sequential");
+        assert_eq!(row.run_label, "linux-pass");
+        assert_eq!(row.samples, 100);
+        assert_eq!(row.failures, 0);
+        assert_eq!(row.sequential_fps, Some(377.112));
+    }
+
+    #[test]
+    fn summarizes_modes() {
+        let rows = vec![
+            super::DecodeCsvRow {
+                mode: "decoder_creation".to_string(),
+                run_label: "a".to_string(),
+                video: "v".to_string(),
+                distance_s: None,
+                burst_size: None,
+                samples: 1,
+                failures: 0,
+                avg_ms: 10.0,
+                p95_ms: 10.0,
+                p99_ms: 10.0,
+                max_ms: 10.0,
+                sequential_fps: None,
+            },
+            super::DecodeCsvRow {
+                mode: "sequential".to_string(),
+                run_label: "a".to_string(),
+                video: "v".to_string(),
+                distance_s: None,
+                burst_size: None,
+                samples: 100,
+                failures: 0,
+                avg_ms: 2.5,
+                p95_ms: 3.5,
+                p99_ms: 5.0,
+                max_ms: 6.0,
+                sequential_fps: Some(380.0),
+            },
+            super::DecodeCsvRow {
+                mode: "seek".to_string(),
+                run_label: "a".to_string(),
+                video: "v".to_string(),
+                distance_s: Some(2.0),
+                burst_size: None,
+                samples: 3,
+                failures: 0,
+                avg_ms: 150.0,
+                p95_ms: 200.0,
+                p99_ms: 200.0,
+                max_ms: 200.0,
+                sequential_fps: Some(380.0),
+            },
+            super::DecodeCsvRow {
+                mode: "random_access".to_string(),
+                run_label: "a".to_string(),
+                video: "v".to_string(),
+                distance_s: None,
+                burst_size: None,
+                samples: 50,
+                failures: 0,
+                avg_ms: 120.0,
+                p95_ms: 300.0,
+                p99_ms: 350.0,
+                max_ms: 360.0,
+                sequential_fps: Some(380.0),
+            },
+            super::DecodeCsvRow {
+                mode: "duplicate_batch".to_string(),
+                run_label: "a".to_string(),
+                video: "v".to_string(),
+                distance_s: None,
+                burst_size: Some(8),
+                samples: 10,
+                failures: 0,
+                avg_ms: 5.0,
+                p95_ms: 7.0,
+                p99_ms: 7.5,
+                max_ms: 8.0,
+                sequential_fps: Some(380.0),
+            },
+        ];
+        let (core, seeks, duplicates) = summarize(&rows).expect("summary");
+        assert!((core.decoder_creation_ms - 10.0).abs() < f64::EPSILON);
+        assert!((core.sequential_fps - 380.0).abs() < f64::EPSILON);
+        assert_eq!(seeks.len(), 1);
+        assert_eq!(seeks[0].distance_millis, 2000);
+        assert_eq!(duplicates.len(), 1);
+        assert_eq!(duplicates[0].burst_size, 8);
+    }
+
+    #[test]
+    fn writes_summary_and_delta_rows() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("timestamp")
+            .as_nanos();
+        let path = PathBuf::from(format!("/tmp/decode-csv-report-{unique}.csv"));
+
+        let summary = SummaryEntry {
+            label: "label-a".to_string(),
+            video: "video-1".to_string(),
+            core: super::CoreSummary {
+                decoder_creation_ms: 10.0,
+                sequential_fps: 380.0,
+                sequential_decode_p95_ms: 3.5,
+                random_access_avg_ms: 120.0,
+                random_access_p95_ms: 300.0,
+            },
+            seeks: vec![super::SeekSummary {
+                distance_millis: 2000,
+                rows: 1,
+                samples: 3,
+                failures: 0,
+                avg_ms: 150.0,
+                p95_ms: 200.0,
+                p99_ms: 200.0,
+                max_ms: 200.0,
+            }],
+            duplicates: vec![super::DuplicateSummary {
+                mode: "duplicate_batch".to_string(),
+                burst_size: 8,
+                rows: 1,
+                samples: 10,
+                failures: 0,
+                avg_ms: 5.0,
+                p95_ms: 7.0,
+                p99_ms: 7.5,
+                max_ms: 8.0,
+            }],
+        };
+
+        append_summary_csv(&path, std::slice::from_ref(&summary)).expect("summary csv");
+        append_delta_csv(
+            &path,
+            "baseline",
+            "candidate",
+            "video-1",
+            &summary,
+            &summary,
+        )
+        .expect("delta csv");
+
+        let contents = fs::read_to_string(&path).expect("read csv");
+        let lines = contents.lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), 7);
+        assert!(lines[0].contains("timestamp_ms,mode,label,video"));
+        assert!(lines[1].contains("summary_core"));
+        assert!(lines[2].contains("summary_seek"));
+        assert!(lines[3].contains("summary_duplicate"));
+        assert!(lines[4].contains("delta_core"));
+        assert!(lines[5].contains("delta_seek"));
+        assert!(lines[6].contains("delta_duplicate"));
+
+        let _ = fs::remove_file(path);
+    }
+}

--- a/crates/editor/examples/playback-benchmark.rs
+++ b/crates/editor/examples/playback-benchmark.rs
@@ -1,0 +1,279 @@
+use cap_audio::AudioData;
+use cap_rendering::decoder::spawn_decoder;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+use tokio::runtime::Runtime;
+
+#[derive(Debug, Clone)]
+struct Config {
+    video_path: PathBuf,
+    audio_path: Option<PathBuf>,
+    fps: u32,
+    max_frames: usize,
+}
+
+#[derive(Debug, Default)]
+struct PlaybackStats {
+    decoded_frames: usize,
+    failed_frames: usize,
+    missed_deadlines: usize,
+    decode_times_ms: Vec<f64>,
+    sequential_elapsed_secs: f64,
+    effective_fps: f64,
+    seek_samples_ms: Vec<(f32, f64)>,
+}
+
+fn get_video_duration(path: &Path) -> f32 {
+    let output = Command::new("ffprobe")
+        .args([
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+        ])
+        .arg(path)
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => {
+            let duration_str = String::from_utf8_lossy(&output.stdout);
+            duration_str.trim().parse().unwrap_or(0.0)
+        }
+        _ => 0.0,
+    }
+}
+
+fn percentile(samples: &[f64], p: f64) -> f64 {
+    let mut filtered: Vec<f64> = samples.iter().copied().filter(|v| !v.is_nan()).collect();
+    if filtered.is_empty() {
+        return 0.0;
+    }
+    filtered.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let idx = ((p / 100.0) * (filtered.len() - 1) as f64).round() as usize;
+    filtered[idx.min(filtered.len() - 1)]
+}
+
+async fn run_playback_benchmark(config: &Config) -> Result<PlaybackStats, String> {
+    let mut stats = PlaybackStats::default();
+    let decoder = spawn_decoder(
+        "benchmark",
+        config.video_path.clone(),
+        config.fps,
+        0.0,
+        false,
+    )
+    .await
+    .map_err(|e| format!("Failed to create decoder: {e}"))?;
+
+    let duration_secs = get_video_duration(&config.video_path);
+    if duration_secs <= 0.0 {
+        return Err("Unable to determine video duration".to_string());
+    }
+
+    let total_frames = ((duration_secs as f64 * config.fps as f64).ceil() as usize)
+        .max(1)
+        .min(config.max_frames);
+    let frame_interval = Duration::from_secs_f64(1.0 / config.fps as f64);
+
+    let start = Instant::now();
+    for frame_idx in 0..total_frames {
+        let frame_deadline = start + frame_interval.mul_f64(frame_idx as f64);
+        if Instant::now() < frame_deadline {
+            tokio::time::sleep_until(tokio::time::Instant::from_std(frame_deadline)).await;
+        }
+
+        let frame_time = frame_idx as f32 / config.fps as f32;
+        let decode_start = Instant::now();
+        if decoder.get_frame(frame_time).await.is_some() {
+            stats.decoded_frames += 1;
+            let decode_ms = decode_start.elapsed().as_secs_f64() * 1000.0;
+            stats.decode_times_ms.push(decode_ms);
+            if Instant::now() > frame_deadline + frame_interval {
+                stats.missed_deadlines += 1;
+            }
+        } else {
+            stats.failed_frames += 1;
+        }
+    }
+
+    stats.sequential_elapsed_secs = start.elapsed().as_secs_f64();
+    if stats.sequential_elapsed_secs > 0.0 {
+        stats.effective_fps = stats.decoded_frames as f64 / stats.sequential_elapsed_secs;
+    }
+
+    let seek_points = [0.5_f32, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0];
+    for point in seek_points {
+        if point >= duration_secs {
+            continue;
+        }
+        let seek_start = Instant::now();
+        let _ = decoder.get_frame(point).await;
+        let seek_ms = seek_start.elapsed().as_secs_f64() * 1000.0;
+        stats.seek_samples_ms.push((point, seek_ms));
+    }
+
+    Ok(stats)
+}
+
+fn print_report(config: &Config, stats: &PlaybackStats) {
+    println!("\n{}", "=".repeat(68));
+    println!("Playback Benchmark Report");
+    println!("{}", "=".repeat(68));
+    println!("Video: {}", config.video_path.display());
+    println!("Target FPS: {}", config.fps);
+    println!("Frame Budget: {:.2}ms", 1000.0 / config.fps as f64);
+
+    println!("\nSequential Playback Simulation");
+    println!("Decoded Frames: {}", stats.decoded_frames);
+    println!("Failed Frames: {}", stats.failed_frames);
+    println!("Missed Deadlines: {}", stats.missed_deadlines);
+    println!("Elapsed: {:.2}s", stats.sequential_elapsed_secs);
+    println!("Effective FPS: {:.2}", stats.effective_fps);
+
+    if !stats.decode_times_ms.is_empty() {
+        let avg = stats.decode_times_ms.iter().sum::<f64>() / stats.decode_times_ms.len() as f64;
+        let min = stats
+            .decode_times_ms
+            .iter()
+            .copied()
+            .fold(f64::INFINITY, f64::min);
+        let max = stats
+            .decode_times_ms
+            .iter()
+            .copied()
+            .fold(f64::NEG_INFINITY, f64::max);
+        println!("Decode avg: {:.2}ms", avg);
+        println!("Decode min: {:.2}ms", min);
+        println!(
+            "Decode p95: {:.2}ms",
+            percentile(&stats.decode_times_ms, 95.0)
+        );
+        println!(
+            "Decode p99: {:.2}ms",
+            percentile(&stats.decode_times_ms, 99.0)
+        );
+        println!("Decode max: {:.2}ms", max);
+    }
+
+    if !stats.seek_samples_ms.is_empty() {
+        println!("\nSeek Samples");
+        for (secs, ms) in &stats.seek_samples_ms {
+            println!("{:>5.1}s -> {:>8.2}ms", secs, ms);
+        }
+    }
+
+    if let Some(audio_path) = &config.audio_path {
+        match AudioData::from_file(audio_path) {
+            Ok(audio) => {
+                let audio_duration = audio.sample_count() as f64 / AudioData::SAMPLE_RATE as f64;
+                let video_duration = get_video_duration(&config.video_path) as f64;
+                let diff_ms = (audio_duration - video_duration).abs() * 1000.0;
+                println!("\nAudio Duration Comparison");
+                println!("Audio: {:.3}s", audio_duration);
+                println!("Video: {:.3}s", video_duration);
+                println!("Difference: {:.2}ms", diff_ms);
+            }
+            Err(err) => {
+                println!("\nAudio Duration Comparison");
+                println!("Failed to load audio {}: {}", audio_path.display(), err);
+            }
+        }
+    }
+
+    println!("{}", "=".repeat(68));
+}
+
+fn parse_args() -> Result<Config, String> {
+    let args: Vec<String> = std::env::args().collect();
+    let mut video_path: Option<PathBuf> = None;
+    let mut audio_path: Option<PathBuf> = None;
+    let mut fps = 60_u32;
+    let mut max_frames = 600_usize;
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--video" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err("Missing value for --video".to_string());
+                }
+                video_path = Some(PathBuf::from(&args[i]));
+            }
+            "--audio" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err("Missing value for --audio".to_string());
+                }
+                audio_path = Some(PathBuf::from(&args[i]));
+            }
+            "--fps" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err("Missing value for --fps".to_string());
+                }
+                fps = args[i]
+                    .parse::<u32>()
+                    .map_err(|_| "Invalid --fps value".to_string())?;
+            }
+            "--max-frames" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err("Missing value for --max-frames".to_string());
+                }
+                max_frames = args[i]
+                    .parse::<usize>()
+                    .map_err(|_| "Invalid --max-frames value".to_string())?;
+            }
+            "--help" | "-h" => {
+                println!(
+                    "Usage: playback-benchmark --video <path> [--audio <path>] [--fps <n>] [--max-frames <n>]"
+                );
+                std::process::exit(0);
+            }
+            unknown => {
+                return Err(format!("Unknown argument: {unknown}"));
+            }
+        }
+        i += 1;
+    }
+
+    let video_path = video_path.ok_or_else(|| "Missing required --video".to_string())?;
+    if !video_path.exists() {
+        return Err(format!(
+            "Video path does not exist: {}",
+            video_path.display()
+        ));
+    }
+
+    Ok(Config {
+        video_path,
+        audio_path,
+        fps,
+        max_frames,
+    })
+}
+
+fn main() {
+    let config = match parse_args() {
+        Ok(config) => config,
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(1);
+        }
+    };
+
+    let rt = Runtime::new().expect("Failed to create tokio runtime");
+    match rt.block_on(run_playback_benchmark(&config)) {
+        Ok(stats) => {
+            print_report(&config, &stats);
+        }
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/editor/examples/playback-benchmark.rs
+++ b/crates/editor/examples/playback-benchmark.rs
@@ -135,7 +135,8 @@ fn write_csv(path: &PathBuf, config: &Config, stats: &PlaybackStats) -> Result<(
             "seek_failures",
         ]
         .join(",");
-        writeln!(file, "{header}").map_err(|error| format!("write {} / {error}", path.display()))?;
+        writeln!(file, "{header}")
+            .map_err(|error| format!("write {} / {error}", path.display()))?;
     }
 
     let timestamp_ms = std::time::SystemTime::now()

--- a/crates/editor/examples/playback-csv-report.rs
+++ b/crates/editor/examples/playback-csv-report.rs
@@ -1,0 +1,844 @@
+use std::collections::BTreeMap;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+
+#[derive(Clone)]
+struct PlaybackCsvRow {
+    mode: String,
+    run_label: String,
+    video: String,
+    effective_fps: f64,
+    decode_p95_ms: f64,
+    missed_deadlines: usize,
+    seek_distance_s: Option<f64>,
+    seek_avg_ms: Option<f64>,
+    seek_p95_ms: Option<f64>,
+    seek_max_ms: Option<f64>,
+    seek_samples: usize,
+    seek_failures: usize,
+}
+
+#[derive(Clone, Copy)]
+struct SequentialSummary {
+    samples: usize,
+    effective_fps: f64,
+    decode_p95_ms: f64,
+    missed_deadlines: usize,
+}
+
+#[derive(Clone, Copy)]
+struct SeekSummary {
+    distance_millis: i64,
+    samples: usize,
+    seek_avg_ms: f64,
+    seek_p95_ms: f64,
+    seek_max_ms: f64,
+    seek_samples: usize,
+    seek_failures: usize,
+}
+
+#[derive(Clone)]
+struct SummaryEntry {
+    label: String,
+    video: String,
+    sequential: SequentialSummary,
+    seeks: Vec<SeekSummary>,
+}
+
+fn median_f64(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let index = sorted.len() / 2;
+    if sorted.len().is_multiple_of(2) {
+        (sorted[index - 1] + sorted[index]) / 2.0
+    } else {
+        sorted[index]
+    }
+}
+
+fn median_usize(values: &[usize]) -> usize {
+    if values.is_empty() {
+        return 0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort();
+    let index = sorted.len() / 2;
+    if sorted.len().is_multiple_of(2) {
+        (sorted[index - 1] + sorted[index]) / 2
+    } else {
+        sorted[index]
+    }
+}
+
+fn parse_optional_f64(field: &str) -> Option<f64> {
+    let value = field.trim_matches('"');
+    if value.is_empty() {
+        None
+    } else {
+        value.parse::<f64>().ok()
+    }
+}
+
+fn parse_optional_usize(field: &str) -> Option<usize> {
+    let value = field.trim_matches('"');
+    if value.is_empty() {
+        None
+    } else {
+        value.parse::<usize>().ok()
+    }
+}
+
+fn parse_csv_line(line: &str) -> Option<PlaybackCsvRow> {
+    let fields = line.split(',').collect::<Vec<_>>();
+    if fields.len() < 22 {
+        return None;
+    }
+    if fields.first().copied() == Some("timestamp_ms") {
+        return None;
+    }
+
+    let mode = fields[1].trim_matches('"').to_string();
+    if mode != "sequential" && mode != "seek" {
+        return None;
+    }
+
+    let run_label = fields[2].trim_matches('"');
+    let seek_distance_s = parse_optional_f64(fields[16]);
+    let seek_avg_ms = parse_optional_f64(fields[17]);
+    let seek_p95_ms = parse_optional_f64(fields[18]);
+    let seek_max_ms = parse_optional_f64(fields[19]);
+
+    Some(PlaybackCsvRow {
+        mode,
+        run_label: if run_label.is_empty() {
+            "unlabeled".to_string()
+        } else {
+            run_label.to_string()
+        },
+        video: fields[3].trim_matches('"').to_string(),
+        effective_fps: fields[10].parse::<f64>().ok()?,
+        decode_p95_ms: fields[13].parse::<f64>().ok()?,
+        missed_deadlines: fields[9].parse::<usize>().ok()?,
+        seek_distance_s,
+        seek_avg_ms,
+        seek_p95_ms,
+        seek_max_ms,
+        seek_samples: parse_optional_usize(fields[20]).unwrap_or(0),
+        seek_failures: parse_optional_usize(fields[21]).unwrap_or(0),
+    })
+}
+
+fn parse_csv_file(path: &PathBuf) -> Result<Vec<PlaybackCsvRow>, String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|error| format!("read {} / {error}", path.display()))?;
+    Ok(contents.lines().filter_map(parse_csv_line).collect())
+}
+
+fn summarize(rows: &[PlaybackCsvRow]) -> Option<(SequentialSummary, Vec<SeekSummary>)> {
+    let sequential_rows = rows
+        .iter()
+        .filter(|row| row.mode == "sequential")
+        .collect::<Vec<_>>();
+    if sequential_rows.is_empty() {
+        return None;
+    }
+
+    let sequential = SequentialSummary {
+        samples: sequential_rows.len(),
+        effective_fps: median_f64(
+            &sequential_rows
+                .iter()
+                .map(|row| row.effective_fps)
+                .collect::<Vec<_>>(),
+        ),
+        decode_p95_ms: median_f64(
+            &sequential_rows
+                .iter()
+                .map(|row| row.decode_p95_ms)
+                .collect::<Vec<_>>(),
+        ),
+        missed_deadlines: median_usize(
+            &sequential_rows
+                .iter()
+                .map(|row| row.missed_deadlines)
+                .collect::<Vec<_>>(),
+        ),
+    };
+
+    let mut seek_groups = BTreeMap::<i64, Vec<&PlaybackCsvRow>>::new();
+    for row in rows.iter().filter(|row| row.mode == "seek") {
+        let Some(distance) = row.seek_distance_s else {
+            continue;
+        };
+        let distance_millis = (distance * 1000.0).round() as i64;
+        seek_groups.entry(distance_millis).or_default().push(row);
+    }
+
+    let seeks = seek_groups
+        .into_iter()
+        .map(|(distance_millis, rows)| SeekSummary {
+            distance_millis,
+            samples: rows.len(),
+            seek_avg_ms: median_f64(
+                &rows
+                    .iter()
+                    .filter_map(|row| row.seek_avg_ms)
+                    .collect::<Vec<_>>(),
+            ),
+            seek_p95_ms: median_f64(
+                &rows
+                    .iter()
+                    .filter_map(|row| row.seek_p95_ms)
+                    .collect::<Vec<_>>(),
+            ),
+            seek_max_ms: median_f64(
+                &rows
+                    .iter()
+                    .filter_map(|row| row.seek_max_ms)
+                    .collect::<Vec<_>>(),
+            ),
+            seek_samples: rows.iter().map(|row| row.seek_samples).sum(),
+            seek_failures: rows.iter().map(|row| row.seek_failures).sum(),
+        })
+        .collect::<Vec<_>>();
+
+    Some((sequential, seeks))
+}
+
+fn group_by_label_and_video(
+    rows: &[PlaybackCsvRow],
+) -> BTreeMap<(String, String), Vec<PlaybackCsvRow>> {
+    rows.iter().fold(
+        BTreeMap::<(String, String), Vec<PlaybackCsvRow>>::new(),
+        |mut acc, row| {
+            acc.entry((row.run_label.clone(), row.video.clone()))
+                .or_default()
+                .push(row.clone());
+            acc
+        },
+    )
+}
+
+fn format_distance(distance_millis: i64) -> String {
+    format!("{:.3}", distance_millis as f64 / 1000.0)
+}
+
+fn print_summary(label: &str, video: &str, sequential: SequentialSummary, seeks: &[SeekSummary]) {
+    println!(
+        "{label} video={video}: sequential_samples={} effective_fps={:.2} decode_p95={:.2}ms missed_deadlines={}",
+        sequential.samples,
+        sequential.effective_fps,
+        sequential.decode_p95_ms,
+        sequential.missed_deadlines
+    );
+    for seek in seeks {
+        println!(
+            "{label} video={video} seek_distance={}s: samples={} seek_avg={:.2}ms seek_p95={:.2}ms seek_max={:.2}ms seek_rows_samples={} seek_failures={}",
+            format_distance(seek.distance_millis),
+            seek.samples,
+            seek.seek_avg_ms,
+            seek.seek_p95_ms,
+            seek.seek_max_ms,
+            seek.seek_samples,
+            seek.seek_failures
+        );
+    }
+}
+
+fn print_delta(
+    baseline_label: &str,
+    candidate_label: &str,
+    video: &str,
+    baseline: SequentialSummary,
+    candidate: SequentialSummary,
+) {
+    println!(
+        "delta({candidate_label}-{baseline_label}) video={video}: effective_fps={:+.2} decode_p95={:+.2}ms missed_deadlines={:+}",
+        candidate.effective_fps - baseline.effective_fps,
+        candidate.decode_p95_ms - baseline.decode_p95_ms,
+        candidate.missed_deadlines as i64 - baseline.missed_deadlines as i64
+    );
+}
+
+fn print_seek_delta(
+    baseline_label: &str,
+    candidate_label: &str,
+    video: &str,
+    distance_millis: i64,
+    baseline: SeekSummary,
+    candidate: SeekSummary,
+) {
+    println!(
+        "delta({candidate_label}-{baseline_label}) video={video} seek_distance={}s: seek_avg={:+.2}ms seek_p95={:+.2}ms seek_max={:+.2}ms",
+        format_distance(distance_millis),
+        candidate.seek_avg_ms - baseline.seek_avg_ms,
+        candidate.seek_p95_ms - baseline.seek_p95_ms,
+        candidate.seek_max_ms - baseline.seek_max_ms
+    );
+}
+
+fn write_csv_header(path: &PathBuf, file: &mut std::fs::File) -> Result<(), String> {
+    if path.exists() && path.metadata().map(|meta| meta.len()).unwrap_or(0) > 0 {
+        return Ok(());
+    }
+    let header = [
+        "timestamp_ms",
+        "mode",
+        "label",
+        "video",
+        "distance_s",
+        "samples",
+        "effective_fps",
+        "decode_p95_ms",
+        "missed_deadlines",
+        "seek_avg_ms",
+        "seek_p95_ms",
+        "seek_max_ms",
+        "seek_samples",
+        "seek_failures",
+        "baseline_label",
+        "candidate_label",
+        "delta_effective_fps",
+        "delta_decode_p95_ms",
+        "delta_missed_deadlines",
+        "delta_seek_avg_ms",
+        "delta_seek_p95_ms",
+        "delta_seek_max_ms",
+    ]
+    .join(",");
+    writeln!(file, "{header}").map_err(|error| format!("write {} / {error}", path.display()))
+}
+
+fn append_summary_csv(path: &PathBuf, summaries: &[SummaryEntry]) -> Result<(), String> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|error| format!("open {} / {error}", path.display()))?;
+    write_csv_header(path, &mut file)?;
+    let timestamp_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default();
+
+    for entry in summaries {
+        writeln!(
+            file,
+            "{timestamp_ms},summary_sequential,\"{}\",\"{}\",\"\",{},{:.3},{:.3},{},\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\"",
+            entry.label,
+            entry.video,
+            entry.sequential.samples,
+            entry.sequential.effective_fps,
+            entry.sequential.decode_p95_ms,
+            entry.sequential.missed_deadlines
+        )
+        .map_err(|error| format!("write {} / {error}", path.display()))?;
+
+        for seek in &entry.seeks {
+            writeln!(
+                file,
+                "{timestamp_ms},summary_seek,\"{}\",\"{}\",{},{},\"\",\"\",\"\",{:.3},{:.3},{:.3},{},{},\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\"",
+                entry.label,
+                entry.video,
+                format_distance(seek.distance_millis),
+                seek.samples,
+                seek.seek_avg_ms,
+                seek.seek_p95_ms,
+                seek.seek_max_ms,
+                seek.seek_samples,
+                seek.seek_failures
+            )
+            .map_err(|error| format!("write {} / {error}", path.display()))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn append_delta_csv(
+    path: &PathBuf,
+    baseline_label: &str,
+    candidate_label: &str,
+    video: &str,
+    baseline: SequentialSummary,
+    candidate: SequentialSummary,
+    baseline_seeks: &[SeekSummary],
+    candidate_seeks: &[SeekSummary],
+) -> Result<(), String> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|error| format!("open {} / {error}", path.display()))?;
+    write_csv_header(path, &mut file)?;
+    let timestamp_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default();
+
+    writeln!(
+        file,
+        "{timestamp_ms},delta_sequential,\"\",\"{}\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"{}\",\"{}\",{:.3},{:.3},{},\"\",\"\",\"\"",
+        video,
+        baseline_label,
+        candidate_label,
+        candidate.effective_fps - baseline.effective_fps,
+        candidate.decode_p95_ms - baseline.decode_p95_ms,
+        candidate.missed_deadlines as i64 - baseline.missed_deadlines as i64
+    )
+    .map_err(|error| format!("write {} / {error}", path.display()))?;
+
+    let baseline_by_distance = baseline_seeks
+        .iter()
+        .map(|seek| (seek.distance_millis, *seek))
+        .collect::<BTreeMap<_, _>>();
+    let candidate_by_distance = candidate_seeks
+        .iter()
+        .map(|seek| (seek.distance_millis, *seek))
+        .collect::<BTreeMap<_, _>>();
+    for (distance_millis, baseline_seek) in baseline_by_distance {
+        let Some(candidate_seek) = candidate_by_distance.get(&distance_millis) else {
+            continue;
+        };
+        writeln!(
+            file,
+            "{timestamp_ms},delta_seek,\"\",\"{}\",{},\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"{}\",\"{}\",\"\",\"\",\"\",{:.3},{:.3},{:.3}",
+            video,
+            format_distance(distance_millis),
+            baseline_label,
+            candidate_label,
+            candidate_seek.seek_avg_ms - baseline_seek.seek_avg_ms,
+            candidate_seek.seek_p95_ms - baseline_seek.seek_p95_ms,
+            candidate_seek.seek_max_ms - baseline_seek.seek_max_ms
+        )
+        .map_err(|error| format!("write {} / {error}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+fn main() {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.is_empty() {
+        eprintln!(
+            "Usage: playback-csv-report --csv <path> [--csv <path> ...] [--label <run-label>] [--baseline-label <run-label> --candidate-label <run-label>] [--output-csv <path>]"
+        );
+        std::process::exit(1);
+    }
+
+    let mut csv_paths = Vec::<PathBuf>::new();
+    let mut label: Option<String> = None;
+    let mut baseline_label: Option<String> = None;
+    let mut candidate_label: Option<String> = None;
+    let mut output_csv: Option<PathBuf> = None;
+
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--csv" => {
+                if let Some(value) = args.get(index + 1) {
+                    csv_paths.push(PathBuf::from(value));
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --csv");
+                std::process::exit(1);
+            }
+            "--label" => {
+                if let Some(value) = args.get(index + 1) {
+                    label = Some(value.clone());
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --label");
+                std::process::exit(1);
+            }
+            "--baseline-label" => {
+                if let Some(value) = args.get(index + 1) {
+                    baseline_label = Some(value.clone());
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --baseline-label");
+                std::process::exit(1);
+            }
+            "--candidate-label" => {
+                if let Some(value) = args.get(index + 1) {
+                    candidate_label = Some(value.clone());
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --candidate-label");
+                std::process::exit(1);
+            }
+            "--output-csv" => {
+                if let Some(value) = args.get(index + 1) {
+                    output_csv = Some(PathBuf::from(value));
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --output-csv");
+                std::process::exit(1);
+            }
+            unknown => {
+                eprintln!("Unknown argument: {unknown}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    if csv_paths.is_empty() {
+        eprintln!("At least one --csv path is required");
+        std::process::exit(1);
+    }
+
+    let mut all_rows = Vec::<PlaybackCsvRow>::new();
+    for path in &csv_paths {
+        match parse_csv_file(path) {
+            Ok(mut rows) => all_rows.append(&mut rows),
+            Err(error) => {
+                eprintln!("{error}");
+                std::process::exit(1);
+            }
+        }
+    }
+    if all_rows.is_empty() {
+        eprintln!("No rows found");
+        std::process::exit(1);
+    }
+
+    let grouped_rows = group_by_label_and_video(&all_rows);
+    let mut summary_entries = Vec::<SummaryEntry>::new();
+
+    if let Some(label) = label {
+        let rows = grouped_rows
+            .iter()
+            .filter(|((group_label, _), _)| group_label == &label)
+            .map(|((_, video), rows)| (video.clone(), rows.clone()))
+            .collect::<Vec<_>>();
+        if rows.is_empty() {
+            eprintln!("No rows found for label: {label}");
+            std::process::exit(1);
+        }
+        for (video, rows) in rows {
+            let Some((sequential, seeks)) = summarize(&rows) else {
+                continue;
+            };
+            print_summary(&label, &video, sequential, &seeks);
+            summary_entries.push(SummaryEntry {
+                label: label.clone(),
+                video,
+                sequential,
+                seeks,
+            });
+        }
+    } else {
+        for ((group_label, video), rows) in grouped_rows.clone() {
+            let Some((sequential, seeks)) = summarize(&rows) else {
+                continue;
+            };
+            print_summary(&group_label, &video, sequential, &seeks);
+            summary_entries.push(SummaryEntry {
+                label: group_label,
+                video,
+                sequential,
+                seeks,
+            });
+        }
+    }
+
+    if summary_entries.is_empty() {
+        eprintln!("No summaries produced");
+        std::process::exit(1);
+    }
+
+    if let Some(path) = &output_csv
+        && let Err(error) = append_summary_csv(path, &summary_entries)
+    {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+
+    if let (Some(baseline_label), Some(candidate_label)) = (baseline_label, candidate_label) {
+        let baseline_groups = grouped_rows
+            .iter()
+            .filter(|((label_key, _), _)| label_key == &baseline_label)
+            .map(|((_, video), rows)| (video.clone(), rows.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let candidate_groups = grouped_rows
+            .iter()
+            .filter(|((label_key, _), _)| label_key == &candidate_label)
+            .map(|((_, video), rows)| (video.clone(), rows.clone()))
+            .collect::<BTreeMap<_, _>>();
+
+        if baseline_groups.is_empty() {
+            eprintln!("No rows found for baseline label: {baseline_label}");
+            std::process::exit(1);
+        }
+        if candidate_groups.is_empty() {
+            eprintln!("No rows found for candidate label: {candidate_label}");
+            std::process::exit(1);
+        }
+
+        let mut printed = false;
+        for (video, baseline_rows) in baseline_groups {
+            let Some(candidate_rows) = candidate_groups.get(&video) else {
+                continue;
+            };
+            let Some((baseline_summary, baseline_seeks)) = summarize(&baseline_rows) else {
+                continue;
+            };
+            let Some((candidate_summary, candidate_seeks)) = summarize(candidate_rows) else {
+                continue;
+            };
+            print_delta(
+                &baseline_label,
+                &candidate_label,
+                &video,
+                baseline_summary,
+                candidate_summary,
+            );
+            let baseline_seek_map = baseline_seeks
+                .iter()
+                .map(|seek| (seek.distance_millis, *seek))
+                .collect::<BTreeMap<_, _>>();
+            for candidate_seek in &candidate_seeks {
+                let Some(baseline_seek) = baseline_seek_map.get(&candidate_seek.distance_millis)
+                else {
+                    continue;
+                };
+                print_seek_delta(
+                    &baseline_label,
+                    &candidate_label,
+                    &video,
+                    candidate_seek.distance_millis,
+                    *baseline_seek,
+                    *candidate_seek,
+                );
+            }
+            if let Some(path) = &output_csv
+                && let Err(error) = append_delta_csv(
+                    path,
+                    &baseline_label,
+                    &candidate_label,
+                    &video,
+                    baseline_summary,
+                    candidate_summary,
+                    &baseline_seeks,
+                    &candidate_seeks,
+                )
+            {
+                eprintln!("{error}");
+                std::process::exit(1);
+            }
+            printed = true;
+        }
+        if !printed {
+            eprintln!("No overlapping videos found between baseline and candidate labels");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        SummaryEntry, append_delta_csv, append_summary_csv, group_by_label_and_video,
+        parse_csv_line, summarize,
+    };
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn parses_sequential_csv_line() {
+        let line = "1771042665305,sequential,\"linux-pass-a\",\"/tmp/cap-bench-1080p60.mp4\",60,240,10,240,0,1,59.982,4.001,1.355,2.566,4.269,5.252,\"\",\"\",\"\",\"\",\"\",\"\"";
+        let row = parse_csv_line(line).expect("expected row");
+        assert_eq!(row.mode, "sequential");
+        assert_eq!(row.run_label, "linux-pass-a");
+        assert!((row.effective_fps - 59.982).abs() < f64::EPSILON);
+        assert_eq!(row.seek_distance_s, None);
+    }
+
+    #[test]
+    fn parses_seek_csv_line() {
+        let line = "1771042665305,seek,\"linux-pass-a\",\"/tmp/cap-bench-1080p60.mp4\",60,240,10,240,0,1,59.982,4.001,1.355,2.566,4.269,5.252,2.000,149.213,364.124,364.124,10,0";
+        let row = parse_csv_line(line).expect("expected row");
+        assert_eq!(row.mode, "seek");
+        assert_eq!(row.seek_samples, 10);
+        assert_eq!(row.seek_failures, 0);
+        assert_eq!(row.seek_distance_s, Some(2.0));
+    }
+
+    #[test]
+    fn summarizes_sequential_and_seek_medians() {
+        let rows = vec![
+            super::PlaybackCsvRow {
+                mode: "sequential".to_string(),
+                run_label: "label-a".to_string(),
+                video: "video-1".to_string(),
+                effective_fps: 59.0,
+                decode_p95_ms: 3.0,
+                missed_deadlines: 1,
+                seek_distance_s: None,
+                seek_avg_ms: None,
+                seek_p95_ms: None,
+                seek_max_ms: None,
+                seek_samples: 0,
+                seek_failures: 0,
+            },
+            super::PlaybackCsvRow {
+                mode: "sequential".to_string(),
+                run_label: "label-a".to_string(),
+                video: "video-1".to_string(),
+                effective_fps: 61.0,
+                decode_p95_ms: 2.0,
+                missed_deadlines: 3,
+                seek_distance_s: None,
+                seek_avg_ms: None,
+                seek_p95_ms: None,
+                seek_max_ms: None,
+                seek_samples: 0,
+                seek_failures: 0,
+            },
+            super::PlaybackCsvRow {
+                mode: "seek".to_string(),
+                run_label: "label-a".to_string(),
+                video: "video-1".to_string(),
+                effective_fps: 60.0,
+                decode_p95_ms: 0.0,
+                missed_deadlines: 0,
+                seek_distance_s: Some(2.0),
+                seek_avg_ms: Some(100.0),
+                seek_p95_ms: Some(120.0),
+                seek_max_ms: Some(130.0),
+                seek_samples: 10,
+                seek_failures: 0,
+            },
+            super::PlaybackCsvRow {
+                mode: "seek".to_string(),
+                run_label: "label-a".to_string(),
+                video: "video-1".to_string(),
+                effective_fps: 60.0,
+                decode_p95_ms: 0.0,
+                missed_deadlines: 0,
+                seek_distance_s: Some(2.0),
+                seek_avg_ms: Some(140.0),
+                seek_p95_ms: Some(180.0),
+                seek_max_ms: Some(190.0),
+                seek_samples: 10,
+                seek_failures: 1,
+            },
+        ];
+        let (sequential, seeks) = summarize(&rows).expect("summary");
+        assert_eq!(sequential.samples, 2);
+        assert!((sequential.effective_fps - 60.0).abs() < f64::EPSILON);
+        assert_eq!(sequential.missed_deadlines, 2);
+        assert_eq!(seeks.len(), 1);
+        assert_eq!(seeks[0].distance_millis, 2000);
+        assert_eq!(seeks[0].seek_samples, 20);
+        assert_eq!(seeks[0].seek_failures, 1);
+        assert!((seeks[0].seek_avg_ms - 120.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn groups_rows_by_label_and_video() {
+        let rows = vec![
+            super::PlaybackCsvRow {
+                mode: "sequential".to_string(),
+                run_label: "label-a".to_string(),
+                video: "video-1".to_string(),
+                effective_fps: 60.0,
+                decode_p95_ms: 2.0,
+                missed_deadlines: 0,
+                seek_distance_s: None,
+                seek_avg_ms: None,
+                seek_p95_ms: None,
+                seek_max_ms: None,
+                seek_samples: 0,
+                seek_failures: 0,
+            },
+            super::PlaybackCsvRow {
+                mode: "sequential".to_string(),
+                run_label: "label-a".to_string(),
+                video: "video-2".to_string(),
+                effective_fps: 60.0,
+                decode_p95_ms: 2.0,
+                missed_deadlines: 0,
+                seek_distance_s: None,
+                seek_avg_ms: None,
+                seek_p95_ms: None,
+                seek_max_ms: None,
+                seek_samples: 0,
+                seek_failures: 0,
+            },
+        ];
+        let groups = group_by_label_and_video(&rows);
+        assert_eq!(groups.len(), 2);
+        assert!(groups.contains_key(&("label-a".to_string(), "video-1".to_string())));
+        assert!(groups.contains_key(&("label-a".to_string(), "video-2".to_string())));
+    }
+
+    #[test]
+    fn writes_summary_and_delta_csv_rows() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("timestamp")
+            .as_nanos();
+        let path = PathBuf::from(format!("/tmp/playback-csv-report-{unique}.csv"));
+
+        let sequential = super::SequentialSummary {
+            samples: 2,
+            effective_fps: 60.0,
+            decode_p95_ms: 2.0,
+            missed_deadlines: 1,
+        };
+        let seeks = vec![super::SeekSummary {
+            distance_millis: 2000,
+            samples: 2,
+            seek_avg_ms: 120.0,
+            seek_p95_ms: 150.0,
+            seek_max_ms: 170.0,
+            seek_samples: 20,
+            seek_failures: 0,
+        }];
+
+        append_summary_csv(
+            &path,
+            &[SummaryEntry {
+                label: "label-a".to_string(),
+                video: "video-1".to_string(),
+                sequential,
+                seeks: seeks.clone(),
+            }],
+        )
+        .expect("summary csv");
+
+        append_delta_csv(
+            &path,
+            "baseline",
+            "candidate",
+            "video-1",
+            sequential,
+            sequential,
+            &seeks,
+            &seeks,
+        )
+        .expect("delta csv");
+
+        let contents = fs::read_to_string(&path).expect("read csv");
+        let rows = contents.lines().collect::<Vec<_>>();
+        assert_eq!(rows.len(), 5);
+        assert!(rows[0].contains("timestamp_ms,mode,label,video"));
+        assert!(rows[1].contains("summary_sequential"));
+        assert!(rows[2].contains("summary_seek"));
+        assert!(rows[3].contains("delta_sequential"));
+        assert!(rows[4].contains("delta_seek"));
+
+        let _ = fs::remove_file(path);
+    }
+}

--- a/crates/editor/examples/playback-startup-report.rs
+++ b/crates/editor/examples/playback-startup-report.rs
@@ -535,6 +535,14 @@ fn append_run_metrics_csv(
                 "audio pre-rendered callback",
                 stats.audio_prerender_startup_ms.as_slice(),
             ),
+            (
+                "audio startup path streaming",
+                stats.audio_stream_path_selected_ms.as_slice(),
+            ),
+            (
+                "audio startup path prerendered",
+                stats.audio_prerender_path_selected_ms.as_slice(),
+            ),
         ];
 
         for (name, values) in metric_rows {
@@ -740,12 +748,14 @@ fn main() {
                     let (audio_path, stream_samples, prerendered_samples) =
                         detect_audio_startup_path(stats);
                     println!(
-                        "{}: decoded[{}] rendered[{}] audio_stream[{}] audio_prerender[{}] audio_path={} stream_samples={} prerender_samples={}",
+                        "{}: decoded[{}] rendered[{}] audio_stream[{}] audio_prerender[{}] audio_path_streaming[{}] audio_path_prerendered[{}] audio_path={} stream_samples={} prerender_samples={}",
                         run_id_key,
                         metric_brief(&stats.decode_startup_ms),
                         metric_brief(&stats.render_startup_ms),
                         metric_brief(&stats.audio_stream_startup_ms),
                         metric_brief(&stats.audio_prerender_startup_ms),
+                        metric_brief(&stats.audio_stream_path_selected_ms),
+                        metric_brief(&stats.audio_prerender_path_selected_ms),
                         audio_startup_path_label(audio_path),
                         stream_samples,
                         prerendered_samples,
@@ -821,6 +831,14 @@ fn main() {
             "audio pre-rendered callback",
             &stats.audio_prerender_startup_ms,
         );
+        print_metric(
+            "audio startup path streaming",
+            &stats.audio_stream_path_selected_ms,
+        );
+        print_metric(
+            "audio startup path prerendered",
+            &stats.audio_prerender_path_selected_ms,
+        );
         let (audio_path, stream_samples, prerendered_samples) = detect_audio_startup_path(&stats);
         println!(
             "audio startup path: {} (stream_samples={} prerender_samples={})",
@@ -840,6 +858,14 @@ fn main() {
                 (
                     "audio pre-rendered callback",
                     stats.audio_prerender_startup_ms.as_slice(),
+                ),
+                (
+                    "audio startup path streaming",
+                    stats.audio_stream_path_selected_ms.as_slice(),
+                ),
+                (
+                    "audio startup path prerendered",
+                    stats.audio_prerender_path_selected_ms.as_slice(),
                 ),
             ];
             let audio_summary = detect_audio_startup_path(&stats);
@@ -915,6 +941,16 @@ fn main() {
             &baseline_stats.audio_prerender_startup_ms,
             &candidate_stats.audio_prerender_startup_ms,
         );
+        print_delta(
+            "audio startup path streaming",
+            &baseline_stats.audio_stream_path_selected_ms,
+            &candidate_stats.audio_stream_path_selected_ms,
+        );
+        print_delta(
+            "audio startup path prerendered",
+            &baseline_stats.audio_prerender_path_selected_ms,
+            &candidate_stats.audio_prerender_path_selected_ms,
+        );
         let (baseline_audio_path, baseline_stream_samples, baseline_prerendered_samples) =
             detect_audio_startup_path(&baseline_stats);
         let (candidate_audio_path, candidate_stream_samples, candidate_prerendered_samples) =
@@ -950,6 +986,16 @@ fn main() {
                     "audio pre-rendered callback",
                     baseline_stats.audio_prerender_startup_ms.as_slice(),
                     candidate_stats.audio_prerender_startup_ms.as_slice(),
+                ),
+                (
+                    "audio startup path streaming",
+                    baseline_stats.audio_stream_path_selected_ms.as_slice(),
+                    candidate_stats.audio_stream_path_selected_ms.as_slice(),
+                ),
+                (
+                    "audio startup path prerendered",
+                    baseline_stats.audio_prerender_path_selected_ms.as_slice(),
+                    candidate_stats.audio_prerender_path_selected_ms.as_slice(),
                 ),
             ];
             let baseline_audio_summary = detect_audio_startup_path(&baseline_stats);

--- a/crates/editor/examples/playback-startup-report.rs
+++ b/crates/editor/examples/playback-startup-report.rs
@@ -1,0 +1,131 @@
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+    path::PathBuf,
+};
+
+#[derive(Default)]
+struct EventStats {
+    decode_startup_ms: Vec<f64>,
+    render_startup_ms: Vec<f64>,
+    audio_stream_startup_ms: Vec<f64>,
+    audio_prerender_startup_ms: Vec<f64>,
+}
+
+fn percentile(values: &[f64], percentile: f64) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let index = ((percentile / 100.0) * (sorted.len().saturating_sub(1) as f64)).round() as usize;
+    sorted[index.min(sorted.len().saturating_sub(1))]
+}
+
+fn parse_startup_ms(line: &str) -> Option<f64> {
+    if let Some(index) = line.find("startup_ms=") {
+        let start = index + "startup_ms=".len();
+        let tail = &line[start..];
+        let end = tail
+            .find(|ch: char| !(ch.is_ascii_digit() || ch == '.'))
+            .unwrap_or(tail.len());
+        return tail[..end].parse::<f64>().ok();
+    }
+
+    if let Some(index) = line.find("\"startup_ms\":") {
+        let start = index + "\"startup_ms\":".len();
+        let tail = line[start..].trim_start();
+        let end = tail
+            .find(|ch: char| !(ch.is_ascii_digit() || ch == '.'))
+            .unwrap_or(tail.len());
+        return tail[..end].parse::<f64>().ok();
+    }
+
+    None
+}
+
+fn print_metric(name: &str, values: &[f64]) {
+    if values.is_empty() {
+        println!("{name}: no samples");
+        return;
+    }
+
+    let avg = values.iter().sum::<f64>() / values.len() as f64;
+    let min = values.iter().copied().fold(f64::INFINITY, f64::min);
+    let max = values.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    let p50 = percentile(values, 50.0);
+    let p95 = percentile(values, 95.0);
+
+    println!(
+        "{name}: samples={} avg={avg:.2}ms p50={p50:.2}ms p95={p95:.2}ms min={min:.2}ms max={max:.2}ms",
+        values.len()
+    );
+}
+
+fn parse_log(path: &PathBuf, stats: &mut EventStats) -> Result<(), String> {
+    let file = File::open(path).map_err(|error| format!("open {} / {error}", path.display()))?;
+    let reader = BufReader::new(file);
+
+    for line in reader.lines() {
+        let line = line.map_err(|error| format!("read {} / {error}", path.display()))?;
+        let Some(startup_ms) = parse_startup_ms(&line) else {
+            continue;
+        };
+
+        if line.contains("Playback first decoded frame ready") {
+            stats.decode_startup_ms.push(startup_ms);
+        } else if line.contains("Playback first frame rendered") {
+            stats.render_startup_ms.push(startup_ms);
+        } else if line.contains("Audio streaming callback started") {
+            stats.audio_stream_startup_ms.push(startup_ms);
+        } else if line.contains("Audio pre-rendered callback started") {
+            stats.audio_prerender_startup_ms.push(startup_ms);
+        }
+    }
+
+    Ok(())
+}
+
+fn main() {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.is_empty() {
+        eprintln!("Usage: playback-startup-report --log <path> [--log <path> ...]");
+        std::process::exit(1);
+    }
+
+    let mut logs = Vec::<PathBuf>::new();
+    let mut index = 0usize;
+
+    while index < args.len() {
+        if args[index] == "--log" {
+            if let Some(value) = args.get(index + 1) {
+                logs.push(PathBuf::from(value));
+                index += 2;
+                continue;
+            }
+            eprintln!("Missing value for --log");
+            std::process::exit(1);
+        }
+
+        eprintln!("Unknown argument: {}", args[index]);
+        std::process::exit(1);
+    }
+
+    let mut stats = EventStats::default();
+    for log in &logs {
+        if let Err(error) = parse_log(log, &mut stats) {
+            eprintln!("{error}");
+            std::process::exit(1);
+        }
+    }
+
+    println!("Playback startup metrics");
+    print_metric("first decoded frame", &stats.decode_startup_ms);
+    print_metric("first rendered frame", &stats.render_startup_ms);
+    print_metric("audio streaming callback", &stats.audio_stream_startup_ms);
+    print_metric(
+        "audio pre-rendered callback",
+        &stats.audio_prerender_startup_ms,
+    );
+}

--- a/crates/editor/examples/playback-startup-report.rs
+++ b/crates/editor/examples/playback-startup-report.rs
@@ -149,3 +149,36 @@ fn main() {
         &stats.audio_prerender_startup_ms,
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_csv_startup_event, parse_startup_ms};
+
+    #[test]
+    fn parses_csv_startup_event() {
+        let parsed = parse_csv_startup_event("1739530000000,first_rendered_frame,123.456,42");
+        assert!(parsed.is_some());
+        let (event, startup_ms) = parsed.expect("expected CSV startup event");
+        assert_eq!(event, "first_rendered_frame");
+        assert!((startup_ms - 123.456).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parses_structured_startup_ms_field() {
+        let parsed =
+            parse_startup_ms("INFO Playback first frame rendered startup_ms=87.25 frame=1");
+        assert!(parsed.is_some());
+        let startup_ms = parsed.expect("expected startup_ms");
+        assert!((startup_ms - 87.25).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parses_json_startup_ms_field() {
+        let parsed = parse_startup_ms(
+            "{\"level\":\"INFO\",\"fields\":{\"startup_ms\":42.5},\"message\":\"Audio streaming callback started\"}",
+        );
+        assert!(parsed.is_some());
+        let startup_ms = parsed.expect("expected startup_ms");
+        assert!((startup_ms - 42.5).abs() < f64::EPSILON);
+    }
+}

--- a/crates/editor/examples/playback-startup-report.rs
+++ b/crates/editor/examples/playback-startup-report.rs
@@ -12,6 +12,16 @@ struct EventStats {
     audio_prerender_startup_ms: Vec<f64>,
 }
 
+#[derive(Clone, Copy)]
+struct MetricSummary {
+    samples: usize,
+    avg: f64,
+    p50: f64,
+    p95: f64,
+    min: f64,
+    max: f64,
+}
+
 fn percentile(values: &[f64], percentile: f64) -> f64 {
     if values.is_empty() {
         return 0.0;
@@ -46,9 +56,20 @@ fn parse_startup_ms(line: &str) -> Option<f64> {
 }
 
 fn print_metric(name: &str, values: &[f64]) {
-    if values.is_empty() {
+    let Some(summary) = summarize(values) else {
         println!("{name}: no samples");
         return;
+    };
+
+    println!(
+        "{name}: samples={} avg={:.2}ms p50={:.2}ms p95={:.2}ms min={:.2}ms max={:.2}ms",
+        summary.samples, summary.avg, summary.p50, summary.p95, summary.min, summary.max
+    );
+}
+
+fn summarize(values: &[f64]) -> Option<MetricSummary> {
+    if values.is_empty() {
+        return None;
     }
 
     let avg = values.iter().sum::<f64>() / values.len() as f64;
@@ -57,9 +78,42 @@ fn print_metric(name: &str, values: &[f64]) {
     let p50 = percentile(values, 50.0);
     let p95 = percentile(values, 95.0);
 
+    Some(MetricSummary {
+        samples: values.len(),
+        avg,
+        p50,
+        p95,
+        min,
+        max,
+    })
+}
+
+fn print_delta(name: &str, baseline: &[f64], candidate: &[f64]) {
+    let Some(base_summary) = summarize(baseline) else {
+        println!("{name}: no baseline samples");
+        return;
+    };
+    let Some(candidate_summary) = summarize(candidate) else {
+        println!("{name}: no candidate samples");
+        return;
+    };
+
+    let avg_delta = candidate_summary.avg - base_summary.avg;
+    let p95_delta = candidate_summary.p95 - base_summary.p95;
+    let avg_pct = if base_summary.avg.abs() > f64::EPSILON {
+        avg_delta / base_summary.avg * 100.0
+    } else {
+        0.0
+    };
+    let p95_pct = if base_summary.p95.abs() > f64::EPSILON {
+        p95_delta / base_summary.p95 * 100.0
+    } else {
+        0.0
+    };
+
     println!(
-        "{name}: samples={} avg={avg:.2}ms p50={p50:.2}ms p95={p95:.2}ms min={min:.2}ms max={max:.2}ms",
-        values.len()
+        "{name}: avg_delta={avg_delta:.2}ms ({avg_pct:+.1}%) p95_delta={p95_delta:.2}ms ({p95_pct:+.1}%) baseline_samples={} candidate_samples={}",
+        base_summary.samples, candidate_summary.samples
     );
 }
 
@@ -110,49 +164,125 @@ fn parse_csv_startup_event(line: &str) -> Option<(&str, f64)> {
 fn main() {
     let args = std::env::args().skip(1).collect::<Vec<_>>();
     if args.is_empty() {
-        eprintln!("Usage: playback-startup-report --log <path> [--log <path> ...]");
+        eprintln!(
+            "Usage: playback-startup-report [--log <path> ...] [--baseline-log <path> ... --candidate-log <path> ...]"
+        );
         std::process::exit(1);
     }
 
     let mut logs = Vec::<PathBuf>::new();
+    let mut baseline_logs = Vec::<PathBuf>::new();
+    let mut candidate_logs = Vec::<PathBuf>::new();
     let mut index = 0usize;
 
     while index < args.len() {
-        if args[index] == "--log" {
-            if let Some(value) = args.get(index + 1) {
-                logs.push(PathBuf::from(value));
-                index += 2;
-                continue;
+        match args[index].as_str() {
+            "--log" => {
+                if let Some(value) = args.get(index + 1) {
+                    logs.push(PathBuf::from(value));
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --log");
+                std::process::exit(1);
             }
-            eprintln!("Missing value for --log");
-            std::process::exit(1);
+            "--baseline-log" => {
+                if let Some(value) = args.get(index + 1) {
+                    baseline_logs.push(PathBuf::from(value));
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --baseline-log");
+                std::process::exit(1);
+            }
+            "--candidate-log" => {
+                if let Some(value) = args.get(index + 1) {
+                    candidate_logs.push(PathBuf::from(value));
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --candidate-log");
+                std::process::exit(1);
+            }
+            _ => {
+                eprintln!("Unknown argument: {}", args[index]);
+                std::process::exit(1);
+            }
         }
+    }
 
-        eprintln!("Unknown argument: {}", args[index]);
+    if logs.is_empty() && baseline_logs.is_empty() && candidate_logs.is_empty() {
+        eprintln!("No logs provided");
         std::process::exit(1);
     }
 
-    let mut stats = EventStats::default();
-    for log in &logs {
-        if let Err(error) = parse_log(log, &mut stats) {
-            eprintln!("{error}");
-            std::process::exit(1);
-        }
+    if baseline_logs.is_empty() != candidate_logs.is_empty() {
+        eprintln!("Both --baseline-log and --candidate-log must be provided together");
+        std::process::exit(1);
     }
 
-    println!("Playback startup metrics");
-    print_metric("first decoded frame", &stats.decode_startup_ms);
-    print_metric("first rendered frame", &stats.render_startup_ms);
-    print_metric("audio streaming callback", &stats.audio_stream_startup_ms);
-    print_metric(
-        "audio pre-rendered callback",
-        &stats.audio_prerender_startup_ms,
-    );
+    if !logs.is_empty() {
+        let mut stats = EventStats::default();
+        for log in &logs {
+            if let Err(error) = parse_log(log, &mut stats) {
+                eprintln!("{error}");
+                std::process::exit(1);
+            }
+        }
+
+        println!("Playback startup metrics");
+        print_metric("first decoded frame", &stats.decode_startup_ms);
+        print_metric("first rendered frame", &stats.render_startup_ms);
+        print_metric("audio streaming callback", &stats.audio_stream_startup_ms);
+        print_metric(
+            "audio pre-rendered callback",
+            &stats.audio_prerender_startup_ms,
+        );
+    }
+
+    if !baseline_logs.is_empty() {
+        let mut baseline_stats = EventStats::default();
+        for log in &baseline_logs {
+            if let Err(error) = parse_log(log, &mut baseline_stats) {
+                eprintln!("{error}");
+                std::process::exit(1);
+            }
+        }
+        let mut candidate_stats = EventStats::default();
+        for log in &candidate_logs {
+            if let Err(error) = parse_log(log, &mut candidate_stats) {
+                eprintln!("{error}");
+                std::process::exit(1);
+            }
+        }
+
+        println!("Startup delta (candidate - baseline)");
+        print_delta(
+            "first decoded frame",
+            &baseline_stats.decode_startup_ms,
+            &candidate_stats.decode_startup_ms,
+        );
+        print_delta(
+            "first rendered frame",
+            &baseline_stats.render_startup_ms,
+            &candidate_stats.render_startup_ms,
+        );
+        print_delta(
+            "audio streaming callback",
+            &baseline_stats.audio_stream_startup_ms,
+            &candidate_stats.audio_stream_startup_ms,
+        );
+        print_delta(
+            "audio pre-rendered callback",
+            &baseline_stats.audio_prerender_startup_ms,
+            &candidate_stats.audio_prerender_startup_ms,
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_csv_startup_event, parse_startup_ms};
+    use super::{parse_csv_startup_event, parse_startup_ms, summarize};
 
     #[test]
     fn parses_csv_startup_event() {
@@ -180,5 +310,13 @@ mod tests {
         assert!(parsed.is_some());
         let startup_ms = parsed.expect("expected startup_ms");
         assert!((startup_ms - 42.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn summarizes_metrics() {
+        let summary = summarize(&[10.0, 20.0, 30.0]).expect("expected summary");
+        assert_eq!(summary.samples, 3);
+        assert!((summary.avg - 20.0).abs() < f64::EPSILON);
+        assert!((summary.p50 - 20.0).abs() < f64::EPSILON);
     }
 }

--- a/crates/editor/examples/scrub-benchmark.rs
+++ b/crates/editor/examples/scrub-benchmark.rs
@@ -1,0 +1,308 @@
+use cap_rendering::decoder::spawn_decoder;
+use futures::future::join_all;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Instant;
+use tokio::runtime::Runtime;
+
+#[derive(Debug, Clone)]
+struct Config {
+    video_path: PathBuf,
+    fps: u32,
+    bursts: usize,
+    burst_size: usize,
+    sweep_seconds: f32,
+}
+
+#[derive(Debug, Default)]
+struct ScrubStats {
+    last_request_latency_ms: Vec<f64>,
+    request_latency_ms: Vec<f64>,
+    failed_requests: usize,
+    successful_requests: usize,
+}
+
+fn get_video_duration(path: &PathBuf) -> Result<f32, String> {
+    let output = Command::new("ffprobe")
+        .args([
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+        ])
+        .arg(path)
+        .output()
+        .map_err(|error| format!("ffprobe spawn failed: {error}"))?;
+
+    if !output.status.success() {
+        return Err("ffprobe failed".to_string());
+    }
+
+    let duration_str = String::from_utf8_lossy(&output.stdout);
+    duration_str
+        .trim()
+        .parse::<f32>()
+        .map_err(|error| format!("invalid duration: {error}"))
+}
+
+fn percentile(samples: &[f64], percentile: f64) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let mut values = samples.to_vec();
+    values.sort_by(f64::total_cmp);
+    let index = ((percentile / 100.0) * (values.len().saturating_sub(1) as f64)).round() as usize;
+    values[index.min(values.len().saturating_sub(1))]
+}
+
+fn generate_burst_targets(
+    duration: f32,
+    burst_index: usize,
+    burst_size: usize,
+    sweep: f32,
+) -> Vec<f32> {
+    let effective_duration = duration.max(0.1);
+    let max_target = (effective_duration - 0.01).max(0.0);
+    let start = (((burst_index as f32 * 0.618_034) % 1.0) * effective_duration).min(max_target);
+    let step = if burst_size > 1 {
+        sweep / (burst_size as f32 - 1.0)
+    } else {
+        0.0
+    };
+
+    (0..burst_size)
+        .map(|i| (start + step * i as f32).min(max_target))
+        .collect()
+}
+
+async fn run_scrub_benchmark(config: &Config) -> Result<ScrubStats, String> {
+    let duration = get_video_duration(&config.video_path)?;
+    if duration <= 0.0 {
+        return Err("video duration is zero".to_string());
+    }
+
+    let decoder = spawn_decoder(
+        "scrub-benchmark",
+        config.video_path.clone(),
+        config.fps,
+        0.0,
+        false,
+    )
+    .await
+    .map_err(|error| format!("decoder init failed: {error}"))?;
+
+    let mut stats = ScrubStats::default();
+
+    for burst_index in 0..config.bursts {
+        let targets = generate_burst_targets(
+            duration,
+            burst_index,
+            config.burst_size,
+            config.sweep_seconds,
+        );
+        let requests = targets.into_iter().enumerate().map(|(index, target)| {
+            let decoder = decoder.clone();
+            async move {
+                let start = Instant::now();
+                let decoded = decoder.get_frame(target).await.is_some();
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                (index, decoded, latency_ms)
+            }
+        });
+
+        let mut results = join_all(requests).await;
+        results.sort_by_key(|(index, _, _)| *index);
+
+        if let Some((_, decoded, latency_ms)) = results.last().copied() {
+            if decoded {
+                stats.last_request_latency_ms.push(latency_ms);
+            }
+        }
+
+        for (_, decoded, latency_ms) in results {
+            if decoded {
+                stats.successful_requests = stats.successful_requests.saturating_add(1);
+                stats.request_latency_ms.push(latency_ms);
+            } else {
+                stats.failed_requests = stats.failed_requests.saturating_add(1);
+            }
+        }
+    }
+
+    Ok(stats)
+}
+
+fn print_report(config: &Config, stats: &ScrubStats) {
+    println!("\n{}", "=".repeat(68));
+    println!("Scrub Burst Benchmark Report");
+    println!("{}", "=".repeat(68));
+    println!("Video: {}", config.video_path.display());
+    println!("FPS: {}", config.fps);
+    println!("Bursts: {}", config.bursts);
+    println!("Burst size: {}", config.burst_size);
+    println!("Sweep seconds: {:.2}", config.sweep_seconds);
+    println!("Successful requests: {}", stats.successful_requests);
+    println!("Failed requests: {}", stats.failed_requests);
+
+    if !stats.request_latency_ms.is_empty() {
+        let avg =
+            stats.request_latency_ms.iter().sum::<f64>() / stats.request_latency_ms.len() as f64;
+        println!("\nAll Request Latency");
+        println!("  avg: {:.2}ms", avg);
+        println!(
+            "  p95: {:.2}ms",
+            percentile(&stats.request_latency_ms, 95.0)
+        );
+        println!(
+            "  p99: {:.2}ms",
+            percentile(&stats.request_latency_ms, 99.0)
+        );
+        println!(
+            "  max: {:.2}ms",
+            stats
+                .request_latency_ms
+                .iter()
+                .copied()
+                .fold(f64::NEG_INFINITY, f64::max)
+        );
+    }
+
+    if !stats.last_request_latency_ms.is_empty() {
+        let avg = stats.last_request_latency_ms.iter().sum::<f64>()
+            / stats.last_request_latency_ms.len() as f64;
+        println!("\nLast Request In Burst Latency");
+        println!("  avg: {:.2}ms", avg);
+        println!(
+            "  p95: {:.2}ms",
+            percentile(&stats.last_request_latency_ms, 95.0)
+        );
+        println!(
+            "  p99: {:.2}ms",
+            percentile(&stats.last_request_latency_ms, 99.0)
+        );
+        println!(
+            "  max: {:.2}ms",
+            stats
+                .last_request_latency_ms
+                .iter()
+                .copied()
+                .fold(f64::NEG_INFINITY, f64::max)
+        );
+    }
+
+    println!("{}", "=".repeat(68));
+}
+
+fn parse_args() -> Result<Config, String> {
+    let args = std::env::args().collect::<Vec<_>>();
+    let mut video_path: Option<PathBuf> = None;
+    let mut fps = 60u32;
+    let mut bursts = 50usize;
+    let mut burst_size = 12usize;
+    let mut sweep_seconds = 2.0f32;
+
+    let mut index = 1usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--video" => {
+                index += 1;
+                if index >= args.len() {
+                    return Err("missing value for --video".to_string());
+                }
+                video_path = Some(PathBuf::from(&args[index]));
+            }
+            "--fps" => {
+                index += 1;
+                if index >= args.len() {
+                    return Err("missing value for --fps".to_string());
+                }
+                fps = args[index]
+                    .parse::<u32>()
+                    .map_err(|_| "invalid value for --fps".to_string())?;
+            }
+            "--bursts" => {
+                index += 1;
+                if index >= args.len() {
+                    return Err("missing value for --bursts".to_string());
+                }
+                bursts = args[index]
+                    .parse::<usize>()
+                    .map_err(|_| "invalid value for --bursts".to_string())?;
+            }
+            "--burst-size" => {
+                index += 1;
+                if index >= args.len() {
+                    return Err("missing value for --burst-size".to_string());
+                }
+                burst_size = args[index]
+                    .parse::<usize>()
+                    .map_err(|_| "invalid value for --burst-size".to_string())?;
+            }
+            "--sweep-seconds" => {
+                index += 1;
+                if index >= args.len() {
+                    return Err("missing value for --sweep-seconds".to_string());
+                }
+                sweep_seconds = args[index]
+                    .parse::<f32>()
+                    .map_err(|_| "invalid value for --sweep-seconds".to_string())?;
+            }
+            "--help" | "-h" => {
+                println!(
+                    "Usage: scrub-benchmark --video <path> [--fps <n>] [--bursts <n>] [--burst-size <n>] [--sweep-seconds <n>]"
+                );
+                std::process::exit(0);
+            }
+            unknown => return Err(format!("unknown argument: {unknown}")),
+        }
+        index += 1;
+    }
+
+    let Some(video_path) = video_path else {
+        return Err("missing required --video".to_string());
+    };
+    if !video_path.exists() {
+        return Err(format!(
+            "video path does not exist: {}",
+            video_path.display()
+        ));
+    }
+    if burst_size == 0 {
+        return Err("--burst-size must be > 0".to_string());
+    }
+    if bursts == 0 {
+        return Err("--bursts must be > 0".to_string());
+    }
+    if sweep_seconds <= 0.0 {
+        return Err("--sweep-seconds must be > 0".to_string());
+    }
+
+    Ok(Config {
+        video_path,
+        fps,
+        bursts,
+        burst_size,
+        sweep_seconds,
+    })
+}
+
+fn main() {
+    let config = match parse_args() {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("{error}");
+            std::process::exit(1);
+        }
+    };
+
+    let runtime = Runtime::new().expect("failed to create tokio runtime");
+    match runtime.block_on(run_scrub_benchmark(&config)) {
+        Ok(stats) => print_report(&config, &stats),
+        Err(error) => {
+            eprintln!("{error}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/editor/examples/scrub-benchmark.rs
+++ b/crates/editor/examples/scrub-benchmark.rs
@@ -403,6 +403,8 @@ fn write_csv(
             "supersede_min_pixels",
             "supersede_min_requests",
             "supersede_min_span_frames",
+            "latest_first_min_requests",
+            "latest_first_min_span_frames",
             "all_avg_ms",
             "all_p95_ms",
             "all_p99_ms",
@@ -447,10 +449,13 @@ fn write_csv(
     let supersede_min_pixels = scrub_env_value("CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_PIXELS");
     let supersede_min_requests = scrub_env_value("CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_REQUESTS");
     let supersede_min_span_frames = scrub_env_value("CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES");
+    let latest_first_min_requests = scrub_env_value("CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_REQUESTS");
+    let latest_first_min_span_frames =
+        scrub_env_value("CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_SPAN_FRAMES");
     let latest_first_disabled = scrub_env_value("CAP_FFMPEG_SCRUB_LATEST_FIRST_DISABLED");
     let run_label = scrub_run_label(config);
     let common_prefix = format!(
-        "{timestamp_ms},{{scope}},{{run_index}},\"{}\",\"{}\",{},{},{},{:.3},{},\"{}\",\"{}\",\"{}\",\"{}\"",
+        "{timestamp_ms},{{scope}},{{run_index}},\"{}\",\"{}\",{},{},{},{:.3},{},\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\"",
         run_label,
         config.video_path.display(),
         config.fps,
@@ -461,7 +466,9 @@ fn write_csv(
         supersede_disabled,
         supersede_min_pixels,
         supersede_min_requests,
-        supersede_min_span_frames
+        supersede_min_span_frames,
+        latest_first_min_requests,
+        latest_first_min_span_frames
     );
 
     for (index, summary) in summaries.iter().enumerate() {

--- a/crates/editor/examples/scrub-benchmark.rs
+++ b/crates/editor/examples/scrub-benchmark.rs
@@ -431,6 +431,7 @@ fn write_csv(
             "long_seek_max_ms",
             "long_seek_successful_requests",
             "long_seek_failed_requests",
+            "latest_first_disabled",
         ]
         .join(",");
         writeln!(file, "{header}")
@@ -446,6 +447,7 @@ fn write_csv(
     let supersede_min_pixels = scrub_env_value("CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_PIXELS");
     let supersede_min_requests = scrub_env_value("CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_REQUESTS");
     let supersede_min_span_frames = scrub_env_value("CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES");
+    let latest_first_disabled = scrub_env_value("CAP_FFMPEG_SCRUB_LATEST_FIRST_DISABLED");
     let run_label = scrub_run_label(config);
     let common_prefix = format!(
         "{timestamp_ms},{{scope}},{{run_index}},\"{}\",\"{}\",{},{},{},{:.3},{},\"{}\",\"{}\",\"{}\",\"{}\"",
@@ -468,7 +470,7 @@ fn write_csv(
         let long = summary.seek_distance[SeekDistanceBucket::Long.as_index()];
         writeln!(
             file,
-            "{},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{},{},{:.3},{:.3},{:.3},{:.3},{},{},{:.3},{:.3},{:.3},{:.3},{},{},{:.3},{:.3},{:.3},{:.3},{},{}",
+            "{},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{},{},{:.3},{:.3},{:.3},{:.3},{},{},{:.3},{:.3},{:.3},{:.3},{},{},{:.3},{:.3},{:.3},{:.3},{},{},\"{}\"",
             common_prefix
                 .replace("{scope}", "run")
                 .replace("{run_index}", &(index + 1).to_string()),
@@ -499,7 +501,8 @@ fn write_csv(
             long.p99_ms,
             long.max_ms,
             long.successful_requests,
-            long.failed_requests
+            long.failed_requests,
+            latest_first_disabled
         )
         .map_err(|error| format!("write {} / {error}", path.display()))?;
     }
@@ -509,7 +512,7 @@ fn write_csv(
     let long = aggregate.seek_distance[SeekDistanceBucket::Long.as_index()];
     writeln!(
         file,
-        "{},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{},{},{:.3},{:.3},{:.3},{:.3},{},{},{:.3},{:.3},{:.3},{:.3},{},{},{:.3},{:.3},{:.3},{:.3},{},{}",
+        "{},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{},{},{:.3},{:.3},{:.3},{:.3},{},{},{:.3},{:.3},{:.3},{:.3},{},{},{:.3},{:.3},{:.3},{:.3},{},{},\"{}\"",
         common_prefix
             .replace("{scope}", "aggregate")
             .replace("{run_index}", "0"),
@@ -540,7 +543,8 @@ fn write_csv(
         long.p99_ms,
         long.max_ms,
         long.successful_requests,
-        long.failed_requests
+        long.failed_requests,
+        latest_first_disabled
     )
     .map_err(|error| format!("write {} / {error}", path.display()))?;
 

--- a/crates/editor/examples/scrub-benchmark.rs
+++ b/crates/editor/examples/scrub-benchmark.rs
@@ -405,6 +405,7 @@ fn write_csv(
             "supersede_min_span_frames",
             "latest_first_min_requests",
             "latest_first_min_span_frames",
+            "latest_first_min_pixels",
             "all_avg_ms",
             "all_p95_ms",
             "all_p99_ms",
@@ -452,10 +453,11 @@ fn write_csv(
     let latest_first_min_requests = scrub_env_value("CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_REQUESTS");
     let latest_first_min_span_frames =
         scrub_env_value("CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_SPAN_FRAMES");
+    let latest_first_min_pixels = scrub_env_value("CAP_FFMPEG_SCRUB_LATEST_FIRST_MIN_PIXELS");
     let latest_first_disabled = scrub_env_value("CAP_FFMPEG_SCRUB_LATEST_FIRST_DISABLED");
     let run_label = scrub_run_label(config);
     let common_prefix = format!(
-        "{timestamp_ms},{{scope}},{{run_index}},\"{}\",\"{}\",{},{},{},{:.3},{},\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\"",
+        "{timestamp_ms},{{scope}},{{run_index}},\"{}\",\"{}\",{},{},{},{:.3},{},\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\"",
         run_label,
         config.video_path.display(),
         config.fps,
@@ -468,7 +470,8 @@ fn write_csv(
         supersede_min_requests,
         supersede_min_span_frames,
         latest_first_min_requests,
-        latest_first_min_span_frames
+        latest_first_min_span_frames,
+        latest_first_min_pixels
     );
 
     for (index, summary) in summaries.iter().enumerate() {

--- a/crates/editor/examples/scrub-csv-report.rs
+++ b/crates/editor/examples/scrub-csv-report.rs
@@ -1,0 +1,317 @@
+use std::path::PathBuf;
+
+#[derive(Clone)]
+struct ScrubCsvRow {
+    scope: String,
+    run_label: String,
+    video: String,
+    all_avg_ms: f64,
+    all_p95_ms: f64,
+    last_avg_ms: f64,
+    last_p95_ms: f64,
+    successful_requests: usize,
+    failed_requests: usize,
+}
+
+#[derive(Clone, Copy)]
+struct Summary {
+    samples: usize,
+    all_avg_ms: f64,
+    all_p95_ms: f64,
+    last_avg_ms: f64,
+    last_p95_ms: f64,
+    successful_requests: usize,
+    failed_requests: usize,
+}
+
+fn median(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let index = sorted.len() / 2;
+    if sorted.len().is_multiple_of(2) {
+        (sorted[index - 1] + sorted[index]) / 2.0
+    } else {
+        sorted[index]
+    }
+}
+
+fn summarize(rows: &[ScrubCsvRow]) -> Option<Summary> {
+    if rows.is_empty() {
+        return None;
+    }
+
+    let all_avg = rows.iter().map(|row| row.all_avg_ms).collect::<Vec<_>>();
+    let all_p95 = rows.iter().map(|row| row.all_p95_ms).collect::<Vec<_>>();
+    let last_avg = rows.iter().map(|row| row.last_avg_ms).collect::<Vec<_>>();
+    let last_p95 = rows.iter().map(|row| row.last_p95_ms).collect::<Vec<_>>();
+
+    Some(Summary {
+        samples: rows.len(),
+        all_avg_ms: median(&all_avg),
+        all_p95_ms: median(&all_p95),
+        last_avg_ms: median(&last_avg),
+        last_p95_ms: median(&last_p95),
+        successful_requests: rows.iter().map(|row| row.successful_requests).sum(),
+        failed_requests: rows.iter().map(|row| row.failed_requests).sum(),
+    })
+}
+
+fn parse_csv_line(line: &str) -> Option<ScrubCsvRow> {
+    let fields = line.split(',').collect::<Vec<_>>();
+    if fields.len() < 24 {
+        return None;
+    }
+    if fields.first().copied() == Some("timestamp_ms") {
+        return None;
+    }
+
+    Some(ScrubCsvRow {
+        scope: fields[1].to_string(),
+        run_label: fields[3].trim_matches('"').to_string(),
+        video: fields[4].trim_matches('"').to_string(),
+        all_avg_ms: fields[14].parse::<f64>().ok()?,
+        all_p95_ms: fields[15].parse::<f64>().ok()?,
+        last_avg_ms: fields[18].parse::<f64>().ok()?,
+        last_p95_ms: fields[19].parse::<f64>().ok()?,
+        successful_requests: fields[22].parse::<usize>().ok()?,
+        failed_requests: fields[23].parse::<usize>().ok()?,
+    })
+}
+
+fn parse_csv_file(path: &PathBuf) -> Result<Vec<ScrubCsvRow>, String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|error| format!("read {} / {error}", path.display()))?;
+    Ok(contents
+        .lines()
+        .filter_map(parse_csv_line)
+        .filter(|row| row.scope == "aggregate")
+        .collect())
+}
+
+fn print_summary(label: &str, summary: Summary) {
+    println!(
+        "{label}: samples={} all_avg={:.2}ms all_p95={:.2}ms last_avg={:.2}ms last_p95={:.2}ms successful={} failed={}",
+        summary.samples,
+        summary.all_avg_ms,
+        summary.all_p95_ms,
+        summary.last_avg_ms,
+        summary.last_p95_ms,
+        summary.successful_requests,
+        summary.failed_requests
+    );
+}
+
+fn print_delta(baseline_label: &str, baseline: Summary, candidate_label: &str, candidate: Summary) {
+    println!(
+        "delta({candidate_label}-{baseline_label}): all_avg={:+.2}ms all_p95={:+.2}ms last_avg={:+.2}ms last_p95={:+.2}ms",
+        candidate.all_avg_ms - baseline.all_avg_ms,
+        candidate.all_p95_ms - baseline.all_p95_ms,
+        candidate.last_avg_ms - baseline.last_avg_ms,
+        candidate.last_p95_ms - baseline.last_p95_ms
+    );
+}
+
+fn main() {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.is_empty() {
+        eprintln!(
+            "Usage: scrub-csv-report --csv <path> [--csv <path> ...] [--label <run-label>] [--baseline-label <run-label> --candidate-label <run-label>]"
+        );
+        std::process::exit(1);
+    }
+
+    let mut csv_paths = Vec::<PathBuf>::new();
+    let mut label: Option<String> = None;
+    let mut baseline_label: Option<String> = None;
+    let mut candidate_label: Option<String> = None;
+
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--csv" => {
+                if let Some(value) = args.get(index + 1) {
+                    csv_paths.push(PathBuf::from(value));
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --csv");
+                std::process::exit(1);
+            }
+            "--label" => {
+                if let Some(value) = args.get(index + 1) {
+                    label = Some(value.clone());
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --label");
+                std::process::exit(1);
+            }
+            "--baseline-label" => {
+                if let Some(value) = args.get(index + 1) {
+                    baseline_label = Some(value.clone());
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --baseline-label");
+                std::process::exit(1);
+            }
+            "--candidate-label" => {
+                if let Some(value) = args.get(index + 1) {
+                    candidate_label = Some(value.clone());
+                    index += 2;
+                    continue;
+                }
+                eprintln!("Missing value for --candidate-label");
+                std::process::exit(1);
+            }
+            unknown => {
+                eprintln!("Unknown argument: {unknown}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    if csv_paths.is_empty() {
+        eprintln!("At least one --csv path is required");
+        std::process::exit(1);
+    }
+
+    let mut all_rows = Vec::<ScrubCsvRow>::new();
+    for path in &csv_paths {
+        match parse_csv_file(path) {
+            Ok(mut rows) => all_rows.append(&mut rows),
+            Err(error) => {
+                eprintln!("{error}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    if all_rows.is_empty() {
+        eprintln!("No aggregate rows found");
+        std::process::exit(1);
+    }
+
+    if let Some(label) = label {
+        let rows = all_rows
+            .iter()
+            .filter(|row| row.run_label == label)
+            .cloned()
+            .collect::<Vec<_>>();
+        if rows.is_empty() {
+            eprintln!("No rows found for label: {label}");
+            std::process::exit(1);
+        }
+        if let Some(video) = rows.first().map(|row| row.video.clone()) {
+            println!("video={video}");
+        }
+        if let Some(summary) = summarize(&rows) {
+            print_summary(&label, summary);
+        }
+    } else {
+        let groups = all_rows.iter().fold(
+            std::collections::BTreeMap::<String, Vec<ScrubCsvRow>>::new(),
+            |mut acc, row| {
+                acc.entry(row.run_label.clone())
+                    .or_default()
+                    .push(row.clone());
+                acc
+            },
+        );
+        for (group_label, rows) in groups {
+            if let Some(summary) = summarize(&rows) {
+                print_summary(&group_label, summary);
+            }
+        }
+    }
+
+    if let (Some(baseline_label), Some(candidate_label)) = (baseline_label, candidate_label) {
+        let baseline_rows = all_rows
+            .iter()
+            .filter(|row| row.run_label == baseline_label)
+            .cloned()
+            .collect::<Vec<_>>();
+        let candidate_rows = all_rows
+            .iter()
+            .filter(|row| row.run_label == candidate_label)
+            .cloned()
+            .collect::<Vec<_>>();
+        let Some(baseline_summary) = summarize(&baseline_rows) else {
+            eprintln!("No rows found for baseline label: {baseline_label}");
+            std::process::exit(1);
+        };
+        let Some(candidate_summary) = summarize(&candidate_rows) else {
+            eprintln!("No rows found for candidate label: {candidate_label}");
+            std::process::exit(1);
+        };
+        print_delta(
+            &baseline_label,
+            baseline_summary,
+            &candidate_label,
+            candidate_summary,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_csv_line, summarize};
+
+    #[test]
+    fn parses_aggregate_csv_line() {
+        let line = "1771039415444,aggregate,0,\"linux-pass-a\",\"/tmp/cap-bench-1080p60.mp4\",60,6,12,2.000,2,\"\",\"\",\"\",\"\",199.009,410.343,410.344,410.346,213.930,410.343,410.343,410.343,144,0";
+        let row = parse_csv_line(line).expect("expected row");
+        assert_eq!(row.scope, "aggregate");
+        assert_eq!(row.run_label, "linux-pass-a");
+        assert!((row.last_avg_ms - 213.93).abs() < f64::EPSILON);
+        assert_eq!(row.successful_requests, 144);
+    }
+
+    #[test]
+    fn summarizes_medians() {
+        let rows = vec![
+            super::ScrubCsvRow {
+                scope: "aggregate".to_string(),
+                run_label: "x".to_string(),
+                video: "v".to_string(),
+                all_avg_ms: 10.0,
+                all_p95_ms: 20.0,
+                last_avg_ms: 30.0,
+                last_p95_ms: 40.0,
+                successful_requests: 10,
+                failed_requests: 0,
+            },
+            super::ScrubCsvRow {
+                scope: "aggregate".to_string(),
+                run_label: "x".to_string(),
+                video: "v".to_string(),
+                all_avg_ms: 12.0,
+                all_p95_ms: 24.0,
+                last_avg_ms: 28.0,
+                last_p95_ms: 42.0,
+                successful_requests: 12,
+                failed_requests: 1,
+            },
+            super::ScrubCsvRow {
+                scope: "aggregate".to_string(),
+                run_label: "x".to_string(),
+                video: "v".to_string(),
+                all_avg_ms: 8.0,
+                all_p95_ms: 16.0,
+                last_avg_ms: 26.0,
+                last_p95_ms: 38.0,
+                successful_requests: 8,
+                failed_requests: 0,
+            },
+        ];
+        let summary = summarize(&rows).expect("expected summary");
+        assert_eq!(summary.samples, 3);
+        assert!((summary.all_avg_ms - 10.0).abs() < f64::EPSILON);
+        assert!((summary.last_avg_ms - 28.0).abs() < f64::EPSILON);
+        assert_eq!(summary.successful_requests, 30);
+        assert_eq!(summary.failed_requests, 1);
+    }
+}

--- a/crates/editor/examples/scrub-csv-report.rs
+++ b/crates/editor/examples/scrub-csv-report.rs
@@ -109,9 +109,13 @@ fn parse_csv_line(line: &str) -> Option<ScrubCsvRow> {
     let supersede_min_pixels = fields[11].trim_matches('"');
     let supersede_min_requests = fields[12].trim_matches('"');
     let supersede_min_span_frames = fields[13].trim_matches('"');
+    let latest_first_disabled = fields
+        .get(42)
+        .map(|value| value.trim_matches('"'))
+        .unwrap_or_default();
     let run_label = fields[3].trim_matches('"');
     let config_label = format!(
-        "cfg(disabled={},min_pixels={},min_requests={},min_span={})",
+        "cfg(disabled={},min_pixels={},min_requests={},min_span={},latest_first={})",
         if supersede_disabled.is_empty() {
             "default"
         } else {
@@ -131,6 +135,11 @@ fn parse_csv_line(line: &str) -> Option<ScrubCsvRow> {
             "default"
         } else {
             supersede_min_span_frames
+        },
+        if latest_first_disabled.is_empty() {
+            "default"
+        } else {
+            latest_first_disabled
         }
     );
 
@@ -536,7 +545,17 @@ mod tests {
         let row = parse_csv_line(line).expect("expected row");
         assert_eq!(
             row.run_label,
-            "cfg(disabled=default,min_pixels=2000000,min_requests=7,min_span=20)"
+            "cfg(disabled=default,min_pixels=2000000,min_requests=7,min_span=20,latest_first=default)"
+        );
+    }
+
+    #[test]
+    fn parses_latest_first_flag_from_extended_rows() {
+        let line = "1771039415444,aggregate,0,\"\",\"/tmp/cap-bench-1080p60.mp4\",60,6,12,2.000,2,\"\",\"2000000\",\"7\",\"20\",199.009,410.343,410.344,410.346,213.930,410.343,410.343,410.343,144,0,199.009,410.343,410.344,410.346,120,0,220.009,430.343,430.344,430.346,20,0,240.009,450.343,450.344,450.346,4,0,\"1\"";
+        let row = parse_csv_line(line).expect("expected row");
+        assert_eq!(
+            row.run_label,
+            "cfg(disabled=default,min_pixels=2000000,min_requests=7,min_span=20,latest_first=1)"
         );
     }
 

--- a/crates/rendering/src/decoder/ffmpeg.rs
+++ b/crates/rendering/src/decoder/ffmpeg.rs
@@ -102,7 +102,7 @@ fn scrub_supersession_config() -> ScrubSupersessionConfig {
             .unwrap_or(8);
         let min_span_frames = parse_u32_env("CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES")
             .filter(|value| *value > 0)
-            .unwrap_or((FRAME_CACHE_SIZE as u32 / 2).max(1));
+            .unwrap_or(25);
         let min_pixels = parse_u64_env("CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_PIXELS")
             .filter(|value| *value > 0)
             .unwrap_or(3_686_400);

--- a/crates/rendering/src/decoder/ffmpeg.rs
+++ b/crates/rendering/src/decoder/ffmpeg.rs
@@ -102,7 +102,7 @@ fn scrub_supersession_config() -> ScrubSupersessionConfig {
             .unwrap_or(8);
         let min_span_frames = parse_u32_env("CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES")
             .filter(|value| *value > 0)
-            .unwrap_or(25);
+            .unwrap_or(20);
         let min_pixels = parse_u64_env("CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_PIXELS")
             .filter(|value| *value > 0)
             .unwrap_or(3_686_400);

--- a/crates/rendering/src/decoder/ffmpeg.rs
+++ b/crates/rendering/src/decoder/ffmpeg.rs
@@ -99,7 +99,7 @@ fn scrub_supersession_config() -> ScrubSupersessionConfig {
     *SCRUB_SUPERSESSION_CONFIG.get_or_init(|| {
         let min_requests = parse_usize_env("CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_REQUESTS")
             .filter(|value| *value > 0)
-            .unwrap_or(8);
+            .unwrap_or(7);
         let min_span_frames = parse_u32_env("CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_SPAN_FRAMES")
             .filter(|value| *value > 0)
             .unwrap_or(20);

--- a/crates/rendering/src/decoder/ffmpeg.rs
+++ b/crates/rendering/src/decoder/ffmpeg.rs
@@ -105,7 +105,7 @@ fn scrub_supersession_config() -> ScrubSupersessionConfig {
             .unwrap_or(20);
         let min_pixels = parse_u64_env("CAP_FFMPEG_SCRUB_SUPERSEDE_MIN_PIXELS")
             .filter(|value| *value > 0)
-            .unwrap_or(3_686_400);
+            .unwrap_or(2_000_000);
         let disabled = env::var("CAP_FFMPEG_SCRUB_SUPERSEDE_DISABLED")
             .ok()
             .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))

--- a/crates/rendering/src/decoder/ffmpeg.rs
+++ b/crates/rendering/src/decoder/ffmpeg.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
-use ffmpeg::{format, frame, sys::AVHWDeviceType};
+use ffmpeg::{format, frame};
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use ffmpeg::sys::AVHWDeviceType;
 use std::{
     cell::RefCell,
     collections::BTreeMap,

--- a/crates/rendering/src/frame_pipeline.rs
+++ b/crates/rendering/src/frame_pipeline.rs
@@ -428,9 +428,7 @@ pub async fn finish_encoder(
     uniforms: &ProjectUniforms,
     encoder: wgpu::CommandEncoder,
 ) -> Result<RenderedFrame, RenderingError> {
-    if let Some(prev) = session.pipelined_readback.take_pending() {
-        let _ = prev.wait(device).await;
-    }
+    let previous_pending = session.pipelined_readback.take_pending();
 
     session.pipelined_readback.perform_resize_if_needed(device);
 
@@ -448,6 +446,10 @@ pub async fn finish_encoder(
         .pipelined_readback
         .take_pending()
         .expect("just submitted a readback");
+
+    if let Some(previous_pending) = previous_pending {
+        let _ = previous_pending.wait(device).await;
+    }
 
     pending.wait(device).await
 }

--- a/crates/scap-ffmpeg/src/lib.rs
+++ b/crates/scap-ffmpeg/src/lib.rs
@@ -11,6 +11,20 @@ pub use direct3d::*;
 mod cpal;
 pub use cpal::*;
 
+#[cfg(not(any(target_os = "macos", windows)))]
+#[derive(Debug, Clone, Copy)]
+pub struct AsFFmpegError;
+
+#[cfg(not(any(target_os = "macos", windows)))]
+impl std::fmt::Display for AsFFmpegError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FFmpeg conversion is unsupported on this platform")
+    }
+}
+
+#[cfg(not(any(target_os = "macos", windows)))]
+impl std::error::Error for AsFFmpegError {}
+
 pub trait AsFFmpeg {
     fn as_ffmpeg(&self) -> Result<ffmpeg::frame::Video, AsFFmpegError>;
 }

--- a/crates/scap-targets/src/lib.rs
+++ b/crates/scap-targets/src/lib.rs
@@ -152,10 +152,9 @@ impl Window {
     }
 
     pub fn display_relative_logical_bounds(&self) -> Option<LogicalBounds> {
-        let display = self.display()?;
-
         #[cfg(target_os = "macos")]
         {
+            let display = self.display()?;
             let display_logical_bounds = display.raw_handle().logical_bounds()?;
             let window_logical_bounds = self.raw_handle().logical_bounds()?;
 
@@ -170,6 +169,7 @@ impl Window {
 
         #[cfg(windows)]
         {
+            let display = self.display()?;
             let display_physical_bounds = display.raw_handle().physical_bounds()?;
             let display_logical_size = display.logical_size()?;
             let window_physical_bounds: PhysicalBounds = self.raw_handle().physical_bounds()?;
@@ -194,6 +194,12 @@ impl Window {
                     display_relative_physical_bounds.size().height() * scale,
                 ),
             ))
+        }
+
+        #[cfg(not(any(target_os = "macos", windows)))]
+        {
+            self.logical_size()
+                .map(|size| LogicalBounds::new(LogicalPosition::new(0.0, 0.0), size))
         }
     }
 }

--- a/crates/scap-targets/src/platform/linux.rs
+++ b/crates/scap-targets/src/platform/linux.rs
@@ -1,0 +1,128 @@
+use std::str::FromStr;
+
+use crate::bounds::{LogicalSize, PhysicalSize};
+
+#[derive(Clone, Copy)]
+pub struct DisplayImpl(u64);
+
+impl DisplayImpl {
+    pub fn primary() -> Self {
+        Self(0)
+    }
+
+    pub fn list() -> Vec<Self> {
+        vec![Self::primary()]
+    }
+
+    pub fn raw_id(&self) -> DisplayIdImpl {
+        DisplayIdImpl(self.0)
+    }
+
+    pub fn get_containing_cursor() -> Option<Self> {
+        Some(Self::primary())
+    }
+
+    pub fn name(&self) -> Option<String> {
+        Some("Display".to_string())
+    }
+
+    pub fn physical_size(&self) -> Option<PhysicalSize> {
+        Some(PhysicalSize::new(1920.0, 1080.0))
+    }
+
+    pub fn logical_size(&self) -> Option<LogicalSize> {
+        self.physical_size()
+            .map(|size| LogicalSize::new(size.width(), size.height()))
+    }
+
+    pub fn refresh_rate(&self) -> f64 {
+        60.0
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct WindowImpl(u64);
+
+impl WindowImpl {
+    pub fn list() -> Vec<Self> {
+        Vec::new()
+    }
+
+    pub fn list_containing_cursor() -> Vec<Self> {
+        Vec::new()
+    }
+
+    pub fn get_topmost_at_cursor() -> Option<Self> {
+        None
+    }
+
+    pub fn id(&self) -> WindowIdImpl {
+        WindowIdImpl(self.0)
+    }
+
+    pub fn level(&self) -> Option<i32> {
+        Some(0)
+    }
+
+    pub fn physical_size(&self) -> Option<PhysicalSize> {
+        None
+    }
+
+    pub fn logical_size(&self) -> Option<LogicalSize> {
+        None
+    }
+
+    pub fn owner_name(&self) -> Option<String> {
+        None
+    }
+
+    pub fn app_icon(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    pub fn display(&self) -> Option<DisplayImpl> {
+        Some(DisplayImpl::primary())
+    }
+
+    pub fn name(&self) -> Option<String> {
+        None
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct DisplayIdImpl(u64);
+
+impl std::fmt::Display for DisplayIdImpl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for DisplayIdImpl {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<u64>()
+            .map(Self)
+            .map_err(|_| "Invalid display ID".to_string())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct WindowIdImpl(u64);
+
+impl std::fmt::Display for WindowIdImpl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for WindowIdImpl {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<u64>()
+            .map(Self)
+            .map_err(|_| "Invalid window ID".to_string())
+    }
+}

--- a/crates/scap-targets/src/platform/mod.rs
+++ b/crates/scap-targets/src/platform/mod.rs
@@ -7,3 +7,8 @@ pub use macos::*;
 mod win;
 #[cfg(windows)]
 pub use win::*;
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+pub use linux::*;

--- a/crates/timestamp/src/lib.rs
+++ b/crates/timestamp/src/lib.rs
@@ -79,6 +79,11 @@ impl Timestamp {
         {
             Self::MachAbsoluteTime(MachAbsoluteTimestamp::from_cpal(instant))
         }
+        #[cfg(not(any(target_os = "macos", windows)))]
+        {
+            let _ = instant;
+            Self::Instant(Instant::now())
+        }
     }
 }
 


### PR DESCRIPTION
Enable Linux compilation for `scap-targets` and add a new playback benchmark example to unblock performance testing on Linux.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-322071ae-8f07-438d-b2f5-08ed680fde57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-322071ae-8f07-438d-b2f5-08ed680fde57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core frame transport/rendering logic (SAB atomics, ordering, backpressure, fallbacks), so regressions could impact playback smoothness or stability despite added tests and telemetry.
> 
> **Overview**
> **Playback/transport pipeline hardening and instrumentation.** The desktop app’s frame ingestion/transport path is refactored to better handle *out-of-order frames*, worker backpressure, and SharedArrayBuffer (SAB) write failures, with a set of small decision utilities (order, retry, inflight, stride dispatch, buffer sizing) plus unit tests.
> 
> **SAB + worker flow changes.** `socket.ts` now dynamically resizes the SAB based on incoming frame sizes, retries SAB writes with a capped limit before falling back to worker transfer, tracks worker in-flight frames (with backpressure/superseded-drop accounting), and records extensive per-window and total counters. The `frame-worker` render queue is simplified to a single latest queued frame, adds out-of-order drop logic, and reports render source (`shared` vs `worker`).
> 
> **Telemetry/UI updates and format cleanup.** `PerformanceOverlay` polls `getFpsStats()` and displays/copies the new transport metrics. NV12-specific paths are removed from `webgpu-renderer` and the main-thread/worker frame handling, and `stride-correction-worker` now includes `frameNumber` plus validation/error responses to keep direct rendering ordered.
> 
> **Cross-platform build fixes.** Rust crates add non-macOS/windows stubs/guards (`camera-ffmpeg` unsupported error; `cursor-capture` bounds gated) to allow compilation on other platforms (e.g., Linux).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f792f1cf6d9c21dbf09cbd89f8549913abc4bb3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR enables Linux compilation for `scap-targets` and adds comprehensive playback performance benchmarking infrastructure. The changes include:

- **Linux compilation support**: Added stub implementations across multiple crates (`scap-targets`, `camera-ffmpeg`, `scap-ffmpeg`, `cursor-capture`, `timestamp`) with conditional compilation guards. The Linux implementations return hardcoded/no-op values to enable builds but don't provide real functionality yet.

- **Playback benchmarking suite**: Added 5 new benchmark examples (`playback-benchmark`, `scrub-benchmark`, `decode-benchmark`, and corresponding CSV report tools) with extensive documentation in `PLAYBACK-BENCHMARKS.md` and `PLAYBACK-FINDINGS.md`.

- **Frame transport refactor**: Major improvements to the desktop app's frame handling:
  - Extracted frame transport logic into modular utilities (`frame-transport-config`, `-inflight`, `-order`, `-retry`, `-stride`)
  - Enhanced SharedArrayBuffer management with dynamic resizing, retry logic, and comprehensive metrics
  - Added backpressure control and supersession logic to prevent worker overload
  - Removed main-thread NV12 conversion code
  - Added 40+ performance metrics tracked in `PerformanceOverlay`

- **Decoder optimizations**: FFmpeg decoder now supports "scrub supersession" and "latest-first" prioritization via environment variables to improve seek performance during video scrubbing.

- **Playback improvements**: Added startup tracing, environment-based configuration flags, and enhanced frame caching in the editor playback system.

The frame transport changes are well-tested with comprehensive unit tests for each new module. The benchmarking infrastructure provides detailed CSV output for performance analysis.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor caveats around the Linux stub implementations
- The changes are well-structured and thoroughly tested. The frame transport refactor improves modularity and adds comprehensive unit tests. The benchmarking infrastructure is solid with extensive documentation. The Linux stubs are clearly marked as non-functional placeholders. Main concern is the complexity of the `socket.ts` refactor (1100+ lines changed), though the modular extraction helps. The decoder changes use environment variables for tuning, which is appropriate for performance experimentation.
- Pay close attention to `apps/desktop/src/utils/socket.ts` due to the extensive refactoring and new frame ordering/backpressure logic

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/scap-targets/src/platform/linux.rs | Added Linux stub implementation with hardcoded values (1920x1080, 60Hz) to enable compilation; no real functionality yet |
| crates/editor/src/playback.rs | Improved playback with startup tracing, environment-based configuration flags, and enhanced frame caching |
| crates/rendering/src/decoder/ffmpeg.rs | Added scrub supersession logic with latest-first prioritization, configurable via environment variables for performance tuning |
| apps/desktop/src/utils/socket.ts | Major refactor: removed NV12 main-thread conversion, added frame transport modules, retry logic, inflight tracking, and comprehensive metrics |
| apps/desktop/src/utils/frame-transport-config.ts | New module for shared buffer configuration with dynamic sizing and alignment logic |
| apps/desktop/src/utils/shared-frame-buffer.ts | Enhanced shared frame buffer with writable slot search, shutdown signaling, and improved synchronization |
| apps/desktop/src/utils/frame-worker.ts | Simplified worker by removing complex queuing logic and NV12 handling, focusing on SharedArrayBuffer consumption |
| apps/desktop/src/routes/editor/PerformanceOverlay.tsx | Added extensive transport statistics tracking with 40+ metrics for frame buffer, worker, and ordering performance |

</details>



<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[Frame Received from Rust] --> B{Frame Order Check}
    B -->|Out of Order| C[Drop Frame]
    B -->|In Order| D{SharedArrayBuffer Available?}
    
    D -->|Yes| E{SAB Write Attempt}
    E -->|Success| F[Producer Writes to SAB]
    E -->|Busy/Full| G{Retry Count < Limit?}
    G -->|Yes| H[Schedule Retry]
    G -->|No| I[Fallback to Worker]
    
    D -->|No| I
    H --> E
    
    F --> J[Consumer Reads from SAB]
    J --> K[Render Directly]
    
    I --> L{Worker Inflight < Limit?}
    L -->|Yes| M[Send to Frame Worker]
    L -->|No| N[Backpressure Drop]
    
    M --> O{Needs Stride Correction?}
    O -->|Yes| P{Stride Worker Available?}
    P -->|Yes| Q[Stride Correction Worker]
    P -->|No| R[Queue for Later]
    Q --> S[Worker Renders Frame]
    O -->|No| S
    
    R --> P
    S --> T[Post ImageBitmap]
    T --> U[Main Thread Renders]
    
    K --> V[Performance Metrics]
    U --> V
    C --> V
    N --> V
```

<sub>Last reviewed commit: f792f1c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->