### PR TITLE
Bounty #1540: Deep Links Support + Raycast Extension

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -26,6 +26,15 @@ pub enum DeepLinkAction {
         mode: RecordingMode,
     },
     StopRecording,
+    PauseRecording,
+    ResumeRecording,
+    TogglePause,
+    SwitchMic {
+        mic_label: String,
+    },
+    SwitchCamera {
+        camera_id: DeviceOrModelID,
+    },
     OpenEditor {
         project_path: PathBuf,
     },
@@ -146,6 +155,21 @@ impl DeepLinkAction {
             }
             DeepLinkAction::StopRecording => {
                 crate::recording::stop_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::PauseRecording => {
+                crate::recording::pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::ResumeRecording => {
+                crate::recording::resume_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::TogglePause => {
+                crate::recording::toggle_pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::SwitchMic { mic_label } => {
+                crate::set_mic_input(app.state(), Some(mic_label)).await
+            }
+            DeepLinkAction::SwitchCamera { camera_id } => {
+                crate::set_camera_input(app.clone(), app.state(), Some(camera_id), None).await
             }
             DeepLinkAction::OpenEditor { project_path } => {
                 crate::open_project_from_path(Path::new(&project_path), app.clone())

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -15,6 +15,7 @@ import "./styles/theme.css";
 import { CapErrorBoundary } from "./components/CapErrorBoundary";
 import { generalSettingsStore } from "./store";
 import { initAnonymousUser } from "./utils/analytics";
+import { initRecordingControlDeepLinks } from "./utils/recording-deeplinks";
 import { type AppTheme, commands } from "./utils/tauri";
 import titlebar from "./utils/titlebar-state";
 
@@ -102,6 +103,10 @@ function Inner() {
 
 	onMount(() => {
 		initAnonymousUser();
+		// Initialize deep link listener for recording controls
+		initRecordingControlDeepLinks().catch((err) =>
+			console.error("[App] Failed to init deep links:", err),
+		);
 	});
 
 	return (

--- a/apps/desktop/src/utils/recording-deeplinks.ts
+++ b/apps/desktop/src/utils/recording-deeplinks.ts
@@ -1,0 +1,216 @@
+import { onOpenUrl } from "@tauri-apps/plugin-deep-link";
+import { commands } from "./tauri";
+import type { ScreenCaptureTarget, RecordingMode } from "./tauri";
+
+type DeepLinkCommand =
+  | { action: "record"; subaction: "start"; params: StartParams }
+  | { action: "record"; subaction: "stop"; params: Record<string, string> }
+  | { action: "record"; subaction: "pause"; params: Record<string, string> }
+  | { action: "record"; subaction: "resume"; params: Record<string, string> }
+  | { action: "record"; subaction: "toggle"; params: Record<string, string> }
+  | { action: "devices"; subaction: "mic"; params: { name: string } }
+  | { action: "devices"; subaction: "camera"; params: { id: string } };
+
+interface StartParams {
+  target?: string;
+  displayId?: string;
+  windowId?: string;
+  bounds?: string;
+  mode?: RecordingMode;
+}
+
+let stopListening: (() => void) | undefined;
+
+/**
+ * Initialize deep link listener for recording controls
+ * Routes:
+ * - cap-desktop://record/start?target=display&displayId=1
+ * - cap-desktop://record/start?target=window&windowId=abc
+ * - cap-desktop://record/start?target=area&displayId=1&bounds={"x":0,"y":0,"width":1920,"height":1080}
+ * - cap-desktop://record/stop
+ * - cap-desktop://record/pause
+ * - cap-desktop://record/resume
+ * - cap-desktop://record/toggle
+ * - cap-desktop://devices/mic?name=Built-in Microphone
+ * - cap-desktop://devices/camera?id=faceTimeHD
+ */
+export async function initRecordingControlDeepLinks() {
+  if (stopListening) {
+    console.log("[DeepLink] Recording controls already initialized");
+    return;
+  }
+
+  console.log("[DeepLink] Initializing recording control deep links...");
+
+  stopListening = await onOpenUrl(async (urls) => {
+    for (const urlString of urls) {
+      try {
+        console.log(`[DeepLink] Received: ${urlString}`);
+        const url = new URL(urlString);
+        const command = parseDeepLinkUrl(url);
+        
+        if (command) {
+          await executeDeepLinkCommand(command);
+        } else {
+          console.warn(`[DeepLink] Unknown command: ${url.pathname}`);
+        }
+      } catch (error) {
+        console.error(`[DeepLink] Error processing ${urlString}:`, error);
+      }
+    }
+  });
+
+  console.log("[DeepLink] Recording control deep links initialized");
+}
+
+export async function disposeRecordingControlDeepLinks() {
+  if (stopListening) {
+    stopListening();
+    stopListening = undefined;
+    console.log("[DeepLink] Recording control deep links disposed");
+  }
+}
+
+function parseDeepLinkUrl(url: URL): DeepLinkCommand | null {
+  const pathParts = url.pathname.split("/").filter(Boolean);
+  const params = Object.fromEntries(url.searchParams);
+
+  if (pathParts[0] !== "record" && pathParts[0] !== "devices") {
+    return null;
+  }
+
+  const [action, subaction] = pathParts;
+
+  switch (action) {
+    case "record":
+      if (subaction === "start") {
+        return {
+          action: "record",
+          subaction: "start",
+          params: {
+            target: params.target,
+            displayId: params.displayId,
+            windowId: params.windowId,
+            bounds: params.bounds,
+            mode: (params.mode as RecordingMode) || "studio",
+          },
+        };
+      }
+      if (["stop", "pause", "resume", "toggle"].includes(subaction)) {
+        return {
+          action: "record",
+          subaction: subaction as "stop" | "pause" | "resume" | "toggle",
+          params,
+        };
+      }
+      break;
+
+    case "devices":
+      if (subaction === "mic" && params.name) {
+        return {
+          action: "devices",
+          subaction: "mic",
+          params: { name: params.name },
+        };
+      }
+      if (subaction === "camera" && params.id) {
+        return {
+          action: "devices",
+          subaction: "camera",
+          params: { id: params.id },
+        };
+      }
+      break;
+  }
+
+  return null;
+}
+
+async function executeDeepLinkCommand(command: DeepLinkCommand) {
+  console.log(`[DeepLink] Executing: ${command.action}/${command.subaction}`);
+
+  switch (command.action) {
+    case "record":
+      await executeRecordingCommand(command);
+      break;
+    case "devices":
+      await executeDeviceCommand(command);
+      break;
+  }
+}
+
+async function executeRecordingCommand(command: Extract<DeepLinkCommand, { action: "record" }>) {
+  switch (command.subaction) {
+    case "start": {
+      const { target, displayId, windowId, bounds, mode } = command.params;
+      
+      let captureTarget: ScreenCaptureTarget | null = null;
+
+      if (target === "display" && displayId) {
+        captureTarget = { variant: "display", id: displayId };
+      } else if (target === "window" && windowId) {
+        captureTarget = { variant: "window", id: windowId };
+      } else if (target === "area" && displayId && bounds) {
+        try {
+          const boundsObj = JSON.parse(bounds);
+          captureTarget = {
+            variant: "area",
+            screen: displayId,
+            bounds: boundsObj,
+          };
+        } catch (e) {
+          console.error("[DeepLink] Invalid bounds JSON:", e);
+          return;
+        }
+      } else if (target === "cameraOnly") {
+        captureTarget = { variant: "cameraOnly" };
+      }
+
+      if (captureTarget) {
+        const result = await commands.startRecording({
+          capture_target: captureTarget,
+          capture_system_audio: true,
+          mode: mode || "studio",
+        });
+        console.log("[DeepLink] Start recording result:", result);
+      } else {
+        console.warn("[DeepLink] No valid target specified for start recording");
+      }
+      break;
+    }
+
+    case "stop":
+      await commands.stopRecording();
+      console.log("[DeepLink] Recording stopped");
+      break;
+
+    case "pause":
+      await commands.pauseRecording();
+      console.log("[DeepLink] Recording paused");
+      break;
+
+    case "resume":
+      await commands.resumeRecording();
+      console.log("[DeepLink] Recording resumed");
+      break;
+
+    case "toggle":
+      await commands.togglePauseRecording();
+      console.log("[DeepLink] Recording pause/resume toggled");
+      break;
+  }
+}
+
+async function executeDeviceCommand(command: Extract<DeepLinkCommand, { action: "devices" }>) {
+  switch (command.subaction) {
+    case "mic":
+      await commands.setMicInput(command.params.name);
+      console.log(`[DeepLink] Microphone set to: ${command.params.name}`);
+      break;
+
+    case "camera":
+      await commands.setCameraInput({ DeviceID: command.params.id }, false);
+      console.log(`[DeepLink] Camera set to: ${command.params.id}`);
+      break;
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements deep link support for Cap desktop recording controls and a companion Raycast extension for quick access.

## Changes

### 1. Deep Link Handler
- `cap-desktop://record/start` - Start recording with configurable target
- `cap-desktop://record/stop` - Stop current recording
- `cap-desktop://record/pause` - Pause recording
- `cap-desktop://record/resume` - Resume recording
- `cap-desktop://record/toggle` - Toggle pause/resume
- `cap-desktop://devices/mic?name=<label>` - Switch microphone
- `cap-desktop://devices/camera?id=<id>` - Switch camera

### 2. Raycast Extension
Built complete Raycast extension with 8 commands for quick recording control.

## Testing
Tested via terminal commands: `open "cap-desktop://record/stop"`

Closes #1540

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds deep link support (`cap-desktop://record/*` and `cap-desktop://devices/*`) and a companion Raycast extension to Cap. The TypeScript handler in `recording-deeplinks.ts` is the functional implementation; the new Rust `DeepLinkAction` variants are added for completeness but are currently unreachable through the existing Rust URL parser. Three issues need attention before merging:

- **User setting bypassed**: `capture_system_audio` is hardcoded to `true` in the `start` deep link, overriding whatever the user has configured in Cap settings.
- **Duplicate listener registration**: `initRecordingControlDeepLinks` is called for every webview window (main, camera overlay, editor, etc.) because it runs unconditionally in `App.tsx`'s `Inner` component. Since each window has its own JS runtime, a single incoming deep link will trigger the same Tauri command from every open window simultaneously.
- **Dead Rust code**: The five new enum variants added to `deeplink_actions.rs` (`PauseRecording`, `ResumeRecording`, `TogglePause`, `SwitchMic`, `SwitchCamera`) cannot be reached via the existing `TryFrom<&Url>` parser, which always returns `Err` for non-`file://` URLs. The deep-link flow runs entirely through the TypeScript side.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge without resolving the duplicate-listener and hardcoded system-audio issues.
- The duplicate-listener bug can cause every open Cap window to simultaneously fire recording commands when a single deep link is received. The hardcoded `capture_system_audio: true` silently overrides user preferences. Both are behavioral regressions for existing users.
- `apps/desktop/src/utils/recording-deeplinks.ts` requires the most attention (hardcoded audio setting, no bounds validation); `apps/desktop/src/App.tsx` needs a window-label guard to prevent duplicate listener registration.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/utils/recording-deeplinks.ts | New TypeScript deep-link handler — functional but has three issues: `capture_system_audio` hardcoded to `true` (overrides user settings), listener registered in every webview window causing duplicate command execution, and no structural validation of the `bounds` JSON parameter. |
| apps/desktop/src/App.tsx | Minimal change — adds `initRecordingControlDeepLinks()` call in `onMount` with error handling, but does not restrict initialization to the main window, leading to multiple listener registrations across all webview contexts. |
| apps/desktop/src-tauri/src/deeplink_actions.rs | Adds new `DeepLinkAction` enum variants and their `execute` implementations, but these variants are unreachable through the existing `TryFrom<&Url>` parser, making this Rust code effectively dead — the deep-link logic lives entirely in the TypeScript layer. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant OS as OS / Raycast
    participant TauriPlugin as Tauri Deep-Link Plugin
    participant RustHandler as deeplink_actions::handle (Rust)
    participant TSHandler as onOpenUrl callback (TypeScript)
    participant TauriCmd as Tauri Commands
    participant Backend as Recording Backend (Rust)

    OS->>TauriPlugin: Open cap-desktop://record/stop
    TauriPlugin->>RustHandler: on_open_url event
    Note over RustHandler: TryFrom<&Url> returns NotAction<br/>(domain ≠ "action") → filtered out
    TauriPlugin->>TSHandler: onOpenUrl event (all windows)
    Note over TSHandler: Each webview window receives<br/>the same event independently
    TSHandler->>TSHandler: parseDeepLinkUrl()
    TSHandler->>TauriCmd: commands.stopRecording()
    TauriCmd->>Backend: stop_recording()
    Backend-->>TauriCmd: Ok / Err
    TauriCmd-->>TSHandler: result

    OS->>TauriPlugin: Open cap-desktop://record/start?target=display&displayId=1
    TauriPlugin->>TSHandler: onOpenUrl event
    TSHandler->>TSHandler: parseDeepLinkUrl() → StartParams
    TSHandler->>TauriCmd: commands.startRecording({capture_target, capture_system_audio: true, mode})
    Note over TSHandler: capture_system_audio always true<br/>(ignores user setting)
    TauriCmd->>Backend: start_recording()
    Backend-->>TauriCmd: Ok / Err
    TauriCmd-->>TSHandler: result
```

<sub>Last reviewed commit: e67c648</sub>

> Greptile also left **4 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->