### PR TITLE
feat: dead zone logic for auto-zoom to prevent jittery segments

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -124,6 +124,8 @@ pub struct GeneralSettingsStore {
     #[serde(default)]
     pub auto_zoom_on_clicks: bool,
     #[serde(default)]
+    pub auto_zoom_config: cap_project::AutoZoomConfig,
+    #[serde(default)]
     pub post_deletion_behaviour: PostDeletionBehaviour,
     #[serde(default = "default_excluded_windows")]
     pub excluded_windows: Vec<WindowExclusion>,
@@ -203,6 +205,7 @@ impl Default for GeneralSettingsStore {
             recording_countdown: Some(3),
             enable_native_camera_preview: default_enable_native_camera_preview(),
             auto_zoom_on_clicks: false,
+            auto_zoom_config: cap_project::AutoZoomConfig::default(),
             post_deletion_behaviour: PostDeletionBehaviour::DoNothing,
             excluded_windows: default_excluded_windows(),
             delete_instant_recordings_after_upload: false,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2111,17 +2111,21 @@ async fn update_project_config_in_memory(
 
 #[tauri::command]
 #[specta::specta]
-#[instrument(skip(editor_instance))]
+#[instrument(skip(app, editor_instance))]
 async fn generate_zoom_segments_from_clicks(
+    app: AppHandle,
     editor_instance: WindowEditorInstance,
 ) -> Result<Vec<ZoomSegment>, String> {
+    let settings = GeneralSettingsStore::get(&app)
+        .unwrap_or(None)
+        .unwrap_or_default();
     let meta = editor_instance.meta();
     let recordings = &editor_instance.recordings;
 
     let zoom_segments = recording::generate_zoom_segments_for_project(
         meta,
         recordings,
-        &cap_project::AutoZoomConfig::default(),
+        &settings.auto_zoom_config,
     );
 
     Ok(zoom_segments)

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2118,7 +2118,11 @@ async fn generate_zoom_segments_from_clicks(
     let meta = editor_instance.meta();
     let recordings = &editor_instance.recordings;
 
-    let zoom_segments = recording::generate_zoom_segments_for_project(meta, recordings);
+    let zoom_segments = recording::generate_zoom_segments_for_project(
+        meta,
+        recordings,
+        &cap_project::AutoZoomConfig::default(),
+    );
 
     Ok(zoom_segments)
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2122,11 +2122,8 @@ async fn generate_zoom_segments_from_clicks(
     let meta = editor_instance.meta();
     let recordings = &editor_instance.recordings;
 
-    let zoom_segments = recording::generate_zoom_segments_for_project(
-        meta,
-        recordings,
-        &settings.auto_zoom_config,
-    );
+    let zoom_segments =
+        recording::generate_zoom_segments_for_project(meta, recordings, &settings.auto_zoom_config);
 
     Ok(zoom_segments)
 }

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2011,6 +2011,7 @@ fn generate_zoom_segments_from_clicks_impl(
     let movement_event_distance_threshold = config.movement_event_distance_threshold;
     let movement_window_distance_threshold = config.movement_window_distance_threshold;
     let auto_zoom_amount = config.zoom_amount;
+    let dead_zone_radius = config.dead_zone_radius;
 
     if max_duration <= 0.0 {
         return Vec::new();
@@ -2072,7 +2073,7 @@ fn generate_zoom_segments_from_clicks_impl(
 
         let mut found_group = false;
         for group in click_groups.iter_mut() {
-            let can_join = group.iter().any(|&group_idx| {
+            let time_and_spatial = group.iter().any(|&group_idx| {
                 let group_click = &clicks[group_idx];
                 let group_time = group_click.time_ms / 1000.0;
                 let time_close = (click_time - group_time).abs() < click_group_time_threshold_secs;
@@ -2089,7 +2090,25 @@ fn generate_zoom_segments_from_clicks_impl(
                 time_close && spatial_close
             });
 
-            if can_join {
+            let in_dead_zone = dead_zone_radius > 0.0 && click_pos.is_some() && {
+                let (cx, cy) = click_pos.unwrap();
+                let group_positions: Vec<(f64, f64)> = group
+                    .iter()
+                    .filter_map(|&gi| click_positions.get(&gi).copied())
+                    .collect();
+                if group_positions.is_empty() {
+                    false
+                } else {
+                    let count = group_positions.len() as f64;
+                    let centroid_x = group_positions.iter().map(|(x, _)| x).sum::<f64>() / count;
+                    let centroid_y = group_positions.iter().map(|(_, y)| y).sum::<f64>() / count;
+                    let dx = cx - centroid_x;
+                    let dy = cy - centroid_y;
+                    (dx * dx + dy * dy).sqrt() < dead_zone_radius
+                }
+            };
+
+            if time_and_spatial || in_dead_zone {
                 group.push(*idx);
                 found_group = true;
                 break;
@@ -2488,6 +2507,65 @@ mod tests {
         assert!(
             segments.is_empty(),
             "small jitter should not generate segments"
+        );
+    }
+
+    #[test]
+    fn dead_zone_merges_nearby_clicks() {
+        let clicks = vec![click_event(1_000.0), click_event(5_000.0)];
+        let moves = vec![move_event(999.0, 0.5, 0.5), move_event(4_999.0, 0.55, 0.55)];
+
+        let config = cap_project::AutoZoomConfig {
+            dead_zone_radius: 0.1,
+            ..Default::default()
+        };
+
+        let segments = generate_zoom_segments_from_clicks_impl(clicks, moves, 20.0, &config);
+
+        assert!(
+            segments.len() <= 1,
+            "nearby clicks within dead zone should merge into at most 1 segment, got {}",
+            segments.len()
+        );
+    }
+
+    #[test]
+    fn dead_zone_allows_distant_clicks() {
+        let clicks = vec![click_event(1_000.0), click_event(5_000.0)];
+        let moves = vec![move_event(999.0, 0.2, 0.2), move_event(4_999.0, 0.8, 0.8)];
+
+        let config = cap_project::AutoZoomConfig {
+            dead_zone_radius: 0.1,
+            ..Default::default()
+        };
+
+        let segments = generate_zoom_segments_from_clicks_impl(clicks, moves, 20.0, &config);
+
+        assert_eq!(
+            segments.len(),
+            2,
+            "distant clicks outside dead zone should produce 2 separate segments, got {}",
+            segments.len()
+        );
+    }
+
+    #[test]
+    fn dead_zone_zero_disables() {
+        let clicks = vec![click_event(1_000.0), click_event(5_000.0)];
+        let moves = vec![move_event(999.0, 0.5, 0.5), move_event(4_999.0, 0.55, 0.55)];
+
+        let config = cap_project::AutoZoomConfig {
+            dead_zone_radius: 0.0,
+            ..Default::default()
+        };
+
+        let segments = generate_zoom_segments_from_clicks_impl(clicks, moves, 20.0, &config);
+
+        assert_eq!(
+            segments.len(),
+            2,
+            "with dead_zone_radius=0.0, nearby clicks should produce 2 segments, got {}",
+            segments.len()
         );
     }
 }

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -1989,29 +1989,28 @@ async fn finalize_studio_recording(
     Ok(())
 }
 
-/// Core logic for generating zoom segments based on mouse click events.
-/// This is an experimental feature that automatically creates zoom effects
-/// around user interactions to highlight important moments.
 fn generate_zoom_segments_from_clicks_impl(
     mut clicks: Vec<CursorClickEvent>,
     mut moves: Vec<CursorMoveEvent>,
     max_duration: f64,
+    config: &cap_project::AutoZoomConfig,
 ) -> Vec<ZoomSegment> {
     const STOP_PADDING_SECONDS: f64 = 0.5;
-    const CLICK_GROUP_TIME_THRESHOLD_SECS: f64 = 2.5;
-    const CLICK_GROUP_SPATIAL_THRESHOLD: f64 = 0.15;
-    const CLICK_PRE_PADDING: f64 = 0.4;
-    const CLICK_POST_PADDING: f64 = 1.8;
-    const MOVEMENT_PRE_PADDING: f64 = 0.3;
-    const MOVEMENT_POST_PADDING: f64 = 1.5;
-    const MERGE_GAP_THRESHOLD: f64 = 0.8;
-    const MIN_SEGMENT_DURATION: f64 = 1.0;
     const MOVEMENT_WINDOW_SECONDS: f64 = 1.5;
-    const MOVEMENT_EVENT_DISTANCE_THRESHOLD: f64 = 0.02;
-    const MOVEMENT_WINDOW_DISTANCE_THRESHOLD: f64 = 0.08;
-    const AUTO_ZOOM_AMOUNT: f64 = 1.5;
     const SHAKE_FILTER_THRESHOLD: f64 = 0.33;
     const SHAKE_FILTER_WINDOW_MS: f64 = 150.0;
+
+    let click_group_time_threshold_secs = config.click_group_time_threshold;
+    let click_group_spatial_threshold = config.click_group_spatial_threshold;
+    let click_pre_padding = config.click_pre_padding;
+    let click_post_padding = config.click_post_padding;
+    let movement_pre_padding = config.movement_pre_padding;
+    let movement_post_padding = config.movement_post_padding;
+    let merge_gap_threshold = config.merge_gap_threshold;
+    let min_segment_duration = config.min_segment_duration;
+    let movement_event_distance_threshold = config.movement_event_distance_threshold;
+    let movement_window_distance_threshold = config.movement_window_distance_threshold;
+    let auto_zoom_amount = config.zoom_amount;
 
     if max_duration <= 0.0 {
         return Vec::new();
@@ -2076,13 +2075,13 @@ fn generate_zoom_segments_from_clicks_impl(
             let can_join = group.iter().any(|&group_idx| {
                 let group_click = &clicks[group_idx];
                 let group_time = group_click.time_ms / 1000.0;
-                let time_close = (click_time - group_time).abs() < CLICK_GROUP_TIME_THRESHOLD_SECS;
+                let time_close = (click_time - group_time).abs() < click_group_time_threshold_secs;
 
                 let spatial_close = match (click_pos, click_positions.get(&group_idx)) {
                     (Some((x1, y1)), Some((x2, y2))) => {
                         let dx = x1 - x2;
                         let dy = y1 - y2;
-                        (dx * dx + dy * dy).sqrt() < CLICK_GROUP_SPATIAL_THRESHOLD
+                        (dx * dx + dy * dy).sqrt() < click_group_spatial_threshold
                     }
                     _ => true,
                 };
@@ -2116,8 +2115,8 @@ fn generate_zoom_segments_from_clicks_impl(
         let group_start = times.iter().cloned().fold(f64::INFINITY, f64::min);
         let group_end = times.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
 
-        let start = (group_start - CLICK_PRE_PADDING).max(0.0);
-        let end = (group_end + CLICK_POST_PADDING).min(activity_end_limit);
+        let start = (group_start - click_pre_padding).max(0.0);
+        let end = (group_end + click_post_padding).min(activity_end_limit);
 
         if end > start {
             intervals.push((start, end));
@@ -2199,15 +2198,15 @@ fn generate_zoom_segments_from_clicks_impl(
             window_distance = 0.0;
         }
 
-        let significant_movement = distance >= MOVEMENT_EVENT_DISTANCE_THRESHOLD
-            || window_distance >= MOVEMENT_WINDOW_DISTANCE_THRESHOLD;
+        let significant_movement = distance >= movement_event_distance_threshold
+            || window_distance >= movement_window_distance_threshold;
 
         if !significant_movement {
             continue;
         }
 
-        let start = (time - MOVEMENT_PRE_PADDING).max(0.0);
-        let end = (time + MOVEMENT_POST_PADDING).min(activity_end_limit);
+        let start = (time - movement_pre_padding).max(0.0);
+        let end = (time + movement_post_padding).min(activity_end_limit);
 
         if end > start {
             intervals.push((start, end));
@@ -2223,7 +2222,7 @@ fn generate_zoom_segments_from_clicks_impl(
     let mut merged: Vec<(f64, f64)> = Vec::new();
     for interval in intervals {
         if let Some(last) = merged.last_mut()
-            && interval.0 <= last.1 + MERGE_GAP_THRESHOLD
+            && interval.0 <= last.1 + merge_gap_threshold
         {
             last.1 = last.1.max(interval.1);
             continue;
@@ -2235,14 +2234,14 @@ fn generate_zoom_segments_from_clicks_impl(
         .into_iter()
         .filter_map(|(start, end)| {
             let duration = end - start;
-            if duration < MIN_SEGMENT_DURATION {
+            if duration < min_segment_duration {
                 return None;
             }
 
             Some(ZoomSegment {
                 start,
                 end,
-                amount: AUTO_ZOOM_AMOUNT,
+                amount: auto_zoom_amount,
                 mode: ZoomMode::Auto,
                 glide_direction: GlideDirection::None,
                 glide_speed: 0.5,
@@ -2253,13 +2252,11 @@ fn generate_zoom_segments_from_clicks_impl(
         .collect()
 }
 
-/// Generates zoom segments based on mouse click events during recording.
-/// Used during the recording completion process.
 pub fn generate_zoom_segments_from_clicks(
     recording: &studio_recording::CompletedRecording,
     recordings: &ProjectRecordingsMeta,
+    config: &cap_project::AutoZoomConfig,
 ) -> Vec<ZoomSegment> {
-    // Build a temporary RecordingMeta so we can use the common implementation
     let recording_meta = RecordingMeta {
         platform: None,
         project_path: recording.project_path.clone(),
@@ -2269,14 +2266,13 @@ pub fn generate_zoom_segments_from_clicks(
         upload: None,
     };
 
-    generate_zoom_segments_for_project(&recording_meta, recordings)
+    generate_zoom_segments_for_project(&recording_meta, recordings, config)
 }
 
-/// Generates zoom segments from clicks for an existing project.
-/// Used in the editor context where we have RecordingMeta.
 pub fn generate_zoom_segments_for_project(
     recording_meta: &RecordingMeta,
     recordings: &ProjectRecordingsMeta,
+    config: &cap_project::AutoZoomConfig,
 ) -> Vec<ZoomSegment> {
     let RecordingMetaInner::Studio(studio_meta) = &recording_meta.inner else {
         return Vec::new();
@@ -2309,7 +2305,7 @@ pub fn generate_zoom_segments_for_project(
         }
     }
 
-    generate_zoom_segments_from_clicks_impl(all_clicks, all_moves, recordings.duration())
+    generate_zoom_segments_from_clicks_impl(all_clicks, all_moves, recordings.duration(), config)
 }
 
 fn project_config_from_recording(
@@ -2355,7 +2351,11 @@ fn project_config_from_recording(
         .collect::<Vec<_>>();
 
     let zoom_segments = if settings.auto_zoom_on_clicks {
-        generate_zoom_segments_from_clicks(completed_recording, recordings)
+        generate_zoom_segments_from_clicks(
+            completed_recording,
+            recordings,
+            &settings.auto_zoom_config,
+        )
     } else {
         Vec::new()
     };
@@ -2429,8 +2429,12 @@ mod tests {
 
     #[test]
     fn skips_trailing_stop_click() {
-        let segments =
-            generate_zoom_segments_from_clicks_impl(vec![click_event(11_900.0)], vec![], 12.0);
+        let segments = generate_zoom_segments_from_clicks_impl(
+            vec![click_event(11_900.0)],
+            vec![],
+            12.0,
+            &cap_project::AutoZoomConfig::default(),
+        );
 
         assert!(
             segments.is_empty(),
@@ -2447,7 +2451,12 @@ mod tests {
             move_event(1_940.0, 0.74, 0.78),
         ];
 
-        let segments = generate_zoom_segments_from_clicks_impl(clicks, moves, 20.0);
+        let segments = generate_zoom_segments_from_clicks_impl(
+            clicks,
+            moves,
+            20.0,
+            &cap_project::AutoZoomConfig::default(),
+        );
 
         assert!(
             !segments.is_empty(),
@@ -2469,7 +2478,12 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let segments = generate_zoom_segments_from_clicks_impl(Vec::new(), jitter_moves, 15.0);
+        let segments = generate_zoom_segments_from_clicks_impl(
+            Vec::new(),
+            jitter_moves,
+            15.0,
+            &cap_project::AutoZoomConfig::default(),
+        );
 
         assert!(
             segments.is_empty(),

--- a/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
@@ -1,11 +1,49 @@
+import { Slider as KSlider } from "@kobalte/core/slider";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { type } from "@tauri-apps/plugin-os";
 import { createResource, Show } from "solid-js";
 import { createStore } from "solid-js/store";
 
 import { generalSettingsStore } from "~/store";
-import { commands, type GeneralSettingsStore } from "~/utils/tauri";
+import {
+	commands,
+	type AutoZoomConfig,
+	type GeneralSettingsStore,
+} from "~/utils/tauri";
 import { ToggleSettingItem } from "./Setting";
+
+function SettingSlider(props: {
+	label: string;
+	value: number;
+	onChange: (v: number) => void;
+	min: number;
+	max: number;
+	step: number;
+	format?: (v: number) => string;
+}) {
+	return (
+		<div class="space-y-1.5">
+			<div class="flex justify-between items-center text-sm">
+				<span class="text-gray-11">{props.label}</span>
+				<span class="text-gray-12 font-medium">
+					{props.format ? props.format(props.value) : props.value}
+				</span>
+			</div>
+			<KSlider
+				value={[props.value]}
+				onChange={(v) => props.onChange(v[0])}
+				minValue={props.min}
+				maxValue={props.max}
+				step={props.step}
+			>
+				<KSlider.Track class="h-[0.3rem] cursor-pointer relative bg-gray-4 rounded-full w-full">
+					<KSlider.Fill class="absolute h-full rounded-full bg-blue-9" />
+					<KSlider.Thumb class="block size-4 rounded-full bg-white border-2 border-blue-9 -top-[0.35rem] outline-none" />
+				</KSlider.Track>
+			</KSlider>
+		</div>
+	);
+}
 
 export default function ExperimentalSettings() {
 	const [store] = createResource(() => generalSettingsStore.get());
@@ -27,8 +65,31 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 			enableNativeCameraPreview: false,
 			autoZoomOnClicks: false,
 			custom_cursor_capture2: true,
+			autoZoomConfig: {
+				zoomAmount: 1.5,
+				clickGroupTimeThreshold: 2.5,
+				clickGroupSpatialThreshold: 0.15,
+				clickPrePadding: 0.4,
+				clickPostPadding: 1.8,
+				movementPrePadding: 0.3,
+				movementPostPadding: 1.5,
+				mergeGapThreshold: 0.8,
+				minSegmentDuration: 1.0,
+				movementEventDistanceThreshold: 0.02,
+				movementWindowDistanceThreshold: 0.08,
+			},
 		},
 	);
+
+	const handleConfigChange = <K extends keyof AutoZoomConfig>(
+		key: K,
+		value: AutoZoomConfig[K],
+	) => {
+		setSettings("autoZoomConfig", key, value);
+		generalSettingsStore.set({
+			autoZoomConfig: { ...settings.autoZoomConfig, [key]: value },
+		});
+	};
 
 	const handleChange = async <K extends keyof typeof settings>(
 		key: K,
@@ -95,6 +156,53 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 							}}
 						/>
 					</div>
+					<Show when={settings.autoZoomOnClicks}>
+						<div class="px-3 py-3 space-y-4">
+							<SettingSlider
+								label="Zoom Amount"
+								value={settings.autoZoomConfig?.zoomAmount ?? 1.5}
+								onChange={(v) => handleConfigChange("zoomAmount", v)}
+								min={1.0}
+								max={4.0}
+								step={0.1}
+								format={(v) => `${v.toFixed(1)}x`}
+							/>
+							<SettingSlider
+								label="Sensitivity"
+								value={
+									settings.autoZoomConfig
+										?.movementWindowDistanceThreshold ?? 0.08
+								}
+								onChange={(v) =>
+									handleConfigChange(
+										"movementWindowDistanceThreshold",
+										v,
+									)
+								}
+								min={0.02}
+								max={0.2}
+								step={0.01}
+								format={(v) => {
+									if (v <= 0.05) return "High";
+									if (v <= 0.12) return "Medium";
+									return "Low";
+								}}
+							/>
+							<SettingSlider
+								label="Smoothing"
+								value={
+									settings.autoZoomConfig?.mergeGapThreshold ?? 0.8
+								}
+								onChange={(v) =>
+									handleConfigChange("mergeGapThreshold", v)
+								}
+								min={0.2}
+								max={2.0}
+								step={0.1}
+								format={(v) => `${v.toFixed(1)}s`}
+							/>
+						</div>
+					</Show>
 				</div>
 			</div>
 		</div>

--- a/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
@@ -77,6 +77,7 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 				minSegmentDuration: 1.0,
 				movementEventDistanceThreshold: 0.02,
 				movementWindowDistanceThreshold: 0.08,
+				deadZoneRadius: 0.1,
 			},
 		},
 	);

--- a/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
@@ -6,8 +6,8 @@ import { createStore } from "solid-js/store";
 
 import { generalSettingsStore } from "~/store";
 import {
-	commands,
 	type AutoZoomConfig,
+	commands,
 	type GeneralSettingsStore,
 } from "~/utils/tauri";
 import { ToggleSettingItem } from "./Setting";
@@ -170,14 +170,11 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 							<SettingSlider
 								label="Sensitivity"
 								value={
-									settings.autoZoomConfig
-										?.movementWindowDistanceThreshold ?? 0.08
+									settings.autoZoomConfig?.movementWindowDistanceThreshold ??
+									0.08
 								}
 								onChange={(v) =>
-									handleConfigChange(
-										"movementWindowDistanceThreshold",
-										v,
-									)
+									handleConfigChange("movementWindowDistanceThreshold", v)
 								}
 								min={0.02}
 								max={0.2}
@@ -190,12 +187,8 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 							/>
 							<SettingSlider
 								label="Smoothing"
-								value={
-									settings.autoZoomConfig?.mergeGapThreshold ?? 0.8
-								}
-								onChange={(v) =>
-									handleConfigChange("mergeGapThreshold", v)
-								}
+								value={settings.autoZoomConfig?.mergeGapThreshold ?? 0.8}
+								onChange={(v) => handleConfigChange("mergeGapThreshold", v)}
 								min={0.2}
 								max={2.0}
 								step={0.1}

--- a/crates/project/src/configuration.rs
+++ b/crates/project/src/configuration.rs
@@ -455,6 +455,40 @@ impl Default for ScreenMovementSpring {
     }
 }
 
+#[derive(Type, Serialize, Deserialize, Clone, Copy, Debug)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AutoZoomConfig {
+    pub zoom_amount: f64,
+    pub click_group_time_threshold: f64,
+    pub click_group_spatial_threshold: f64,
+    pub click_pre_padding: f64,
+    pub click_post_padding: f64,
+    pub movement_pre_padding: f64,
+    pub movement_post_padding: f64,
+    pub merge_gap_threshold: f64,
+    pub min_segment_duration: f64,
+    pub movement_event_distance_threshold: f64,
+    pub movement_window_distance_threshold: f64,
+}
+
+impl Default for AutoZoomConfig {
+    fn default() -> Self {
+        Self {
+            zoom_amount: 1.5,
+            click_group_time_threshold: 2.5,
+            click_group_spatial_threshold: 0.15,
+            click_pre_padding: 0.4,
+            click_post_padding: 1.8,
+            movement_pre_padding: 0.3,
+            movement_post_padding: 1.5,
+            merge_gap_threshold: 0.8,
+            min_segment_duration: 1.0,
+            movement_event_distance_threshold: 0.02,
+            movement_window_distance_threshold: 0.08,
+        }
+    }
+}
+
 impl CursorAnimationStyle {
     pub fn preset(self) -> Option<CursorSmoothingPreset> {
         match self {

--- a/crates/project/src/configuration.rs
+++ b/crates/project/src/configuration.rs
@@ -469,6 +469,7 @@ pub struct AutoZoomConfig {
     pub min_segment_duration: f64,
     pub movement_event_distance_threshold: f64,
     pub movement_window_distance_threshold: f64,
+    pub dead_zone_radius: f64,
 }
 
 impl Default for AutoZoomConfig {
@@ -485,6 +486,7 @@ impl Default for AutoZoomConfig {
             min_segment_duration: 1.0,
             movement_event_distance_threshold: 0.02,
             movement_window_distance_threshold: 0.08,
+            dead_zone_radius: 0.1,
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds dead zone filtering to auto-zoom segment generation (refs #1646, builds on #1663):

- **New `dead_zone_radius` config field** (default 0.1 = 10% of screen) — if cursor stays within this radius of a previous click group's centroid, clicks merge into the same group regardless of time gap
- **Modified click grouping** — dead zone check runs alongside the existing time+spatial proximity check, using centroid distance
- **3 new tests** — merges nearby clicks, separates distant clicks, disables at radius 0.0
- **TypeScript defaults updated** to include the new field

### How it works

Before: Two clicks 4s apart at (0.5, 0.5) and (0.55, 0.55) → 2 separate zoom segments → jittery zoom-in/out

After: Same clicks with `dead_zone_radius: 0.1` → grouped into 1 segment → smooth experience

### Backward compatibility

`dead_zone_radius` defaults to 0.1 via `#[serde(default)]`. Existing recordings are unaffected since auto-zoom segments are regenerated from click data, not stored with this parameter.

## Test plan

- [ ] `dead_zone_merges_nearby_clicks` — clicks within radius merge to 1 segment
- [ ] `dead_zone_allows_distant_clicks` — clicks outside radius stay separate
- [ ] `dead_zone_zero_disables` — radius 0.0 produces same behavior as before
- [ ] Manual: record with repeated clicks in same area → single smooth zoom instead of flickering

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a configurable `dead_zone_radius` to the auto-zoom click-grouping algorithm so that spatially close clicks are merged into a single zoom segment even when the time gap between them exceeds `click_group_time_threshold`, preventing jittery zoom-in/out on repeated interactions with the same UI element. It also lifts all previously hard-coded zoom constants into a new `AutoZoomConfig` struct and exposes three of them (zoom amount, sensitivity, smoothing) as UI sliders in the Experimental settings page.

Key observations:
- The dead zone centroid is the running average of all positions already in the group. Each new click slightly shifts the centroid, which may then accept the next click that is slightly further away; over many incremental clicks this can cause the dead zone to slowly drift across the screen (see inline comment for a worked example). Using the first click in the group as a fixed anchor would eliminate this behaviour.
- The dead zone check scans **all** groups with no temporal guard; a click on the same button 2 minutes later will silently merge into the original group, potentially producing a multi-minute zoom segment. This is explicitly intentional per the PR description, but deserves an in-code comment explaining the trade-off.
- The `dead_zone_merges_nearby_clicks` test assertion `segments.len() <= 1` passes even when zero segments are produced, which would indicate the feature is broken rather than working; it should assert `== 1`.
- `dead_zone_radius` is included in `AutoZoomConfig` and its TypeScript defaults, but no UI slider is exposed for it, so users cannot tune the feature that this PR is specifically introducing.

<h3>Confidence Score: 3/5</h3>

- The core algorithm works for the common case but has two algorithmic edge cases (centroid drift and unbounded temporal merging) that can produce unexpectedly long zoom segments in longer recordings.
- The refactor from hard-coded constants to AutoZoomConfig is clean and backward-compatible. The dead zone logic is generally sound for short recordings and the targeted use-case (same button clicked repeatedly). However, the lack of any time bound on the dead zone merge and the centroid drift property are real algorithmic concerns that could silently degrade the user experience in longer recordings — neither is guarded against in the tests. The weak test assertion also means the core happy-path test could pass even if the merge produced no segment at all.
- apps/desktop/src-tauri/src/recording.rs — dead zone grouping logic and test assertions

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/recording.rs | Core implementation of dead zone logic and refactor of hardcoded constants into AutoZoomConfig; centroid drift and unbounded temporal merging are concerns, and the new test assertion is weaker than it should be. |
| crates/project/src/configuration.rs | Adds well-structured AutoZoomConfig struct with sensible defaults and proper serde/specta derives; no issues found. |
| apps/desktop/src-tauri/src/general_settings.rs | Adds auto_zoom_config field to GeneralSettingsStore with correct serde default and Default impl; straightforward and correct. |
| apps/desktop/src-tauri/src/lib.rs | Threads AppHandle into the Tauri command to read auto_zoom_config from persisted settings; uses a double-unwrap with fallback to default which silently discards read errors, but this is consistent with settings-reading patterns elsewhere. |
| apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx | Adds SettingSlider component and UI for zoom amount, sensitivity, and smoothing; handleConfigChange is intentionally synchronous (consistent with handleChange which also doesn't await generalSettingsStore.set); dead_zone_radius has no corresponding UI control, so users can't tune the core new feature from the settings page. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[New click event] --> B{Has position?}
    B -- No --> C[time_and_spatial check only]
    B -- Yes --> D{dead_zone_radius > 0?}
    D -- No --> C
    D -- Yes --> E[Iterate existing click_groups]
    C --> E

    E --> F{time_and_spatial:\ntime_close AND spatial_close?}
    F -- Yes --> G[Merge into group\nbreak]
    F -- No --> H{in_dead_zone:\ndist to running centroid < radius?}
    H -- Yes --> G
    H -- No --> I{More groups?}
    I -- Yes --> E
    I -- No --> J[Create new group]

    G --> K[Recompute centroid\ncentroid drifts toward new click]
    J --> L[Centroid = single click position]

    K --> M[Generate interval:\ngroup_start − pre_padding .. group_end + post_padding]
    L --> M
    M --> N{duration ≥ min_segment_duration?}
    N -- Yes --> O[Add ZoomSegment]
    N -- No --> P[Discard]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/desktop/src-tauri/src/recording.rs`, line 2571-2580 ([link](https://github.com/capsoftware/cap/blob/e308026c8f2095cb4d2bfa90d63de38bc4abf2b4/apps/desktop/src-tauri/src/recording.rs#L2571-L2580)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Weak assertion allows a false pass on zero segments**

   The assertion `segments.len() <= 1` also passes when `segments` is empty (0 segments). This means if the dead zone merge logic silently failed to group the two nearby clicks but still produced zero segments (e.g. the merged group's interval was filtered out), the test would still pass, giving a false green. Since the two merged clicks form an interval of `[0.6s, 6.8s]` (duration 6.2s), which comfortably exceeds `min_segment_duration = 1.0s`, exactly 1 segment should always be produced. The assertion should be tightened to `== 1`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src-tauri/src/recording.rs
   Line: 2571-2580

   Comment:
   **Weak assertion allows a false pass on zero segments**

   The assertion `segments.len() <= 1` also passes when `segments` is empty (0 segments). This means if the dead zone merge logic silently failed to group the two nearby clicks but still produced zero segments (e.g. the merged group's interval was filtered out), the test would still pass, giving a false green. Since the two merged clicks form an interval of `[0.6s, 6.8s]` (duration 6.2s), which comfortably exceeds `min_segment_duration = 1.0s`, exactly 1 segment should always be produced. The assertion should be tightened to `== 1`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/desktop/src-tauri/src/recording.rs`, line 2093-2115 ([link](https://github.com/capsoftware/cap/blob/e308026c8f2095cb4d2bfa90d63de38bc4abf2b4/apps/desktop/src-tauri/src/recording.rs#L2093-L2115)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead zone applies to all groups regardless of time, can create very long zoom segments**

   The `in_dead_zone` check iterates over **all** existing `click_groups` with no temporal filter. This means that if a user clicks at position (0.5, 0.5) at t=0s, clicks somewhere else for a long stretch, and then clicks at (0.51, 0.51) at t=120s, the second click will merge into the very first group — producing a single zoom segment spanning over 2 minutes once the post-padding is applied.

   The PR description calls this intentional ("regardless of time gap"), but in a long recording this silently creates a single enormous zoom segment from the union of `[group_start − click_pre_padding, last_click + click_post_padding]`, which is almost certainly not what the user expects.

   A practical guard would be to bound the dead zone merge by the same `click_group_time_threshold` used for normal spatial grouping, or by some separate configurable dead zone time limit (e.g. `dead_zone_time_limit_secs`). At minimum the behaviour should be documented in a comment so future reviewers understand the intentional "any time gap" design.

   ```rust
   // Consider adding a temporal guard, e.g.:
   let time_ok_for_dead_zone = dead_zone_time_limit == 0.0
       || (click_time - clicks[*group.last().unwrap()].time_ms / 1000.0).abs()
           < dead_zone_time_limit;

   let in_dead_zone = time_ok_for_dead_zone
       && dead_zone_radius > 0.0
       && click_pos.is_some()
       && { /* centroid check */ };
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src-tauri/src/recording.rs
   Line: 2093-2115

   Comment:
   **Dead zone applies to all groups regardless of time, can create very long zoom segments**

   The `in_dead_zone` check iterates over **all** existing `click_groups` with no temporal filter. This means that if a user clicks at position (0.5, 0.5) at t=0s, clicks somewhere else for a long stretch, and then clicks at (0.51, 0.51) at t=120s, the second click will merge into the very first group — producing a single zoom segment spanning over 2 minutes once the post-padding is applied.

   The PR description calls this intentional ("regardless of time gap"), but in a long recording this silently creates a single enormous zoom segment from the union of `[group_start − click_pre_padding, last_click + click_post_padding]`, which is almost certainly not what the user expects.

   A practical guard would be to bound the dead zone merge by the same `click_group_time_threshold` used for normal spatial grouping, or by some separate configurable dead zone time limit (e.g. `dead_zone_time_limit_secs`). At minimum the behaviour should be documented in a comment so future reviewers understand the intentional "any time gap" design.

   ```rust
   // Consider adding a temporal guard, e.g.:
   let time_ok_for_dead_zone = dead_zone_time_limit == 0.0
       || (click_time - clicks[*group.last().unwrap()].time_ms / 1000.0).abs()
           < dead_zone_time_limit;

   let in_dead_zone = time_ok_for_dead_zone
       && dead_zone_radius > 0.0
       && click_pos.is_some()
       && { /* centroid check */ };
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/recording.rs
Line: 2571-2580

Comment:
**Weak assertion allows a false pass on zero segments**

The assertion `segments.len() <= 1` also passes when `segments` is empty (0 segments). This means if the dead zone merge logic silently failed to group the two nearby clicks but still produced zero segments (e.g. the merged group's interval was filtered out), the test would still pass, giving a false green. Since the two merged clicks form an interval of `[0.6s, 6.8s]` (duration 6.2s), which comfortably exceeds `min_segment_duration = 1.0s`, exactly 1 segment should always be produced. The assertion should be tightened to `== 1`.

```suggestion
        assert_eq!(
            segments.len(),
            1,
            "nearby clicks within dead zone should merge into exactly 1 segment, got {}",
            segments.len()
        );
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/recording.rs
Line: 2093-2115

Comment:
**Dead zone applies to all groups regardless of time, can create very long zoom segments**

The `in_dead_zone` check iterates over **all** existing `click_groups` with no temporal filter. This means that if a user clicks at position (0.5, 0.5) at t=0s, clicks somewhere else for a long stretch, and then clicks at (0.51, 0.51) at t=120s, the second click will merge into the very first group — producing a single zoom segment spanning over 2 minutes once the post-padding is applied.

The PR description calls this intentional ("regardless of time gap"), but in a long recording this silently creates a single enormous zoom segment from the union of `[group_start − click_pre_padding, last_click + click_post_padding]`, which is almost certainly not what the user expects.

A practical guard would be to bound the dead zone merge by the same `click_group_time_threshold` used for normal spatial grouping, or by some separate configurable dead zone time limit (e.g. `dead_zone_time_limit_secs`). At minimum the behaviour should be documented in a comment so future reviewers understand the intentional "any time gap" design.

```rust
// Consider adding a temporal guard, e.g.:
let time_ok_for_dead_zone = dead_zone_time_limit == 0.0
    || (click_time - clicks[*group.last().unwrap()].time_ms / 1000.0).abs()
        < dead_zone_time_limit;

let in_dead_zone = time_ok_for_dead_zone
    && dead_zone_radius > 0.0
    && click_pos.is_some()
    && { /* centroid check */ };
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/recording.rs
Line: 2101-2108

Comment:
**Centroid drift: repeated near-boundary clicks can shift the dead zone across the screen**

The centroid used for the dead zone check is recomputed as the average of **all** positions already in the group, including those added via previous dead zone merges. Each time a click near the boundary of the dead zone is accepted, the centroid shifts slightly in that direction, which may then accept the next click that is slightly further away, and so on.

Concretely with `dead_zone_radius = 0.1`:
- Click at `(0.50, 0.50)` → centroid `(0.50, 0.50)`
- Click at `(0.56, 0.56)` (dist ≈ 0.085 < 0.1) → merges, centroid shifts to `(0.53, 0.53)`
- Click at `(0.62, 0.62)` (dist from new centroid ≈ 0.127 > 0.1) — just misses in this case, but with slightly smaller steps the group can creep across the screen.

For the typical use case (same button clicked repeatedly) this is harmless, but a user doing a slow drag-with-pauses could inadvertently merge distant clicks into one group. One mitigation is to compute the centroid only from the **first** click in the group (i.e. the "anchor"), rather than from the running average of all members.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(recording): add..."](https://github.com/capsoftware/cap/commit/e308026c8f2095cb4d2bfa90d63de38bc4abf2b4)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->