### PR TITLE
fix(windows): revert editor to RGBA output and fix DX12 adapter selec…

### DIFF
--- a/apps/desktop/src-tauri/src/gpu_context.rs
+++ b/apps/desktop/src-tauri/src/gpu_context.rs
@@ -49,13 +49,31 @@ pub struct SharedGpuContext {
 static GPU: OnceCell<Option<SharedGpuContext>> = OnceCell::const_new();
 
 async fn init_gpu_inner() -> Option<SharedGpuContext> {
-    #[cfg(target_os = "windows")]
-    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
-        backends: wgpu::Backends::DX12 | wgpu::Backends::VULKAN,
-        ..Default::default()
-    });
     #[cfg(not(target_os = "windows"))]
     let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor::default());
+
+    #[cfg(target_os = "windows")]
+    let instance = {
+        let dx12_instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::DX12,
+            ..Default::default()
+        });
+        let has_dx12 = dx12_instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                force_fallback_adapter: false,
+                compatible_surface: None,
+            })
+            .await
+            .is_ok();
+        if has_dx12 {
+            tracing::info!("Using DX12 backend for shared GPU context");
+            dx12_instance
+        } else {
+            tracing::info!("DX12 not available for shared context, falling back to all backends");
+            wgpu::Instance::new(&wgpu::InstanceDescriptor::default())
+        }
+    };
 
     let hardware_adapter = instance
         .request_adapter(&wgpu::RequestAdapterOptions {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -147,48 +147,20 @@ impl Renderer {
                     break;
                 }
             }
-            let nv12_result = frame_renderer
-                .render_nv12(
-                    current.segment_frames.clone(),
-                    current.uniforms.clone(),
+            match frame_renderer
+                .render_immediate(
+                    current.segment_frames,
+                    current.uniforms,
                     &current.cursor,
                     &mut layers,
                 )
-                .await;
-
-            match nv12_result {
-                Ok(pipeline_frame) => {
-                    if let Some(prev) = pipeline_frame {
-                        (self.frame_cb)(EditorFrameOutput::Nv12(prev));
-                    }
-                    match frame_renderer.flush_pipeline_nv12().await {
-                        Some(Ok(current_frame)) => {
-                            (self.frame_cb)(EditorFrameOutput::Nv12(current_frame));
-                        }
-                        Some(Err(e)) => {
-                            tracing::warn!(error = %e, "Failed to flush NV12 pipeline frame");
-                        }
-                        None => {}
-                    }
+                .await
+            {
+                Ok(frame) => {
+                    (self.frame_cb)(EditorFrameOutput::Rgba(frame));
                 }
                 Err(e) => {
-                    tracing::warn!(error = %e, "NV12 render failed, falling back to RGBA");
-                    match frame_renderer
-                        .render_immediate(
-                            current.segment_frames,
-                            current.uniforms,
-                            &current.cursor,
-                            &mut layers,
-                        )
-                        .await
-                    {
-                        Ok(frame) => {
-                            (self.frame_cb)(EditorFrameOutput::Rgba(frame));
-                        }
-                        Err(e) => {
-                            tracing::error!(error = %e, "Failed to render frame in editor");
-                        }
-                    }
+                    tracing::error!(error = %e, "Failed to render frame in editor");
                 }
             }
 


### PR DESCRIPTION
Changes
1. Enable MediaFoundation Hardware Decoder (biggest win)
The native Windows MediaFoundation decoder was fully implemented but never called from spawn_decoder(). Now it is tried first with FFmpeg as automatic fallback — mirroring the macOS pattern (AVAssetReader → FFmpeg).

Native D3D11VA hardware-accelerated video decoding (NVDEC/VCN/Quick Sync)
D3D11 shared texture handles (Y/UV planes) for zero-copy GPU texture sharing
Falls back to FFmpeg transparently if MF fails
2. DX12 Backend Selection
wgpu was selecting Vulkan over DX12 on some NVIDIA systems. Fixed by probing for DX12 first and using it exclusively when present. Required for D3D11↔D3D12 shared handle interop. Falls back to all backends if DX12 unavailable.

3. D3D11 Zero-Copy in Display Layer
Added shared texture handle support to prepare_with_encoder() NV12 path, eliminating a GPU→CPU→GPU round-trip per frame.

4. High-Performance GPU Selection
Added powerPreference: "high-performance" to frontend WebGPU requestAdapter().

5. DX12 Preference in GPU Converters
Consistent DX12 backend preference across all gpu-converter crates.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two Windows-specific GPU issues discovered during testing with NVIDIA RTX 2000:

- **Editor reverted to RGBA output**: The NV12 render pipeline (compute shader + buffer readback) was hanging on Vulkan backend, causing `BufferAsyncError`. The editor now uses the proven `render_immediate()` RGBA path, while the NV12 pipeline remains available for the export path where it's been battle-tested.
- **DX12 backend selection fixed**: The previous `DX12 | Vulkan` backend specification allowed wgpu to pick Vulkan over DX12, breaking D3D11 shared handle zero-copy. The fix probes for DX12 availability first with a DX12-only instance, only falling back to all backends if DX12 isn't present. This pattern is applied in both `gpu_context.rs` (shared context) and `rendering/src/lib.rs` (`RenderVideoConstants`).

Minor observations:
- The `EditorFrameOutput::Nv12` enum variant and `Nv12RenderedFrame` import are now dead code since the editor only emits `Rgba` frames.
- The DX12 probe-and-fallback logic is duplicated between two files and could be extracted into a shared helper.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it reverts to a known-working RGBA render path and adds a sensible DX12 probe fallback.
- The editor revert simplifies code and removes a code path that was causing hangs on certain GPU/backend configurations. The DX12 probe logic is a reasonable approach to ensure the correct backend is selected. No correctness issues found; comments are style-level improvements (dead code cleanup, deduplication). Score of 4 rather than 5 because the dead Nv12 code path should ideally be cleaned up to avoid confusion.
- `crates/editor/src/editor.rs` has a dead `Nv12` variant that should be cleaned up if the NV12 path is not planned for re-enablement in the editor.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/gpu_context.rs | Replaces DX12|Vulkan backend selection with a DX12-first probe that falls back to all backends. Duplicates probe logic with `crates/rendering/src/lib.rs`; adapter from probe is discarded and re-requested. |
| crates/editor/src/editor.rs | Reverts editor from NV12 pipeline to proven RGBA `render_immediate()` path. Simplifies render loop significantly. The `EditorFrameOutput::Nv12` variant and `Nv12RenderedFrame` import are now dead code. |
| crates/rendering/src/lib.rs | Same DX12-first probe-and-fallback pattern as `gpu_context.rs`. Logic is identical and could be extracted into a shared function to avoid duplication. |

</details>



<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[Windows GPU Init] --> B{Create DX12-only Instance}
    B --> C{Probe: DX12 adapter available?}
    C -->|Yes| D[Use DX12 Instance]
    C -->|No| E[Create default Instance - all backends]
    D --> F{Request hardware adapter}
    E --> F
    F -->|Found| G[Use hardware GPU adapter]
    F -->|Not found| H{Request software fallback adapter}
    H -->|Found| I[Use software adapter - reduced perf]
    H -->|Not found| J[GPU init fails]
    G --> K[Create device + queue]
    I --> K
    K --> L[Editor: render_immediate RGBA path]
    K --> M[Export: NV12 pipeline available]
```

<sub>Last reviewed commit: d045c4f</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))

<!-- /greptile_comment -->