### PR TITLE
feat: add deep link handlers for remote control (Raycast support)

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -103,8 +103,8 @@ impl TryFrom<&Url> for DeepLinkAction {
             Some("toggle-mic") => return Ok(Self::ToggleMic),
             Some("toggle-cam") => return Ok(Self::ToggleCam),
             Some(v) if v != "action" => return Err(ActionParseFromUrlError::NotAction),
-            None => return Err(ActionParseFromUrlError::NotAction),
-            _ => {}
+            Some("action") => {}
+            None => return Err(ActionParseFromUrlError::Invalid),
         }
 
         let params = url

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -119,6 +119,36 @@ impl TryFrom<&Url> for DeepLinkAction {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::{ActionParseFromUrlError, DeepLinkAction};
+    use tauri::Url;
+
+    #[test]
+    fn parse_hostless_action_url_returns_invalid() {
+        let url = Url::parse("cap:?value=%7B%7D").expect("url should parse");
+        let result = DeepLinkAction::try_from(&url);
+
+        assert!(matches!(result, Err(ActionParseFromUrlError::Invalid)));
+    }
+
+    #[test]
+    fn parse_non_action_host_returns_not_action() {
+        let url = Url::parse("cap://login?value=%7B%7D").expect("url should parse");
+        let result = DeepLinkAction::try_from(&url);
+
+        assert!(matches!(result, Err(ActionParseFromUrlError::NotAction)));
+    }
+
+    #[test]
+    fn parse_toggle_mic_shortcut_host() {
+        let url = Url::parse("cap://toggle-mic").expect("url should parse");
+        let result = DeepLinkAction::try_from(&url);
+
+        assert!(matches!(result, Ok(DeepLinkAction::ToggleMic)));
+    }
+}
+
 impl DeepLinkAction {
     async fn execute_start_recording(
         app: &AppHandle,


### PR DESCRIPTION
This PR adds 6 new deep link handlers to the desktop app: record, stop, pause, resume, toggle-mic, and toggle-cam. These handlers allow external tools like Raycast to control Cap recording state. I have also prepared a Raycast extension to accompany these changes. Resolves #1540

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds 6 new deep link handlers (`record`, `stop`, `pause`, `resume`, `toggle-mic`, `toggle-cam`) to enable remote control of Cap's recording state via external tools like Raycast.

**Key changes:**
- Added 6 new variants to the `DeepLinkAction` enum for parameter-free remote control operations
- Modified URL parsing to support simple domain-based routing (e.g., `cap://record`, `cap://stop`) instead of requiring query parameters
- Implemented handlers that integrate with existing recording functions and settings store
- `Record` handler uses saved settings to start recording, while toggle handlers flip camera/mic state based on current state

**Implementation notes:**
- The `Record` handler duplicates significant logic from `StartRecording` for reading settings and initializing recording state
- All handlers properly integrate with the existing `crate::recording` module functions
- Toggle handlers correctly read current state and flip between enabled/disabled using the settings store as the source for device selection

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it adds well-scoped remote control functionality without modifying core recording logic
- The implementation properly integrates with existing recording functions and uses the established settings store pattern. The new handlers are isolated additions that don't affect existing functionality. One minor style suggestion for reducing code duplication, but no critical issues
- No files require special attention - the single modified file has straightforward logic

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/deeplink_actions.rs | Adds 6 new deep link handlers (record, stop, pause, resume, toggle-mic, toggle-cam) for remote control via Raycast; handlers properly integrate with existing recording functions |

</details>



<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[Deep Link URL] --> B{Parse URL Domain}
    B -->|cap://record| C[Record Handler]
    B -->|cap://stop| D[StopRecording Handler]
    B -->|cap://pause| E[Pause Handler]
    B -->|cap://resume| F[Resume Handler]
    B -->|cap://toggle-mic| G[ToggleMic Handler]
    B -->|cap://toggle-cam| H[ToggleCam Handler]
    B -->|cap://action?value=...| I[Parse Query Params]
    
    C --> J[Get RecordingSettingsStore]
    J --> K[Set Camera Input]
    K --> L[Set Mic Input]
    L --> M[Start Recording]
    
    G --> N{Current Mic State}
    N -->|Some| O[Set to None]
    N -->|None| P[Get from Settings]
    P --> Q[Set Mic Input]
    
    H --> R{Camera In Use?}
    R -->|Yes| S[Disable Camera]
    R -->|No| T[Get from Settings]
    T --> U[Enable Camera]
```

<sub>Last reviewed commit: ffc468d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->