### PR TITLE
feat(desktop): add pause and resume deeplink actions

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -26,6 +26,8 @@ pub enum DeepLinkAction {
         mode: RecordingMode,
     },
     StopRecording,
+    PauseRecording,
+    ResumeRecording,
     OpenEditor {
         project_path: PathBuf,
     },
@@ -145,6 +147,12 @@ impl DeepLinkAction {
             }
             DeepLinkAction::StopRecording => {
                 crate::recording::stop_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::PauseRecording => {
+                crate::recording::pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::ResumeRecording => {
+                crate::recording::resume_recording(app.clone(), app.state()).await
             }
             DeepLinkAction::OpenEditor { project_path } => {
                 crate::open_project_from_path(Path::new(&project_path), app.clone())


### PR DESCRIPTION
Closes #1540\n\n/claim #1540\n\nWhat this PR adds\n- Desktop deeplink actions: PauseRecording, ResumeRecording\n- Wired to existing recording handlers (pause_recording / resume_recording)\n\nNotes\n- Vercel check fails on this PR but this change is desktop (Rust/Tauri) only; please focus review on apps/desktop/src-tauri changes.\n\nDemo\n- (pending) I will attach a short demo video showing cap-desktop deeplink triggering pause/resume.