### PR TITLE
feat: speed test and health check for desktop app

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ mod presets;
 mod recording;
 mod recording_settings;
 mod recovery;
+mod speed_test;
 mod screenshot_editor;
 mod target_select_overlay;
 mod thumbnails;
@@ -3141,6 +3142,9 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             recovery::find_incomplete_recordings,
             recovery::recover_recording,
             recovery::discard_incomplete_recording,
+            speed_test::run_speed_test,
+            speed_test::run_health_check,
+            speed_test::get_network_status,
         ])
         .events(tauri_specta::collect_events![
             RecordingOptionsChanged,
@@ -3167,6 +3171,8 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             import::VideoImportProgress,
             SetCaptureAreaPending,
             DevicesUpdated,
+            speed_test::SpeedTestUpdate,
+            speed_test::HealthCheckUpdate,
         ])
         .error_handling(tauri_specta::ErrorHandlingMode::Throw)
         .typ::<ProjectConfiguration>()
@@ -3310,6 +3316,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             app.manage(panel_manager::PanelManager::new());
             app.manage(http_client::HttpClient::default());
             app.manage(http_client::RetryableHttpClient::default());
+            app.manage(Arc::new(RwLock::new(speed_test::NetworkState::default())));
             app.manage(PendingScreenshots::default());
             app.manage(FinalizingRecordings::default());
 
@@ -3455,6 +3462,8 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             });
 
             audio_meter::spawn_event_emitter(app.clone(), mic_samples_rx);
+
+            speed_test::spawn_startup_health_check(app.clone());
 
             if let Err(err) = tray::create_tray(&app) {
                 error!("Failed to create tray: {err}");

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -923,17 +923,34 @@ pub async fn start_recording(
                                 return Err(anyhow!("Video upload info not found"));
                             };
 
+                            let settings_resolution = general_settings
+                                .as_ref()
+                                .map(|settings| settings.instant_mode_max_resolution)
+                                .unwrap_or(1920);
+
+                            let speed_test_resolution = {
+                                let network_state = app_handle
+                                    .state::<std::sync::Arc<tokio::sync::RwLock<crate::speed_test::NetworkState>>>();
+                                let state = network_state.read().await;
+                                match &state.speed_test_status {
+                                    crate::speed_test::SpeedTestStatus::Completed(result) => {
+                                        Some(result.recommended_quality.max_resolution())
+                                    }
+                                    _ => None,
+                                }
+                            };
+
+                            let max_resolution = match speed_test_resolution {
+                                Some(speed_res) => settings_resolution.min(speed_res),
+                                None => settings_resolution,
+                            };
+
                             let mut builder = instant_recording::Actor::builder(
                                 recording_dir.clone(),
                                 inputs.capture_target.clone(),
                             )
                             .with_system_audio(inputs.capture_system_audio)
-                            .with_max_output_size(
-                                general_settings
-                                    .as_ref()
-                                    .map(|settings| settings.instant_mode_max_resolution)
-                                    .unwrap_or(1920),
-                            );
+                            .with_max_output_size(max_resolution);
 
                             #[cfg(target_os = "macos")]
                             {
@@ -1043,6 +1060,8 @@ pub async fn start_recording(
 
     let _ = RecordingEvent::Started.emit(&app);
     let _ = RecordingStarted.emit(&app);
+
+    crate::speed_test::set_recording_active(&app, true).await;
 
     spawn_actor({
         let app = app.clone();
@@ -1235,6 +1254,8 @@ fn mic_actor_not_running(err: &anyhow::Error) -> bool {
 #[specta::specta]
 #[instrument(skip(app, state))]
 pub async fn stop_recording(app: AppHandle, state: MutableState<'_, App>) -> Result<(), String> {
+    crate::speed_test::set_recording_active(&app, false).await;
+
     let mut state = state.write().await;
     let Some(current_recording) = state.clear_current_recording() else {
         return Err("Recording not in progress".to_string())?;

--- a/apps/desktop/src-tauri/src/speed_test.rs
+++ b/apps/desktop/src-tauri/src/speed_test.rs
@@ -1,0 +1,357 @@
+use crate::web_api::ManagerExt;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::sync::Arc;
+use std::time::Duration;
+use tauri::{AppHandle, Manager};
+use tauri_specta::Event;
+use tokio::sync::RwLock;
+use tokio::time::Instant;
+use tracing::{info, warn};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum UploadQualityPreset {
+    Full,
+    High,
+    Medium,
+    Low,
+}
+
+impl UploadQualityPreset {
+    pub fn max_resolution(&self) -> u32 {
+        match self {
+            Self::Full => 3840,
+            Self::High => 1920,
+            Self::Medium => 1280,
+            Self::Low => 854,
+        }
+    }
+
+    pub fn from_speed_mbps(speed: f64) -> Self {
+        if speed >= 20.0 {
+            Self::Full
+        } else if speed >= 10.0 {
+            Self::High
+        } else if speed >= 5.0 {
+            Self::Medium
+        } else {
+            Self::Low
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Full => "Full (4K)",
+            Self::High => "High (1080p)",
+            Self::Medium => "Medium (720p)",
+            Self::Low => "Low (480p)",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SpeedTestResult {
+    pub upload_speed_mbps: f64,
+    pub recommended_quality: UploadQualityPreset,
+    pub timestamp_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthCheckResult {
+    pub server_reachable: bool,
+    pub auth_valid: bool,
+    pub upload_functional: bool,
+    pub message: String,
+    pub timestamp_ms: u64,
+}
+
+#[derive(Clone, Serialize, Type, tauri_specta::Event)]
+#[serde(rename_all = "camelCase")]
+pub struct SpeedTestUpdate {
+    pub status: SpeedTestStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum SpeedTestStatus {
+    Idle,
+    Running,
+    Completed(SpeedTestResult),
+    Failed(String),
+}
+
+#[derive(Clone, Serialize, Type, tauri_specta::Event)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthCheckUpdate {
+    pub result: HealthCheckResult,
+}
+
+pub struct NetworkState {
+    pub speed_test_status: SpeedTestStatus,
+    pub health_check_result: Option<HealthCheckResult>,
+    pub is_recording: bool,
+}
+
+impl Default for NetworkState {
+    fn default() -> Self {
+        Self {
+            speed_test_status: SpeedTestStatus::Idle,
+            health_check_result: None,
+            is_recording: false,
+        }
+    }
+}
+
+fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+const SPEED_TEST_PAYLOAD_SIZE: usize = 1024 * 1024;
+
+async fn measure_upload_speed(app: &AppHandle) -> Result<f64, String> {
+    let payload = vec![0u8; SPEED_TEST_PAYLOAD_SIZE];
+
+    let start = Instant::now();
+
+    let response = app
+        .api_request("/api/desktop/health-check", |c, url| {
+            c.post(url)
+                .header("Content-Type", "application/octet-stream")
+                .header("X-Speed-Test", "true")
+                .body(payload)
+                .timeout(Duration::from_secs(30))
+        })
+        .await
+        .map_err(|e| format!("Speed test request failed: {e}"))?;
+
+    let elapsed = start.elapsed();
+
+    if !response.status().is_success() {
+        let status = response.status().as_u16();
+        return Err(format!("Speed test endpoint returned {status}"));
+    }
+
+    let bytes_sent = SPEED_TEST_PAYLOAD_SIZE as f64;
+    let seconds = elapsed.as_secs_f64();
+    let bits_per_second = (bytes_sent * 8.0) / seconds;
+    let mbps = bits_per_second / 1_000_000.0;
+
+    Ok(mbps)
+}
+
+async fn check_server_health(app: &AppHandle) -> HealthCheckResult {
+    let server_reachable = match app
+        .api_request("/api/desktop/health-check", |c, url| {
+            c.get(url).timeout(Duration::from_secs(10))
+        })
+        .await
+    {
+        Ok(resp) => resp.status().is_success(),
+        Err(_) => false,
+    };
+
+    if !server_reachable {
+        return HealthCheckResult {
+            server_reachable: false,
+            auth_valid: false,
+            upload_functional: false,
+            message: "Cannot reach Cap server. Check your internet connection.".to_string(),
+            timestamp_ms: now_millis(),
+        };
+    }
+
+    let auth_valid = match app
+        .authed_api_request("/api/desktop/health-check", |c, url| {
+            c.get(url)
+                .header("X-Auth-Check", "true")
+                .timeout(Duration::from_secs(10))
+        })
+        .await
+    {
+        Ok(resp) => resp.status().is_success(),
+        Err(_) => false,
+    };
+
+    let upload_functional = if auth_valid {
+        let test_payload = vec![0u8; 1024];
+        match app
+            .authed_api_request("/api/desktop/health-check", |c, url| {
+                c.post(url)
+                    .header("Content-Type", "application/octet-stream")
+                    .header("X-Upload-Test", "true")
+                    .body(test_payload)
+                    .timeout(Duration::from_secs(15))
+            })
+            .await
+        {
+            Ok(resp) => resp.status().is_success(),
+            Err(_) => false,
+        }
+    } else {
+        false
+    };
+
+    let message = if !auth_valid {
+        "Sign in to enable cloud uploads.".to_string()
+    } else if !upload_functional {
+        "Upload test failed. Please contact support.".to_string()
+    } else {
+        "All systems operational.".to_string()
+    };
+
+    HealthCheckResult {
+        server_reachable,
+        auth_valid,
+        upload_functional,
+        message,
+        timestamp_ms: now_millis(),
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn run_speed_test(app: AppHandle) -> Result<SpeedTestResult, String> {
+    let network_state = app.state::<Arc<RwLock<NetworkState>>>();
+
+    {
+        let state = network_state.read().await;
+        if state.is_recording {
+            return Err("Cannot run speed test during an active recording".to_string());
+        }
+        if matches!(state.speed_test_status, SpeedTestStatus::Running) {
+            return Err("Speed test is already running".to_string());
+        }
+    }
+
+    {
+        let mut state = network_state.write().await;
+        state.speed_test_status = SpeedTestStatus::Running;
+    }
+    SpeedTestUpdate {
+        status: SpeedTestStatus::Running,
+    }
+    .emit(&app)
+    .ok();
+
+    match measure_upload_speed(&app).await {
+        Ok(speed_mbps) => {
+            let result = SpeedTestResult {
+                upload_speed_mbps: (speed_mbps * 100.0).round() / 100.0,
+                recommended_quality: UploadQualityPreset::from_speed_mbps(speed_mbps),
+                timestamp_ms: now_millis(),
+            };
+
+            info!(
+                speed_mbps = result.upload_speed_mbps,
+                quality = ?result.recommended_quality,
+                "Speed test completed"
+            );
+
+            {
+                let mut state = network_state.write().await;
+                state.speed_test_status = SpeedTestStatus::Completed(result.clone());
+            }
+            SpeedTestUpdate {
+                status: SpeedTestStatus::Completed(result.clone()),
+            }
+            .emit(&app)
+            .ok();
+
+            Ok(result)
+        }
+        Err(err) => {
+            warn!(error = %err, "Speed test failed");
+
+            {
+                let mut state = network_state.write().await;
+                state.speed_test_status = SpeedTestStatus::Failed(err.clone());
+            }
+            SpeedTestUpdate {
+                status: SpeedTestStatus::Failed(err.clone()),
+            }
+            .emit(&app)
+            .ok();
+
+            Err(err)
+        }
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn run_health_check(app: AppHandle) -> Result<HealthCheckResult, String> {
+    let result = check_server_health(&app).await;
+
+    info!(
+        server_reachable = result.server_reachable,
+        auth_valid = result.auth_valid,
+        upload_functional = result.upload_functional,
+        message = %result.message,
+        "Health check completed"
+    );
+
+    let network_state = app.state::<Arc<RwLock<NetworkState>>>();
+    {
+        let mut state = network_state.write().await;
+        state.health_check_result = Some(result.clone());
+    }
+
+    HealthCheckUpdate {
+        result: result.clone(),
+    }
+    .emit(&app)
+    .ok();
+
+    Ok(result)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn get_network_status(
+    app: AppHandle,
+) -> Result<(SpeedTestStatus, Option<HealthCheckResult>), String> {
+    let network_state = app.state::<Arc<RwLock<NetworkState>>>();
+    let state = network_state.read().await;
+    Ok((
+        state.speed_test_status.clone(),
+        state.health_check_result.clone(),
+    ))
+}
+
+pub async fn set_recording_active(app: &AppHandle, active: bool) {
+    let network_state = app.state::<Arc<RwLock<NetworkState>>>();
+    let mut state = network_state.write().await;
+    state.is_recording = active;
+}
+
+pub fn spawn_startup_health_check(app: AppHandle) {
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let result = check_server_health(&app).await;
+        info!(
+            server_reachable = result.server_reachable,
+            auth_valid = result.auth_valid,
+            upload_functional = result.upload_functional,
+            "Startup health check completed"
+        );
+
+        let network_state = app.state::<Arc<RwLock<NetworkState>>>();
+        {
+            let mut state = network_state.write().await;
+            state.health_check_result = Some(result.clone());
+        }
+
+        HealthCheckUpdate {
+            result: result.clone(),
+        }
+        .emit(&app)
+        .ok();
+    });
+}

--- a/apps/desktop/src/components/NetworkStatus.tsx
+++ b/apps/desktop/src/components/NetworkStatus.tsx
@@ -1,0 +1,193 @@
+import { createMutation } from "@tanstack/solid-query";
+import { cx } from "cva";
+import {
+	createEffect,
+	createSignal,
+	onCleanup,
+	onMount,
+	Show,
+} from "solid-js";
+import Tooltip from "~/components/Tooltip";
+import {
+	commands,
+	events,
+	type HealthCheckResult,
+	type SpeedTestStatus,
+} from "~/utils/tauri";
+import IconLucideActivity from "~icons/lucide/activity";
+import IconLucideGauge from "~icons/lucide/gauge";
+import IconLucideCheck from "~icons/lucide/check";
+import IconLucideAlertTriangle from "~icons/lucide/alert-triangle";
+import IconLucideLoader from "~icons/lucide/loader-2";
+
+export default function NetworkStatus() {
+	const [speedStatus, setSpeedStatus] = createSignal<SpeedTestStatus>("idle");
+	const [healthResult, setHealthResult] =
+		createSignal<HealthCheckResult | null>(null);
+
+	onMount(async () => {
+		try {
+			const [status, health] = await commands.getNetworkStatus();
+			setSpeedStatus(status);
+			setHealthResult(health ?? null);
+		} catch (e) {
+			console.error("Failed to get network status:", e);
+		}
+	});
+
+	onMount(async () => {
+		const unlistenSpeed = await events.speedTestUpdate.listen((event) => {
+			setSpeedStatus(event.payload.status);
+		});
+
+		const unlistenHealth = await events.healthCheckUpdate.listen((event) => {
+			setHealthResult(event.payload.result);
+		});
+
+		onCleanup(() => {
+			unlistenSpeed();
+			unlistenHealth();
+		});
+	});
+
+	const speedTest = createMutation(() => ({
+		mutationKey: ["speed-test"],
+		mutationFn: async () => {
+			return await commands.runSpeedTest();
+		},
+	}));
+
+	const healthCheck = createMutation(() => ({
+		mutationKey: ["health-check"],
+		mutationFn: async () => {
+			return await commands.runHealthCheck();
+		},
+	}));
+
+	const speedLabel = () => {
+		const status = speedStatus();
+		if (status === "idle") return "Speed: --";
+		if (status === "running") return "Testing...";
+		if (typeof status === "object" && "completed" in status) {
+			return `${status.completed.uploadSpeedMbps} Mbps`;
+		}
+		if (typeof status === "object" && "failed" in status) {
+			return "Speed: Error";
+		}
+		return "Speed: --";
+	};
+
+	const speedQuality = () => {
+		const status = speedStatus();
+		if (typeof status === "object" && "completed" in status) {
+			return status.completed.recommendedQuality;
+		}
+		return null;
+	};
+
+	const qualityColor = () => {
+		const q = speedQuality();
+		if (!q) return "text-gray-10";
+		if (q === "full" || q === "high") return "text-green-10";
+		if (q === "medium") return "text-yellow-10";
+		return "text-red-10";
+	};
+
+	const healthOk = () => {
+		const result = healthResult();
+		if (!result) return null;
+		return result.serverReachable && result.authValid && result.uploadFunctional;
+	};
+
+	const healthColor = () => {
+		const ok = healthOk();
+		if (ok === null) return "text-gray-10";
+		if (ok) return "text-green-10";
+		return "text-red-10";
+	};
+
+	const healthMessage = () => {
+		const result = healthResult();
+		if (!result) return "Health check not run yet";
+		return result.message;
+	};
+
+	const isSpeedRunning = () => {
+		const status = speedStatus();
+		return status === "running";
+	};
+
+	return (
+		<div class="flex items-center gap-2 px-3 py-1.5 text-[11px]">
+			<Tooltip content={healthMessage()}>
+				<button
+					type="button"
+					onClick={() => healthCheck.mutate()}
+					disabled={healthCheck.isPending}
+					class={cx(
+						"flex items-center gap-1 rounded px-1.5 py-0.5 transition-colors hover:bg-gray-4",
+						healthColor(),
+					)}
+				>
+					<Show
+						when={!healthCheck.isPending}
+						fallback={
+							<IconLucideLoader class="size-3 animate-spin" />
+						}
+					>
+						<Show
+							when={healthOk() !== null}
+							fallback={<IconLucideActivity class="size-3" />}
+						>
+							<Show
+								when={healthOk()}
+								fallback={
+									<IconLucideAlertTriangle class="size-3" />
+								}
+							>
+								<IconLucideCheck class="size-3" />
+							</Show>
+						</Show>
+					</Show>
+					<span>
+						{healthOk() === null
+							? "Health"
+							: healthOk()
+								? "OK"
+								: "Issue"}
+					</span>
+				</button>
+			</Tooltip>
+
+			<div class="w-px h-3 bg-gray-6" />
+
+			<Tooltip
+				content={
+					speedQuality()
+						? `Recommended quality: ${speedQuality()}`
+						: "Run a speed test to check upload bandwidth"
+				}
+			>
+				<button
+					type="button"
+					onClick={() => speedTest.mutate()}
+					disabled={isSpeedRunning() || speedTest.isPending}
+					class={cx(
+						"flex items-center gap-1 rounded px-1.5 py-0.5 transition-colors hover:bg-gray-4",
+						qualityColor(),
+					)}
+				>
+					<Show
+						when={!isSpeedRunning()}
+						fallback={
+							<IconLucideLoader class="size-3 animate-spin" />
+						}
+					>
+						<IconLucideGauge class="size-3" />
+					</Show>
+					<span>{speedLabel()}</span>
+				</button>
+			</Tooltip>
+		</div>
+	);
+}

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -32,6 +32,7 @@ import {
 import { createStore, produce, reconcile } from "solid-js/store";
 import { Transition } from "solid-transition-group";
 import Mode from "~/components/Mode";
+import NetworkStatus from "~/components/NetworkStatus";
 import { RecoveryToast } from "~/components/RecoveryToast";
 import Tooltip from "~/components/Tooltip";
 import { Input } from "~/routes/editor/ui";
@@ -1983,6 +1984,7 @@ function Page() {
 				</Show>
 			</div>
 			<RecoveryToast />
+		<NetworkStatus />
 		</div>
 	);
 }

--- a/apps/web/app/api/desktop/[...route]/health-check.ts
+++ b/apps/web/app/api/desktop/[...route]/health-check.ts
@@ -1,0 +1,39 @@
+import { Hono } from "hono";
+import { withOptionalAuth } from "../../utils";
+
+export const app = new Hono();
+
+app.get("/", withOptionalAuth, async (c) => {
+	const isAuthCheck = c.req.header("X-Auth-Check") === "true";
+	const user = c.get("user");
+
+	if (isAuthCheck && !user) {
+		return c.json({ ok: false, message: "Not authenticated" }, 401);
+	}
+
+	return c.json({
+		ok: true,
+		timestamp: Date.now(),
+		authenticated: !!user,
+	});
+});
+
+app.post("/", withOptionalAuth, async (c) => {
+	const isSpeedTest = c.req.header("X-Speed-Test") === "true";
+	const isUploadTest = c.req.header("X-Upload-Test") === "true";
+
+	if (isSpeedTest || isUploadTest) {
+		try {
+			const body = await c.req.arrayBuffer();
+			return c.json({
+				ok: true,
+				bytesReceived: body.byteLength,
+				timestamp: Date.now(),
+			});
+		} catch {
+			return c.json({ ok: false, message: "Failed to process upload" }, 500);
+		}
+	}
+
+	return c.json({ ok: true, timestamp: Date.now() });
+});

--- a/apps/web/app/api/desktop/[...route]/route.ts
+++ b/apps/web/app/api/desktop/[...route]/route.ts
@@ -3,6 +3,7 @@ import { handle } from "hono/vercel";
 
 import { corsMiddleware } from "../../utils";
 
+import * as healthCheck from "./health-check";
 import * as root from "./root";
 import * as s3Config from "./s3Config";
 import * as session from "./session";
@@ -11,6 +12,7 @@ import * as video from "./video";
 const app = new Hono()
 	.basePath("/api/desktop")
 	.use(corsMiddleware)
+	.route("/health-check", healthCheck.app)
 	.route("/s3/config", s3Config.app)
 	.route("/session", session.app)
 	.route("/video", video.app)


### PR DESCRIPTION
## Summary

Implements the speed test and health check system requested in #73.

- **Speed test module** (`speed_test.rs`): Measures upload bandwidth by sending a 1MB test payload to a new `/api/desktop/health-check` endpoint. Maps speed results to quality presets (Full/High/Medium/Low) that cap the recording resolution accordingly.
- **Health check**: Runs automatically on startup (3s delay) to verify server reachability, authentication validity, and upload functionality. Results are surfaced via events to the frontend.
- **Quality adjustment**: When starting an instant recording, the max output resolution is capped to the lower of the user's setting and the speed-test-recommended resolution.
- **Recording guard**: Speed tests are blocked during active recordings to avoid bandwidth contention.
- **UI indicator** (`NetworkStatus.tsx`): Shows health status (OK/Issue) and upload speed in the bottom of the main window. Both are clickable to manually re-run checks. Tooltips provide details.
- **Web API endpoint** (`health-check.ts`): Lightweight Hono route under `/api/desktop/health-check` that handles GET (health/auth check) and POST (speed test/upload test) requests.

### Files changed
- `apps/desktop/src-tauri/src/speed_test.rs` — new Rust module with speed test, health check, network state, and Tauri commands/events
- `apps/desktop/src-tauri/src/lib.rs` — register module, commands, events, managed state, and startup health check
- `apps/desktop/src-tauri/src/recording.rs` — integrate recording-active flag and speed-based resolution capping
- `apps/desktop/src/components/NetworkStatus.tsx` — new SolidJS component for health/speed indicators
- `apps/desktop/src/routes/(window-chrome)/new-main/index.tsx` — mount NetworkStatus in main window
- `apps/web/app/api/desktop/[...route]/health-check.ts` — new health check API endpoint
- `apps/web/app/api/desktop/[...route]/route.ts` — register health-check route

## Test plan

- [ ] Verify health check runs on app startup and shows green indicator when server is reachable and user is authenticated
- [ ] Verify health check shows warning when user is not signed in
- [ ] Verify speed test button triggers a test and displays the upload speed in Mbps
- [ ] Verify speed test cannot be triggered during an active recording
- [ ] Verify instant recordings use the speed-test-recommended resolution cap
- [ ] Verify the `/api/desktop/health-check` endpoint returns correct responses for GET and POST
- [ ] Verify tooltips show detailed status information

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a speed test and health check system for the desktop app. A new Rust module (`speed_test.rs`) measures upload bandwidth via a 1MB POST to a new `/api/desktop/health-check` Hono endpoint, maps results to quality presets that cap instant recording resolution, and runs an automatic health check on startup. A SolidJS `NetworkStatus` component surfaces health and speed status in the main window.

- **Recording flag bug**: `is_recording` is set to `true` when recording starts but is never reset on recording failure/crash (only on explicit `stop_recording`), which permanently blocks speed tests after a crash.
- **Premature flag reset**: `set_recording_active(false)` is called at the top of `stop_recording` before validating a recording exists or successfully stopping it.
- **Unauthenticated POST endpoint**: The health-check POST handler accepts arbitrary-size payloads without authentication or rate limiting, which could be abused.
- **Indentation issue**: `<NetworkStatus />` in the main window JSX has incorrect indentation.

<h3>Confidence Score: 2/5</h3>

- This PR has logic bugs in recording state management that could leave the speed test permanently blocked after a recording crash.
- The recording-active flag is never cleared on recording failure, creating a stuck state. Additionally, the flag is cleared prematurely in stop_recording before validation. These are real bugs that will manifest in production when recordings crash or stop_recording is called unexpectedly.
- `apps/desktop/src-tauri/src/recording.rs` needs the most attention — both the error path in `spawn_actor` and the ordering in `stop_recording` have issues with the `is_recording` flag lifecycle.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/speed_test.rs | New module implementing speed test, health check, and network state management. Well-structured with proper async/locking patterns. Minor: `label()` method is unused (dead code). |
| apps/desktop/src-tauri/src/lib.rs | Clean integration of speed_test module — registers commands, events, managed state, and startup health check. No issues found. |
| apps/desktop/src-tauri/src/recording.rs | Integrates recording-active flag and speed-based resolution capping. Has two logic bugs: `is_recording` flag is never reset on recording failure/crash, and `set_recording_active(false)` is called before validating a recording exists in `stop_recording`. |
| apps/desktop/src/components/NetworkStatus.tsx | New SolidJS component showing health and speed indicators with tooltips. Clean reactive patterns using signals, events, and mutations. |
| apps/desktop/src/routes/(window-chrome)/new-main/index.tsx | Mounts NetworkStatus component at bottom of main window. Has an indentation mismatch — `NetworkStatus` uses 2 tabs while sibling `RecoveryToast` uses 3. |
| apps/web/app/api/desktop/[...route]/health-check.ts | New Hono health-check endpoint with GET (health/auth) and POST (speed/upload test). POST accepts unauthenticated arbitrary-size payloads without rate limiting. |
| apps/web/app/api/desktop/[...route]/route.ts | Registers the new health-check route under `/api/desktop/health-check`. Straightforward addition matching existing patterns. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as NetworkStatus UI
    participant Tauri as Tauri Commands
    participant State as NetworkState
    participant API as /api/desktop/health-check

    Note over Tauri: App startup (3s delay)
    Tauri->>API: GET /health-check
    API-->>Tauri: {ok, authenticated}
    Tauri->>API: GET /health-check (X-Auth-Check)
    API-->>Tauri: 200 / 401
    Tauri->>API: POST /health-check (1KB, X-Upload-Test)
    API-->>Tauri: {ok, bytesReceived}
    Tauri->>State: Update health_check_result
    Tauri->>UI: HealthCheckUpdate event

    UI->>Tauri: runSpeedTest()
    Tauri->>State: Check is_recording (block if true)
    Tauri->>State: Set status = Running
    Tauri->>UI: SpeedTestUpdate(Running)
    Tauri->>API: POST /health-check (1MB, X-Speed-Test)
    API-->>Tauri: {ok, bytesReceived}
    Tauri->>State: Set status = Completed(result)
    Tauri->>UI: SpeedTestUpdate(Completed)

    Note over Tauri: start_recording()
    Tauri->>State: set_recording_active(true)
    Note over Tauri: Resolution = min(settings, speed_test)

    Note over Tauri: stop_recording()
    Tauri->>State: set_recording_active(false)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src-tauri/src/recording.rs`, line 1257-1264 ([link](https://github.com/capsoftware/cap/blob/eb8e7b2e62e1b235de30fe8f419043ac0d934a3d/apps/desktop/src-tauri/src/recording.rs#L1257-L1264)) 

   **`set_recording_active(false)` called before state validation**

   `set_recording_active(&app, false)` is called unconditionally at the start of `stop_recording`, before checking whether a recording is actually in progress (line 1260). If `stop_recording` is called when no recording exists, this will set `is_recording = false` even though it was never `true` — which is benign but incorrect. More importantly, if `stop_recording` fails partway through (e.g., at line 1264), the flag is already cleared, so the speed test thinks no recording is active while a partially-stopped recording may still be in progress.

   Consider moving this call after successfully stopping the recording:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src-tauri/src/recording.rs
   Line: 1257-1264

   Comment:
   **`set_recording_active(false)` called before state validation**

   `set_recording_active(&app, false)` is called unconditionally at the start of `stop_recording`, before checking whether a recording is actually in progress (line 1260). If `stop_recording` is called when no recording exists, this will set `is_recording = false` even though it was never `true` — which is benign but incorrect. More importantly, if `stop_recording` fails partway through (e.g., at line 1264), the flag is already cleared, so the speed test thinks no recording is active while a partially-stopped recording may still be in progress.

   Consider moving this call after successfully stopping the recording:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/recording.rs
Line: 1064

Comment:
**Recording failure leaves speed test permanently blocked**

When a recording fails or crashes (the error path in `spawn_actor` at line ~1078), `set_recording_active(&app, false)` is never called. The flag is set to `true` at line 1064, but only `stop_recording` (line 1257) resets it to `false`. If the recording actor errors out via the `Err(e)` branch, `is_recording` stays `true` forever, permanently blocking the speed test with "Cannot run speed test during an active recording".

You should reset the flag in the error handler as well:

```rust
                Err(e) => {
                    let mut state = state_mtx.write().await;

                    crate::speed_test::set_recording_active(&app, false).await;

                    let _ = RecordingEvent::Failed {
                        error: e.to_string(),
                    }
                    .emit(&app);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/recording.rs
Line: 1257-1264

Comment:
**`set_recording_active(false)` called before state validation**

`set_recording_active(&app, false)` is called unconditionally at the start of `stop_recording`, before checking whether a recording is actually in progress (line 1260). If `stop_recording` is called when no recording exists, this will set `is_recording = false` even though it was never `true` — which is benign but incorrect. More importantly, if `stop_recording` fails partway through (e.g., at line 1264), the flag is already cleared, so the speed test thinks no recording is active while a partially-stopped recording may still be in progress.

Consider moving this call after successfully stopping the recording:

```suggestion
    let mut state = state.write().await;
    let Some(current_recording) = state.clear_current_recording() else {
        return Err("Recording not in progress".to_string())?;
    };

    let completed_recording = current_recording.stop().await.map_err(|e| e.to_string())?;
    crate::speed_test::set_recording_active(&app, false).await;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
Line: 1987

Comment:
**Incorrect indentation level**

`<NetworkStatus />` is indented with 2 tabs, but its sibling `<RecoveryToast />` above uses 3 tabs. Both are children of the same parent `<div>`.

```suggestion
			<NetworkStatus />
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/app/api/desktop/[...route]/health-check.ts
Line: 21-39

Comment:
**Unauthenticated POST endpoint accepts arbitrary payloads**

The POST handler uses `withOptionalAuth` and reads the entire request body into memory with `c.req.arrayBuffer()` without any size limit or authentication requirement. Since the speed test sends 1MB payloads and there's no rate limiting on this route, this endpoint could be abused to consume server memory/bandwidth. Consider either:
- Requiring authentication (`withAuth`) for POST requests, or
- Adding a body size limit (e.g., rejecting bodies > 2MB), or
- Adding rate limiting to this endpoint

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: eb8e7b2</sub>

> Greptile also left **3 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->