### PR TITLE
feat(deeplink): add new deep link actions for recording control and c…

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -26,12 +26,46 @@ pub enum DeepLinkAction {
         mode: RecordingMode,
     },
     StopRecording,
+
+    PauseRecording,
+    ResumeRecording,
+    TogglePauseRecording,
+
+    TakeScreenshot {
+        capture_mode: CaptureMode,
+    },
+
+    /// Open Cap's target selection overlay UI (clean UX for Raycast).
+    OpenTargetPicker {
+        /// Optional: open the picker in a specific target mode if supported by the UI.
+        target_mode: Option<crate::RecordingTargetMode>,
+    },
+
     OpenEditor {
         project_path: PathBuf,
     },
     OpenSettings {
         page: Option<String>,
     },
+
+    /// Copies a JSON list of cameras to the clipboard.
+    ListCameras,
+    /// Sets the camera by Device/Model ID (null disables camera).
+    SetCamera {
+        camera: Option<DeviceOrModelID>,
+    },
+
+    /// Copies a JSON list of microphone labels to the clipboard.
+    ListMicrophones,
+    /// Sets the microphone by label (null disables microphone).
+    SetMicrophone {
+        mic_label: Option<String>,
+    },
+
+    /// Copies a JSON list of capture displays to the clipboard.
+    ListDisplays,
+    /// Copies a JSON list of capture windows to the clipboard.
+    ListWindows,
 }
 
 pub fn handle(app_handle: &AppHandle, urls: Vec<Url>) {
@@ -147,11 +181,128 @@ impl DeepLinkAction {
             DeepLinkAction::StopRecording => {
                 crate::recording::stop_recording(app.clone(), app.state()).await
             }
+
+            DeepLinkAction::PauseRecording => {
+                crate::recording::pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::ResumeRecording => {
+                crate::recording::resume_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::TogglePauseRecording => {
+                crate::recording::toggle_pause_recording(app.clone(), app.state()).await
+            }
+
+            DeepLinkAction::TakeScreenshot { capture_mode } => {
+                let target: ScreenCaptureTarget = match capture_mode {
+                    CaptureMode::Screen(name) => cap_recording::screen_capture::list_displays()
+                        .into_iter()
+                        .find(|(s, _)| s.name == name)
+                        .map(|(s, _)| ScreenCaptureTarget::Display { id: s.id })
+                        .ok_or(format!("No screen with name \"{}\"", &name))?,
+                    CaptureMode::Window(name) => cap_recording::screen_capture::list_windows()
+                        .into_iter()
+                        .find(|(w, _)| w.name == name)
+                        .map(|(w, _)| ScreenCaptureTarget::Window { id: w.id })
+                        .ok_or(format!("No window with name \"{}\"", &name))?,
+                };
+
+                crate::recording::take_screenshot(app.clone(), target)
+                    .await
+                    .map(|_| ())
+            }
+
+            DeepLinkAction::OpenTargetPicker { target_mode } => {
+                // Show the overlay on the primary display (best-effort).
+                // If display enumeration fails, fall back to showing the main window.
+                let display_id = cap_recording::screen_capture::list_displays()
+                    .into_iter()
+                    .next()
+                    .map(|(d, _)| d.id)
+                    .ok_or_else(|| "No displays found".to_string());
+
+                match display_id {
+                    Ok(display_id) => ShowCapWindow::TargetSelectOverlay {
+                        display_id,
+                        target_mode,
+                    }
+                    .show(app)
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| e.to_string()),
+                    Err(_) => ShowCapWindow::Main {
+                        init_target_mode: target_mode,
+                    }
+                    .show(app)
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| e.to_string()),
+                }
+            }
+
             DeepLinkAction::OpenEditor { project_path } => {
                 crate::open_project_from_path(Path::new(&project_path), app.clone())
             }
             DeepLinkAction::OpenSettings { page } => {
                 crate::show_window(app.clone(), ShowCapWindow::Settings { page }).await
+            }
+
+            DeepLinkAction::ListCameras => {
+                let cameras: Vec<_> = cap_camera::list_cameras()
+                    .map(|c| {
+                        serde_json::json!({
+                            "device_id": c.device_id(),
+                            "display_name": c.display_name(),
+                            "model_id": c.model_id(),
+                        })
+                    })
+                    .collect();
+
+                let json = serde_json::to_string(&cameras).map_err(|e| e.to_string())?;
+                crate::write_clipboard_string(app.state(), json).await
+            }
+            DeepLinkAction::SetCamera { camera } => {
+                let state = app.state::<ArcLock<App>>();
+                crate::set_camera_input(app.clone(), state, camera, None).await
+            }
+
+            DeepLinkAction::ListMicrophones => {
+                let mics = cap_recording::feeds::microphone::MicrophoneFeed::list();
+                let names: Vec<_> = mics.keys().cloned().collect();
+                let json = serde_json::to_string(&names).map_err(|e| e.to_string())?;
+                crate::write_clipboard_string(app.state(), json).await
+            }
+            DeepLinkAction::SetMicrophone { mic_label } => {
+                let state = app.state::<ArcLock<App>>();
+                crate::set_mic_input(state, mic_label).await
+            }
+
+            DeepLinkAction::ListDisplays => {
+                let displays: Vec<_> = cap_recording::screen_capture::list_displays()
+                    .into_iter()
+                    .map(|(d, _)| {
+                        serde_json::json!({
+                            "id": d.id,
+                            "name": d.name,
+                        })
+                    })
+                    .collect();
+
+                let json = serde_json::to_string(&displays).map_err(|e| e.to_string())?;
+                crate::write_clipboard_string(app.state(), json).await
+            }
+            DeepLinkAction::ListWindows => {
+                let windows: Vec<_> = cap_recording::screen_capture::list_windows()
+                    .into_iter()
+                    .map(|(w, _)| {
+                        serde_json::json!({
+                            "id": w.id,
+                            "name": w.name,
+                        })
+                    })
+                    .collect();
+
+                let json = serde_json::to_string(&windows).map_err(|e| e.to_string())?;
+                crate::write_clipboard_string(app.state(), json).await
             }
         }
     }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -35,9 +35,7 @@ pub enum DeepLinkAction {
         capture_mode: CaptureMode,
     },
 
-    /// Open Cap's target selection overlay UI (clean UX for Raycast).
     OpenTargetPicker {
-        /// Optional: open the picker in a specific target mode if supported by the UI.
         target_mode: Option<crate::RecordingTargetMode>,
     },
 
@@ -48,23 +46,17 @@ pub enum DeepLinkAction {
         page: Option<String>,
     },
 
-    /// Copies a JSON list of cameras to the clipboard.
     ListCameras,
-    /// Sets the camera by Device/Model ID (null disables camera).
     SetCamera {
         camera: Option<DeviceOrModelID>,
     },
 
-    /// Copies a JSON list of microphone labels to the clipboard.
     ListMicrophones,
-    /// Sets the microphone by label (null disables microphone).
     SetMicrophone {
         mic_label: Option<String>,
     },
 
-    /// Copies a JSON list of capture displays to the clipboard.
     ListDisplays,
-    /// Copies a JSON list of capture windows to the clipboard.
     ListWindows,
 }
 
@@ -218,7 +210,7 @@ impl DeepLinkAction {
                     .into_iter()
                     .next()
                     .map(|(d, _)| d.id)
-                    .ok_or_else(|| "No displays found".to_string());
+                    .ok_or("No displays found".to_string());
 
                 match display_id {
                     Ok(display_id) => ShowCapWindow::TargetSelectOverlay {


### PR DESCRIPTION
# Summary
Fixes #1540 
This PR expands Cap Desktop’s deeplink action system (Tauri/Rust) to support the additional actions needed for a Raycast integration, while preserving all existing deeplink behavior.

# Changes

## New deeplink actions (added to `DeepLinkAction`)
- Recording control
  - `pause_recording`
  - `resume_recording`
  - `toggle_pause_recording`
- Screenshot
  - `take_screenshot` (supports screen or window targets)
- Target selection UI
  - `open_target_picker` (optionally with a target mode)
- Cameras
  - `list_cameras` (copies JSON to clipboard)
  - `set_camera` (by Device/Model ID; `null` disables camera)
- Microphones
  - `list_microphones` (copies JSON to clipboard)
  - `set_microphone` (by label; `null` disables microphone)
- Capture sources
  - `list_displays` (copies JSON to clipboard)
  - `list_windows` (copies JSON to clipboard)

## Execution behavior
- Recording pause/resume/toggle delegates to existing recording control functions in `crate::recording`.
- Screenshot resolves the requested screen/window into a `ScreenCaptureTarget` and calls `crate::recording::take_screenshot`.
- `List*` actions serialize results to JSON and write to clipboard via `crate::write_clipboard_string` (so Raycast can consume results without additional IPC).
- `SetCamera` / `SetMicrophone` delegates to the existing input selection flows (`set_camera_input`, `set_mic_input`).
- `OpenTargetPicker` attempts to show the target selection overlay on the primary display and falls back to opening the main window if necessary.

# Files changed
- `apps/desktop/src-tauri/src/deeplink_actions.rs`

# Notes
- This PR only updates the Cap Desktop side. The Raycast extension itself should be implemented in the Raycast extensions repository (not in this monorepo).
- Local builds may require system dependencies for `ffmpeg-sys-next` (e.g. `pkg-config`) depending on the environment.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends Cap Desktop's deeplink system with 12 new actions (pause/resume/toggle recording, screenshot, target picker, list/set camera, list/set microphone, list displays/windows) to support a Raycast integration. Changes are confined to `deeplink_actions.rs` and delegate cleanly to existing Rust functions.

- **P1 — Code comments must be removed**: Nine comment lines (`///` doc-comments on enum variants and `//` inline comments in the execute branch) violate the project's strict no-comments convention from CLAUDE.md.
- **P2 — Duplicated `CaptureMode` resolution**: The `match capture_mode { Screen(…) => …, Window(…) => … }` block is copied verbatim from `StartRecording` into `TakeScreenshot`; a shared helper would eliminate the duplication.
- **P2 — Workspace Clippy lint**: `.ok_or_else(|| \"No displays found\".to_string())` triggers the denied `unnecessary_lazy_evaluations` lint and will fail CI.

<h3>Confidence Score: 4/5</h3>

Requires minor fixes before merging: remove code comments and resolve the Clippy lint to pass CI.

The logic itself is sound and integrates cleanly with existing Tauri commands, but the no-comments rule (a hard project convention) is violated in multiple places, and the unnecessary_lazy_evaluations Clippy lint is workspace-denied and will fail CI. Both must be addressed before this can land.

apps/desktop/src-tauri/src/deeplink_actions.rs — code comments and Clippy lint

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. Deeplink payloads are deserialized via serde from a `?value=` query parameter; actions are gated to the `cap://action` URL scheme. Camera/microphone/display enumeration and clipboard writes use existing authenticated Tauri state — no new attack surface is introduced.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/deeplink_actions.rs | Adds 12 new deeplink actions for Raycast integration; violates the no-code-comments rule (9 comment lines), duplicates CaptureMode resolution logic from StartRecording, and contains a workspace-denied Clippy pattern (unnecessary_lazy_evaluations). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    URL["cap://action?value=..."] --> PARSE["DeepLinkAction::try_from(url)"]
    PARSE --> EXEC["action.execute(app)"]

    EXEC --> REC["Recording Control"]
    EXEC --> SCREEN["Screenshot"]
    EXEC --> PICKER["OpenTargetPicker"]
    EXEC --> MEDIA["Camera / Mic"]
    EXEC --> SOURCES["List Sources"]
    EXEC --> EXISTING["Existing Actions\n(Start/Stop/OpenEditor/OpenSettings)"]

    REC --> PAUSE["pause_recording()"]
    REC --> RESUME["resume_recording()"]
    REC --> TOGGLE["toggle_pause_recording()"]

    SCREEN --> RESOLVE1["Resolve CaptureMode\n→ ScreenCaptureTarget"]
    RESOLVE1 --> SHOT["take_screenshot()"]

    PICKER --> DISPLAYS["list_displays()"]
    DISPLAYS --> |"found"| OVERLAY["ShowCapWindow::TargetSelectOverlay"]
    DISPLAYS --> |"empty"| MAIN["ShowCapWindow::Main"]

    MEDIA --> CAM_LIST["ListCameras → clipboard JSON"]
    MEDIA --> CAM_SET["SetCamera → set_camera_input()"]
    MEDIA --> MIC_LIST["ListMicrophones → clipboard JSON"]
    MEDIA --> MIC_SET["SetMicrophone → set_mic_input()"]

    SOURCES --> DISP_LIST["ListDisplays → clipboard JSON"]
    SOURCES --> WIN_LIST["ListWindows → clipboard JSON"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/deeplink_actions.rs
Line: 38-68

Comment:
**Code comments violate project convention**

The project's CLAUDE.md mandates **zero comments** of any kind — no doc-comments (`///`), no line comments (`//`). This PR introduces nine comment lines across enum variant doc-comments (lines 38–68) and inline implementation comments (lines 215–216). All of them must be removed; naming and types should carry the intent instead.

```suggestion
    OpenTargetPicker {
        target_mode: Option<crate::RecordingTargetMode>,
    },

    OpenEditor {
        project_path: PathBuf,
    },
    OpenSettings {
        page: Option<String>,
    },

    ListCameras,
    SetCamera {
        camera: Option<DeviceOrModelID>,
    },

    ListMicrophones,
    SetMicrophone {
        mic_label: Option<String>,
    },

    ListDisplays,
    ListWindows,
```

The same applies to the inline comments on lines 215–216 inside `OpenTargetPicker`'s execute branch.

**Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/deeplink_actions.rs
Line: 195-212

Comment:
**Duplicated `CaptureMode` → `ScreenCaptureTarget` resolution**

The exact same `match capture_mode { Screen(name) => ..., Window(name) => ... }` block is copy-pasted from `StartRecording` (lines 157–168) into `TakeScreenshot`. Extract it to a private helper to keep things DRY:

```rust
fn resolve_capture_target(capture_mode: CaptureMode) -> Result<ScreenCaptureTarget, String> {
    match capture_mode {
        CaptureMode::Screen(name) => cap_recording::screen_capture::list_displays()
            .into_iter()
            .find(|(s, _)| s.name == name)
            .map(|(s, _)| ScreenCaptureTarget::Display { id: s.id })
            .ok_or(format!("No screen with name \"{}\"", &name)),
        CaptureMode::Window(name) => cap_recording::screen_capture::list_windows()
            .into_iter()
            .find(|(w, _)| w.name == name)
            .map(|(w, _)| ScreenCaptureTarget::Window { id: w.id })
            .ok_or(format!("No window with name \"{}\"", &name)),
    }
}
```

Both arms in `StartRecording` and `TakeScreenshot` can then call `resolve_capture_target(capture_mode)?`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src-tauri/src/deeplink_actions.rs
Line: 221

Comment:
**`unnecessary_lazy_evaluations` Clippy lint (workspace deny)**

The workspace Clippy config denies `unnecessary_lazy_evaluations`. `.ok_or_else(|| "No displays found".to_string())` is a closure over a trivially-cheap string literal — Clippy will flag this and fail CI. Prefer the eager form:

```suggestion
                    .ok_or("No displays found".to_string());
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(deeplink): add new deep link action..."](https://github.com/capsoftware/cap/commit/5df45f813679172d45bbd6694a768127d6fa1312) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27834996)</sub>

> Greptile also left **3 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))

<!-- /greptile_comment -->