### PR TITLE
feat: configurable auto-zoom settings with UI sliders

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -124,6 +124,8 @@ pub struct GeneralSettingsStore {
     #[serde(default)]
     pub auto_zoom_on_clicks: bool,
     #[serde(default)]
+    pub auto_zoom_config: cap_project::AutoZoomConfig,
+    #[serde(default)]
     pub post_deletion_behaviour: PostDeletionBehaviour,
     #[serde(default = "default_excluded_windows")]
     pub excluded_windows: Vec<WindowExclusion>,
@@ -203,6 +205,7 @@ impl Default for GeneralSettingsStore {
             recording_countdown: Some(3),
             enable_native_camera_preview: default_enable_native_camera_preview(),
             auto_zoom_on_clicks: false,
+            auto_zoom_config: cap_project::AutoZoomConfig::default(),
             post_deletion_behaviour: PostDeletionBehaviour::DoNothing,
             excluded_windows: default_excluded_windows(),
             delete_instant_recordings_after_upload: false,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2111,17 +2111,21 @@ async fn update_project_config_in_memory(
 
 #[tauri::command]
 #[specta::specta]
-#[instrument(skip(editor_instance))]
+#[instrument(skip(app, editor_instance))]
 async fn generate_zoom_segments_from_clicks(
+    app: AppHandle,
     editor_instance: WindowEditorInstance,
 ) -> Result<Vec<ZoomSegment>, String> {
+    let settings = GeneralSettingsStore::get(&app)
+        .unwrap_or(None)
+        .unwrap_or_default();
     let meta = editor_instance.meta();
     let recordings = &editor_instance.recordings;
 
     let zoom_segments = recording::generate_zoom_segments_for_project(
         meta,
         recordings,
-        &cap_project::AutoZoomConfig::default(),
+        &settings.auto_zoom_config,
     );
 
     Ok(zoom_segments)

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2118,7 +2118,11 @@ async fn generate_zoom_segments_from_clicks(
     let meta = editor_instance.meta();
     let recordings = &editor_instance.recordings;
 
-    let zoom_segments = recording::generate_zoom_segments_for_project(meta, recordings);
+    let zoom_segments = recording::generate_zoom_segments_for_project(
+        meta,
+        recordings,
+        &cap_project::AutoZoomConfig::default(),
+    );
 
     Ok(zoom_segments)
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2122,11 +2122,8 @@ async fn generate_zoom_segments_from_clicks(
     let meta = editor_instance.meta();
     let recordings = &editor_instance.recordings;
 
-    let zoom_segments = recording::generate_zoom_segments_for_project(
-        meta,
-        recordings,
-        &settings.auto_zoom_config,
-    );
+    let zoom_segments =
+        recording::generate_zoom_segments_for_project(meta, recordings, &settings.auto_zoom_config);
 
     Ok(zoom_segments)
 }

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -1989,29 +1989,28 @@ async fn finalize_studio_recording(
     Ok(())
 }
 
-/// Core logic for generating zoom segments based on mouse click events.
-/// This is an experimental feature that automatically creates zoom effects
-/// around user interactions to highlight important moments.
 fn generate_zoom_segments_from_clicks_impl(
     mut clicks: Vec<CursorClickEvent>,
     mut moves: Vec<CursorMoveEvent>,
     max_duration: f64,
+    config: &cap_project::AutoZoomConfig,
 ) -> Vec<ZoomSegment> {
     const STOP_PADDING_SECONDS: f64 = 0.5;
-    const CLICK_GROUP_TIME_THRESHOLD_SECS: f64 = 2.5;
-    const CLICK_GROUP_SPATIAL_THRESHOLD: f64 = 0.15;
-    const CLICK_PRE_PADDING: f64 = 0.4;
-    const CLICK_POST_PADDING: f64 = 1.8;
-    const MOVEMENT_PRE_PADDING: f64 = 0.3;
-    const MOVEMENT_POST_PADDING: f64 = 1.5;
-    const MERGE_GAP_THRESHOLD: f64 = 0.8;
-    const MIN_SEGMENT_DURATION: f64 = 1.0;
     const MOVEMENT_WINDOW_SECONDS: f64 = 1.5;
-    const MOVEMENT_EVENT_DISTANCE_THRESHOLD: f64 = 0.02;
-    const MOVEMENT_WINDOW_DISTANCE_THRESHOLD: f64 = 0.08;
-    const AUTO_ZOOM_AMOUNT: f64 = 1.5;
     const SHAKE_FILTER_THRESHOLD: f64 = 0.33;
     const SHAKE_FILTER_WINDOW_MS: f64 = 150.0;
+
+    let click_group_time_threshold_secs = config.click_group_time_threshold;
+    let click_group_spatial_threshold = config.click_group_spatial_threshold;
+    let click_pre_padding = config.click_pre_padding;
+    let click_post_padding = config.click_post_padding;
+    let movement_pre_padding = config.movement_pre_padding;
+    let movement_post_padding = config.movement_post_padding;
+    let merge_gap_threshold = config.merge_gap_threshold;
+    let min_segment_duration = config.min_segment_duration;
+    let movement_event_distance_threshold = config.movement_event_distance_threshold;
+    let movement_window_distance_threshold = config.movement_window_distance_threshold;
+    let auto_zoom_amount = config.zoom_amount;
 
     if max_duration <= 0.0 {
         return Vec::new();
@@ -2076,13 +2075,13 @@ fn generate_zoom_segments_from_clicks_impl(
             let can_join = group.iter().any(|&group_idx| {
                 let group_click = &clicks[group_idx];
                 let group_time = group_click.time_ms / 1000.0;
-                let time_close = (click_time - group_time).abs() < CLICK_GROUP_TIME_THRESHOLD_SECS;
+                let time_close = (click_time - group_time).abs() < click_group_time_threshold_secs;
 
                 let spatial_close = match (click_pos, click_positions.get(&group_idx)) {
                     (Some((x1, y1)), Some((x2, y2))) => {
                         let dx = x1 - x2;
                         let dy = y1 - y2;
-                        (dx * dx + dy * dy).sqrt() < CLICK_GROUP_SPATIAL_THRESHOLD
+                        (dx * dx + dy * dy).sqrt() < click_group_spatial_threshold
                     }
                     _ => true,
                 };
@@ -2116,8 +2115,8 @@ fn generate_zoom_segments_from_clicks_impl(
         let group_start = times.iter().cloned().fold(f64::INFINITY, f64::min);
         let group_end = times.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
 
-        let start = (group_start - CLICK_PRE_PADDING).max(0.0);
-        let end = (group_end + CLICK_POST_PADDING).min(activity_end_limit);
+        let start = (group_start - click_pre_padding).max(0.0);
+        let end = (group_end + click_post_padding).min(activity_end_limit);
 
         if end > start {
             intervals.push((start, end));
@@ -2199,15 +2198,15 @@ fn generate_zoom_segments_from_clicks_impl(
             window_distance = 0.0;
         }
 
-        let significant_movement = distance >= MOVEMENT_EVENT_DISTANCE_THRESHOLD
-            || window_distance >= MOVEMENT_WINDOW_DISTANCE_THRESHOLD;
+        let significant_movement = distance >= movement_event_distance_threshold
+            || window_distance >= movement_window_distance_threshold;
 
         if !significant_movement {
             continue;
         }
 
-        let start = (time - MOVEMENT_PRE_PADDING).max(0.0);
-        let end = (time + MOVEMENT_POST_PADDING).min(activity_end_limit);
+        let start = (time - movement_pre_padding).max(0.0);
+        let end = (time + movement_post_padding).min(activity_end_limit);
 
         if end > start {
             intervals.push((start, end));
@@ -2223,7 +2222,7 @@ fn generate_zoom_segments_from_clicks_impl(
     let mut merged: Vec<(f64, f64)> = Vec::new();
     for interval in intervals {
         if let Some(last) = merged.last_mut()
-            && interval.0 <= last.1 + MERGE_GAP_THRESHOLD
+            && interval.0 <= last.1 + merge_gap_threshold
         {
             last.1 = last.1.max(interval.1);
             continue;
@@ -2235,14 +2234,14 @@ fn generate_zoom_segments_from_clicks_impl(
         .into_iter()
         .filter_map(|(start, end)| {
             let duration = end - start;
-            if duration < MIN_SEGMENT_DURATION {
+            if duration < min_segment_duration {
                 return None;
             }
 
             Some(ZoomSegment {
                 start,
                 end,
-                amount: AUTO_ZOOM_AMOUNT,
+                amount: auto_zoom_amount,
                 mode: ZoomMode::Auto,
                 glide_direction: GlideDirection::None,
                 glide_speed: 0.5,
@@ -2253,13 +2252,11 @@ fn generate_zoom_segments_from_clicks_impl(
         .collect()
 }
 
-/// Generates zoom segments based on mouse click events during recording.
-/// Used during the recording completion process.
 pub fn generate_zoom_segments_from_clicks(
     recording: &studio_recording::CompletedRecording,
     recordings: &ProjectRecordingsMeta,
+    config: &cap_project::AutoZoomConfig,
 ) -> Vec<ZoomSegment> {
-    // Build a temporary RecordingMeta so we can use the common implementation
     let recording_meta = RecordingMeta {
         platform: None,
         project_path: recording.project_path.clone(),
@@ -2269,14 +2266,13 @@ pub fn generate_zoom_segments_from_clicks(
         upload: None,
     };
 
-    generate_zoom_segments_for_project(&recording_meta, recordings)
+    generate_zoom_segments_for_project(&recording_meta, recordings, config)
 }
 
-/// Generates zoom segments from clicks for an existing project.
-/// Used in the editor context where we have RecordingMeta.
 pub fn generate_zoom_segments_for_project(
     recording_meta: &RecordingMeta,
     recordings: &ProjectRecordingsMeta,
+    config: &cap_project::AutoZoomConfig,
 ) -> Vec<ZoomSegment> {
     let RecordingMetaInner::Studio(studio_meta) = &recording_meta.inner else {
         return Vec::new();
@@ -2309,7 +2305,7 @@ pub fn generate_zoom_segments_for_project(
         }
     }
 
-    generate_zoom_segments_from_clicks_impl(all_clicks, all_moves, recordings.duration())
+    generate_zoom_segments_from_clicks_impl(all_clicks, all_moves, recordings.duration(), config)
 }
 
 fn project_config_from_recording(
@@ -2355,7 +2351,11 @@ fn project_config_from_recording(
         .collect::<Vec<_>>();
 
     let zoom_segments = if settings.auto_zoom_on_clicks {
-        generate_zoom_segments_from_clicks(completed_recording, recordings)
+        generate_zoom_segments_from_clicks(
+            completed_recording,
+            recordings,
+            &settings.auto_zoom_config,
+        )
     } else {
         Vec::new()
     };
@@ -2429,8 +2429,12 @@ mod tests {
 
     #[test]
     fn skips_trailing_stop_click() {
-        let segments =
-            generate_zoom_segments_from_clicks_impl(vec![click_event(11_900.0)], vec![], 12.0);
+        let segments = generate_zoom_segments_from_clicks_impl(
+            vec![click_event(11_900.0)],
+            vec![],
+            12.0,
+            &cap_project::AutoZoomConfig::default(),
+        );
 
         assert!(
             segments.is_empty(),
@@ -2447,7 +2451,12 @@ mod tests {
             move_event(1_940.0, 0.74, 0.78),
         ];
 
-        let segments = generate_zoom_segments_from_clicks_impl(clicks, moves, 20.0);
+        let segments = generate_zoom_segments_from_clicks_impl(
+            clicks,
+            moves,
+            20.0,
+            &cap_project::AutoZoomConfig::default(),
+        );
 
         assert!(
             !segments.is_empty(),
@@ -2469,7 +2478,12 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let segments = generate_zoom_segments_from_clicks_impl(Vec::new(), jitter_moves, 15.0);
+        let segments = generate_zoom_segments_from_clicks_impl(
+            Vec::new(),
+            jitter_moves,
+            15.0,
+            &cap_project::AutoZoomConfig::default(),
+        );
 
         assert!(
             segments.is_empty(),

--- a/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
@@ -1,11 +1,49 @@
+import { Slider as KSlider } from "@kobalte/core/slider";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { type } from "@tauri-apps/plugin-os";
 import { createResource, Show } from "solid-js";
 import { createStore } from "solid-js/store";
 
 import { generalSettingsStore } from "~/store";
-import { commands, type GeneralSettingsStore } from "~/utils/tauri";
+import {
+	commands,
+	type AutoZoomConfig,
+	type GeneralSettingsStore,
+} from "~/utils/tauri";
 import { ToggleSettingItem } from "./Setting";
+
+function SettingSlider(props: {
+	label: string;
+	value: number;
+	onChange: (v: number) => void;
+	min: number;
+	max: number;
+	step: number;
+	format?: (v: number) => string;
+}) {
+	return (
+		<div class="space-y-1.5">
+			<div class="flex justify-between items-center text-sm">
+				<span class="text-gray-11">{props.label}</span>
+				<span class="text-gray-12 font-medium">
+					{props.format ? props.format(props.value) : props.value}
+				</span>
+			</div>
+			<KSlider
+				value={[props.value]}
+				onChange={(v) => props.onChange(v[0])}
+				minValue={props.min}
+				maxValue={props.max}
+				step={props.step}
+			>
+				<KSlider.Track class="h-[0.3rem] cursor-pointer relative bg-gray-4 rounded-full w-full">
+					<KSlider.Fill class="absolute h-full rounded-full bg-blue-9" />
+					<KSlider.Thumb class="block size-4 rounded-full bg-white border-2 border-blue-9 -top-[0.35rem] outline-none" />
+				</KSlider.Track>
+			</KSlider>
+		</div>
+	);
+}
 
 export default function ExperimentalSettings() {
 	const [store] = createResource(() => generalSettingsStore.get());
@@ -27,8 +65,31 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 			enableNativeCameraPreview: false,
 			autoZoomOnClicks: false,
 			custom_cursor_capture2: true,
+			autoZoomConfig: {
+				zoomAmount: 1.5,
+				clickGroupTimeThreshold: 2.5,
+				clickGroupSpatialThreshold: 0.15,
+				clickPrePadding: 0.4,
+				clickPostPadding: 1.8,
+				movementPrePadding: 0.3,
+				movementPostPadding: 1.5,
+				mergeGapThreshold: 0.8,
+				minSegmentDuration: 1.0,
+				movementEventDistanceThreshold: 0.02,
+				movementWindowDistanceThreshold: 0.08,
+			},
 		},
 	);
+
+	const handleConfigChange = <K extends keyof AutoZoomConfig>(
+		key: K,
+		value: AutoZoomConfig[K],
+	) => {
+		setSettings("autoZoomConfig", key, value);
+		generalSettingsStore.set({
+			autoZoomConfig: { ...settings.autoZoomConfig, [key]: value },
+		});
+	};
 
 	const handleChange = async <K extends keyof typeof settings>(
 		key: K,
@@ -95,6 +156,53 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 							}}
 						/>
 					</div>
+					<Show when={settings.autoZoomOnClicks}>
+						<div class="px-3 py-3 space-y-4">
+							<SettingSlider
+								label="Zoom Amount"
+								value={settings.autoZoomConfig?.zoomAmount ?? 1.5}
+								onChange={(v) => handleConfigChange("zoomAmount", v)}
+								min={1.0}
+								max={4.0}
+								step={0.1}
+								format={(v) => `${v.toFixed(1)}x`}
+							/>
+							<SettingSlider
+								label="Sensitivity"
+								value={
+									settings.autoZoomConfig
+										?.movementWindowDistanceThreshold ?? 0.08
+								}
+								onChange={(v) =>
+									handleConfigChange(
+										"movementWindowDistanceThreshold",
+										v,
+									)
+								}
+								min={0.02}
+								max={0.2}
+								step={0.01}
+								format={(v) => {
+									if (v <= 0.05) return "High";
+									if (v <= 0.12) return "Medium";
+									return "Low";
+								}}
+							/>
+							<SettingSlider
+								label="Smoothing"
+								value={
+									settings.autoZoomConfig?.mergeGapThreshold ?? 0.8
+								}
+								onChange={(v) =>
+									handleConfigChange("mergeGapThreshold", v)
+								}
+								min={0.2}
+								max={2.0}
+								step={0.1}
+								format={(v) => `${v.toFixed(1)}s`}
+							/>
+						</div>
+					</Show>
 				</div>
 			</div>
 		</div>

--- a/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
@@ -6,8 +6,8 @@ import { createStore } from "solid-js/store";
 
 import { generalSettingsStore } from "~/store";
 import {
-	commands,
 	type AutoZoomConfig,
+	commands,
 	type GeneralSettingsStore,
 } from "~/utils/tauri";
 import { ToggleSettingItem } from "./Setting";
@@ -170,14 +170,11 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 							<SettingSlider
 								label="Sensitivity"
 								value={
-									settings.autoZoomConfig
-										?.movementWindowDistanceThreshold ?? 0.08
+									settings.autoZoomConfig?.movementWindowDistanceThreshold ??
+									0.08
 								}
 								onChange={(v) =>
-									handleConfigChange(
-										"movementWindowDistanceThreshold",
-										v,
-									)
+									handleConfigChange("movementWindowDistanceThreshold", v)
 								}
 								min={0.02}
 								max={0.2}
@@ -190,12 +187,8 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 							/>
 							<SettingSlider
 								label="Smoothing"
-								value={
-									settings.autoZoomConfig?.mergeGapThreshold ?? 0.8
-								}
-								onChange={(v) =>
-									handleConfigChange("mergeGapThreshold", v)
-								}
+								value={settings.autoZoomConfig?.mergeGapThreshold ?? 0.8}
+								onChange={(v) => handleConfigChange("mergeGapThreshold", v)}
 								min={0.2}
 								max={2.0}
 								step={0.1}

--- a/crates/project/src/configuration.rs
+++ b/crates/project/src/configuration.rs
@@ -455,6 +455,40 @@ impl Default for ScreenMovementSpring {
     }
 }
 
+#[derive(Type, Serialize, Deserialize, Clone, Copy, Debug)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AutoZoomConfig {
+    pub zoom_amount: f64,
+    pub click_group_time_threshold: f64,
+    pub click_group_spatial_threshold: f64,
+    pub click_pre_padding: f64,
+    pub click_post_padding: f64,
+    pub movement_pre_padding: f64,
+    pub movement_post_padding: f64,
+    pub merge_gap_threshold: f64,
+    pub min_segment_duration: f64,
+    pub movement_event_distance_threshold: f64,
+    pub movement_window_distance_threshold: f64,
+}
+
+impl Default for AutoZoomConfig {
+    fn default() -> Self {
+        Self {
+            zoom_amount: 1.5,
+            click_group_time_threshold: 2.5,
+            click_group_spatial_threshold: 0.15,
+            click_pre_padding: 0.4,
+            click_post_padding: 1.8,
+            movement_pre_padding: 0.3,
+            movement_post_padding: 1.5,
+            merge_gap_threshold: 0.8,
+            min_segment_duration: 1.0,
+            movement_event_distance_threshold: 0.02,
+            movement_window_distance_threshold: 0.08,
+        }
+    }
+}
+
 impl CursorAnimationStyle {
     pub fn preset(self) -> Option<CursorSmoothingPreset> {
         match self {


### PR DESCRIPTION
## Summary

Promotes auto-zoom from experimental toggle to configurable feature (refs #1646):

- **New `AutoZoomConfig` struct** — extracts all 11 hardcoded constants from zoom segment generation into a serializable, backward-compatible config with `#[serde(default)]`
- **Wired through the full stack** — `GeneralSettingsStore` → Tauri IPC command → `generate_zoom_segments_from_clicks_impl`
- **3 settings sliders** in Experimental Settings (shown when auto-zoom is enabled): Zoom Amount (1-4x), Sensitivity (High/Medium/Low), Smoothing (0.2-2.0s)
- **Zero behavior change** for existing recordings — all defaults match the previous hardcoded values exactly

### Files changed

| File | Change |
|------|--------|
| `crates/project/src/configuration.rs` | Added `AutoZoomConfig` struct with 11 fields |
| `apps/desktop/src-tauri/src/general_settings.rs` | Added `auto_zoom_config` to `GeneralSettingsStore` |
| `apps/desktop/src-tauri/src/recording.rs` | Parameterized segment generation to accept config |
| `apps/desktop/src-tauri/src/lib.rs` | Updated IPC command to pass settings config |
| `apps/desktop/src/routes/.../experimental.tsx` | Added `SettingSlider` component and 3 config sliders |

### Backward compatibility

Every new field uses `#[serde(default)]` with values matching the old hardcoded constants:

| Old Constant | Default |
|---|---|
| `AUTO_ZOOM_AMOUNT` | 1.5 |
| `CLICK_GROUP_TIME_THRESHOLD_SECS` | 2.5 |
| `CLICK_GROUP_SPATIAL_THRESHOLD` | 0.15 |
| `CLICK_PRE_PADDING` | 0.4 |
| `CLICK_POST_PADDING` | 1.8 |
| `MERGE_GAP_THRESHOLD` | 0.8 |
| `MIN_SEGMENT_DURATION` | 1.0 |

This is the first of 5 incremental PRs to promote auto-zoom to production quality.

## Test plan

- [ ] Existing 3 Rust tests pass with `AutoZoomConfig::default()` — verified locally (`cargo check -p cap-project` passes; tests require ffmpeg for full `cap-desktop` build)
- [ ] Open Settings → Experimental → Enable "Auto zoom on clicks" → sliders appear
- [ ] Adjust sliders → values persist across settings close/reopen
- [ ] Record a Studio Mode session with auto-zoom → zoom segments generated with configured amount
- [ ] Existing recordings without config render identically (serde defaults)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes auto-zoom from an on/off experimental toggle to a fully configurable feature by extracting 11 hardcoded constants into a new `AutoZoomConfig` struct that is persisted in `GeneralSettingsStore` and surfaced via three UI sliders (Zoom Amount, Sensitivity, Smoothing). The Rust side is clean and backward-compatible — all defaults match the previous constants and `#[serde(default)]` is used throughout. The TypeScript UI is well-structured with a reusable `SettingSlider` component.

**Notable issues:**

- **Sensitivity slider controls only half the detection condition** — `movementEventDistanceThreshold` (per-frame) is left at its default `0.02` while only `movementWindowDistanceThreshold` is exposed. Since the significance check uses `||`, the per-frame branch can still fire at the "Low" end of the slider, making the sensitivity control weaker than users would expect.
- **Hardcoded TS defaults duplicate Rust defaults** — the inline fallback object in `Inner` (lines 68–80) mirrors `AutoZoomConfig::default()` exactly, creating a hidden maintenance dependency that could silently drift.
- **Minor: non-idiomatic error handling** — `unwrap_or(None)` on the settings fetch in `lib.rs` is functional but less readable than the `.ok().flatten()` pattern already used elsewhere in the codebase.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for an experimental feature branch, but the Sensitivity slider has a functional gap that could confuse users expecting full low-sensitivity behaviour.
- The Rust plumbing and serde compatibility are solid. The main concern is the UX correctness of the Sensitivity slider — lowering it to "Low" still allows frequent zoom triggers via the unconfigured per-frame distance threshold. This won't cause crashes or data loss but it is a user-visible behaviour mismatch that should ideally be addressed before the feature is promoted to non-experimental. Score also reflects the duplicate default values and the minor idiomatic issue.
- Pay close attention to `apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx` — the Sensitivity slider and the hardcoded default config object both warrant a second look before this exits experimental.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx | Adds SettingSlider component and 3 config sliders. Key issue: the "Sensitivity" slider only adjusts movementWindowDistanceThreshold, leaving movementEventDistanceThreshold at its default, which weakens the low-sensitivity end of the range. Also hardcodes default config values that duplicate Rust defaults. |
| crates/project/src/configuration.rs | Adds AutoZoomConfig struct with 11 fields, all with serde defaults matching previous hardcoded constants. Clean implementation with proper derive macros and camelCase serialization for TypeScript interop. |
| apps/desktop/src-tauri/src/general_settings.rs | Adds auto_zoom_config field to GeneralSettingsStore with #[serde(default)], correctly wired through Default impl. Straightforward and backward-compatible. |
| apps/desktop/src-tauri/src/recording.rs | Parameterizes generate_zoom_segments_from_clicks_impl, generate_zoom_segments_from_clicks, and generate_zoom_segments_for_project to accept &AutoZoomConfig. Hardcoded constants correctly extracted into config locals. STOP_PADDING_SECONDS, MOVEMENT_WINDOW_SECONDS, SHAKE_FILTER_THRESHOLD, and SHAKE_FILTER_WINDOW_MS intentionally remain as internal constants. Tests updated to pass AutoZoomConfig::default(). |
| apps/desktop/src-tauri/src/lib.rs | generate_zoom_segments_from_clicks command now accepts AppHandle to load settings and pass auto_zoom_config. Uses slightly non-idiomatic unwrap_or(None) pattern (minor style issue) to fetch settings. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as experimental.tsx
    participant Store as generalSettingsStore
    participant IPC as Tauri IPC
    participant GSS as GeneralSettingsStore
    participant REC as recording.rs
    participant CFG as AutoZoomConfig

    UI->>Store: generalSettingsStore.set({ autoZoomConfig })
    Store->>IPC: persists to disk (JSON with camelCase)

    Note over UI,IPC: Editor — "Generate zoom from clicks"
    UI->>IPC: generate_zoom_segments_from_clicks()
    IPC->>GSS: GeneralSettingsStore::get(&app)
    GSS-->>IPC: Ok(Some(settings)) or fallback to Default
    IPC->>REC: generate_zoom_segments_for_project(meta, recordings, &settings.auto_zoom_config)
    REC->>CFG: destructure AutoZoomConfig fields
    CFG-->>REC: zoom_amount, thresholds, paddings…
    REC-->>IPC: Vec<ZoomSegment>
    IPC-->>UI: zoom segments applied to timeline

    Note over REC,CFG: Recording completion (studio mode)
    REC->>GSS: GeneralSettingsStore::get(&app)
    GSS-->>REC: settings with auto_zoom_config
    REC->>REC: generate_zoom_segments_from_clicks(recording, recordings, &settings.auto_zoom_config)
    REC-->>REC: project_config with zoom_segments
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx`, line 58-82 ([link](https://github.com/capsoftware/cap/blob/680a8e5aabbb09bcbf730b4eeea1afbee80abee1/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx#L58-L82)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Hardcoded defaults duplicated from Rust**

   The `autoZoomConfig` default object on lines 68–80 exactly mirrors the values in `AutoZoomConfig::default()` in Rust. This creates a silent maintenance hazard: if any default changes on the Rust side (e.g. tuning `click_post_padding` in a later PR), the TypeScript fallback silently stays stale and the UI will show incorrect defaults when `initialStore` is `null`.

   Since `initialStore` comes from `generalSettingsStore.get()` and the backend already applies `#[serde(default)]`, the TypeScript fallback is only exercised before the first async load. Consider trusting the backend for defaults and initialising the store without an inline `autoZoomConfig` override, or at minimum adding a comment linking the two so reviewers know to keep them in sync.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
   Line: 58-82

   Comment:
   **Hardcoded defaults duplicated from Rust**

   The `autoZoomConfig` default object on lines 68–80 exactly mirrors the values in `AutoZoomConfig::default()` in Rust. This creates a silent maintenance hazard: if any default changes on the Rust side (e.g. tuning `click_post_padding` in a later PR), the TypeScript fallback silently stays stale and the UI will show incorrect defaults when `initialStore` is `null`.

   Since `initialStore` comes from `generalSettingsStore.get()` and the backend already applies `#[serde(default)]`, the TypeScript fallback is only exercised before the first async load. Consider trusting the backend for defaults and initialising the store without an inline `autoZoomConfig` override, or at minimum adding a comment linking the two so reviewers know to keep them in sync.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
Line: 170-187

Comment:
**"Sensitivity" slider only controls half the detection condition**

The "Sensitivity" slider adjusts `movementWindowDistanceThreshold` (cumulative window distance) but leaves `movementEventDistanceThreshold` (per-frame distance) fixed at `0.02`. In `generate_zoom_segments_from_clicks_impl`, movement detection is an **OR** condition:

```rust
let significant_movement = distance >= movement_event_distance_threshold   // fixed: 0.02
    || window_distance >= movement_window_distance_threshold;              // slider-controlled
```

This means even at "Low" sensitivity (`movementWindowDistanceThreshold = 0.2`), any single frame where the cursor travels ≥ 2% of normalised screen width still triggers a zoom. In practice the per-frame branch can dominate, making the "Low" end of the slider much weaker than users expect.

To make the slider fully effective, both thresholds should scale together. You could either:
- Expose `movementEventDistanceThreshold` as part of the sensitivity curve, or
- Derive `movementEventDistanceThreshold` proportionally from the `movementWindowDistanceThreshold` value rather than keeping it at its hardcoded default.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
Line: 58-82

Comment:
**Hardcoded defaults duplicated from Rust**

The `autoZoomConfig` default object on lines 68–80 exactly mirrors the values in `AutoZoomConfig::default()` in Rust. This creates a silent maintenance hazard: if any default changes on the Rust side (e.g. tuning `click_post_padding` in a later PR), the TypeScript fallback silently stays stale and the UI will show incorrect defaults when `initialStore` is `null`.

Since `initialStore` comes from `generalSettingsStore.get()` and the backend already applies `#[serde(default)]`, the TypeScript fallback is only exercised before the first async load. Consider trusting the backend for defaults and initialising the store without an inline `autoZoomConfig` override, or at minimum adding a comment linking the two so reviewers know to keep them in sync.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/lib.rs
Line: 2119-2121

Comment:
**Idiomatic error handling with `ok().flatten()`**

`unwrap_or(None)` on a `Result<Option<T>>` is non-idiomatic and silently discards the error. The codebase already uses a cleaner pattern elsewhere (e.g. `recording.rs:598` uses `.ok().flatten()`):

```suggestion
    let settings = GeneralSettingsStore::get(&app)
        .ok()
        .flatten()
        .unwrap_or_default();
```

This makes the intent explicit — convert `Err` to `None`, then fall back to defaults — and is consistent with the rest of the file.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["style: apply cargo f..."](https://github.com/capsoftware/cap/commit/680a8e5aabbb09bcbf730b4eeea1afbee80abee1)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->