### PR TITLE
fix: implement deterministic pause/resume and optimize deep link handling

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -33,7 +33,6 @@ pub enum DeepLinkAction {
         page: Option<String>,
     },
     StartDefaultRecording,
-    PauseRecording,
     ResumeRecording,
     TogglePauseRecording,
 }
@@ -129,7 +128,6 @@ impl DeepLinkAction {
             DeepLinkAction::StartRecording { .. }
             | DeepLinkAction::StopRecording
             | DeepLinkAction::StartDefaultRecording
-            | DeepLinkAction::PauseRecording
             | DeepLinkAction::ResumeRecording
             | DeepLinkAction::TogglePauseRecording => {
                 crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
@@ -185,9 +183,6 @@ impl DeepLinkAction {
             }
             DeepLinkAction::StartDefaultRecording => {
                 crate::RequestOpenRecordingPicker { target_mode: None }.emit(app).map_err(|e| e.to_string())
-            }
-            DeepLinkAction::PauseRecording => {
-                crate::recording::pause_recording(app.clone(), app.state()).await
             }
             DeepLinkAction::ResumeRecording => {
                 crate::recording::resume_recording(app.clone(), app.state()).await

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -38,21 +38,24 @@ pub enum DeepLinkAction {
 }
 
 pub fn handle(app_handle: &AppHandle, urls: Vec<Url>) {
-    trace!("Handling deep actions for: {:?}", &urls);
-
     let actions: Vec<_> = urls
         .into_iter()
         .filter(|url| !url.as_str().is_empty())
         .filter_map(|url| {
             DeepLinkAction::try_from(&url)
-                .map_err(|e| match e {
-                    ActionParseFromUrlError::ParseFailed(msg) => {
-                        error!("Failed to parse deep link \"{}\": {}", &url, msg)
+                .map_err(|e| {
+                    let mut safe_url = url.clone();
+                    safe_url.set_query(None);
+                    safe_url.set_fragment(None);
+                    match e {
+                        ActionParseFromUrlError::ParseFailed(msg) => {
+                            error!("Failed to parse deep link \"{}\": {}", safe_url, msg)
+                        }
+                        ActionParseFromUrlError::Invalid => {
+                            warn!("Invalid deep link format \"{}\"", safe_url)
+                        }
+                        ActionParseFromUrlError::NotAction => {}
                     }
-                    ActionParseFromUrlError::Invalid => {
-                        warn!("Invalid deep link format \"{}\"", &url)
-                    }
-                    ActionParseFromUrlError::NotAction => {}
                 })
                 .ok()
         })

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -105,9 +105,11 @@ impl TryFrom<&Url> for DeepLinkAction {
             } else if host.eq_ignore_ascii_case("stop") || path.eq_ignore_ascii_case("stop") {
                 Some(Self::StopRecording)
             } else if host.eq_ignore_ascii_case("pause") || path.eq_ignore_ascii_case("pause") {
-                Some(Self::TogglePauseRecording)
+                Some(Self::PauseRecording)
             } else if host.eq_ignore_ascii_case("resume") || path.eq_ignore_ascii_case("resume") {
                 Some(Self::ResumeRecording)
+            } else if host.eq_ignore_ascii_case("toggle-pause") || path.eq_ignore_ascii_case("toggle-pause") {
+                Some(Self::TogglePauseRecording)
             } else {
                 None
             };
@@ -139,6 +141,7 @@ impl DeepLinkAction {
             | DeepLinkAction::StartDefaultRecording
             | DeepLinkAction::StopRecording
             | DeepLinkAction::ResumeRecording
+            | DeepLinkAction::PauseRecording
             | DeepLinkAction::TogglePauseRecording => {
                 crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
             }
@@ -197,14 +200,11 @@ impl DeepLinkAction {
             DeepLinkAction::ResumeRecording => {
                 crate::recording::resume_recording(app.clone(), app.state()).await
             }
+            DeepLinkAction::PauseRecording => {
+                crate::recording::pause_recording(app.clone(), app.state()).await
+            }
             DeepLinkAction::TogglePauseRecording => {
                 crate::recording::toggle_pause_recording(app.clone(), app.state()).await
-            }
-        }
-    }
-}
-ding => {
-                crate::recording::pause_recording(app.clone(), app.state()).await
             }
         }
     }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -167,7 +167,7 @@ impl DeepLinkAction {
                 crate::show_window(app.clone(), ShowCapWindow::Settings { page }).await
             }
             DeepLinkAction::StartDefaultRecording => {
-                app.emit("request-open-recording-picker", ()).map_err(|e| e.to_string())
+                crate::RequestOpenRecordingPicker { target_mode: None }.emit(app).map_err(|e| e.to_string())
             }
             DeepLinkAction::PauseRecording => {
                 crate::recording::pause_recording(app.clone(), app.state()).await

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -136,19 +136,17 @@ impl TryFrom<&Url> for DeepLinkAction {
 
 impl DeepLinkAction {
     pub async fn execute(self, app: &AppHandle) -> Result<(), String> {
-        match &self {
+        let should_notify = match &self {
             DeepLinkAction::StartRecording { .. }
             | DeepLinkAction::StartDefaultRecording
             | DeepLinkAction::StopRecording
             | DeepLinkAction::ResumeRecording
             | DeepLinkAction::PauseRecording
-            | DeepLinkAction::TogglePauseRecording => {
-                crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
-            }
-            _ => {}
-        }
+            | DeepLinkAction::TogglePauseRecording => true,
+            _ => false,
+        };
 
-        match self {
+        let result = match self {
             DeepLinkAction::StartRecording {
                 capture_mode,
                 camera,
@@ -206,6 +204,12 @@ impl DeepLinkAction {
             DeepLinkAction::TogglePauseRecording => {
                 crate::recording::toggle_pause_recording(app.clone(), app.state()).await
             }
+        };
+
+        if result.is_ok() && should_notify {
+            crate::notifications::NotificationType::DeepLinkTriggered.send(app);
         }
+
+        result
     }
 }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -92,6 +92,10 @@ impl TryFrom<&Url> for DeepLinkAction {
         }
 
         if url.scheme().eq_ignore_ascii_case("cap") {
+            if url.path() != "/" {
+                return Err(ActionParseFromUrlError::Invalid);
+            }
+
             return match url.host_str() {
                 Some(h) if h.eq_ignore_ascii_case("record") => Ok(Self::StartDefaultRecording),
                 Some(h) if h.eq_ignore_ascii_case("stop") => Ok(Self::StopRecording),
@@ -126,7 +130,7 @@ impl DeepLinkAction {
             | DeepLinkAction::StartDefaultRecording
             | DeepLinkAction::PauseRecording
             | DeepLinkAction::ResumeRecording => {
-                crate::notifications::NotificationType::DeepLinkTriggered.send(app);
+                crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
             }
             _ => {}
         }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -35,6 +35,7 @@ pub enum DeepLinkAction {
     StartDefaultRecording,
     PauseRecording,
     ResumeRecording,
+    TogglePauseRecording,
 }
 
 pub fn handle(app_handle: &AppHandle, urls: Vec<Url>) {
@@ -99,7 +100,7 @@ impl TryFrom<&Url> for DeepLinkAction {
             return match url.host_str() {
                 Some(h) if h.eq_ignore_ascii_case("record") => Ok(Self::StartDefaultRecording),
                 Some(h) if h.eq_ignore_ascii_case("stop") => Ok(Self::StopRecording),
-                Some(h) if h.eq_ignore_ascii_case("pause") => Ok(Self::PauseRecording),
+                Some(h) if h.eq_ignore_ascii_case("pause") => Ok(Self::TogglePauseRecording),
                 Some(h) if h.eq_ignore_ascii_case("resume") => Ok(Self::ResumeRecording),
                 _ => Err(ActionParseFromUrlError::Invalid),
             };
@@ -129,7 +130,8 @@ impl DeepLinkAction {
             | DeepLinkAction::StopRecording
             | DeepLinkAction::StartDefaultRecording
             | DeepLinkAction::PauseRecording
-            | DeepLinkAction::ResumeRecording => {
+            | DeepLinkAction::ResumeRecording
+            | DeepLinkAction::TogglePauseRecording => {
                 crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
             }
             _ => {}
@@ -189,6 +191,9 @@ impl DeepLinkAction {
             }
             DeepLinkAction::ResumeRecording => {
                 crate::recording::resume_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::TogglePauseRecording => {
+                crate::recording::toggle_pause_recording(app.clone(), app.state()).await
             }
         }
     }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -35,6 +35,7 @@ pub enum DeepLinkAction {
     StartDefaultRecording,
     ResumeRecording,
     TogglePauseRecording,
+    PauseRecording,
 }
 
 pub fn handle(app_handle: &AppHandle, urls: Vec<Url>) {
@@ -198,6 +199,12 @@ impl DeepLinkAction {
             }
             DeepLinkAction::TogglePauseRecording => {
                 crate::recording::toggle_pause_recording(app.clone(), app.state()).await
+            }
+        }
+    }
+}
+ding => {
+                crate::recording::pause_recording(app.clone(), app.state()).await
             }
         }
     }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -84,19 +84,19 @@ impl TryFrom<&Url> for DeepLinkAction {
 
     fn try_from(url: &Url) -> Result<Self, Self::Error> {
         #[cfg(target_os = "macos")]
-        if url.scheme() == "file" {
+        if url.scheme().eq_ignore_ascii_case("file") {
             return url
                 .to_file_path()
                 .map(|project_path| Self::OpenEditor { project_path })
                 .map_err(|_| ActionParseFromUrlError::Invalid);
         }
 
-        if url.scheme() == "cap" {
+        if url.scheme().eq_ignore_ascii_case("cap") {
             return match url.host_str() {
-                Some("record") => Ok(Self::StartDefaultRecording),
-                Some("stop") => Ok(Self::StopRecording),
-                Some("pause") => Ok(Self::PauseRecording),
-                Some("resume") => Ok(Self::ResumeRecording),
+                Some(h) if h.eq_ignore_ascii_case("record") => Ok(Self::StartDefaultRecording),
+                Some(h) if h.eq_ignore_ascii_case("stop") => Ok(Self::StopRecording),
+                Some(h) if h.eq_ignore_ascii_case("pause") => Ok(Self::PauseRecording),
+                Some(h) if h.eq_ignore_ascii_case("resume") => Ok(Self::ResumeRecording),
                 _ => Err(ActionParseFromUrlError::Invalid),
             };
         }
@@ -120,6 +120,17 @@ impl TryFrom<&Url> for DeepLinkAction {
 
 impl DeepLinkAction {
     pub async fn execute(self, app: &AppHandle) -> Result<(), String> {
+        match &self {
+            DeepLinkAction::StartRecording { .. }
+            | DeepLinkAction::StopRecording
+            | DeepLinkAction::StartDefaultRecording
+            | DeepLinkAction::PauseRecording
+            | DeepLinkAction::ResumeRecording => {
+                crate::notifications::NotificationType::DeepLinkTriggered.send(app);
+            }
+            _ => {}
+        }
+
         match self {
             DeepLinkAction::StartRecording {
                 capture_mode,

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -32,6 +32,9 @@ pub enum DeepLinkAction {
     OpenSettings {
         page: Option<String>,
     },
+    StartDefaultRecording,
+    PauseRecording,
+    ResumeRecording,
 }
 
 pub fn handle(app_handle: &AppHandle, urls: Vec<Url>) {
@@ -86,6 +89,16 @@ impl TryFrom<&Url> for DeepLinkAction {
                 .to_file_path()
                 .map(|project_path| Self::OpenEditor { project_path })
                 .map_err(|_| ActionParseFromUrlError::Invalid);
+        }
+
+        if url.scheme() == "cap" {
+            return match url.host_str() {
+                Some("record") => Ok(Self::StartDefaultRecording),
+                Some("stop") => Ok(Self::StopRecording),
+                Some("pause") => Ok(Self::PauseRecording),
+                Some("resume") => Ok(Self::ResumeRecording),
+                _ => Err(ActionParseFromUrlError::Invalid),
+            };
         }
 
         match url.domain() {
@@ -152,6 +165,15 @@ impl DeepLinkAction {
             }
             DeepLinkAction::OpenSettings { page } => {
                 crate::show_window(app.clone(), ShowCapWindow::Settings { page }).await
+            }
+            DeepLinkAction::StartDefaultRecording => {
+                app.emit("request-open-recording-picker", ()).map_err(|e| e.to_string())
+            }
+            DeepLinkAction::PauseRecording => {
+                crate::recording::pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::ResumeRecording => {
+                crate::recording::resume_recording(app.clone(), app.state()).await
             }
         }
     }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -99,11 +99,11 @@ impl TryFrom<&Url> for DeepLinkAction {
                 return Err(ActionParseFromUrlError::Invalid);
             }
 
-            return match url.host_str().map(|h| h.to_lowercase().as_str()) {
-                Some("record") => Ok(Self::StartDefaultRecording),
-                Some("stop") => Ok(Self::StopRecording),
-                Some("pause") => Ok(Self::TogglePauseRecording),
-                Some("resume") => Ok(Self::ResumeRecording),
+            return match url.host_str().map(|h| h.to_lowercase()) {
+                Some(host) if host == "record" => Ok(Self::StartDefaultRecording),
+                Some(host) if host == "stop" => Ok(Self::StopRecording),
+                Some(host) if host == "pause" => Ok(Self::TogglePauseRecording),
+                Some(host) if host == "resume" => Ok(Self::ResumeRecording),
                 _ => Err(ActionParseFromUrlError::Invalid),
             };
         }
@@ -127,14 +127,17 @@ impl TryFrom<&Url> for DeepLinkAction {
 
 impl DeepLinkAction {
     pub async fn execute(self, app: &AppHandle) -> Result<(), String> {
-        // Trigger security/visibility notification for recording actions
+        // Handle security/visibility notification for deep link actions
         match &self {
-            DeepLinkAction::StartRecording { .. }
-            | DeepLinkAction::StopRecording
-            | DeepLinkAction::StartDefaultRecording
+            // Force notification for actions that START recording (Critical for security)
+            DeepLinkAction::StartRecording { .. } | DeepLinkAction::StartDefaultRecording => {
+                crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
+            }
+            // Other actions respect user's notification preference
+            DeepLinkAction::StopRecording
             | DeepLinkAction::ResumeRecording
             | DeepLinkAction::TogglePauseRecording => {
-                crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
+                crate::notifications::NotificationType::DeepLinkTriggered.send(app);
             }
             _ => {}
         }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -4,7 +4,7 @@ use cap_recording::{
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager, Url};
-use tracing::{trace, warn, error};
+use tracing::{warn, error};
 
 use crate::{App, ArcLock, recording::StartRecordingInputs, windows::ShowCapWindow};
 
@@ -96,18 +96,22 @@ impl TryFrom<&Url> for DeepLinkAction {
         }
 
         if scheme == "cap" {
+            let host = url.host_str().unwrap_or_default();
             let path = url.path().trim_matches('/');
-            if !path.is_empty() {
-                return Err(ActionParseFromUrlError::Invalid);
-            }
 
-            return match url.host_str() {
-                Some(host) if host.eq_ignore_ascii_case("record") => Ok(Self::StartDefaultRecording),
-                Some(host) if host.eq_ignore_ascii_case("stop") => Ok(Self::StopRecording),
-                Some(host) if host.eq_ignore_ascii_case("pause") => Ok(Self::TogglePauseRecording),
-                Some(host) if host.eq_ignore_ascii_case("resume") => Ok(Self::ResumeRecording),
-                _ => Err(ActionParseFromUrlError::Invalid),
+            let action = if host.eq_ignore_ascii_case("record") || path.eq_ignore_ascii_case("record") {
+                Some(Self::StartDefaultRecording)
+            } else if host.eq_ignore_ascii_case("stop") || path.eq_ignore_ascii_case("stop") {
+                Some(Self::StopRecording)
+            } else if host.eq_ignore_ascii_case("pause") || path.eq_ignore_ascii_case("pause") {
+                Some(Self::TogglePauseRecording)
+            } else if host.eq_ignore_ascii_case("resume") || path.eq_ignore_ascii_case("resume") {
+                Some(Self::ResumeRecording)
+            } else {
+                None
             };
+
+            return action.ok_or(ActionParseFromUrlError::Invalid);
         }
 
         match url.domain() {

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -93,17 +93,16 @@ impl TryFrom<&Url> for DeepLinkAction {
         }
 
         if scheme == "cap" {
-            // Robust path check (handles cap://record and cap://record/)
             let path = url.path().trim_matches('/');
             if !path.is_empty() {
                 return Err(ActionParseFromUrlError::Invalid);
             }
 
-            return match url.host_str().map(|h| h.to_lowercase()) {
-                Some(host) if host == "record" => Ok(Self::StartDefaultRecording),
-                Some(host) if host == "stop" => Ok(Self::StopRecording),
-                Some(host) if host == "pause" => Ok(Self::TogglePauseRecording),
-                Some(host) if host == "resume" => Ok(Self::ResumeRecording),
+            return match url.host_str() {
+                Some(host) if host.eq_ignore_ascii_case("record") => Ok(Self::StartDefaultRecording),
+                Some(host) if host.eq_ignore_ascii_case("stop") => Ok(Self::StopRecording),
+                Some(host) if host.eq_ignore_ascii_case("pause") => Ok(Self::TogglePauseRecording),
+                Some(host) if host.eq_ignore_ascii_case("resume") => Ok(Self::ResumeRecording),
                 _ => Err(ActionParseFromUrlError::Invalid),
             };
         }
@@ -127,17 +126,13 @@ impl TryFrom<&Url> for DeepLinkAction {
 
 impl DeepLinkAction {
     pub async fn execute(self, app: &AppHandle) -> Result<(), String> {
-        // Handle security/visibility notification for deep link actions
         match &self {
-            // Force notification for actions that START recording (Critical for security)
-            DeepLinkAction::StartRecording { .. } | DeepLinkAction::StartDefaultRecording => {
-                crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
-            }
-            // Other actions respect user's notification preference
-            DeepLinkAction::StopRecording
+            DeepLinkAction::StartRecording { .. }
+            | DeepLinkAction::StartDefaultRecording
+            | DeepLinkAction::StopRecording
             | DeepLinkAction::ResumeRecording
             | DeepLinkAction::TogglePauseRecording => {
-                crate::notifications::NotificationType::DeepLinkTriggered.send(app);
+                crate::notifications::NotificationType::DeepLinkTriggered.send_always(app);
             }
             _ => {}
         }
@@ -189,7 +184,6 @@ impl DeepLinkAction {
                 crate::show_window(app.clone(), ShowCapWindow::Settings { page }).await
             }
             DeepLinkAction::StartDefaultRecording => {
-                // Perfect payload emission for frontend deserialization
                 crate::RequestOpenRecordingPicker { target_mode: None }.emit(app).map_err(|e| e.to_string())
             }
             DeepLinkAction::ResumeRecording => {

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -4,7 +4,7 @@ use cap_recording::{
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager, Url};
-use tracing::trace;
+use tracing::{trace, warn, error};
 
 use crate::{App, ArcLock, recording::StartRecordingInputs, windows::ShowCapWindow};
 
@@ -47,12 +47,11 @@ pub fn handle(app_handle: &AppHandle, urls: Vec<Url>) {
             DeepLinkAction::try_from(&url)
                 .map_err(|e| match e {
                     ActionParseFromUrlError::ParseFailed(msg) => {
-                        eprintln!("Failed to parse deep link \"{}\": {}", &url, msg)
+                        error!("Failed to parse deep link \"{}\": {}", &url, msg)
                     }
                     ActionParseFromUrlError::Invalid => {
-                        eprintln!("Invalid deep link format \"{}\"", &url)
+                        warn!("Invalid deep link format \"{}\"", &url)
                     }
-                    // Likely login action, not handled here.
                     ActionParseFromUrlError::NotAction => {}
                 })
                 .ok()
@@ -67,7 +66,7 @@ pub fn handle(app_handle: &AppHandle, urls: Vec<Url>) {
     tauri::async_runtime::spawn(async move {
         for action in actions {
             if let Err(e) = action.execute(&app_handle).await {
-                eprintln!("Failed to handle deep link action: {e}");
+                error!("Failed to handle deep link action: {e}");
             }
         }
     });
@@ -83,24 +82,28 @@ impl TryFrom<&Url> for DeepLinkAction {
     type Error = ActionParseFromUrlError;
 
     fn try_from(url: &Url) -> Result<Self, Self::Error> {
+        let scheme = url.scheme().to_lowercase();
+
         #[cfg(target_os = "macos")]
-        if url.scheme().eq_ignore_ascii_case("file") {
+        if scheme == "file" {
             return url
                 .to_file_path()
                 .map(|project_path| Self::OpenEditor { project_path })
                 .map_err(|_| ActionParseFromUrlError::Invalid);
         }
 
-        if url.scheme().eq_ignore_ascii_case("cap") {
-            if url.path() != "/" {
+        if scheme == "cap" {
+            // Robust path check (handles cap://record and cap://record/)
+            let path = url.path().trim_matches('/');
+            if !path.is_empty() {
                 return Err(ActionParseFromUrlError::Invalid);
             }
 
-            return match url.host_str() {
-                Some(h) if h.eq_ignore_ascii_case("record") => Ok(Self::StartDefaultRecording),
-                Some(h) if h.eq_ignore_ascii_case("stop") => Ok(Self::StopRecording),
-                Some(h) if h.eq_ignore_ascii_case("pause") => Ok(Self::TogglePauseRecording),
-                Some(h) if h.eq_ignore_ascii_case("resume") => Ok(Self::ResumeRecording),
+            return match url.host_str().map(|h| h.to_lowercase().as_str()) {
+                Some("record") => Ok(Self::StartDefaultRecording),
+                Some("stop") => Ok(Self::StopRecording),
+                Some("pause") => Ok(Self::TogglePauseRecording),
+                Some("resume") => Ok(Self::ResumeRecording),
                 _ => Err(ActionParseFromUrlError::Invalid),
             };
         }
@@ -124,6 +127,7 @@ impl TryFrom<&Url> for DeepLinkAction {
 
 impl DeepLinkAction {
     pub async fn execute(self, app: &AppHandle) -> Result<(), String> {
+        // Trigger security/visibility notification for recording actions
         match &self {
             DeepLinkAction::StartRecording { .. }
             | DeepLinkAction::StopRecording
@@ -153,12 +157,12 @@ impl DeepLinkAction {
                         .into_iter()
                         .find(|(s, _)| s.name == name)
                         .map(|(s, _)| ScreenCaptureTarget::Display { id: s.id })
-                        .ok_or(format!("No screen with name \"{}\"", &name))?,
+                        .ok_or_else(|| format!("No screen with name \"{}\"", &name))?,
                     CaptureMode::Window(name) => cap_recording::screen_capture::list_windows()
                         .into_iter()
                         .find(|(w, _)| w.name == name)
                         .map(|(w, _)| ScreenCaptureTarget::Window { id: w.id })
-                        .ok_or(format!("No window with name \"{}\"", &name))?,
+                        .ok_or_else(|| format!("No window with name \"{}\"", &name))?,
                 };
 
                 let inputs = StartRecordingInputs {
@@ -182,6 +186,7 @@ impl DeepLinkAction {
                 crate::show_window(app.clone(), ShowCapWindow::Settings { page }).await
             }
             DeepLinkAction::StartDefaultRecording => {
+                // Perfect payload emission for frontend deserialization
                 crate::RequestOpenRecordingPicker { target_mode: None }.emit(app).map_err(|e| e.to_string())
             }
             DeepLinkAction::ResumeRecording => {

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -90,15 +90,23 @@ impl NotificationType {
     }
 
     pub fn send(self, app: &tauri::AppHandle) {
-        send_notification(app, self, false);
+        send_notification(app, self);
     }
 
     pub fn send_always(self, app: &tauri::AppHandle) {
-        send_notification(app, self, true);
+        send_notification_always(app, self);
     }
 }
 
-pub fn send_notification(app: &tauri::AppHandle, notification_type: NotificationType, always: bool) {
+pub fn send_notification(app: &tauri::AppHandle, notification_type: NotificationType) {
+    _send_notification(app, notification_type, false);
+}
+
+pub fn send_notification_always(app: &tauri::AppHandle, notification_type: NotificationType) {
+    _send_notification(app, notification_type, true);
+}
+
+fn _send_notification(app: &tauri::AppHandle, notification_type: NotificationType, always: bool) {
     let enable_notifications = always
         || GeneralSettingsStore::get(app)
             .map(|settings| settings.is_some_and(|s| s.enable_notifications))
@@ -123,6 +131,7 @@ pub fn send_notification(app: &tauri::AppHandle, notification_type: Notification
             | NotificationType::ScreenshotCopiedToClipboard
             | NotificationType::ScreenshotSaveFailed
             | NotificationType::ScreenshotCopyFailed
+            | NotificationType::DeepLinkTriggered
     );
 
     if !skip_sound {

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -14,6 +14,7 @@ pub enum NotificationType {
     ScreenshotCopiedToClipboard,
     ScreenshotSaveFailed,
     ScreenshotCopyFailed,
+    DeepLinkTriggered,
 }
 
 impl NotificationType {
@@ -61,6 +62,11 @@ impl NotificationType {
                 "Copy Failed",
                 "Unable to copy screenshot to clipboard. Please try again",
                 true,
+            ),
+            NotificationType::DeepLinkTriggered => (
+                "Action Triggered",
+                "An action was triggered via a deep link",
+                false,
             ),
         }
     }

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -92,25 +92,16 @@ impl NotificationType {
     pub fn send(self, app: &tauri::AppHandle) {
         send_notification(app, self);
     }
-
-    pub fn send_always(self, app: &tauri::AppHandle) {
-        send_notification_always(app, self);
-    }
 }
 
 pub fn send_notification(app: &tauri::AppHandle, notification_type: NotificationType) {
-    _send_notification(app, notification_type, false);
+    send_notification_inner(app, notification_type);
 }
 
-pub fn send_notification_always(app: &tauri::AppHandle, notification_type: NotificationType) {
-    _send_notification(app, notification_type, true);
-}
-
-fn _send_notification(app: &tauri::AppHandle, notification_type: NotificationType, always: bool) {
-    let enable_notifications = always
-        || GeneralSettingsStore::get(app)
-            .map(|settings| settings.is_some_and(|s| s.enable_notifications))
-            .unwrap_or(false);
+fn send_notification_inner(app: &tauri::AppHandle, notification_type: NotificationType) {
+    let enable_notifications = GeneralSettingsStore::get(app)
+        .map(|settings| settings.is_some_and(|s| s.enable_notifications))
+        .unwrap_or(false);
 
     if !enable_notifications {
         return;

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -90,14 +90,19 @@ impl NotificationType {
     }
 
     pub fn send(self, app: &tauri::AppHandle) {
-        send_notification(app, self);
+        send_notification(app, self, false);
+    }
+
+    pub fn send_always(self, app: &tauri::AppHandle) {
+        send_notification(app, self, true);
     }
 }
 
-pub fn send_notification(app: &tauri::AppHandle, notification_type: NotificationType) {
-    let enable_notifications = GeneralSettingsStore::get(app)
-        .map(|settings| settings.is_some_and(|s| s.enable_notifications))
-        .unwrap_or(false);
+pub fn send_notification(app: &tauri::AppHandle, notification_type: NotificationType, always: bool) {
+    let enable_notifications = always
+        || GeneralSettingsStore::get(app)
+            .map(|settings| settings.is_some_and(|s| s.enable_notifications))
+            .unwrap_or(false);
 
     if !enable_notifications {
         return;

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -30,7 +30,7 @@
 		"updater": { "active": false, "pubkey": "" },
 		"deep-link": {
 			"desktop": {
-				"schemes": ["cap-desktop"]
+				"schemes": ["cap-desktop", "cap"]
 			}
 		}
 	},


### PR DESCRIPTION
Resolves deep link action corruption and implements deterministic pause and resume handlers for the cap:// protocol. This ensures reliable remote control from external tools like Raycast and optimizes the notification experience by preventing audio alerts during deep link execution.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new `cap://` deep link scheme for deterministic recording control (pause, resume, toggle-pause, stop, start) alongside the existing `cap-desktop://` scheme, and registers it in `tauri.conf.json`. URL sanitization before logging and `ok_or_else` for lazy allocation are welcome improvements. All three remaining findings are P2 style/UX concerns — no blocking issues were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/UX concerns with no blocking correctness or security issues

All three findings are P2: the send_always bypass is a minor UX concern, the pre-action notification is cosmetic, and the _send_notification naming is pure style. None affect data integrity or security. Per the confidence guidance, PRs with only P2 findings default to 5/5.

notifications.rs deserves a second look around send_always and the _send_notification naming before the next refactor

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/deeplink_actions.rs | Adds cap:// parsing for five new actions with good URL sanitization; notification fires before action outcome is confirmed |
| apps/desktop/src-tauri/src/notifications.rs | Introduces send_always() that bypasses user notification preference and a misleadingly-named private helper _send_notification |
| apps/desktop/src-tauri/tauri.conf.json | Adds 'cap' alongside 'cap-desktop' in desktop deep-link schemes; straightforward config change |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[cap:// URL received] --> B[try_from URL]
    B -->|scheme == cap| C{match host/path}
    C -->|record| D[StartDefaultRecording]
    C -->|stop| E[StopRecording]
    C -->|pause| F[PauseRecording]
    C -->|resume| G[ResumeRecording]
    C -->|toggle-pause| H[TogglePauseRecording]
    C -->|unknown| I[ActionParseFromUrlError::Invalid]
    B -->|scheme == cap-desktop| J{domain == action?}
    J -->|yes| K[Parse JSON value param]
    K --> L[StartRecording / OpenSettings / etc.]
    D & E & F & G & H & L --> M[execute]
    M --> N[DeepLinkTriggered.send_always BEFORE action]
    N --> O{action result}
    O -->|Ok| P[Success]
    O -->|Err| Q[error! log]
    style N fill:#f96,color:#000
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/notifications.rs
Line: 96-98

Comment:
**`send_always` bypasses the user's notification preference**

`send_always` sets `always = true`, short-circuiting the `enable_notifications` guard at line 110 regardless of user settings. Deep links are commonly triggered programmatically (e.g., Raycast, scripts) at high frequency, so unexpected notifications on every action are especially disruptive to users who have opted out. The notification sound is already suppressed via the `skip_sound` match on `DeepLinkTriggered` — `send_always` is not needed to achieve the PR's stated goal of preventing audio alerts.

```suggestion
    pub fn send_always(self, app: &tauri::AppHandle) {
        send_notification(app, self);
    }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/deeplink_actions.rs
Line: 139-149

Comment:
**Notification fires before action executes — false confirmation on no-op**

`DeepLinkTriggered.send_always(app)` is called unconditionally before the action runs. Both `pause_recording` and `resume_recording` return `Ok(())` silently when no recording is active, so the user receives "Action Triggered" even though nothing changed. Moving the notification after a confirmed successful result avoids this misleading feedback.

```rust
let result = match self {
    // ... existing arms ...
};
if result.is_ok() {
    crate::notifications::NotificationType::DeepLinkTriggered.send(app);
}
result
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/notifications.rs
Line: 109

Comment:
**Misleading leading-underscore on an actively-used private function**

In Rust, a `_` prefix conventionally marks an item as intentionally unused (suppressing dead-code lints). `_send_notification` is called from two places and is not unused. A name like `send_notification_inner` or `send_notification_impl` communicates the intent more clearly.

```suggestion
fn send_notification_inner(app: &tauri::AppHandle, notification_type: NotificationType, always: bool) {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve deep link corruption and im..."](https://github.com/capsoftware/cap/commit/2b0abfe57991128dd43e4f235da0574a207a82b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27526012)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))

<!-- /greptile_comment -->