### PR TITLE
feat(desktop): extend deeplinks + add Raycast extension scaffold

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -26,6 +26,15 @@ pub enum DeepLinkAction {
         mode: RecordingMode,
     },
     StopRecording,
+    PauseRecording,
+    ResumeRecording,
+    TogglePauseRecording,
+    SwitchMicrophone {
+        mic_label: Option<String>,
+    },
+    SwitchCamera {
+        camera: Option<DeviceOrModelID>,
+    },
     OpenEditor {
         project_path: PathBuf,
     },
@@ -145,6 +154,21 @@ impl DeepLinkAction {
             }
             DeepLinkAction::StopRecording => {
                 crate::recording::stop_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::PauseRecording => {
+                crate::recording::pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::ResumeRecording => {
+                crate::recording::resume_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::TogglePauseRecording => {
+                crate::recording::toggle_pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::SwitchMicrophone { mic_label } => {
+                crate::set_mic_input(app.state(), mic_label).await
+            }
+            DeepLinkAction::SwitchCamera { camera } => {
+                crate::set_camera_input(app.clone(), app.state(), camera, None).await
             }
             DeepLinkAction::OpenEditor { project_path } => {
                 crate::open_project_from_path(Path::new(&project_path), app.clone())

--- a/apps/raycast/README.md
+++ b/apps/raycast/README.md
@@ -1,0 +1,22 @@
+# Cap Raycast Extension (WIP)
+
+This extension controls the Cap desktop app through `cap-desktop://action?value=...` deeplinks.
+
+## Supported actions
+
+- `start_recording`
+- `stop_recording`
+- `pause_recording`
+- `resume_recording`
+- `toggle_pause_recording`
+- `switch_microphone`
+- `switch_camera`
+
+## Development
+
+```bash
+pnpm install
+pnpm dev
+```
+
+> Requires the Cap desktop app to be installed and registered for the `cap-desktop://` URL scheme.

--- a/apps/raycast/package.json
+++ b/apps/raycast/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "cap-raycast",
+  "title": "Cap",
+  "description": "Control Cap desktop recording via deeplinks",
+  "version": "0.0.1",
+  "author": "Cap Contributors",
+  "license": "MIT",
+  "commands": [
+    {
+      "name": "start-recording",
+      "title": "Start Recording",
+      "description": "Start a Cap recording from Raycast",
+      "mode": "view"
+    },
+    {
+      "name": "stop-recording",
+      "title": "Stop Recording",
+      "description": "Stop an active Cap recording",
+      "mode": "no-view"
+    },
+    {
+      "name": "pause-recording",
+      "title": "Pause Recording",
+      "description": "Pause active recording",
+      "mode": "no-view"
+    },
+    {
+      "name": "resume-recording",
+      "title": "Resume Recording",
+      "description": "Resume paused recording",
+      "mode": "no-view"
+    },
+    {
+      "name": "toggle-pause-recording",
+      "title": "Toggle Pause Recording",
+      "description": "Toggle pause state",
+      "mode": "no-view"
+    },
+    {
+      "name": "switch-microphone",
+      "title": "Switch Microphone",
+      "description": "Switch Cap microphone by label",
+      "mode": "form"
+    },
+    {
+      "name": "switch-camera",
+      "title": "Switch Camera",
+      "description": "Switch Cap camera by id/model",
+      "mode": "form"
+    }
+  ],
+  "dependencies": {
+    "@raycast/api": "^1.99.0"
+  },
+  "devDependencies": {
+    "@raycast/eslint-config": "^2.0.0",
+    "@types/node": "20.17.24",
+    "eslint": "^8.57.0",
+    "prettier": "^3.5.3",
+    "typescript": "^5.8.2"
+  },
+  "scripts": {
+    "build": "ray build -e dist",
+    "dev": "ray dev",
+    "lint": "ray lint",
+    "publish": "ray publish"
+  }
+}

--- a/apps/raycast/src/lib/cap.ts
+++ b/apps/raycast/src/lib/cap.ts
@@ -1,0 +1,16 @@
+import { closeMainWindow, open, showHUD } from "@raycast/api";
+
+const CAP_DEEPLINK_ACTION_HOST = "action";
+
+export async function dispatchAction(action: unknown) {
+  const value = encodeURIComponent(JSON.stringify(action));
+  const url = `cap-desktop://${CAP_DEEPLINK_ACTION_HOST}?value=${value}`;
+
+  await open(url);
+  await closeMainWindow();
+}
+
+export async function fireSimpleAction(action: string) {
+  await dispatchAction({ type: action });
+  await showHUD(`Cap: ${action}`);
+}

--- a/apps/raycast/src/pause-recording.ts
+++ b/apps/raycast/src/pause-recording.ts
@@ -1,0 +1,5 @@
+import { fireSimpleAction } from "./lib/cap";
+
+export default async function Command() {
+  await fireSimpleAction("pause_recording");
+}

--- a/apps/raycast/src/resume-recording.ts
+++ b/apps/raycast/src/resume-recording.ts
@@ -1,0 +1,5 @@
+import { fireSimpleAction } from "./lib/cap";
+
+export default async function Command() {
+  await fireSimpleAction("resume_recording");
+}

--- a/apps/raycast/src/start-recording.tsx
+++ b/apps/raycast/src/start-recording.tsx
@@ -1,0 +1,55 @@
+import { Action, ActionPanel, Form, showHUD } from "@raycast/api";
+import { dispatchAction } from "./lib/cap";
+
+type Values = {
+  captureType: "screen" | "window";
+  captureName: string;
+  camera: string;
+  microphone: string;
+  captureSystemAudio: boolean;
+  mode: "studio" | "instant";
+};
+
+export default function Command() {
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Start Recording" onSubmit={onSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.Dropdown id="captureType" title="Capture Type" defaultValue="screen">
+        <Form.Dropdown.Item value="screen" title="Screen" />
+        <Form.Dropdown.Item value="window" title="Window" />
+      </Form.Dropdown>
+      <Form.TextField id="captureName" title="Capture Name" placeholder="Display or window name" />
+      <Form.TextField id="camera" title="Camera (optional)" placeholder="Device/model ID" />
+      <Form.TextField id="microphone" title="Microphone (optional)" placeholder="Mic label" />
+      <Form.Checkbox id="captureSystemAudio" title="Capture System Audio" defaultValue={false} />
+      <Form.Dropdown id="mode" title="Mode" defaultValue="studio">
+        <Form.Dropdown.Item value="studio" title="Studio" />
+        <Form.Dropdown.Item value="instant" title="Instant" />
+      </Form.Dropdown>
+    </Form>
+  );
+}
+
+async function onSubmit(values: Values) {
+  const captureMode =
+    values.captureType === "screen"
+      ? { screen: values.captureName }
+      : { window: values.captureName };
+
+  await dispatchAction({
+    start_recording: {
+      capture_mode: captureMode,
+      camera: values.camera ? { DeviceID: values.camera } : null,
+      mic_label: values.microphone || null,
+      capture_system_audio: values.captureSystemAudio,
+      mode: values.mode,
+    },
+  });
+
+  await showHUD("Cap: start_recording");
+}

--- a/apps/raycast/src/stop-recording.ts
+++ b/apps/raycast/src/stop-recording.ts
@@ -1,0 +1,5 @@
+import { fireSimpleAction } from "./lib/cap";
+
+export default async function Command() {
+  await fireSimpleAction("stop_recording");
+}

--- a/apps/raycast/src/switch-camera.tsx
+++ b/apps/raycast/src/switch-camera.tsx
@@ -1,0 +1,28 @@
+import { Action, ActionPanel, Form, showHUD } from "@raycast/api";
+import { dispatchAction } from "./lib/cap";
+
+type Values = { camera: string };
+
+export default function Command() {
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Switch Camera" onSubmit={onSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField id="camera" title="Camera Device/Model ID" placeholder="FaceTime HD Camera" />
+    </Form>
+  );
+}
+
+async function onSubmit(values: Values) {
+  await dispatchAction({
+    switch_camera: {
+      camera: values.camera ? { DeviceID: values.camera } : null,
+    },
+  });
+
+  await showHUD("Cap: switch_camera");
+}

--- a/apps/raycast/src/switch-microphone.tsx
+++ b/apps/raycast/src/switch-microphone.tsx
@@ -1,0 +1,28 @@
+import { Action, ActionPanel, Form, showHUD } from "@raycast/api";
+import { dispatchAction } from "./lib/cap";
+
+type Values = { micLabel: string };
+
+export default function Command() {
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Switch Microphone" onSubmit={onSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField id="micLabel" title="Microphone Label" placeholder="Built-in Microphone" />
+    </Form>
+  );
+}
+
+async function onSubmit(values: Values) {
+  await dispatchAction({
+    switch_microphone: {
+      mic_label: values.micLabel || null,
+    },
+  });
+
+  await showHUD("Cap: switch_microphone");
+}

--- a/apps/raycast/src/toggle-pause-recording.ts
+++ b/apps/raycast/src/toggle-pause-recording.ts
@@ -1,0 +1,5 @@
+import { fireSimpleAction } from "./lib/cap";
+
+export default async function Command() {
+  await fireSimpleAction("toggle_pause_recording");
+}


### PR DESCRIPTION
## Summary
- extend desktop deeplink actions with pause/resume/toggle pause
- add deeplink actions for switching microphone and camera
- add a Raycast extension scaffold in apps/raycast that dispatches Cap deeplinks for recording controls

## Deeplink actions added
- pause_recording
- resume_recording
- toggle_pause_recording
- switch_microphone
- switch_camera

Closes #1540

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended desktop deeplink actions to support pause/resume/toggle recording and device switching (microphone/camera), then added a Raycast extension scaffold to control Cap via these deeplinks.

- Added 5 new `DeepLinkAction` variants in Rust: `PauseRecording`, `ResumeRecording`, `TogglePauseRecording`, `SwitchMicrophone`, `SwitchCamera`
- Created new Raycast extension at `apps/raycast` with 7 commands that dispatch Cap deeplinks
- Critical issue: `fireSimpleAction` in `cap.ts` incorrectly wraps unit variants in `{ type: action }` instead of passing the plain string, which will cause deserialization failures for pause/resume/stop/toggle commands

<h3>Confidence Score: 2/5</h3>

- Critical bug in fireSimpleAction will break 4 of 7 Raycast commands
- The Rust backend implementation is solid, but the TypeScript deeplink dispatch function has a critical serialization bug that breaks unit variant deserialization. Commands using struct variants (start_recording, switch_camera, switch_microphone) will work, but commands using unit variants (pause_recording, resume_recording, stop_recording, toggle_pause_recording) will fail due to incorrect JSON format
- apps/raycast/src/lib/cap.ts requires immediate fix before merge

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/deeplink_actions.rs | Added new deeplink action variants and handlers for pause/resume/toggle and device switching |
| apps/raycast/src/lib/cap.ts | Core deeplink dispatch logic - contains critical bug in fireSimpleAction that will break unit variant actions |
| apps/raycast/src/pause-recording.ts | Pause recording command - affected by fireSimpleAction bug |
| apps/raycast/src/resume-recording.ts | Resume recording command - affected by fireSimpleAction bug |
| apps/raycast/src/stop-recording.ts | Stop recording command - affected by fireSimpleAction bug |
| apps/raycast/src/toggle-pause-recording.ts | Toggle pause command - affected by fireSimpleAction bug |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Raycast
    participant cap.ts
    participant Desktop App
    participant Rust Handler
    
    User->>Raycast: Trigger command
    Raycast->>cap.ts: fireSimpleAction("pause_recording")
    cap.ts->>cap.ts: JSON.stringify({ type: "pause_recording" })
    cap.ts->>Desktop App: cap-desktop://action?value=...
    Desktop App->>Rust Handler: Parse deeplink
    Rust Handler->>Rust Handler: serde_json::from_str<DeepLinkAction>
    Note over Rust Handler: FAILS - expects "pause_recording"<br/>but receives {"type":"pause_recording"}
    Rust Handler-->>User: Error: Failed to parse deeplink
    
    Note over cap.ts,Rust Handler: FIX: Pass action string directly,<br/>not wrapped in object
```

<sub>Last reviewed commit: a595e0e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->