### PR TITLE
fix: prevent mask coverage gap during adjacent segment transitions

### DIFF
--- a/crates/rendering/src/mask.rs
+++ b/crates/rendering/src/mask.rs
@@ -87,15 +87,17 @@ pub fn interpolate_masks(
 
         let fade_duration = segment.fade_duration.max(0.0);
         if fade_duration > 0.0 {
+            let adjacency_epsilon = 1e-3;
+
             let adjacent_before = enabled
                 .iter()
                 .enumerate()
-                .any(|(j, other)| i != j && (segment.start - other.end).abs() < fade_duration);
+                .any(|(j, other)| i != j && (segment.start - other.end).abs() < adjacency_epsilon);
 
             let adjacent_after = enabled
                 .iter()
                 .enumerate()
-                .any(|(j, other)| i != j && (other.start - segment.end).abs() < fade_duration);
+                .any(|(j, other)| i != j && (other.start - segment.end).abs() < adjacency_epsilon);
 
             let time_since_start = (frame_time - segment.start).max(0.0);
             let time_until_end = (segment.end - frame_time).max(0.0);


### PR DESCRIPTION
When two mask segments are directly adjacent (share a boundary) and a zoom is applied, the current interpolation logic can fade out/in at the shared edge. During the transition, opacity briefly drops at that boundary, exposing sensitive content.

All other behavior is unchanged: PreparedMask construction, clamping, feathering, and size handling remain identical.

Fixes: https://github.com/CapSoftware/Cap/issues/1619

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents opacity gaps during adjacent mask segment transitions by detecting when segments share boundaries and skipping fade-in/fade-out at those points

- Collects enabled segments upfront to enable index-based iteration
- Checks for adjacent segments before and after current segment using time boundaries
- Sets fade multipliers to 1.0 when adjacent segments detected, maintaining full opacity
- Found minor threshold issue: using `<` instead of `<=` may miss segments exactly at `fade_duration` apart

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor threshold precision fix recommended
- Core logic correctly detects adjacency and prevents fade gaps, but comparison operator should use `<=` instead of `<` to catch exact boundary matches at `fade_duration` distance
- crates/rendering/src/mask.rs - fix adjacency threshold comparison operators on lines 93 and 98

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/rendering/src/mask.rs | Added adjacency detection to prevent fade gaps at mask boundaries - logic is sound but has a minor threshold precision issue |

</details>



<sub>Last reviewed commit: 1354425</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->