### PR TITLE
feat: add deep-link support and Raycast extension

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -33,7 +33,6 @@ pub enum DeepLinkAction {
         page: Option<String>,
     },
     StartDefaultRecording,
-    PauseRecording,
     ResumeRecording,
     TogglePauseRecording,
 }
@@ -129,7 +128,6 @@ impl DeepLinkAction {
             DeepLinkAction::StartRecording { .. }
             | DeepLinkAction::StopRecording
             | DeepLinkAction::StartDefaultRecording
-            | DeepLinkAction::PauseRecording
             | DeepLinkAction::ResumeRecording
             | DeepLinkAction::TogglePauseRecording => {
                 crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
@@ -185,9 +183,6 @@ impl DeepLinkAction {
             }
             DeepLinkAction::StartDefaultRecording => {
                 crate::RequestOpenRecordingPicker { target_mode: None }.emit(app).map_err(|e| e.to_string())
-            }
-            DeepLinkAction::PauseRecording => {
-                crate::recording::pause_recording(app.clone(), app.state()).await
             }
             DeepLinkAction::ResumeRecording => {
                 crate::recording::resume_recording(app.clone(), app.state()).await

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -38,21 +38,24 @@ pub enum DeepLinkAction {
 }
 
 pub fn handle(app_handle: &AppHandle, urls: Vec<Url>) {
-    trace!("Handling deep actions for: {:?}", &urls);
-
     let actions: Vec<_> = urls
         .into_iter()
         .filter(|url| !url.as_str().is_empty())
         .filter_map(|url| {
             DeepLinkAction::try_from(&url)
-                .map_err(|e| match e {
-                    ActionParseFromUrlError::ParseFailed(msg) => {
-                        error!("Failed to parse deep link \"{}\": {}", &url, msg)
+                .map_err(|e| {
+                    let mut safe_url = url.clone();
+                    safe_url.set_query(None);
+                    safe_url.set_fragment(None);
+                    match e {
+                        ActionParseFromUrlError::ParseFailed(msg) => {
+                            error!("Failed to parse deep link \"{}\": {}", safe_url, msg)
+                        }
+                        ActionParseFromUrlError::Invalid => {
+                            warn!("Invalid deep link format \"{}\"", safe_url)
+                        }
+                        ActionParseFromUrlError::NotAction => {}
                     }
-                    ActionParseFromUrlError::Invalid => {
-                        warn!("Invalid deep link format \"{}\"", &url)
-                    }
-                    ActionParseFromUrlError::NotAction => {}
                 })
                 .ok()
         })

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -167,7 +167,7 @@ impl DeepLinkAction {
                 crate::show_window(app.clone(), ShowCapWindow::Settings { page }).await
             }
             DeepLinkAction::StartDefaultRecording => {
-                app.emit("request-open-recording-picker", ()).map_err(|e| e.to_string())
+                crate::RequestOpenRecordingPicker { target_mode: None }.emit(app).map_err(|e| e.to_string())
             }
             DeepLinkAction::PauseRecording => {
                 crate::recording::pause_recording(app.clone(), app.state()).await

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -92,6 +92,10 @@ impl TryFrom<&Url> for DeepLinkAction {
         }
 
         if url.scheme().eq_ignore_ascii_case("cap") {
+            if url.path() != "/" {
+                return Err(ActionParseFromUrlError::Invalid);
+            }
+
             return match url.host_str() {
                 Some(h) if h.eq_ignore_ascii_case("record") => Ok(Self::StartDefaultRecording),
                 Some(h) if h.eq_ignore_ascii_case("stop") => Ok(Self::StopRecording),
@@ -126,7 +130,7 @@ impl DeepLinkAction {
             | DeepLinkAction::StartDefaultRecording
             | DeepLinkAction::PauseRecording
             | DeepLinkAction::ResumeRecording => {
-                crate::notifications::NotificationType::DeepLinkTriggered.send(app);
+                crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
             }
             _ => {}
         }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -35,6 +35,7 @@ pub enum DeepLinkAction {
     StartDefaultRecording,
     PauseRecording,
     ResumeRecording,
+    TogglePauseRecording,
 }
 
 pub fn handle(app_handle: &AppHandle, urls: Vec<Url>) {
@@ -99,7 +100,7 @@ impl TryFrom<&Url> for DeepLinkAction {
             return match url.host_str() {
                 Some(h) if h.eq_ignore_ascii_case("record") => Ok(Self::StartDefaultRecording),
                 Some(h) if h.eq_ignore_ascii_case("stop") => Ok(Self::StopRecording),
-                Some(h) if h.eq_ignore_ascii_case("pause") => Ok(Self::PauseRecording),
+                Some(h) if h.eq_ignore_ascii_case("pause") => Ok(Self::TogglePauseRecording),
                 Some(h) if h.eq_ignore_ascii_case("resume") => Ok(Self::ResumeRecording),
                 _ => Err(ActionParseFromUrlError::Invalid),
             };
@@ -129,7 +130,8 @@ impl DeepLinkAction {
             | DeepLinkAction::StopRecording
             | DeepLinkAction::StartDefaultRecording
             | DeepLinkAction::PauseRecording
-            | DeepLinkAction::ResumeRecording => {
+            | DeepLinkAction::ResumeRecording
+            | DeepLinkAction::TogglePauseRecording => {
                 crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
             }
             _ => {}
@@ -189,6 +191,9 @@ impl DeepLinkAction {
             }
             DeepLinkAction::ResumeRecording => {
                 crate::recording::resume_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::TogglePauseRecording => {
+                crate::recording::toggle_pause_recording(app.clone(), app.state()).await
             }
         }
     }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -84,19 +84,19 @@ impl TryFrom<&Url> for DeepLinkAction {
 
     fn try_from(url: &Url) -> Result<Self, Self::Error> {
         #[cfg(target_os = "macos")]
-        if url.scheme() == "file" {
+        if url.scheme().eq_ignore_ascii_case("file") {
             return url
                 .to_file_path()
                 .map(|project_path| Self::OpenEditor { project_path })
                 .map_err(|_| ActionParseFromUrlError::Invalid);
         }
 
-        if url.scheme() == "cap" {
+        if url.scheme().eq_ignore_ascii_case("cap") {
             return match url.host_str() {
-                Some("record") => Ok(Self::StartDefaultRecording),
-                Some("stop") => Ok(Self::StopRecording),
-                Some("pause") => Ok(Self::PauseRecording),
-                Some("resume") => Ok(Self::ResumeRecording),
+                Some(h) if h.eq_ignore_ascii_case("record") => Ok(Self::StartDefaultRecording),
+                Some(h) if h.eq_ignore_ascii_case("stop") => Ok(Self::StopRecording),
+                Some(h) if h.eq_ignore_ascii_case("pause") => Ok(Self::PauseRecording),
+                Some(h) if h.eq_ignore_ascii_case("resume") => Ok(Self::ResumeRecording),
                 _ => Err(ActionParseFromUrlError::Invalid),
             };
         }
@@ -120,6 +120,17 @@ impl TryFrom<&Url> for DeepLinkAction {
 
 impl DeepLinkAction {
     pub async fn execute(self, app: &AppHandle) -> Result<(), String> {
+        match &self {
+            DeepLinkAction::StartRecording { .. }
+            | DeepLinkAction::StopRecording
+            | DeepLinkAction::StartDefaultRecording
+            | DeepLinkAction::PauseRecording
+            | DeepLinkAction::ResumeRecording => {
+                crate::notifications::NotificationType::DeepLinkTriggered.send(app);
+            }
+            _ => {}
+        }
+
         match self {
             DeepLinkAction::StartRecording {
                 capture_mode,

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -32,6 +32,9 @@ pub enum DeepLinkAction {
     OpenSettings {
         page: Option<String>,
     },
+    StartDefaultRecording,
+    PauseRecording,
+    ResumeRecording,
 }
 
 pub fn handle(app_handle: &AppHandle, urls: Vec<Url>) {
@@ -86,6 +89,16 @@ impl TryFrom<&Url> for DeepLinkAction {
                 .to_file_path()
                 .map(|project_path| Self::OpenEditor { project_path })
                 .map_err(|_| ActionParseFromUrlError::Invalid);
+        }
+
+        if url.scheme() == "cap" {
+            return match url.host_str() {
+                Some("record") => Ok(Self::StartDefaultRecording),
+                Some("stop") => Ok(Self::StopRecording),
+                Some("pause") => Ok(Self::PauseRecording),
+                Some("resume") => Ok(Self::ResumeRecording),
+                _ => Err(ActionParseFromUrlError::Invalid),
+            };
         }
 
         match url.domain() {
@@ -152,6 +165,15 @@ impl DeepLinkAction {
             }
             DeepLinkAction::OpenSettings { page } => {
                 crate::show_window(app.clone(), ShowCapWindow::Settings { page }).await
+            }
+            DeepLinkAction::StartDefaultRecording => {
+                app.emit("request-open-recording-picker", ()).map_err(|e| e.to_string())
+            }
+            DeepLinkAction::PauseRecording => {
+                crate::recording::pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::ResumeRecording => {
+                crate::recording::resume_recording(app.clone(), app.state()).await
             }
         }
     }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -99,11 +99,11 @@ impl TryFrom<&Url> for DeepLinkAction {
                 return Err(ActionParseFromUrlError::Invalid);
             }
 
-            return match url.host_str().map(|h| h.to_lowercase().as_str()) {
-                Some("record") => Ok(Self::StartDefaultRecording),
-                Some("stop") => Ok(Self::StopRecording),
-                Some("pause") => Ok(Self::TogglePauseRecording),
-                Some("resume") => Ok(Self::ResumeRecording),
+            return match url.host_str().map(|h| h.to_lowercase()) {
+                Some(host) if host == "record" => Ok(Self::StartDefaultRecording),
+                Some(host) if host == "stop" => Ok(Self::StopRecording),
+                Some(host) if host == "pause" => Ok(Self::TogglePauseRecording),
+                Some(host) if host == "resume" => Ok(Self::ResumeRecording),
                 _ => Err(ActionParseFromUrlError::Invalid),
             };
         }
@@ -127,14 +127,17 @@ impl TryFrom<&Url> for DeepLinkAction {
 
 impl DeepLinkAction {
     pub async fn execute(self, app: &AppHandle) -> Result<(), String> {
-        // Trigger security/visibility notification for recording actions
+        // Handle security/visibility notification for deep link actions
         match &self {
-            DeepLinkAction::StartRecording { .. }
-            | DeepLinkAction::StopRecording
-            | DeepLinkAction::StartDefaultRecording
+            // Force notification for actions that START recording (Critical for security)
+            DeepLinkAction::StartRecording { .. } | DeepLinkAction::StartDefaultRecording => {
+                crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
+            }
+            // Other actions respect user's notification preference
+            DeepLinkAction::StopRecording
             | DeepLinkAction::ResumeRecording
             | DeepLinkAction::TogglePauseRecording => {
-                crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
+                crate::notifications::NotificationType::DeepLinkTriggered.send(app);
             }
             _ => {}
         }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -4,7 +4,7 @@ use cap_recording::{
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager, Url};
-use tracing::{trace, warn, error};
+use tracing::{warn, error};
 
 use crate::{App, ArcLock, recording::StartRecordingInputs, windows::ShowCapWindow};
 
@@ -96,18 +96,22 @@ impl TryFrom<&Url> for DeepLinkAction {
         }
 
         if scheme == "cap" {
+            let host = url.host_str().unwrap_or_default();
             let path = url.path().trim_matches('/');
-            if !path.is_empty() {
-                return Err(ActionParseFromUrlError::Invalid);
-            }
 
-            return match url.host_str() {
-                Some(host) if host.eq_ignore_ascii_case("record") => Ok(Self::StartDefaultRecording),
-                Some(host) if host.eq_ignore_ascii_case("stop") => Ok(Self::StopRecording),
-                Some(host) if host.eq_ignore_ascii_case("pause") => Ok(Self::TogglePauseRecording),
-                Some(host) if host.eq_ignore_ascii_case("resume") => Ok(Self::ResumeRecording),
-                _ => Err(ActionParseFromUrlError::Invalid),
+            let action = if host.eq_ignore_ascii_case("record") || path.eq_ignore_ascii_case("record") {
+                Some(Self::StartDefaultRecording)
+            } else if host.eq_ignore_ascii_case("stop") || path.eq_ignore_ascii_case("stop") {
+                Some(Self::StopRecording)
+            } else if host.eq_ignore_ascii_case("pause") || path.eq_ignore_ascii_case("pause") {
+                Some(Self::TogglePauseRecording)
+            } else if host.eq_ignore_ascii_case("resume") || path.eq_ignore_ascii_case("resume") {
+                Some(Self::ResumeRecording)
+            } else {
+                None
             };
+
+            return action.ok_or(ActionParseFromUrlError::Invalid);
         }
 
         match url.domain() {

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -93,17 +93,16 @@ impl TryFrom<&Url> for DeepLinkAction {
         }
 
         if scheme == "cap" {
-            // Robust path check (handles cap://record and cap://record/)
             let path = url.path().trim_matches('/');
             if !path.is_empty() {
                 return Err(ActionParseFromUrlError::Invalid);
             }
 
-            return match url.host_str().map(|h| h.to_lowercase()) {
-                Some(host) if host == "record" => Ok(Self::StartDefaultRecording),
-                Some(host) if host == "stop" => Ok(Self::StopRecording),
-                Some(host) if host == "pause" => Ok(Self::TogglePauseRecording),
-                Some(host) if host == "resume" => Ok(Self::ResumeRecording),
+            return match url.host_str() {
+                Some(host) if host.eq_ignore_ascii_case("record") => Ok(Self::StartDefaultRecording),
+                Some(host) if host.eq_ignore_ascii_case("stop") => Ok(Self::StopRecording),
+                Some(host) if host.eq_ignore_ascii_case("pause") => Ok(Self::TogglePauseRecording),
+                Some(host) if host.eq_ignore_ascii_case("resume") => Ok(Self::ResumeRecording),
                 _ => Err(ActionParseFromUrlError::Invalid),
             };
         }
@@ -127,17 +126,13 @@ impl TryFrom<&Url> for DeepLinkAction {
 
 impl DeepLinkAction {
     pub async fn execute(self, app: &AppHandle) -> Result<(), String> {
-        // Handle security/visibility notification for deep link actions
         match &self {
-            // Force notification for actions that START recording (Critical for security)
-            DeepLinkAction::StartRecording { .. } | DeepLinkAction::StartDefaultRecording => {
-                crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
-            }
-            // Other actions respect user's notification preference
-            DeepLinkAction::StopRecording
+            DeepLinkAction::StartRecording { .. }
+            | DeepLinkAction::StartDefaultRecording
+            | DeepLinkAction::StopRecording
             | DeepLinkAction::ResumeRecording
             | DeepLinkAction::TogglePauseRecording => {
-                crate::notifications::NotificationType::DeepLinkTriggered.send(app);
+                crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
             }
             _ => {}
         }
@@ -189,7 +184,6 @@ impl DeepLinkAction {
                 crate::show_window(app.clone(), ShowCapWindow::Settings { page }).await
             }
             DeepLinkAction::StartDefaultRecording => {
-                // Perfect payload emission for frontend deserialization
                 crate::RequestOpenRecordingPicker { target_mode: None }.emit(app).map_err(|e| e.to_string())
             }
             DeepLinkAction::ResumeRecording => {

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -4,7 +4,7 @@ use cap_recording::{
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager, Url};
-use tracing::trace;
+use tracing::{trace, warn, error};
 
 use crate::{App, ArcLock, recording::StartRecordingInputs, windows::ShowCapWindow};
 
@@ -47,12 +47,11 @@ pub fn handle(app_handle: &AppHandle, urls: Vec<Url>) {
             DeepLinkAction::try_from(&url)
                 .map_err(|e| match e {
                     ActionParseFromUrlError::ParseFailed(msg) => {
-                        eprintln!("Failed to parse deep link \"{}\": {}", &url, msg)
+                        error!("Failed to parse deep link \"{}\": {}", &url, msg)
                     }
                     ActionParseFromUrlError::Invalid => {
-                        eprintln!("Invalid deep link format \"{}\"", &url)
+                        warn!("Invalid deep link format \"{}\"", &url)
                     }
-                    // Likely login action, not handled here.
                     ActionParseFromUrlError::NotAction => {}
                 })
                 .ok()
@@ -67,7 +66,7 @@ pub fn handle(app_handle: &AppHandle, urls: Vec<Url>) {
     tauri::async_runtime::spawn(async move {
         for action in actions {
             if let Err(e) = action.execute(&app_handle).await {
-                eprintln!("Failed to handle deep link action: {e}");
+                error!("Failed to handle deep link action: {e}");
             }
         }
     });
@@ -83,24 +82,28 @@ impl TryFrom<&Url> for DeepLinkAction {
     type Error = ActionParseFromUrlError;
 
     fn try_from(url: &Url) -> Result<Self, Self::Error> {
+        let scheme = url.scheme().to_lowercase();
+
         #[cfg(target_os = "macos")]
-        if url.scheme().eq_ignore_ascii_case("file") {
+        if scheme == "file" {
             return url
                 .to_file_path()
                 .map(|project_path| Self::OpenEditor { project_path })
                 .map_err(|_| ActionParseFromUrlError::Invalid);
         }
 
-        if url.scheme().eq_ignore_ascii_case("cap") {
-            if url.path() != "/" {
+        if scheme == "cap" {
+            // Robust path check (handles cap://record and cap://record/)
+            let path = url.path().trim_matches('/');
+            if !path.is_empty() {
                 return Err(ActionParseFromUrlError::Invalid);
             }
 
-            return match url.host_str() {
-                Some(h) if h.eq_ignore_ascii_case("record") => Ok(Self::StartDefaultRecording),
-                Some(h) if h.eq_ignore_ascii_case("stop") => Ok(Self::StopRecording),
-                Some(h) if h.eq_ignore_ascii_case("pause") => Ok(Self::TogglePauseRecording),
-                Some(h) if h.eq_ignore_ascii_case("resume") => Ok(Self::ResumeRecording),
+            return match url.host_str().map(|h| h.to_lowercase().as_str()) {
+                Some("record") => Ok(Self::StartDefaultRecording),
+                Some("stop") => Ok(Self::StopRecording),
+                Some("pause") => Ok(Self::TogglePauseRecording),
+                Some("resume") => Ok(Self::ResumeRecording),
                 _ => Err(ActionParseFromUrlError::Invalid),
             };
         }
@@ -124,6 +127,7 @@ impl TryFrom<&Url> for DeepLinkAction {
 
 impl DeepLinkAction {
     pub async fn execute(self, app: &AppHandle) -> Result<(), String> {
+        // Trigger security/visibility notification for recording actions
         match &self {
             DeepLinkAction::StartRecording { .. }
             | DeepLinkAction::StopRecording
@@ -153,12 +157,12 @@ impl DeepLinkAction {
                         .into_iter()
                         .find(|(s, _)| s.name == name)
                         .map(|(s, _)| ScreenCaptureTarget::Display { id: s.id })
-                        .ok_or(format!("No screen with name \"{}\"", &name))?,
+                        .ok_or_else(|| format!("No screen with name \"{}\"", &name))?,
                     CaptureMode::Window(name) => cap_recording::screen_capture::list_windows()
                         .into_iter()
                         .find(|(w, _)| w.name == name)
                         .map(|(w, _)| ScreenCaptureTarget::Window { id: w.id })
-                        .ok_or(format!("No window with name \"{}\"", &name))?,
+                        .ok_or_else(|| format!("No window with name \"{}\"", &name))?,
                 };
 
                 let inputs = StartRecordingInputs {
@@ -182,6 +186,7 @@ impl DeepLinkAction {
                 crate::show_window(app.clone(), ShowCapWindow::Settings { page }).await
             }
             DeepLinkAction::StartDefaultRecording => {
+                // Perfect payload emission for frontend deserialization
                 crate::RequestOpenRecordingPicker { target_mode: None }.emit(app).map_err(|e| e.to_string())
             }
             DeepLinkAction::ResumeRecording => {

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -90,15 +90,23 @@ impl NotificationType {
     }
 
     pub fn send(self, app: &tauri::AppHandle) {
-        send_notification(app, self, false);
+        send_notification(app, self);
     }
 
     pub fn send_always(self, app: &tauri::AppHandle) {
-        send_notification(app, self, true);
+        send_notification_always(app, self);
     }
 }
 
-pub fn send_notification(app: &tauri::AppHandle, notification_type: NotificationType, always: bool) {
+pub fn send_notification(app: &tauri::AppHandle, notification_type: NotificationType) {
+    _send_notification(app, notification_type, false);
+}
+
+pub fn send_notification_always(app: &tauri::AppHandle, notification_type: NotificationType) {
+    _send_notification(app, notification_type, true);
+}
+
+fn _send_notification(app: &tauri::AppHandle, notification_type: NotificationType, always: bool) {
     let enable_notifications = always
         || GeneralSettingsStore::get(app)
             .map(|settings| settings.is_some_and(|s| s.enable_notifications))
@@ -123,6 +131,7 @@ pub fn send_notification(app: &tauri::AppHandle, notification_type: Notification
             | NotificationType::ScreenshotCopiedToClipboard
             | NotificationType::ScreenshotSaveFailed
             | NotificationType::ScreenshotCopyFailed
+            | NotificationType::DeepLinkTriggered
     );
 
     if !skip_sound {

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -14,6 +14,7 @@ pub enum NotificationType {
     ScreenshotCopiedToClipboard,
     ScreenshotSaveFailed,
     ScreenshotCopyFailed,
+    DeepLinkTriggered,
 }
 
 impl NotificationType {
@@ -61,6 +62,11 @@ impl NotificationType {
                 "Copy Failed",
                 "Unable to copy screenshot to clipboard. Please try again",
                 true,
+            ),
+            NotificationType::DeepLinkTriggered => (
+                "Action Triggered",
+                "An action was triggered via a deep link",
+                false,
             ),
         }
     }

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -90,14 +90,19 @@ impl NotificationType {
     }
 
     pub fn send(self, app: &tauri::AppHandle) {
-        send_notification(app, self);
+        send_notification(app, self, false);
+    }
+
+    pub fn send_always(self, app: &tauri::AppHandle) {
+        send_notification(app, self, true);
     }
 }
 
-pub fn send_notification(app: &tauri::AppHandle, notification_type: NotificationType) {
-    let enable_notifications = GeneralSettingsStore::get(app)
-        .map(|settings| settings.is_some_and(|s| s.enable_notifications))
-        .unwrap_or(false);
+pub fn send_notification(app: &tauri::AppHandle, notification_type: NotificationType, always: bool) {
+    let enable_notifications = always
+        || GeneralSettingsStore::get(app)
+            .map(|settings| settings.is_some_and(|s| s.enable_notifications))
+            .unwrap_or(false);
 
     if !enable_notifications {
         return;

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -30,7 +30,7 @@
 		"updater": { "active": false, "pubkey": "" },
 		"deep-link": {
 			"desktop": {
-				"schemes": ["cap-desktop"]
+				"schemes": ["cap-desktop", "cap"]
 			}
 		}
 	},


### PR DESCRIPTION
This PR adds deep-link support to Cap (cap://record, cap://stop, cap://pause) and includes a dedicated Raycast extension for remote control.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three new deep-link actions (`StartDefaultRecording`, `PauseRecording`, `ResumeRecording`) and a new `cap://` URL scheme to complement the existing `cap-desktop://` scheme, enabling Raycast and other external tools to remotely control Cap's recording lifecycle via `cap://record`, `cap://stop`, `cap://pause`, and `cap://resume`.

**Key issues found:**
- **P0 – Wrong event payload in `StartDefaultRecording`**: `app.emit("request-open-recording-picker", ())` emits a JSON `null` payload, but the `RequestOpenRecordingPicker` tauri_specta struct expects `{ "target_mode": null }`. Every other call site in `hotkeys.rs` correctly uses `RequestOpenRecordingPicker { target_mode: None }.emit(&app)`. This mismatch will cause the frontend event listener to receive an unexpected payload, likely causing `cap://record` to silently do nothing.
- **P2 – Generic `cap://` scheme expands the attack surface**: Registering the short, guessable `cap` scheme system-wide means any local application or browser link (e.g., a `<a href="cap://record">` on a web page) can invisibly trigger screen recording. The existing `cap-desktop://action?value=...` format was harder to exploit accidentally; the new URLs remove that friction.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — the `cap://record` action will silently fail due to a payload type mismatch in the emitted event.
- The `StartDefaultRecording` handler emits the `request-open-recording-picker` event with a `()` (unit/null) payload instead of the typed `RequestOpenRecordingPicker { target_mode: None }` struct used everywhere else in the codebase. This payload mismatch means the primary advertised feature (`cap://record` opening the recording picker) will not function correctly. The fix is straightforward but the bug must be resolved before merging.
- `apps/desktop/src-tauri/src/deeplink_actions.rs` — specifically the `StartDefaultRecording` arm in the `execute` match.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/deeplink_actions.rs | Adds `StartDefaultRecording`, `PauseRecording`, and `ResumeRecording` variants and a `cap://` URL parsing branch; contains a P0 event payload bug — `app.emit("request-open-recording-picker", ())` emits `null` instead of the expected `{ target_mode: null }`, causing frontend deserialization failure. Also bypasses the typed `tauri_specta` event system used everywhere else in the codebase. |
| apps/desktop/src-tauri/tauri.conf.json | Adds `"cap"` alongside `"cap-desktop"` in the deep-link scheme registration; mechanically correct but introduces a short, guessable system-wide scheme. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Raycast as Raycast or Browser
    participant OS as OS Deep-Link Router
    participant Tauri as Tauri Plugin
    participant Handler as deeplink_actions
    participant Recording as recording module
    participant Frontend as Frontend Webview

    Raycast->>OS: "open cap://record"
    OS->>Tauri: "cap scheme triggered"
    Tauri->>Handler: "urls: [cap://record]"
    Handler->>Handler: "parse: scheme==cap, host==record"
    Handler->>Handler: "Ok(StartDefaultRecording)"
    Handler->>Frontend: "app.emit(request-open-recording-picker, null) ⚠️"
    Note over Frontend: "Expected payload: {target_mode:null}, got: null"

    Raycast->>OS: "open cap://stop"
    OS->>Tauri: "cap scheme triggered"
    Tauri->>Handler: "urls: [cap://stop]"
    Handler->>Handler: "Ok(StopRecording)"
    Handler->>Recording: "stop_recording(app, state)"

    Raycast->>OS: "open cap://pause"
    OS->>Tauri: "cap scheme triggered"
    Tauri->>Handler: "urls: [cap://pause]"
    Handler->>Handler: "Ok(PauseRecording)"
    Handler->>Recording: "pause_recording(app, state)"

    Raycast->>OS: "open cap://resume"
    OS->>Tauri: "cap scheme triggered"
    Tauri->>Handler: "urls: [cap://resume]"
    Handler->>Handler: "Ok(ResumeRecording)"
    Handler->>Recording: "resume_recording(app, state)"
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/deeplink_actions.rs
Line: 169-171

Comment:
**Wrong event payload causes frontend deserialization failure**

`app.emit("request-open-recording-picker", ())` sends a JSON `null` payload, but the `RequestOpenRecordingPicker` struct has a `target_mode: Option<RecordingTargetMode>` field. The auto-generated frontend type expects `{ target_mode: null }`, not `null`. This payload mismatch will likely cause the event to silently fail or be ignored by the frontend listener.

All other call sites in `hotkeys.rs` correctly use the typed `tauri_specta` event. Use the same pattern here:

```suggestion
            DeepLinkAction::StartDefaultRecording => {
                RequestOpenRecordingPicker { target_mode: None }.emit(app).map_err(|e| e.to_string())
            }
```

You'll also need to import `RequestOpenRecordingPicker` at the top of the file (or reference it as `crate::RequestOpenRecordingPicker`).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/deeplink_actions.rs
Line: 94-102

Comment:
**Security: generic `cap://` scheme is accessible by any app or web page**

Registering `cap` as a system-wide URL scheme means any application — including browsers that silently follow `cap://` links in web pages — can trigger `cap://record`, `cap://stop`, `cap://pause`, and `cap://resume` without user confirmation. A malicious web page could embed `<a href="cap://record">` or automatically redirect to it, invisibly starting a screen capture session.

The existing `cap-desktop://action?value=...` scheme has the same surface area, but its JSON-in-query-string format is significantly harder to invoke accidentally or from a web page. The new `cap://` URLs reduce the exploit complexity to a single, guessable link.

Consider requiring explicit user-facing confirmation (e.g., showing a toast/alert before acting), or at minimum documenting this behavior so users are aware that any local app can control their recording session via these URLs.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: implement cap:// deep-link protoco..."](https://github.com/capsoftware/cap/commit/0d085b376d1acd5b019b9fe1de1e04e36198f290) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27162303)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->