### PR TITLE
feat: double-click dedup and right-click filtering for auto-zoom

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -124,6 +124,8 @@ pub struct GeneralSettingsStore {
     #[serde(default)]
     pub auto_zoom_on_clicks: bool,
     #[serde(default)]
+    pub auto_zoom_config: cap_project::AutoZoomConfig,
+    #[serde(default)]
     pub post_deletion_behaviour: PostDeletionBehaviour,
     #[serde(default = "default_excluded_windows")]
     pub excluded_windows: Vec<WindowExclusion>,
@@ -203,6 +205,7 @@ impl Default for GeneralSettingsStore {
             recording_countdown: Some(3),
             enable_native_camera_preview: default_enable_native_camera_preview(),
             auto_zoom_on_clicks: false,
+            auto_zoom_config: cap_project::AutoZoomConfig::default(),
             post_deletion_behaviour: PostDeletionBehaviour::DoNothing,
             excluded_windows: default_excluded_windows(),
             delete_instant_recordings_after_upload: false,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2111,17 +2111,21 @@ async fn update_project_config_in_memory(
 
 #[tauri::command]
 #[specta::specta]
-#[instrument(skip(editor_instance))]
+#[instrument(skip(app, editor_instance))]
 async fn generate_zoom_segments_from_clicks(
+    app: AppHandle,
     editor_instance: WindowEditorInstance,
 ) -> Result<Vec<ZoomSegment>, String> {
+    let settings = GeneralSettingsStore::get(&app)
+        .unwrap_or(None)
+        .unwrap_or_default();
     let meta = editor_instance.meta();
     let recordings = &editor_instance.recordings;
 
     let zoom_segments = recording::generate_zoom_segments_for_project(
         meta,
         recordings,
-        &cap_project::AutoZoomConfig::default(),
+        &settings.auto_zoom_config,
     );
 
     Ok(zoom_segments)

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2118,7 +2118,11 @@ async fn generate_zoom_segments_from_clicks(
     let meta = editor_instance.meta();
     let recordings = &editor_instance.recordings;
 
-    let zoom_segments = recording::generate_zoom_segments_for_project(meta, recordings);
+    let zoom_segments = recording::generate_zoom_segments_for_project(
+        meta,
+        recordings,
+        &cap_project::AutoZoomConfig::default(),
+    );
 
     Ok(zoom_segments)
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2122,11 +2122,8 @@ async fn generate_zoom_segments_from_clicks(
     let meta = editor_instance.meta();
     let recordings = &editor_instance.recordings;
 
-    let zoom_segments = recording::generate_zoom_segments_for_project(
-        meta,
-        recordings,
-        &settings.auto_zoom_config,
-    );
+    let zoom_segments =
+        recording::generate_zoom_segments_for_project(meta, recordings, &settings.auto_zoom_config);
 
     Ok(zoom_segments)
 }

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2011,6 +2011,7 @@ fn generate_zoom_segments_from_clicks_impl(
     let movement_event_distance_threshold = config.movement_event_distance_threshold;
     let movement_window_distance_threshold = config.movement_window_distance_threshold;
     let auto_zoom_amount = config.zoom_amount;
+    let dead_zone_radius = config.dead_zone_radius;
 
     if max_duration <= 0.0 {
         return Vec::new();
@@ -2072,7 +2073,7 @@ fn generate_zoom_segments_from_clicks_impl(
 
         let mut found_group = false;
         for group in click_groups.iter_mut() {
-            let can_join = group.iter().any(|&group_idx| {
+            let time_and_spatial = group.iter().any(|&group_idx| {
                 let group_click = &clicks[group_idx];
                 let group_time = group_click.time_ms / 1000.0;
                 let time_close = (click_time - group_time).abs() < click_group_time_threshold_secs;
@@ -2089,7 +2090,25 @@ fn generate_zoom_segments_from_clicks_impl(
                 time_close && spatial_close
             });
 
-            if can_join {
+            let in_dead_zone = dead_zone_radius > 0.0 && click_pos.is_some() && {
+                let (cx, cy) = click_pos.unwrap();
+                let group_positions: Vec<(f64, f64)> = group
+                    .iter()
+                    .filter_map(|&gi| click_positions.get(&gi).copied())
+                    .collect();
+                if group_positions.is_empty() {
+                    false
+                } else {
+                    let count = group_positions.len() as f64;
+                    let centroid_x = group_positions.iter().map(|(x, _)| x).sum::<f64>() / count;
+                    let centroid_y = group_positions.iter().map(|(_, y)| y).sum::<f64>() / count;
+                    let dx = cx - centroid_x;
+                    let dy = cy - centroid_y;
+                    (dx * dx + dy * dy).sqrt() < dead_zone_radius
+                }
+            };
+
+            if time_and_spatial || in_dead_zone {
                 group.push(*idx);
                 found_group = true;
                 break;
@@ -2488,6 +2507,65 @@ mod tests {
         assert!(
             segments.is_empty(),
             "small jitter should not generate segments"
+        );
+    }
+
+    #[test]
+    fn dead_zone_merges_nearby_clicks() {
+        let clicks = vec![click_event(1_000.0), click_event(5_000.0)];
+        let moves = vec![move_event(999.0, 0.5, 0.5), move_event(4_999.0, 0.55, 0.55)];
+
+        let config = cap_project::AutoZoomConfig {
+            dead_zone_radius: 0.1,
+            ..Default::default()
+        };
+
+        let segments = generate_zoom_segments_from_clicks_impl(clicks, moves, 20.0, &config);
+
+        assert!(
+            segments.len() <= 1,
+            "nearby clicks within dead zone should merge into at most 1 segment, got {}",
+            segments.len()
+        );
+    }
+
+    #[test]
+    fn dead_zone_allows_distant_clicks() {
+        let clicks = vec![click_event(1_000.0), click_event(5_000.0)];
+        let moves = vec![move_event(999.0, 0.2, 0.2), move_event(4_999.0, 0.8, 0.8)];
+
+        let config = cap_project::AutoZoomConfig {
+            dead_zone_radius: 0.1,
+            ..Default::default()
+        };
+
+        let segments = generate_zoom_segments_from_clicks_impl(clicks, moves, 20.0, &config);
+
+        assert_eq!(
+            segments.len(),
+            2,
+            "distant clicks outside dead zone should produce 2 separate segments, got {}",
+            segments.len()
+        );
+    }
+
+    #[test]
+    fn dead_zone_zero_disables() {
+        let clicks = vec![click_event(1_000.0), click_event(5_000.0)];
+        let moves = vec![move_event(999.0, 0.5, 0.5), move_event(4_999.0, 0.55, 0.55)];
+
+        let config = cap_project::AutoZoomConfig {
+            dead_zone_radius: 0.0,
+            ..Default::default()
+        };
+
+        let segments = generate_zoom_segments_from_clicks_impl(clicks, moves, 20.0, &config);
+
+        assert_eq!(
+            segments.len(),
+            2,
+            "with dead_zone_radius=0.0, nearby clicks should produce 2 segments, got {}",
+            segments.len()
         );
     }
 }

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -1989,29 +1989,28 @@ async fn finalize_studio_recording(
     Ok(())
 }
 
-/// Core logic for generating zoom segments based on mouse click events.
-/// This is an experimental feature that automatically creates zoom effects
-/// around user interactions to highlight important moments.
 fn generate_zoom_segments_from_clicks_impl(
     mut clicks: Vec<CursorClickEvent>,
     mut moves: Vec<CursorMoveEvent>,
     max_duration: f64,
+    config: &cap_project::AutoZoomConfig,
 ) -> Vec<ZoomSegment> {
     const STOP_PADDING_SECONDS: f64 = 0.5;
-    const CLICK_GROUP_TIME_THRESHOLD_SECS: f64 = 2.5;
-    const CLICK_GROUP_SPATIAL_THRESHOLD: f64 = 0.15;
-    const CLICK_PRE_PADDING: f64 = 0.4;
-    const CLICK_POST_PADDING: f64 = 1.8;
-    const MOVEMENT_PRE_PADDING: f64 = 0.3;
-    const MOVEMENT_POST_PADDING: f64 = 1.5;
-    const MERGE_GAP_THRESHOLD: f64 = 0.8;
-    const MIN_SEGMENT_DURATION: f64 = 1.0;
     const MOVEMENT_WINDOW_SECONDS: f64 = 1.5;
-    const MOVEMENT_EVENT_DISTANCE_THRESHOLD: f64 = 0.02;
-    const MOVEMENT_WINDOW_DISTANCE_THRESHOLD: f64 = 0.08;
-    const AUTO_ZOOM_AMOUNT: f64 = 1.5;
     const SHAKE_FILTER_THRESHOLD: f64 = 0.33;
     const SHAKE_FILTER_WINDOW_MS: f64 = 150.0;
+
+    let click_group_time_threshold_secs = config.click_group_time_threshold;
+    let click_group_spatial_threshold = config.click_group_spatial_threshold;
+    let click_pre_padding = config.click_pre_padding;
+    let click_post_padding = config.click_post_padding;
+    let movement_pre_padding = config.movement_pre_padding;
+    let movement_post_padding = config.movement_post_padding;
+    let merge_gap_threshold = config.merge_gap_threshold;
+    let min_segment_duration = config.min_segment_duration;
+    let movement_event_distance_threshold = config.movement_event_distance_threshold;
+    let movement_window_distance_threshold = config.movement_window_distance_threshold;
+    let auto_zoom_amount = config.zoom_amount;
 
     if max_duration <= 0.0 {
         return Vec::new();
@@ -2076,13 +2075,13 @@ fn generate_zoom_segments_from_clicks_impl(
             let can_join = group.iter().any(|&group_idx| {
                 let group_click = &clicks[group_idx];
                 let group_time = group_click.time_ms / 1000.0;
-                let time_close = (click_time - group_time).abs() < CLICK_GROUP_TIME_THRESHOLD_SECS;
+                let time_close = (click_time - group_time).abs() < click_group_time_threshold_secs;
 
                 let spatial_close = match (click_pos, click_positions.get(&group_idx)) {
                     (Some((x1, y1)), Some((x2, y2))) => {
                         let dx = x1 - x2;
                         let dy = y1 - y2;
-                        (dx * dx + dy * dy).sqrt() < CLICK_GROUP_SPATIAL_THRESHOLD
+                        (dx * dx + dy * dy).sqrt() < click_group_spatial_threshold
                     }
                     _ => true,
                 };
@@ -2116,8 +2115,8 @@ fn generate_zoom_segments_from_clicks_impl(
         let group_start = times.iter().cloned().fold(f64::INFINITY, f64::min);
         let group_end = times.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
 
-        let start = (group_start - CLICK_PRE_PADDING).max(0.0);
-        let end = (group_end + CLICK_POST_PADDING).min(activity_end_limit);
+        let start = (group_start - click_pre_padding).max(0.0);
+        let end = (group_end + click_post_padding).min(activity_end_limit);
 
         if end > start {
             intervals.push((start, end));
@@ -2199,15 +2198,15 @@ fn generate_zoom_segments_from_clicks_impl(
             window_distance = 0.0;
         }
 
-        let significant_movement = distance >= MOVEMENT_EVENT_DISTANCE_THRESHOLD
-            || window_distance >= MOVEMENT_WINDOW_DISTANCE_THRESHOLD;
+        let significant_movement = distance >= movement_event_distance_threshold
+            || window_distance >= movement_window_distance_threshold;
 
         if !significant_movement {
             continue;
         }
 
-        let start = (time - MOVEMENT_PRE_PADDING).max(0.0);
-        let end = (time + MOVEMENT_POST_PADDING).min(activity_end_limit);
+        let start = (time - movement_pre_padding).max(0.0);
+        let end = (time + movement_post_padding).min(activity_end_limit);
 
         if end > start {
             intervals.push((start, end));
@@ -2223,7 +2222,7 @@ fn generate_zoom_segments_from_clicks_impl(
     let mut merged: Vec<(f64, f64)> = Vec::new();
     for interval in intervals {
         if let Some(last) = merged.last_mut()
-            && interval.0 <= last.1 + MERGE_GAP_THRESHOLD
+            && interval.0 <= last.1 + merge_gap_threshold
         {
             last.1 = last.1.max(interval.1);
             continue;
@@ -2235,14 +2234,14 @@ fn generate_zoom_segments_from_clicks_impl(
         .into_iter()
         .filter_map(|(start, end)| {
             let duration = end - start;
-            if duration < MIN_SEGMENT_DURATION {
+            if duration < min_segment_duration {
                 return None;
             }
 
             Some(ZoomSegment {
                 start,
                 end,
-                amount: AUTO_ZOOM_AMOUNT,
+                amount: auto_zoom_amount,
                 mode: ZoomMode::Auto,
                 glide_direction: GlideDirection::None,
                 glide_speed: 0.5,
@@ -2253,13 +2252,11 @@ fn generate_zoom_segments_from_clicks_impl(
         .collect()
 }
 
-/// Generates zoom segments based on mouse click events during recording.
-/// Used during the recording completion process.
 pub fn generate_zoom_segments_from_clicks(
     recording: &studio_recording::CompletedRecording,
     recordings: &ProjectRecordingsMeta,
+    config: &cap_project::AutoZoomConfig,
 ) -> Vec<ZoomSegment> {
-    // Build a temporary RecordingMeta so we can use the common implementation
     let recording_meta = RecordingMeta {
         platform: None,
         project_path: recording.project_path.clone(),
@@ -2269,14 +2266,13 @@ pub fn generate_zoom_segments_from_clicks(
         upload: None,
     };
 
-    generate_zoom_segments_for_project(&recording_meta, recordings)
+    generate_zoom_segments_for_project(&recording_meta, recordings, config)
 }
 
-/// Generates zoom segments from clicks for an existing project.
-/// Used in the editor context where we have RecordingMeta.
 pub fn generate_zoom_segments_for_project(
     recording_meta: &RecordingMeta,
     recordings: &ProjectRecordingsMeta,
+    config: &cap_project::AutoZoomConfig,
 ) -> Vec<ZoomSegment> {
     let RecordingMetaInner::Studio(studio_meta) = &recording_meta.inner else {
         return Vec::new();
@@ -2309,7 +2305,7 @@ pub fn generate_zoom_segments_for_project(
         }
     }
 
-    generate_zoom_segments_from_clicks_impl(all_clicks, all_moves, recordings.duration())
+    generate_zoom_segments_from_clicks_impl(all_clicks, all_moves, recordings.duration(), config)
 }
 
 fn project_config_from_recording(
@@ -2355,7 +2351,11 @@ fn project_config_from_recording(
         .collect::<Vec<_>>();
 
     let zoom_segments = if settings.auto_zoom_on_clicks {
-        generate_zoom_segments_from_clicks(completed_recording, recordings)
+        generate_zoom_segments_from_clicks(
+            completed_recording,
+            recordings,
+            &settings.auto_zoom_config,
+        )
     } else {
         Vec::new()
     };
@@ -2429,8 +2429,12 @@ mod tests {
 
     #[test]
     fn skips_trailing_stop_click() {
-        let segments =
-            generate_zoom_segments_from_clicks_impl(vec![click_event(11_900.0)], vec![], 12.0);
+        let segments = generate_zoom_segments_from_clicks_impl(
+            vec![click_event(11_900.0)],
+            vec![],
+            12.0,
+            &cap_project::AutoZoomConfig::default(),
+        );
 
         assert!(
             segments.is_empty(),
@@ -2447,7 +2451,12 @@ mod tests {
             move_event(1_940.0, 0.74, 0.78),
         ];
 
-        let segments = generate_zoom_segments_from_clicks_impl(clicks, moves, 20.0);
+        let segments = generate_zoom_segments_from_clicks_impl(
+            clicks,
+            moves,
+            20.0,
+            &cap_project::AutoZoomConfig::default(),
+        );
 
         assert!(
             !segments.is_empty(),
@@ -2469,7 +2478,12 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let segments = generate_zoom_segments_from_clicks_impl(Vec::new(), jitter_moves, 15.0);
+        let segments = generate_zoom_segments_from_clicks_impl(
+            Vec::new(),
+            jitter_moves,
+            15.0,
+            &cap_project::AutoZoomConfig::default(),
+        );
 
         assert!(
             segments.is_empty(),

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2027,6 +2027,10 @@ fn generate_zoom_segments_from_clicks_impl(
         return Vec::new();
     }
 
+    if config.ignore_right_clicks {
+        clicks.retain(|c| c.cursor_num == 0);
+    }
+
     clicks.sort_by(|a, b| {
         a.time_ms
             .partial_cmp(&b.time_ms)
@@ -2037,6 +2041,32 @@ fn generate_zoom_segments_from_clicks_impl(
             .partial_cmp(&b.time_ms)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
+
+    if config.double_click_threshold_ms > 0.0 {
+        let mut i = 0;
+        while i < clicks.len() {
+            if !clicks[i].down {
+                i += 1;
+                continue;
+            }
+            let mut j = i + 1;
+            while j < clicks.len() {
+                if !clicks[j].down {
+                    j += 1;
+                    continue;
+                }
+                if clicks[j].time_ms - clicks[i].time_ms > config.double_click_threshold_ms {
+                    break;
+                }
+                if clicks[j].cursor_num == clicks[i].cursor_num {
+                    clicks.remove(j);
+                } else {
+                    j += 1;
+                }
+            }
+            i += 1;
+        }
+    }
 
     while let Some(index) = clicks.iter().rposition(|c| c.down) {
         let time_secs = clicks[index].time_ms / 1000.0;
@@ -2566,6 +2596,136 @@ mod tests {
             2,
             "with dead_zone_radius=0.0, nearby clicks should produce 2 segments, got {}",
             segments.len()
+        );
+    }
+
+    #[test]
+    fn double_click_deduplication() {
+        let double_clicks = vec![
+            CursorClickEvent {
+                down: true,
+                cursor_num: 0,
+                cursor_id: "default".to_string(),
+                time_ms: 1000.0,
+                active_modifiers: vec![],
+            },
+            CursorClickEvent {
+                down: false,
+                cursor_num: 0,
+                cursor_id: "default".to_string(),
+                time_ms: 1050.0,
+                active_modifiers: vec![],
+            },
+            CursorClickEvent {
+                down: true,
+                cursor_num: 0,
+                cursor_id: "default".to_string(),
+                time_ms: 1200.0,
+                active_modifiers: vec![],
+            },
+            CursorClickEvent {
+                down: false,
+                cursor_num: 0,
+                cursor_id: "default".to_string(),
+                time_ms: 1250.0,
+                active_modifiers: vec![],
+            },
+        ];
+        let moves = vec![move_event(999.0, 0.5, 0.5)];
+
+        let config = cap_project::AutoZoomConfig {
+            double_click_threshold_ms: 400.0,
+            ..Default::default()
+        };
+
+        let double_segments =
+            generate_zoom_segments_from_clicks_impl(double_clicks, moves.clone(), 20.0, &config);
+
+        let single_clicks = vec![click_event(1000.0)];
+        let single_segments =
+            generate_zoom_segments_from_clicks_impl(single_clicks, moves, 20.0, &config);
+
+        assert_eq!(
+            double_segments.len(),
+            single_segments.len(),
+            "double-click should be deduped to same segment count as single click: double={}, single={}",
+            double_segments.len(),
+            single_segments.len()
+        );
+    }
+
+    #[test]
+    fn right_click_ignored() {
+        let clicks = vec![
+            CursorClickEvent {
+                down: true,
+                cursor_num: 1,
+                cursor_id: "default".to_string(),
+                time_ms: 1000.0,
+                active_modifiers: vec![],
+            },
+            CursorClickEvent {
+                down: false,
+                cursor_num: 1,
+                cursor_id: "default".to_string(),
+                time_ms: 1050.0,
+                active_modifiers: vec![],
+            },
+        ];
+        let moves = vec![
+            move_event(500.0, 0.1, 0.1),
+            move_event(999.0, 0.5, 0.5),
+            move_event(1500.0, 0.9, 0.9),
+        ];
+
+        let config = cap_project::AutoZoomConfig {
+            ignore_right_clicks: true,
+            ..Default::default()
+        };
+
+        let segments = generate_zoom_segments_from_clicks_impl(clicks, moves, 20.0, &config);
+
+        let has_click_segment = segments.iter().any(|s| {
+            let click_time_secs = 1.0;
+            s.start <= click_time_secs && s.end >= click_time_secs
+        });
+
+        assert!(
+            !has_click_segment,
+            "right-click should be filtered out when ignore_right_clicks is true"
+        );
+    }
+
+    #[test]
+    fn right_click_allowed_when_disabled() {
+        let clicks = vec![
+            CursorClickEvent {
+                down: true,
+                cursor_num: 1,
+                cursor_id: "default".to_string(),
+                time_ms: 1000.0,
+                active_modifiers: vec![],
+            },
+            CursorClickEvent {
+                down: false,
+                cursor_num: 1,
+                cursor_id: "default".to_string(),
+                time_ms: 1050.0,
+                active_modifiers: vec![],
+            },
+        ];
+        let moves = vec![move_event(999.0, 0.5, 0.5)];
+
+        let config = cap_project::AutoZoomConfig {
+            ignore_right_clicks: false,
+            ..Default::default()
+        };
+
+        let segments = generate_zoom_segments_from_clicks_impl(clicks, moves, 20.0, &config);
+
+        assert!(
+            !segments.is_empty(),
+            "right-click should produce segments when ignore_right_clicks is false"
         );
     }
 }

--- a/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
@@ -1,11 +1,49 @@
+import { Slider as KSlider } from "@kobalte/core/slider";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { type } from "@tauri-apps/plugin-os";
 import { createResource, Show } from "solid-js";
 import { createStore } from "solid-js/store";
 
 import { generalSettingsStore } from "~/store";
-import { commands, type GeneralSettingsStore } from "~/utils/tauri";
+import {
+	commands,
+	type AutoZoomConfig,
+	type GeneralSettingsStore,
+} from "~/utils/tauri";
 import { ToggleSettingItem } from "./Setting";
+
+function SettingSlider(props: {
+	label: string;
+	value: number;
+	onChange: (v: number) => void;
+	min: number;
+	max: number;
+	step: number;
+	format?: (v: number) => string;
+}) {
+	return (
+		<div class="space-y-1.5">
+			<div class="flex justify-between items-center text-sm">
+				<span class="text-gray-11">{props.label}</span>
+				<span class="text-gray-12 font-medium">
+					{props.format ? props.format(props.value) : props.value}
+				</span>
+			</div>
+			<KSlider
+				value={[props.value]}
+				onChange={(v) => props.onChange(v[0])}
+				minValue={props.min}
+				maxValue={props.max}
+				step={props.step}
+			>
+				<KSlider.Track class="h-[0.3rem] cursor-pointer relative bg-gray-4 rounded-full w-full">
+					<KSlider.Fill class="absolute h-full rounded-full bg-blue-9" />
+					<KSlider.Thumb class="block size-4 rounded-full bg-white border-2 border-blue-9 -top-[0.35rem] outline-none" />
+				</KSlider.Track>
+			</KSlider>
+		</div>
+	);
+}
 
 export default function ExperimentalSettings() {
 	const [store] = createResource(() => generalSettingsStore.get());
@@ -27,8 +65,31 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 			enableNativeCameraPreview: false,
 			autoZoomOnClicks: false,
 			custom_cursor_capture2: true,
+			autoZoomConfig: {
+				zoomAmount: 1.5,
+				clickGroupTimeThreshold: 2.5,
+				clickGroupSpatialThreshold: 0.15,
+				clickPrePadding: 0.4,
+				clickPostPadding: 1.8,
+				movementPrePadding: 0.3,
+				movementPostPadding: 1.5,
+				mergeGapThreshold: 0.8,
+				minSegmentDuration: 1.0,
+				movementEventDistanceThreshold: 0.02,
+				movementWindowDistanceThreshold: 0.08,
+			},
 		},
 	);
+
+	const handleConfigChange = <K extends keyof AutoZoomConfig>(
+		key: K,
+		value: AutoZoomConfig[K],
+	) => {
+		setSettings("autoZoomConfig", key, value);
+		generalSettingsStore.set({
+			autoZoomConfig: { ...settings.autoZoomConfig, [key]: value },
+		});
+	};
 
 	const handleChange = async <K extends keyof typeof settings>(
 		key: K,
@@ -95,6 +156,53 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 							}}
 						/>
 					</div>
+					<Show when={settings.autoZoomOnClicks}>
+						<div class="px-3 py-3 space-y-4">
+							<SettingSlider
+								label="Zoom Amount"
+								value={settings.autoZoomConfig?.zoomAmount ?? 1.5}
+								onChange={(v) => handleConfigChange("zoomAmount", v)}
+								min={1.0}
+								max={4.0}
+								step={0.1}
+								format={(v) => `${v.toFixed(1)}x`}
+							/>
+							<SettingSlider
+								label="Sensitivity"
+								value={
+									settings.autoZoomConfig
+										?.movementWindowDistanceThreshold ?? 0.08
+								}
+								onChange={(v) =>
+									handleConfigChange(
+										"movementWindowDistanceThreshold",
+										v,
+									)
+								}
+								min={0.02}
+								max={0.2}
+								step={0.01}
+								format={(v) => {
+									if (v <= 0.05) return "High";
+									if (v <= 0.12) return "Medium";
+									return "Low";
+								}}
+							/>
+							<SettingSlider
+								label="Smoothing"
+								value={
+									settings.autoZoomConfig?.mergeGapThreshold ?? 0.8
+								}
+								onChange={(v) =>
+									handleConfigChange("mergeGapThreshold", v)
+								}
+								min={0.2}
+								max={2.0}
+								step={0.1}
+								format={(v) => `${v.toFixed(1)}s`}
+							/>
+						</div>
+					</Show>
 				</div>
 			</div>
 		</div>

--- a/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
@@ -77,6 +77,7 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 				minSegmentDuration: 1.0,
 				movementEventDistanceThreshold: 0.02,
 				movementWindowDistanceThreshold: 0.08,
+				deadZoneRadius: 0.1,
 			},
 		},
 	);

--- a/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
@@ -78,6 +78,8 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 				movementEventDistanceThreshold: 0.02,
 				movementWindowDistanceThreshold: 0.08,
 				deadZoneRadius: 0.1,
+				doubleClickThresholdMs: 400.0,
+				ignoreRightClicks: true,
 			},
 		},
 	);

--- a/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
@@ -6,8 +6,8 @@ import { createStore } from "solid-js/store";
 
 import { generalSettingsStore } from "~/store";
 import {
-	commands,
 	type AutoZoomConfig,
+	commands,
 	type GeneralSettingsStore,
 } from "~/utils/tauri";
 import { ToggleSettingItem } from "./Setting";
@@ -170,14 +170,11 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 							<SettingSlider
 								label="Sensitivity"
 								value={
-									settings.autoZoomConfig
-										?.movementWindowDistanceThreshold ?? 0.08
+									settings.autoZoomConfig?.movementWindowDistanceThreshold ??
+									0.08
 								}
 								onChange={(v) =>
-									handleConfigChange(
-										"movementWindowDistanceThreshold",
-										v,
-									)
+									handleConfigChange("movementWindowDistanceThreshold", v)
 								}
 								min={0.02}
 								max={0.2}
@@ -190,12 +187,8 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 							/>
 							<SettingSlider
 								label="Smoothing"
-								value={
-									settings.autoZoomConfig?.mergeGapThreshold ?? 0.8
-								}
-								onChange={(v) =>
-									handleConfigChange("mergeGapThreshold", v)
-								}
+								value={settings.autoZoomConfig?.mergeGapThreshold ?? 0.8}
+								onChange={(v) => handleConfigChange("mergeGapThreshold", v)}
 								min={0.2}
 								max={2.0}
 								step={0.1}

--- a/crates/project/src/configuration.rs
+++ b/crates/project/src/configuration.rs
@@ -455,6 +455,40 @@ impl Default for ScreenMovementSpring {
     }
 }
 
+#[derive(Type, Serialize, Deserialize, Clone, Copy, Debug)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AutoZoomConfig {
+    pub zoom_amount: f64,
+    pub click_group_time_threshold: f64,
+    pub click_group_spatial_threshold: f64,
+    pub click_pre_padding: f64,
+    pub click_post_padding: f64,
+    pub movement_pre_padding: f64,
+    pub movement_post_padding: f64,
+    pub merge_gap_threshold: f64,
+    pub min_segment_duration: f64,
+    pub movement_event_distance_threshold: f64,
+    pub movement_window_distance_threshold: f64,
+}
+
+impl Default for AutoZoomConfig {
+    fn default() -> Self {
+        Self {
+            zoom_amount: 1.5,
+            click_group_time_threshold: 2.5,
+            click_group_spatial_threshold: 0.15,
+            click_pre_padding: 0.4,
+            click_post_padding: 1.8,
+            movement_pre_padding: 0.3,
+            movement_post_padding: 1.5,
+            merge_gap_threshold: 0.8,
+            min_segment_duration: 1.0,
+            movement_event_distance_threshold: 0.02,
+            movement_window_distance_threshold: 0.08,
+        }
+    }
+}
+
 impl CursorAnimationStyle {
     pub fn preset(self) -> Option<CursorSmoothingPreset> {
         match self {

--- a/crates/project/src/configuration.rs
+++ b/crates/project/src/configuration.rs
@@ -469,6 +469,7 @@ pub struct AutoZoomConfig {
     pub min_segment_duration: f64,
     pub movement_event_distance_threshold: f64,
     pub movement_window_distance_threshold: f64,
+    pub dead_zone_radius: f64,
 }
 
 impl Default for AutoZoomConfig {
@@ -485,6 +486,7 @@ impl Default for AutoZoomConfig {
             min_segment_duration: 1.0,
             movement_event_distance_threshold: 0.02,
             movement_window_distance_threshold: 0.08,
+            dead_zone_radius: 0.1,
         }
     }
 }

--- a/crates/project/src/configuration.rs
+++ b/crates/project/src/configuration.rs
@@ -470,6 +470,8 @@ pub struct AutoZoomConfig {
     pub movement_event_distance_threshold: f64,
     pub movement_window_distance_threshold: f64,
     pub dead_zone_radius: f64,
+    pub double_click_threshold_ms: f64,
+    pub ignore_right_clicks: bool,
 }
 
 impl Default for AutoZoomConfig {
@@ -487,6 +489,8 @@ impl Default for AutoZoomConfig {
             movement_event_distance_threshold: 0.02,
             movement_window_distance_threshold: 0.08,
             dead_zone_radius: 0.1,
+            double_click_threshold_ms: 400.0,
+            ignore_right_clicks: true,
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds click preprocessing to auto-zoom segment generation (refs #1646, builds on #1663, #1664):

- **Double-click deduplication** — rapid clicks within `double_click_threshold_ms` (default 400ms) on the same button are collapsed to a single click, preventing redundant zoom segments from double-clicks
- **Right-click filtering** — when `ignore_right_clicks` is true (default), non-primary button clicks (cursor_num != 0) are stripped before segment generation, so context menu interactions don't trigger zoom
- **3 new tests** covering dedup, right-click filtering enabled/disabled

### How it works

Preprocessing runs before click sorting and grouping:
1. `clicks.retain(|c| c.cursor_num == 0)` removes right/middle clicks
2. After sorting, a linear scan removes same-button down-clicks within the threshold window

### Config fields added to `AutoZoomConfig`

| Field | Type | Default | Purpose |
|-------|------|---------|---------|
| `double_click_threshold_ms` | f64 | 400.0 | Time window for deduplication |
| `ignore_right_clicks` | bool | true | Filter non-primary clicks |

## Test plan

- [ ] `double_click_deduplication` — two clicks 200ms apart produce same segments as single click
- [ ] `right_click_ignored` — right-click produces no zoom segment when filtering enabled
- [ ] `right_click_allowed_when_disabled` — right-click works normally when filtering disabled
- [ ] Manual: double-click on a file → single smooth zoom, not two jittery zooms

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two click preprocessing steps to the auto-zoom segment generator — double-click deduplication (collapsing rapid same-button clicks within a configurable threshold) and right-click filtering — along with a new `AutoZoomConfig` struct that promotes all previously hardcoded constants into configurable fields. A `dead_zone_radius` feature is also quietly introduced, merging spatially co-located clicks into a single zoom group.

**Key changes:**
- `AutoZoomConfig` struct added to `crates/project/src/configuration.rs` with 14 fields and sensible defaults; wired into `GeneralSettingsStore`, recording completion, and the Tauri editor command.
- `generate_zoom_segments_from_clicks_impl` now accepts `&AutoZoomConfig`, replacing all `const` literals with configurable values, and runs the two new preprocessing passes before grouping.
- Three new tests cover dedup, right-click filtering enabled/disabled, and two dead-zone scenarios.
- `experimental.tsx` gains a `SettingSlider` component and exposes Zoom Amount, Sensitivity, and Smoothing controls when auto-zoom is enabled.

**Issues found:**
- **`right_click_ignored` test is broken**: the three large movement events included in the test generate movement-based segments that cover `t=1.0s`, making `has_click_segment` always `true` and the assertion always fail — even when right-click filtering is working correctly. The moves should be removed or replaced with zero-displacement events.
- **Dead zone merging lacks a time constraint**: `in_dead_zone` checks only spatial proximity to the group centroid, with no temporal bound. Two clicks at the same screen position minutes apart will be collapsed into one group, producing an erroneously long zoom segment. The check should be gated behind the same `click_group_time_threshold_secs` guard used by `time_and_spatial`.
- **Orphaned up-events after dedup**: `clicks.remove(j)` drops the duplicate down-event but leaves its paired up-event in the vector; while harmless today, it leaves the clicks slice inconsistent for any future consumer of up-events.
- **Hardcoded frontend defaults**: the fallback `autoZoomConfig` object in `experimental.tsx` duplicates Rust-side defaults and will silently diverge if backend defaults change.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is: a new test will fail in CI, and the dead zone logic can produce excessively long zoom segments in production recordings.
- Two functional bugs were identified — a broken test that will fail on every CI run, and a time-unbounded dead zone condition that can corrupt segment generation for users who click the same UI element multiple times throughout a recording. Both issues need to be resolved before this is production-ready.
- apps/desktop/src-tauri/src/recording.rs requires the most attention: fix the `right_click_ignored` test move events and add a time constraint to the `in_dead_zone` grouping condition.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/recording.rs | Core zoom-segment logic extended with right-click filtering, double-click dedup, and dead zone merging; contains two bugs: the `right_click_ignored` test will fail due to large movement events generating segments, and the dead zone grouping condition lacks a time constraint that can create excessively long zoom segments. |
| crates/project/src/configuration.rs | New `AutoZoomConfig` struct added with sensible defaults; clean derivation of `Type`, `Serialize`, `Deserialize`, and explicit `Default` impl — no issues found. |
| apps/desktop/src-tauri/src/general_settings.rs | Adds `auto_zoom_config` field to `GeneralSettingsStore` with `#[serde(default)]` and proper `Default` initialization — straightforward and correct. |
| apps/desktop/src-tauri/src/lib.rs | Tauri command updated to accept `AppHandle`, reads settings with a silent fallback to defaults (`unwrap_or(None).unwrap_or_default()`), and threads the config through correctly; the silent error swallowing is acceptable here but worth noting. |
| apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx | New `SettingSlider` component and three auto-zoom sliders added; hardcoded default values in the fallback store object risk drifting from backend defaults, but the UI logic itself is correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[generate_zoom_segments_from_clicks_impl] --> B{ignore_right_clicks?}
    B -- Yes --> C[clicks.retain cursor_num == 0]
    B -- No --> D[Keep all clicks]
    C --> E[Sort clicks by time_ms]
    D --> E
    E --> F{double_click_threshold_ms > 0?}
    F -- Yes --> G[Deduplicate: remove same-button down-clicks within threshold window]
    F -- No --> H[Skip dedup]
    G --> I[Remove trailing clicks beyond activity_end_limit]
    H --> I
    I --> J[Build click_positions map from move events]
    J --> K[Group clicks by time + spatial proximity OR dead zone centroid]
    K --> L[Build click intervals with pre/post padding]
    L --> M[Build movement intervals from significant moves]
    M --> N[Merge overlapping intervals with gap threshold]
    N --> O[Filter segments below min_segment_duration]
    O --> P[Return ZoomSegments with zoom_amount]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/recording.rs
Line: 2675-2696

Comment:
**`right_click_ignored` test will always fail due to movement segments**

The test includes three move events with large displacements — (0.1→0.5→0.9) in both axes — that will generate movement-based zoom segments regardless of whether right-clicks are filtered.

When the move event at `999ms` is processed:
- Distance ≈ `sqrt((0.5-0.1)² + (0.5-0.1)²) ≈ 0.566`, which far exceeds both `movement_event_distance_threshold` (0.02) and `movement_window_distance_threshold` (0.08).
- This produces a segment from `0.699s` to `2.499s`, which covers `t=1.0s` (the click time).

Since `has_click_segment` checks if **any** segment covers `t=1.0s` (not just click-generated ones), the movement segment causes the assertion `!has_click_segment` to fail — even when right-click filtering is working correctly.

To fix the test, the movement events should be removed or replaced with small/stationary ones that won't trigger the movement detection threshold:

```suggestion
        let moves: Vec<cap_project::cursor_captures::CursorMoveEvent> = vec![];
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/recording.rs
Line: 2123-2141

Comment:
**Dead zone merging has no time constraint**

The `in_dead_zone` condition merges a new click into an existing group based purely on spatial proximity to the group's centroid. Unlike `time_and_spatial`, which enforces both `time_close` (< 2.5 s by default) and spatial proximity, `in_dead_zone` has **no temporal bound**.

Consider a scenario where a user clicks a toolbar button at `t=5s`, works for 3 minutes, then clicks the same button again at `t=185s`. Both clicks are within `dead_zone_radius` (0.1) of each other, so the second click is merged into the first group. The resulting segment spans from `~4.6s` to `~186.8s` — nearly the entire recording — instead of producing two short, appropriate zoom segments.

To prevent this, the dead zone check should also respect the same `click_group_time_threshold_secs` (or a comparable time window):

```rust
let in_dead_zone = dead_zone_radius > 0.0 && click_pos.is_some() && {
    let (cx, cy) = click_pos.unwrap();
    // Check time proximity first to avoid iterating positions unnecessarily
    let time_close = group.iter().any(|&gi| {
        let group_time = clicks[gi].time_ms / 1000.0;
        (click_time - group_time).abs() < click_group_time_threshold_secs
    });
    if !time_close {
        false
    } else {
        let group_positions: Vec<(f64, f64)> = group
            .iter()
            .filter_map(|&gi| click_positions.get(&gi).copied())
            .collect();
        if group_positions.is_empty() {
            false
        } else {
            let count = group_positions.len() as f64;
            let centroid_x = group_positions.iter().map(|(x, _)| x).sum::<f64>() / count;
            let centroid_y = group_positions.iter().map(|(_, y)| y).sum::<f64>() / count;
            let dx = cx - centroid_x;
            let dy = cy - centroid_y;
            (dx * dx + dy * dy).sqrt() < dead_zone_radius
        }
    }
};
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/recording.rs
Line: 2045-2069

Comment:
**Dedup removes down events but leaves orphaned up events**

When a duplicate down event is removed via `clicks.remove(j)`, its paired up event (`down: false`) is left in the vector. For example, with a double-click sequence `[1000ms↓, 1050ms↑, 1200ms↓, 1250ms↑]`, after dedup the vector becomes `[1000ms↓, 1050ms↑, 1250ms↑]` — with an orphaned up event at 1250ms.

This doesn't cause incorrect segment generation currently (grouping only iterates `c.down` events), but it leaves the `clicks` vector in an inconsistent state that could silently break future code relying on down/up pairing. Consider also removing the immediately-following up event:

```rust
if clicks[j].cursor_num == clicks[i].cursor_num {
    clicks.remove(j);
    // Also remove the paired up-event if it immediately follows
    if j < clicks.len() && !clicks[j].down && clicks[j].cursor_num == clicks[i].cursor_num {
        clicks.remove(j);
    }
} else {
    j += 1;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
Line: 68-84

Comment:
**Hardcoded default config values may drift from Rust defaults**

The `autoZoomConfig` fallback object in `createStore` duplicates the default values from `AutoZoomConfig::default()` in Rust. If a default is updated on the backend (e.g., `zoom_amount` is bumped from 1.5 to 2.0), the frontend fallback will silently serve the stale value to users who have never persisted a config.

Consider deriving these defaults from the serialized Tauri command response rather than hardcoding them. At a minimum, the fallback should be an empty object (`{}`) that lets backend-provided `serde` defaults fill in, rather than a manually maintained copy:

```suggestion
			autoZoomConfig: {} as AutoZoomConfig,
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(recording): add..."](https://github.com/capsoftware/cap/commit/6822285fd946a0fe222c4f05421e9801a8421dcb)</sub>

> Greptile also left **4 inline comments** on this PR.

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->