### PR TITLE
feat: extend deeplinks + add Raycast extension

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -26,6 +26,15 @@ pub enum DeepLinkAction {
         mode: RecordingMode,
     },
     StopRecording,
+    PauseRecording,
+    ResumeRecording,
+    TogglePauseRecording,
+    SwitchMicrophone {
+        label: Option<String>,
+    },
+    SwitchCamera {
+        camera: Option<DeviceOrModelID>,
+    },
     OpenEditor {
         project_path: PathBuf,
     },
@@ -146,6 +155,23 @@ impl DeepLinkAction {
             }
             DeepLinkAction::StopRecording => {
                 crate::recording::stop_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::PauseRecording => {
+                crate::recording::pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::ResumeRecording => {
+                crate::recording::resume_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::TogglePauseRecording => {
+                crate::recording::toggle_pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::SwitchMicrophone { label } => {
+                let state = app.state::<ArcLock<App>>();
+                crate::set_mic_input(state, label).await
+            }
+            DeepLinkAction::SwitchCamera { camera } => {
+                let state = app.state::<ArcLock<App>>();
+                crate::set_camera_input(app.clone(), state, camera, None).await
             }
             DeepLinkAction::OpenEditor { project_path } => {
                 crate::open_project_from_path(Path::new(&project_path), app.clone())

--- a/extensions/raycast/README.md
+++ b/extensions/raycast/README.md
@@ -1,0 +1,43 @@
+# Cap for Raycast
+
+Control [Cap](https://cap.so) screen recorder directly from Raycast.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| **Start Recording** | Start a new screen recording |
+| **Stop Recording** | Stop the current recording |
+| **Toggle Pause** | Pause or resume the current recording |
+| **Open Cap** | Open the Cap application |
+| **Open Settings** | Open Cap settings |
+| **Recent Recordings** | Browse your recent recordings |
+
+## Requirements
+
+- [Cap](https://cap.so) desktop app installed
+- macOS
+
+## How it works
+
+This extension communicates with Cap via the `cap-desktop://` deep link URL scheme. All commands are executed instantly without opening any UI (except "Recent Recordings" which shows a list view).
+
+## Deep Link Format
+
+Cap uses the following deep link format:
+
+```
+cap-desktop://action?value=<JSON-encoded-action>
+```
+
+### Supported Actions
+
+- `start_recording` — Start recording with capture mode, camera, mic options
+- `stop_recording` — Stop the current recording
+- `pause_recording` — Pause the current recording
+- `resume_recording` — Resume a paused recording
+- `toggle_pause_recording` — Toggle pause/resume
+- `open_editor` — Open a recording in the editor
+- `open_settings` — Open Cap settings
+- `switch_microphone` — Switch to a different microphone
+- `switch_camera` — Switch to a different camera

--- a/extensions/raycast/package.json
+++ b/extensions/raycast/package.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://www.raycast.com/schemas/extension.json",
+  "name": "cap",
+  "title": "Cap",
+  "description": "Control Cap screen recorder — start, stop, pause, and resume recordings directly from Raycast",
+  "icon": "cap-icon.png",
+  "author": "cap",
+  "categories": ["Productivity", "Applications"],
+  "license": "AGPL-3.0",
+  "commands": [
+    {
+      "name": "start-recording",
+      "title": "Start Recording",
+      "description": "Start a new screen recording with Cap",
+      "mode": "no-view",
+      "keywords": ["record", "screen", "capture"]
+    },
+    {
+      "name": "stop-recording",
+      "title": "Stop Recording",
+      "description": "Stop the current recording",
+      "mode": "no-view",
+      "keywords": ["stop", "end", "finish"]
+    },
+    {
+      "name": "toggle-pause",
+      "title": "Toggle Pause",
+      "description": "Pause or resume the current recording",
+      "mode": "no-view",
+      "keywords": ["pause", "resume", "toggle"]
+    },
+    {
+      "name": "open-cap",
+      "title": "Open Cap",
+      "description": "Open the Cap application",
+      "mode": "no-view",
+      "keywords": ["open", "launch"]
+    },
+    {
+      "name": "open-settings",
+      "title": "Open Settings",
+      "description": "Open Cap settings",
+      "mode": "no-view",
+      "keywords": ["settings", "preferences", "config"]
+    },
+    {
+      "name": "recent-recordings",
+      "title": "Recent Recordings",
+      "description": "Browse your recent Cap recordings",
+      "mode": "view",
+      "keywords": ["recent", "history", "list", "browse"]
+    }
+  ],
+  "dependencies": {
+    "@raycast/api": "^1.83.1",
+    "@raycast/utils": "^1.17.0"
+  },
+  "devDependencies": {
+    "@raycast/eslint-config": "^1.0.11",
+    "@types/node": "22.5.4",
+    "@types/react": "18.3.3",
+    "eslint": "^8.57.0",
+    "prettier": "^3.3.3",
+    "typescript": "^5.4.5"
+  },
+  "scripts": {
+    "build": "ray build",
+    "dev": "ray develop",
+    "fix-lint": "ray lint --fix",
+    "lint": "ray lint"
+  }
+}

--- a/extensions/raycast/src/open-cap.ts
+++ b/extensions/raycast/src/open-cap.ts
@@ -1,0 +1,11 @@
+import { showHUD } from "@raycast/api";
+import { openCap } from "./utils";
+
+export default async function command() {
+  try {
+    await openCap();
+    await showHUD("🎬 Opening Cap...");
+  } catch {
+    await showHUD("❌ Failed to open Cap. Is it installed?");
+  }
+}

--- a/extensions/raycast/src/open-settings.ts
+++ b/extensions/raycast/src/open-settings.ts
@@ -1,0 +1,12 @@
+import { showHUD } from "@raycast/api";
+import { sendDeepLink } from "./utils";
+
+export default async function command() {
+  try {
+    // serde struct variant with optional field
+    await sendDeepLink({ open_settings: { page: null } });
+    await showHUD("⚙️ Cap: Opening settings...");
+  } catch {
+    await showHUD("❌ Failed to open settings. Is Cap running?");
+  }
+}

--- a/extensions/raycast/src/recent-recordings.tsx
+++ b/extensions/raycast/src/recent-recordings.tsx
@@ -16,15 +16,13 @@ function getRecordings(): Recording[] {
 
   try {
     return readdirSync(dir)
-      .filter((name) => {
-        const fullPath = join(dir, name);
-        return statSync(fullPath).isDirectory();
-      })
       .map((name) => {
         const fullPath = join(dir, name);
         const stat = statSync(fullPath);
-        return { name, path: fullPath, date: stat.mtime };
+        return { name, path: fullPath, stat };
       })
+      .filter(({ name, stat }) => name.endsWith(".cap") && stat.isDirectory())
+      .map(({ name, path, stat }) => ({ name, path, date: stat.mtime }))
       .sort((a, b) => b.date.getTime() - a.date.getTime())
       .slice(0, 50);
   } catch {
@@ -57,7 +55,7 @@ export default function Command() {
                 <Action
                   title="Open in Cap"
                   onAction={async () => {
-                    await open(`file://${rec.path}`);
+                    await open(`file://${encodeURI(rec.path)}`);
                     await showHUD("Opening in Cap...");
                   }}
                 />

--- a/extensions/raycast/src/recent-recordings.tsx
+++ b/extensions/raycast/src/recent-recordings.tsx
@@ -1,0 +1,73 @@
+import { Action, ActionPanel, List, open, showHUD } from "@raycast/api";
+import { useState, useEffect } from "react";
+import { readdirSync, statSync, existsSync } from "fs";
+import { join } from "path";
+import { getRecordingsDir } from "./utils";
+
+interface Recording {
+  name: string;
+  path: string;
+  date: Date;
+}
+
+function getRecordings(): Recording[] {
+  const dir = getRecordingsDir();
+  if (!existsSync(dir)) return [];
+
+  try {
+    return readdirSync(dir)
+      .filter((name) => {
+        const fullPath = join(dir, name);
+        return statSync(fullPath).isDirectory();
+      })
+      .map((name) => {
+        const fullPath = join(dir, name);
+        const stat = statSync(fullPath);
+        return { name, path: fullPath, date: stat.mtime };
+      })
+      .sort((a, b) => b.date.getTime() - a.date.getTime())
+      .slice(0, 50);
+  } catch {
+    return [];
+  }
+}
+
+export default function Command() {
+  const [recordings, setRecordings] = useState<Recording[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    setRecordings(getRecordings());
+    setIsLoading(false);
+  }, []);
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Search recordings...">
+      {recordings.length === 0 ? (
+        <List.EmptyView title="No recordings found" description="Record something with Cap first!" />
+      ) : (
+        recordings.map((rec) => (
+          <List.Item
+            key={rec.path}
+            title={rec.name}
+            subtitle={rec.date.toLocaleDateString()}
+            accessories={[{ date: rec.date }]}
+            actions={
+              <ActionPanel>
+                <Action
+                  title="Open in Cap"
+                  onAction={async () => {
+                    await open(`file://${rec.path}`);
+                    await showHUD("Opening in Cap...");
+                  }}
+                />
+                <Action.ShowInFinder path={rec.path} />
+                <Action.CopyToClipboard title="Copy Path" content={rec.path} />
+              </ActionPanel>
+            }
+          />
+        ))
+      )}
+    </List>
+  );
+}

--- a/extensions/raycast/src/start-recording.ts
+++ b/extensions/raycast/src/start-recording.ts
@@ -1,0 +1,20 @@
+import { showHUD } from "@raycast/api";
+import { sendDeepLink } from "./utils";
+
+export default async function command() {
+  try {
+    // serde externally-tagged struct variant
+    await sendDeepLink({
+      start_recording: {
+        capture_mode: { screen: "Main Display" },
+        camera: null,
+        mic_label: null,
+        capture_system_audio: false,
+        mode: "instant",
+      },
+    });
+    await showHUD("🔴 Cap: Recording started");
+  } catch {
+    await showHUD("❌ Failed to start recording. Is Cap running?");
+  }
+}

--- a/extensions/raycast/src/stop-recording.ts
+++ b/extensions/raycast/src/stop-recording.ts
@@ -1,0 +1,12 @@
+import { showHUD } from "@raycast/api";
+import { sendDeepLink } from "./utils";
+
+export default async function command() {
+  try {
+    // serde unit variant
+    await sendDeepLink("stop_recording");
+    await showHUD("⏹ Cap: Recording stopped");
+  } catch {
+    await showHUD("❌ Failed to stop recording. Is Cap running?");
+  }
+}

--- a/extensions/raycast/src/toggle-pause.ts
+++ b/extensions/raycast/src/toggle-pause.ts
@@ -1,0 +1,12 @@
+import { showHUD } from "@raycast/api";
+import { sendDeepLink } from "./utils";
+
+export default async function command() {
+  try {
+    // serde unit variant
+    await sendDeepLink("toggle_pause_recording");
+    await showHUD("⏯ Cap: Toggled pause");
+  } catch {
+    await showHUD("❌ Failed to toggle pause. Is Cap running?");
+  }
+}

--- a/extensions/raycast/src/utils.ts
+++ b/extensions/raycast/src/utils.ts
@@ -1,0 +1,32 @@
+import { open, showHUD } from "@raycast/api";
+
+const CAP_DEEPLINK_SCHEME = "cap-desktop://";
+
+/**
+ * Send a deep link action to the Cap desktop app.
+ * URL format: cap-desktop://action?value=<JSON-encoded serde enum>
+ *
+ * The `value` parameter is the serde-serialized DeepLinkAction enum.
+ * For unit variants: `"stop_recording"` (just a string)
+ * For struct variants: `{"start_recording": { ... }}`
+ */
+export async function sendDeepLink(value: string | Record<string, unknown>): Promise<void> {
+  const encodedValue = encodeURIComponent(JSON.stringify(value));
+  const url = `${CAP_DEEPLINK_SCHEME}action?value=${encodedValue}`;
+  await open(url);
+}
+
+/**
+ * Open the Cap app without a specific action.
+ */
+export async function openCap(): Promise<void> {
+  await open(CAP_DEEPLINK_SCHEME);
+}
+
+/**
+ * Get the Cap recordings directory path.
+ */
+export function getRecordingsDir(): string {
+  const home = process.env.HOME || "~";
+  return `${home}/.cap/recordings`;
+}

--- a/extensions/raycast/src/utils.ts
+++ b/extensions/raycast/src/utils.ts
@@ -25,8 +25,9 @@ export async function openCap(): Promise<void> {
 
 /**
  * Get the Cap recordings directory path.
+ * Cap (Tauri) stores recordings under the app data directory.
  */
 export function getRecordingsDir(): string {
   const home = process.env.HOME || "~";
-  return `${home}/.cap/recordings`;
+  return `${home}/Library/Application Support/so.cap.desktop/recordings`;
 }

--- a/extensions/raycast/tsconfig.json
+++ b/extensions/raycast/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://www.raycast.com/schemas/extension.json",
+  "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "strict": true,
     "jsx": "react-jsx",

--- a/extensions/raycast/tsconfig.json
+++ b/extensions/raycast/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://www.raycast.com/schemas/extension.json",
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "react-jsx",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "env.d.ts"]
+}


### PR DESCRIPTION
## 🎯 Bounty: #1540 — Deeplinks support + Raycast Extension

### Deeplinks (Rust)
Extended `DeepLinkAction` enum with new actions:
- `PauseRecording` — pause the current recording
- `ResumeRecording` — resume a paused recording
- `TogglePauseRecording` — toggle pause/resume
- `SwitchMicrophone { label }` — switch to a different mic
- `SwitchCamera { camera }` — switch to a different camera

All new actions delegate to existing functions (`pause_recording`, `resume_recording`, `toggle_pause_recording`, `set_mic_input`, `set_camera_input`).

### Raycast Extension
Full Raycast extension at `extensions/raycast/`:
- **Start Recording** — start screen recording via deeplink
- **Stop Recording** — stop current recording
- **Toggle Pause** — pause/resume recording
- **Open Cap** — launch the app
- **Open Settings** — open Cap settings
- **Recent Recordings** — browse recordings with search

All commands use the `cap-desktop://action?value=<json>` deeplink scheme with correct serde serialization format.

### Testing
- Deeplink URL format matches existing `TryFrom<&Url>` parser
- New Rust variants follow existing patterns (delegate to `crate::recording::*`)
- Raycast commands are no-view for instant execution

Closes #1540

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends Cap's deeplink system with five new Rust actions (`PauseRecording`, `ResumeRecording`, `TogglePauseRecording`, `SwitchMicrophone`, `SwitchCamera`) and ships a full Raycast extension that drives Cap via the `cap-desktop://` deep link scheme. The Rust side is clean and follows established patterns well. The Raycast extension commands for start, stop, toggle-pause, open-cap, and open-settings are all correctly implemented. However, the **Recent Recordings** feature has two bugs that make it non-functional:

- `getRecordingsDir()` returns `$HOME/.cap/recordings`, but Cap stores recordings under the Tauri `app_data_dir()` (`~/Library/Application Support/<bundle-id>/recordings`), so the directory is never found.
- Recording paths are passed directly into `file://` URLs without percent-encoding; paths containing spaces (e.g. `Application Support`) will produce malformed URLs that Cap's Rust URL parser will reject.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the Rust deeplink additions and most Raycast commands; the Recent Recordings feature will be silently broken until the path and URL-encoding issues are fixed.

Two P1 issues affect the same feature (Recent Recordings): wrong recordings directory path and unencoded file:// URLs. All other commands work correctly. Rust changes are solid with no issues found.

extensions/raycast/src/utils.ts (getRecordingsDir path) and extensions/raycast/src/recent-recordings.tsx (file:// URL encoding and directory filtering)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/deeplink_actions.rs | Adds PauseRecording, ResumeRecording, TogglePauseRecording, SwitchMicrophone, and SwitchCamera deeplink actions; each delegates cleanly to existing recording/input functions following established patterns. |
| extensions/raycast/src/utils.ts | Core deeplink helper is correct; however getRecordingsDir() returns ~/.cap/recordings which does not match the actual Tauri app_data_dir path, breaking Recent Recordings entirely. |
| extensions/raycast/src/recent-recordings.tsx | Reads wrong recordings directory and passes unencoded file paths as file:// URLs; both issues prevent recordings from being found or opened correctly. |
| extensions/raycast/src/start-recording.ts | Sends correct serde-tagged struct deeplink to start recording; hardcodes 'Main Display' which may fail on systems with differently named displays, but is a reasonable default. |
| extensions/raycast/tsconfig.json | Compiler options are appropriate, but $schema incorrectly points to the Raycast extension schema instead of the TypeScript config schema. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Raycast
    participant macOS
    participant Cap
    participant Recording

    User->>Raycast: Invoke command (e.g. Toggle Pause)
    Raycast->>Raycast: sendDeepLink("toggle_pause_recording")
    Raycast->>macOS: open cap-desktop://action?value=...
    macOS->>Cap: Deep link event
    Cap->>Cap: Parse URL into DeepLinkAction
    Cap->>Recording: toggle_pause_recording(app, state)
    Recording-->>Cap: Ok(())
    Raycast-->>User: showHUD("Toggled pause")
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: extensions/raycast/src/utils.ts
Line: 29-32

Comment:
**Incorrect recordings directory path**

`getRecordingsDir()` returns `$HOME/.cap/recordings`, but Cap (built with Tauri) stores recordings under the Tauri `app_data_dir()`, which on macOS resolves to `~/Library/Application Support/<bundle-identifier>/recordings` (e.g. `~/Library/Application Support/so.cap.desktop/recordings`). The hardcoded `~/.cap/recordings` path does not exist, so the **Recent Recordings** command will always return an empty list regardless of how many recordings exist.

The correct absolute path cannot be derived from the environment variable alone — it depends on the Tauri bundle identifier. One option is to expose the recordings directory via a dedicated deeplink/URL query so the extension can ask the app, or document the real path for users to override via a Raycast preference.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: extensions/raycast/src/recent-recordings.tsx
Line: 59-61

Comment:
**Unencoded spaces in `file://` URL will break deep link handler**

`rec.path` is a raw filesystem path. On macOS the recordings directory lives under `~/Library/Application Support/…`, which contains a space. Passing `file:///Users/alice/Library/Application Support/…` as-is creates an invalid URL — the Rust `Url` parser will reject it (or produce unexpected results), so `OpenEditor` will never be triggered.

The path must be percent-encoded before constructing the URL:

```suggestion
                    await open(`file://${encodeURI(rec.path)}`);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: extensions/raycast/src/recent-recordings.tsx
Line: 18-29

Comment:
**`statSync` called twice per directory entry**

In the current implementation, every entry that passes the `isDirectory()` filter has `statSync` called again in the `map` step to retrieve `mtime`. This doubles the number of filesystem calls. A single `map`-then-filter pattern avoids the redundancy:

```suggestion
    return readdirSync(dir)
      .map((name) => {
        const fullPath = join(dir, name);
        const stat = statSync(fullPath);
        return { name, path: fullPath, stat };
      })
      .filter(({ stat }) => stat.isDirectory())
      .map(({ name, path, stat }) => ({ name, path, date: stat.mtime }))
      .sort((a, b) => b.date.getTime() - a.date.getTime())
      .slice(0, 50);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: extensions/raycast/src/recent-recordings.tsx
Line: 18-29

Comment:
**No filter for `.cap` directory extension**

`getRecordings()` lists all subdirectories in the recordings folder, including any non-recording artifacts. The Rust side treats only paths ending in `.cap` as valid recording projects (e.g. `"my-recording.cap"`). Adding a name filter keeps the list accurate:

```suggestion
    return readdirSync(dir)
      .filter((name) => {
        const fullPath = join(dir, name);
        return name.endsWith(".cap") && statSync(fullPath).isDirectory();
      })
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: extensions/raycast/tsconfig.json
Line: 2

Comment:
**Wrong `$schema` for `tsconfig.json`**

This file uses the Raycast _extension_ JSON schema (`https://www.raycast.com/schemas/extension.json`), which is intended for `package.json`. The TypeScript configuration schema should point to `"https://json.schemastore.org/tsconfig"` (or be omitted). Using the wrong schema means IDEs will validate this file against Raycast's extension manifest rules, not TypeScript's compiler options, and will flag valid options as errors.

```suggestion
  "$schema": "https://json.schemastore.org/tsconfig",
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: extend deeplinks + add Raycast ext..."](https://github.com/capsoftware/cap/commit/a520f2ad2ba1bc6c29ec3f9ef317664de3b24fae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26687352)</sub>

> Greptile also left **5 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->