### PR TITLE
Fix #1612: Self-hosted deployments break on update due to missing datab

### DIFF
--- a/packages/database/migrate.ts
+++ b/packages/database/migrate.ts
@@ -20,7 +20,7 @@ function errorIsOrgIdMigration(e: unknown): e is DrizzleQueryError {
 }
 
 export async function migrateDb() {
-	runMigrate()
+	await runMigrate()
 		.catch(async (e) => {
 			if (errorIsOrgIdMigration(e)) {
 				console.log("non-null videos.orgId migration failed, running backfill");
@@ -34,5 +34,6 @@ export async function migrateDb() {
 				throw new Error(
 					"videos.orgId backfill failed, you will need to manually update the videos.orgId column before attempting to migrate again.",
 				);
+			throw e;
 		});
 }


### PR DESCRIPTION
Fixes #1612

## Summary
This PR addresses: Self-hosted deployments break on update due to missing database migrations

## Changes
```
packages/database/migrate.ts | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical bug where `migrateDb()` was not awaiting the `runMigrate()` promise, causing unhandled promise rejections in self-hosted deployments. The PR adds the missing `await` keyword on line 23 and adds a missing `throw e;` statement on line 37 in the second catch block to properly rethrow errors that don't match the orgId migration error pattern.

**Key changes:**
- Added `await` before `runMigrate()` call to properly handle async execution
- Added `throw e;` in second catch block to rethrow non-orgId migration errors

These changes ensure that database migration errors are properly surfaced to the caller (`instrumentation.node.ts`), allowing the retry logic and error handling to work correctly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix addresses a critical bug by adding proper async/await handling and error propagation. The changes are minimal (2 lines), well-targeted, and follow correct async/await patterns. No breaking changes or side effects introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/database/migrate.ts | Adds `await` to `runMigrate()` call and rethrows unhandled errors in the second catch block |

</details>



<sub>Last reviewed commit: 114f62a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->