### PR TITLE
feat: add disable update checks setting in the general settings

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -91,6 +91,8 @@ pub struct GeneralSettingsStore {
     #[serde(default)]
     pub hide_dock_icon: bool,
     #[serde(default)]
+    pub disable_update_checks: bool,
+    #[serde(default)]
     pub auto_create_shareable_link: bool,
     #[serde(default = "default_true")]
     pub enable_notifications: bool,
@@ -188,6 +190,7 @@ impl Default for GeneralSettingsStore {
             instance_id: uuid::Uuid::new_v4(),
             upload_individual_files: false,
             hide_dock_icon: false,
+            disable_update_checks: false,
             auto_create_shareable_link: false,
             enable_notifications: true,
             disable_auto_open_links: false,

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -35,7 +35,7 @@ import Mode from "~/components/Mode";
 import { RecoveryToast } from "~/components/RecoveryToast";
 import Tooltip from "~/components/Tooltip";
 import { Input } from "~/routes/editor/ui";
-import { authStore } from "~/store";
+import { authStore, generalSettingsStore } from "~/store";
 import { createSignInMutation } from "~/utils/auth";
 import { createTauriEventListener } from "~/utils/createEventListener";
 import {
@@ -930,6 +930,10 @@ function createUpdateCheck() {
 
 		let update: updater.Update | undefined;
 		try {
+			const generalSettings = await generalSettingsStore.get();
+			
+			if (generalSettings?.disableUpdateChecks ?? false) return;
+			
 			const result = await updater.check();
 			if (result) update = result;
 		} catch (e) {

--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -69,6 +69,7 @@ type ExtendedGeneralSettingsStore = GeneralSettingsStore;
 const createDefaultGeneralSettings = (): ExtendedGeneralSettingsStore => ({
 	uploadIndividualFiles: false,
 	hideDockIcon: false,
+	disableUpdateChecks: false,
 	autoCreateShareableLink: false,
 	enableNotifications: true,
 	enableNativeCameraPreview: false,
@@ -592,6 +593,14 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 						handleChange("serverUrl", origin);
 					}}
 				/>
+				<SettingGroup title="Update Settings">
+					<ToggleSettingItem
+						label="Disable update checks"
+						description="Disable automatic update checks."
+						value={!!settings.disableUpdateChecks}
+						onChange={(v) => handleChange("disableUpdateChecks", v)}
+					/>
+				</SettingGroup>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/routes/(window-chrome)/update.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/update.tsx
@@ -4,6 +4,7 @@ import { getCurrentWindow, UserAttentionType } from "@tauri-apps/api/window";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { createResource, createSignal, Match, Show, Switch } from "solid-js";
+import { generalSettingsStore } from "~/store";
 
 export default function () {
 	const navigate = useNavigate();
@@ -11,6 +12,14 @@ export default function () {
 
 	const [update] = createResource(async () => {
 		try {
+			const settings = await generalSettingsStore.get();
+			const isDisabled = settings?.disableUpdateChecks ?? false;
+			
+			if(isDisabled) {
+				setUpdateError("Update checks are currently disabled.");
+				return;
+			}
+			
 			const update = await check();
 			if (!update) return;
 			return update;

--- a/apps/desktop/src/routes/(window-chrome)/update.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/update.tsx
@@ -9,14 +9,14 @@ import { generalSettingsStore } from "~/store";
 export default function () {
 	const navigate = useNavigate();
 	const [updateError, setUpdateError] = createSignal<string | null>(null);
+	const [updatesDisabled, setUpdatesDisabled] = createSignal<boolean>(false);
 
 	const [update] = createResource(async () => {
 		try {
-			const settings = await generalSettingsStore.get();
-			const isDisabled = settings?.disableUpdateChecks ?? false;
+			const generalSettings = await generalSettingsStore.get();
 			
-			if(isDisabled) {
-				setUpdateError("Update checks are currently disabled.");
+			if (generalSettings?.disableUpdateChecks ?? false) {
+				setUpdatesDisabled(true);
 				return;
 			}
 			
@@ -32,6 +32,15 @@ export default function () {
 
 	return (
 		<div class="flex flex-col justify-center flex-1 items-center gap-[3rem] p-[1rem] text-[0.875rem] font-[400] h-full">
+			<Show when={updatesDisabled()}>
+			    <div class="flex flex-col gap-4 items-center text-center max-w-md">
+					<p class="text-[--text-primary]">Update checks are currently disabled.</p>
+					<p class="text-[--text-tertiary]">
+						To enable updates, go to General Settings and disable "Disable Update Checks".
+					</p>
+			        <Button onClick={() => navigate("/")}>Go Back</Button>
+			    </div>
+			</Show>
 			<Show when={updateError()}>
 				<div class="flex flex-col gap-4 items-center text-center max-w-md">
 					<p class="text-[--text-primary]">{updateError()}</p>
@@ -48,7 +57,7 @@ export default function () {
 			<Show
 				when={!updateError() && update()}
 				fallback={
-					!updateError() && (
+					!updateError() && !updatesDisabled() && (
 						<span class="text-[--text-tertiary]">No update available</span>
 					)
 				}

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -403,6 +403,7 @@ videoImportProgress: "video-import-progress"
 
 /** user-defined types **/
 
+export type AllGpusInfo = { gpus: GpuInfoDiag[]; primaryGpuIndex: number | null; isMultiGpuSystem: boolean; hasDiscreteGpu: boolean }
 export type Annotation = { id: string; type: AnnotationType; x: number; y: number; width: number; height: number; strokeColor: string; strokeWidth: number; fillColor: string; opacity: number; rotation: number; text: string | null; maskType?: MaskType | null; maskLevel?: number | null }
 export type AnnotationType = "arrow" | "circle" | "rectangle" | "text" | "mask"
 export type AppTheme = "system" | "light" | "dark"
@@ -464,7 +465,7 @@ export type ExportSettings = ({ format: "Mp4" } & Mp4ExportSettings) | ({ format
 export type FileType = "recording" | "screenshot"
 export type Flags = { captions: boolean }
 export type FramesRendered = { renderedCount: number; totalFrames: number; type: "FramesRendered" }
-export type GeneralSettingsStore = { instanceId?: string; uploadIndividualFiles?: boolean; hideDockIcon?: boolean; autoCreateShareableLink?: boolean; enableNotifications?: boolean; disableAutoOpenLinks?: boolean; hasCompletedStartup?: boolean; theme?: AppTheme; commercialLicense?: CommercialLicense | null; lastVersion?: string | null; windowTransparency?: boolean; postStudioRecordingBehaviour?: PostStudioRecordingBehaviour; mainWindowRecordingStartBehaviour?: MainWindowRecordingStartBehaviour; custom_cursor_capture2?: boolean; serverUrl?: string; recordingCountdown?: number | null; enableNativeCameraPreview: boolean; autoZoomOnClicks?: boolean; postDeletionBehaviour?: PostDeletionBehaviour; excludedWindows?: WindowExclusion[]; deleteInstantRecordingsAfterUpload?: boolean; instantModeMaxResolution?: number; defaultProjectNameTemplate?: string | null; crashRecoveryRecording?: boolean; maxFps?: number; editorPreviewQuality?: EditorPreviewQuality; mainWindowPosition?: WindowPosition | null; cameraWindowPosition?: WindowPosition | null; cameraWindowPositionsByMonitorName?: { [key in string]: WindowPosition } }
+export type GeneralSettingsStore = { instanceId?: string; uploadIndividualFiles?: boolean; hideDockIcon?: boolean; disableUpdateChecks?: boolean; autoCreateShareableLink?: boolean; enableNotifications?: boolean; disableAutoOpenLinks?: boolean; hasCompletedStartup?: boolean; theme?: AppTheme; commercialLicense?: CommercialLicense | null; lastVersion?: string | null; windowTransparency?: boolean; postStudioRecordingBehaviour?: PostStudioRecordingBehaviour; mainWindowRecordingStartBehaviour?: MainWindowRecordingStartBehaviour; custom_cursor_capture2?: boolean; serverUrl?: string; recordingCountdown?: number | null; enableNativeCameraPreview: boolean; autoZoomOnClicks?: boolean; postDeletionBehaviour?: PostDeletionBehaviour; excludedWindows?: WindowExclusion[]; deleteInstantRecordingsAfterUpload?: boolean; instantModeMaxResolution?: number; defaultProjectNameTemplate?: string | null; crashRecoveryRecording?: boolean; maxFps?: number; editorPreviewQuality?: EditorPreviewQuality; mainWindowPosition?: WindowPosition | null; cameraWindowPosition?: WindowPosition | null; cameraWindowPositionsByMonitorName?: { [key in string]: WindowPosition } }
 export type GifExportSettings = { fps: number; resolution_base: XY<number>; quality: GifQuality | null }
 export type GifQuality = { 
 /**
@@ -476,6 +477,7 @@ quality: number | null;
  */
 fast: boolean | null }
 export type GlideDirection = "none" | "left" | "right" | "up" | "down"
+export type GpuInfoDiag = { vendor: string; description: string; dedicatedVideoMemoryMb: number; adapterIndex: number; isSoftwareAdapter: boolean; isBasicRenderDriver: boolean; supportsHardwareEncoding: boolean }
 export type HapticPattern = "alignment" | "levelChange" | "generic"
 export type HapticPerformanceTime = "default" | "now" | "drawCompleted"
 export type Hotkey = { code: string; meta: boolean; ctrl: boolean; alt: boolean; shift: boolean }
@@ -489,7 +491,6 @@ export type JsonValue<T> = [T]
 export type LogicalBounds = { position: LogicalPosition; size: LogicalSize }
 export type LogicalPosition = { x: number; y: number }
 export type LogicalSize = { width: number; height: number }
-export type MacOSVersionInfo = { major: number; minor: number; patch: number; displayName: string; buildNumber: string; isAppleSilicon: boolean }
 export type MainWindowRecordingStartBehaviour = "close" | "minimise"
 export type MaskKeyframes = { position?: MaskVectorKeyframe[]; size?: MaskVectorKeyframe[]; intensity?: MaskScalarKeyframe[] }
 export type MaskKind = "sensitive" | "highlight"
@@ -533,6 +534,7 @@ export type RecordingStatus = "pending" | "recording"
 export type RecordingStopped = null
 export type RecordingTargetMode = "display" | "window" | "area" | "camera"
 export type RenderFrameEvent = { frame_number: number; fps: number; resolution_base: XY<number> }
+export type RenderingStatus = { isUsingSoftwareRendering: boolean; isUsingBasicRenderDriver: boolean; hardwareEncodingAvailable: boolean; warningMessage: string | null }
 export type RequestOpenRecordingPicker = { target_mode: RecordingTargetMode | null }
 export type RequestOpenSettings = { page: string }
 export type RequestScreenCapturePrewarm = { force?: boolean }
@@ -555,7 +557,7 @@ export type StartRecordingInputs = { capture_target: ScreenCaptureTarget; captur
 export type StereoMode = "stereo" | "monoL" | "monoR"
 export type StudioRecordingMeta = { segment: SingleSegment } | { inner: MultipleSegments }
 export type StudioRecordingStatus = { status: "InProgress" } | { status: "NeedsRemux" } | { status: "Failed"; error: string } | { status: "Complete" }
-export type SystemDiagnostics = { macosVersion: MacOSVersionInfo | null; availableEncoders: string[]; screenCaptureSupported: boolean; metalSupported: boolean; gpuName: string | null }
+export type SystemDiagnostics = { windowsVersion: WindowsVersionInfo | null; gpuInfo: GpuInfoDiag | null; allGpus: AllGpusInfo | null; renderingStatus: RenderingStatus; availableEncoders: string[]; graphicsCaptureSupported: boolean; d3D11VideoProcessorAvailable: boolean }
 export type TargetUnderCursor = { display_id: DisplayId | null; window: WindowUnderCursor | null }
 export type TextSegment = { start: number; end: number; enabled?: boolean; content?: string; center?: XY<number>; size?: XY<number>; fontFamily?: string; fontSize?: number; fontWeight?: number; italic?: boolean; color?: string; fadeDuration?: number }
 export type TimelineConfiguration = { segments: TimelineSegment[]; zoomSegments: ZoomSegment[]; sceneSegments?: SceneSegment[]; maskSegments?: MaskSegment[]; textSegments?: TextSegment[] }
@@ -574,6 +576,7 @@ export type WindowExclusion = { bundleIdentifier?: string | null; ownerName?: st
 export type WindowId = string
 export type WindowPosition = { x: number; y: number; displayId?: DisplayId | null }
 export type WindowUnderCursor = { id: WindowId; app_name: string; bounds: LogicalBounds }
+export type WindowsVersionInfo = { major: number; minor: number; build: number; displayName: string; meetsRequirements: boolean; isWindows11: boolean }
 export type XY<T> = { x: T; y: T }
 export type ZoomMode = "auto" | { manual: { x: number; y: number } }
 export type ZoomSegment = { start: number; end: number; amount: number; mode: ZoomMode; glideDirection?: GlideDirection; glideSpeed?: number; instantAnimation?: boolean; edgeSnapRatio?: number }


### PR DESCRIPTION
## Fixes #1607 Add a setting to always ignore updates.

## Summary
This PR introduces a user setting that allows disabling automatic update checks.  
When enabled, the application will skip checking for updates entirely.

## Changes
- Added a new boolean field `disable_update_checks` in `GeneralSettingsStore`
- Implemented a toggle in the General Settings menu using `ToggleSettingItem`
- Updated `update.tsx` to skip update checks via an early return when the setting is enabled
- Added a dedicated signal for disabled update check state in `updates.tsx`.
- Updated `new-main/index.tsx` to skip automatic update checks on app startup when disabled

## Result
Users now have full control over whether the app performs update checks.

## Preview
<img width="855" height="641" alt="image" src="https://github.com/user-attachments/assets/deede105-efae-4ea4-bfbe-19e2b7c3d198" />

---

<img width="1147" height="784" alt="image" src="https://github.com/user-attachments/assets/2383b19a-251a-464d-b511-a62c4a71ac33" />