### PR TITLE
Fix: add missing deeplink recording and device actions

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -26,6 +26,15 @@ pub enum DeepLinkAction {
         mode: RecordingMode,
     },
     StopRecording,
+    PauseRecording,
+    ResumeRecording,
+    TogglePauseRecording,
+    SetMicrophone {
+        mic_label: Option<String>,
+    },
+    SetCamera {
+        camera: Option<DeviceOrModelID>,
+    },
     OpenEditor {
         project_path: PathBuf,
     },
@@ -146,6 +155,21 @@ impl DeepLinkAction {
             DeepLinkAction::StopRecording => {
                 crate::recording::stop_recording(app.clone(), app.state()).await
             }
+            DeepLinkAction::PauseRecording => {
+                crate::recording::pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::ResumeRecording => {
+                crate::recording::resume_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::TogglePauseRecording => {
+                crate::recording::toggle_pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::SetMicrophone { mic_label } => {
+                crate::set_mic_input(app.state(), mic_label).await
+            }
+            DeepLinkAction::SetCamera { camera } => {
+                crate::set_camera_input(app.clone(), app.state(), camera, Some(true)).await
+            }
             DeepLinkAction::OpenEditor { project_path } => {
                 crate::open_project_from_path(Path::new(&project_path), app.clone())
             }
@@ -153,5 +177,51 @@ impl DeepLinkAction {
                 crate::show_window(app.clone(), ShowCapWindow::Settings { page }).await
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_pause_recording_legacy_json_deeplink() {
+        let url = Url::parse("cap-desktop://action?value=%22pause_recording%22").unwrap();
+        let action = DeepLinkAction::try_from(&url).unwrap();
+
+        assert!(matches!(action, DeepLinkAction::PauseRecording));
+    }
+
+    #[test]
+    fn parses_set_microphone_legacy_json_deeplink() {
+        let url = Url::parse(
+            "cap-desktop://action?value=%7B%22set_microphone%22:%7B%22mic_label%22:%22External%20Microphone%22%7D%7D",
+        )
+        .unwrap();
+
+        let action = DeepLinkAction::try_from(&url).unwrap();
+
+        assert!(matches!(
+            action,
+            DeepLinkAction::SetMicrophone { mic_label }
+            if mic_label.as_deref() == Some("External Microphone")
+        ));
+    }
+
+    #[test]
+    fn parses_set_camera_legacy_json_deeplink() {
+        let url = Url::parse(
+            "cap-desktop://action?value=%7B%22set_camera%22:%7B%22camera%22:%7B%22DeviceID%22:%22camera-1%22%7D%7D%7D",
+        )
+        .unwrap();
+
+        let action = DeepLinkAction::try_from(&url).unwrap();
+
+        assert!(matches!(
+            action,
+            DeepLinkAction::SetCamera {
+                camera: Some(DeviceOrModelID::DeviceID(id))
+            } if id == "camera-1"
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- add new desktop deeplink actions for recording controls: `pause_recording`, `resume_recording`, `toggle_pause_recording`
- add deeplink actions for device switching: `set_microphone` and `set_camera`
- wire new actions to existing desktop handlers in `recording.rs` and `lib.rs`
- add parsing tests for legacy JSON deeplinks to prevent regressions

## Testing
- Unable to run `cargo test -p cap-desktop deeplink_actions -- --nocapture` in this environment because `cargo` is not installed in PATH.

/claim #1540

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends `deeplink_actions.rs` with five new deeplink actions (`PauseRecording`, `ResumeRecording`, `TogglePauseRecording`, `SetMicrophone`, and `SetCamera`) and wires them to the existing Tauri command handlers in `recording.rs` and `lib.rs`. The changes are additive and follow established patterns already used by `StartRecording` and `StopRecording`.

**Key changes:**
- Three new unit-variant recording-control actions (`pause_recording`, `resume_recording`, `toggle_pause_recording`) delegate to the corresponding `crate::recording::*` functions.
- Two new parameterised device-switching actions (`SetMicrophone`, `SetCamera`) delegate to the private-but-descendant-accessible `crate::set_mic_input` and `crate::set_camera_input` Tauri commands.
- Parsing tests are added for 3 of 5 new actions; `ResumeRecording` and `TogglePauseRecording` do not have equivalent tests yet.
- `SetCamera` unconditionally passes `skip_camera_window: Some(true)`, suppressing the camera preview popup on camera switch — behaviour that differs from `StartRecording` and is currently undocumented.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor follow-up work on test coverage and one undocumented behaviour.
- The implementation is straightforward and mirrors existing deeplink patterns. Function signatures are correctly matched, serde naming aligns with the URL encoding in tests, and no breaking changes are introduced. The two gaps are: missing round-trip tests for `ResumeRecording` and `TogglePauseRecording`, and the silently-suppressed camera preview window for `SetCamera` deeplinks that could confuse future maintainers.
- apps/desktop/src-tauri/src/deeplink_actions.rs — review the missing tests and the `skip_camera_window: Some(true)` decision.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/deeplink_actions.rs | Adds `PauseRecording`, `ResumeRecording`, `TogglePauseRecording`, `SetMicrophone`, and `SetCamera` deeplink actions and wires them to existing handlers; parsing tests cover only 3 of 5 new actions (missing `ResumeRecording` and `TogglePauseRecording`), and the decision to suppress the camera preview window (`skip_camera_window: Some(true)`) for the `SetCamera` deeplink is undocumented. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    URL["cap-desktop://action?value=..."] --> Parse["DeepLinkAction::try_from(url)"]
    Parse --> Deserialise["serde_json::from_str(value)"]

    Deserialise -->|pause_recording| PR["PauseRecording"]
    Deserialise -->|resume_recording| RR["ResumeRecording"]
    Deserialise -->|toggle_pause_recording| TPR["TogglePauseRecording"]
    Deserialise -->|set_microphone| SM["SetMicrophone { mic_label }"]
    Deserialise -->|set_camera| SC["SetCamera { camera }"]

    PR --> pause["crate::recording::pause_recording()"]
    RR --> resume["crate::recording::resume_recording()"]
    TPR --> toggle["crate::recording::toggle_pause_recording()"]
    SM --> setMic["crate::set_mic_input(state, mic_label)"]
    SC --> setCam["crate::set_camera_input(app, state, camera, Some(true))"]

    setCam -->|skip_camera_window=true| noPop["Camera preview window NOT shown"]
    setCam -->|camera=None| disableCam["Camera input removed"]
```

<sub>Last reviewed commit: bf6f9aa</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->