### PR TITLE
Fix #1550: Transcription workflow fails on Docker image with Node 24

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1
 
-FROM node:24-alpine AS base
+FROM node:22-alpine AS base
 RUN corepack enable
 
 FROM base AS builder


### PR DESCRIPTION
Fixes #1550

## Summary
This PR addresses: Transcription workflow fails on Docker image with Node 24

## Changes
```
apps/web/Dockerfile | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Downgraded Docker base image from `node:24-alpine` to `node:22-alpine` to resolve transcription workflow failures. The `ffmpeg-static` package used in the transcription pipeline (`apps/web/lib/audio-extract.ts`) has compatibility issues with Node.js 24, causing the workflow to fail when extracting audio for Deepgram transcription. This is a safe and appropriate fix that aligns with the project's existing Node version requirements (`package.json` specifies `node: ">=20"`).

- Changed base image from `node:24-alpine` to `node:22-alpine` in `apps/web/Dockerfile:3`
- Ensures compatibility with `ffmpeg-static` binary path resolution
- Maintains alignment with project's Node.js engine requirements

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal change that fixes a critical transcription workflow issue
- Single-line change downgrading from Node 24 to Node 22 addresses known compatibility issues with ffmpeg-static. The change is conservative, aligns with project requirements (package.json specifies node >=20), and directly addresses the reported issue. No breaking changes or risks introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/Dockerfile | Downgraded base image from `node:24-alpine` to `node:22-alpine` to fix transcription workflow compatibility |

</details>



<sub>Last reviewed commit: 271d911</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->