### PR TITLE
feat: Raycast Deeplink Extension (#1540)

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -13,6 +13,7 @@ use crate::{App, ArcLock, recording::StartRecordingInputs, windows::ShowCapWindo
 pub enum CaptureMode {
     Screen(String),
     Window(String),
+    PrimaryScreen,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -26,6 +27,14 @@ pub enum DeepLinkAction {
         mode: RecordingMode,
     },
     StopRecording,
+    PauseRecording,
+    ResumeRecording,
+    SwitchMicrophone {
+        mic_label: Option<String>,
+    },
+    SwitchCamera {
+        camera: Option<DeviceOrModelID>,
+    },
     OpenEditor {
         project_path: PathBuf,
     },
@@ -121,6 +130,11 @@ impl DeepLinkAction {
                 crate::set_mic_input(state.clone(), mic_label).await?;
 
                 let capture_target: ScreenCaptureTarget = match capture_mode {
+                    CaptureMode::PrimaryScreen => cap_recording::screen_capture::list_displays()
+                        .into_iter()
+                        .next()
+                        .map(|(s, _)| ScreenCaptureTarget::Display { id: s.id })
+                        .ok_or("No screens available".to_string())?,
                     CaptureMode::Screen(name) => cap_recording::screen_capture::list_displays()
                         .into_iter()
                         .find(|(s, _)| s.name == name)
@@ -146,6 +160,18 @@ impl DeepLinkAction {
             }
             DeepLinkAction::StopRecording => {
                 crate::recording::stop_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::PauseRecording => {
+                crate::recording::pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::ResumeRecording => {
+                crate::recording::resume_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::SwitchMicrophone { mic_label } => {
+                crate::set_mic_input(app.state(), mic_label).await
+            }
+            DeepLinkAction::SwitchCamera { camera } => {
+                crate::set_camera_input(app.clone(), app.state(), camera, None).await
             }
             DeepLinkAction::OpenEditor { project_path } => {
                 crate::open_project_from_path(Path::new(&project_path), app.clone())

--- a/apps/raycast/package.json
+++ b/apps/raycast/package.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://www.raycast.com/downloads/extension.schema.json",
+  "name": "cap-controls",
+  "title": "Cap Controls",
+  "description": "Control the Cap screen recording app directly from Raycast",
+  "icon": "command-icon.png",
+  "author": "Ojas2095",
+  "license": "MIT",
+  "commands": [
+    {
+      "name": "start",
+      "title": "Start Recording",
+      "description": "Start a Cap recording",
+      "mode": "no-view"
+    },
+    {
+      "name": "stop",
+      "title": "Stop Recording",
+      "description": "Stops the current Cap recording",
+      "mode": "no-view"
+    },
+    {
+      "name": "pause",
+      "title": "Pause Recording",
+      "description": "Pauses the current Cap recording",
+      "mode": "no-view"
+    },
+    {
+      "name": "resume",
+      "title": "Resume Recording",
+      "description": "Resumes the paused Cap recording",
+      "mode": "no-view"
+    },
+    {
+      "name": "switch-mic",
+      "title": "Switch Microphone",
+      "description": "Switch Cap's recording microphone",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "micLabel",
+          "type": "text",
+          "placeholder": "Microphone Name (or 'none')",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "switch-camera",
+      "title": "Switch Camera",
+      "description": "Switch Cap's recording camera",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "cameraId",
+          "type": "text",
+          "placeholder": "Camera ID (or 'none')",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "dependencies": {
+    "@raycast/api": "^1.65.0"
+  },
+  "devDependencies": {
+    "@raycast/eslint-config": "^1.0.6",
+    "@types/node": "20.8.10",
+    "@types/react": "18.2.27",
+    "eslint": "^8.51.0",
+    "prettier": "^3.0.3",
+    "typescript": "^5.2.2"
+  },
+  "scripts": {
+    "build": "ray build -e dist",
+    "dev": "ray develop",
+    "publish": "npx @raycast/api@latest publish"
+  }
+}

--- a/apps/raycast/src/pause.ts
+++ b/apps/raycast/src/pause.ts
@@ -1,0 +1,5 @@
+import { sendCapCommand } from "./utils";
+
+export default async function Command() {
+  await sendCapCommand("pause_recording");
+}

--- a/apps/raycast/src/resume.ts
+++ b/apps/raycast/src/resume.ts
@@ -1,0 +1,5 @@
+import { sendCapCommand } from "./utils";
+
+export default async function Command() {
+  await sendCapCommand("resume_recording");
+}

--- a/apps/raycast/src/start.ts
+++ b/apps/raycast/src/start.ts
@@ -1,0 +1,11 @@
+import { sendCapCommand } from "./utils";
+
+export default async function Command() {
+  await sendCapCommand("start_recording", {
+    capture_mode: "primary_screen",
+    camera: null,
+    mic_label: null,
+    capture_system_audio: true,
+    mode: "Screen"
+  });
+}

--- a/apps/raycast/src/stop.ts
+++ b/apps/raycast/src/stop.ts
@@ -1,0 +1,5 @@
+import { sendCapCommand } from "./utils";
+
+export default async function Command() {
+  await sendCapCommand("stop_recording");
+}

--- a/apps/raycast/src/switch-camera.ts
+++ b/apps/raycast/src/switch-camera.ts
@@ -1,0 +1,8 @@
+import { LaunchProps } from "@raycast/api";
+import { sendCapCommand } from "./utils";
+
+export default async function Command(props: LaunchProps<{ arguments: { cameraId: string } }>) {
+  await sendCapCommand("switch_camera", {
+    camera: props.arguments.cameraId === "none" ? null : { DeviceID: props.arguments.cameraId }
+  });
+}

--- a/apps/raycast/src/switch-mic.ts
+++ b/apps/raycast/src/switch-mic.ts
@@ -1,0 +1,8 @@
+import { LaunchProps } from "@raycast/api";
+import { sendCapCommand } from "./utils";
+
+export default async function Command(props: LaunchProps<{ arguments: { micLabel: string } }>) {
+  await sendCapCommand("switch_microphone", {
+    mic_label: props.arguments.micLabel === "none" ? null : props.arguments.micLabel
+  });
+}

--- a/apps/raycast/src/utils.ts
+++ b/apps/raycast/src/utils.ts
@@ -1,0 +1,17 @@
+import { open, showHUD } from "@raycast/api";
+
+export async function sendCapCommand(action: string, objectValue?: Record<string, unknown>) {
+
+  const valuePayload = objectValue 
+    ? JSON.stringify({ [action]: objectValue }) 
+    : `"${action}"`;
+    
+  const url = `cap://action?value=${encodeURIComponent(valuePayload)}`;
+  try {
+    await open(url);
+    await showHUD(`Sent to Cap`);
+  } catch (error) {
+    await showHUD("Failed to communicate with Cap. Is it installed?");
+    console.error(error);
+  }
+}

--- a/apps/raycast/tsconfig.json
+++ b/apps/raycast/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2021",
+    "jsx": "react",
+    "lib": ["ES2021", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Fixes #1540. Adds support for Pause, Resume, Switch Microphone and Camera deeplink commands. Includes official Raycast extension package inside apps/raycast mapped to these endpoints.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Raycast extension (`apps/raycast`) for controlling Cap recordings via deeplinks, and extends the desktop's `deeplink_actions.rs` with four new action variants: `PauseRecording`, `ResumeRecording`, `SwitchMicrophone`, and `SwitchCamera`. The Rust side is implemented correctly, but two TypeScript commands have bugs that will cause silent failures at runtime.

- **`switch-camera.ts`**: Sends the camera ID as a bare string, but Rust's `DeviceOrModelID` enum requires the tagged-object format `{\"DeviceID\": \"...\"}` — any non-`\"none\"` input will always fail to deserialize.
- **`start.ts`**: Hardcodes `\"Built-in Retina Display\"` which only matches a specific subset of Apple displays; this will fail on most machines.

<h3>Confidence Score: 4/5</h3>

Not safe to merge as-is — two Raycast commands will silently fail at runtime due to incorrect JSON serialization and a hardcoded display name.

Two P1 findings: switch_camera sends the wrong JSON format for DeviceOrModelID, and start_recording hardcodes a display name that won't resolve on most machines. The Rust desktop changes are clean and correct. Fixing the two TypeScript issues is required before this is usable.

apps/raycast/src/switch-camera.ts and apps/raycast/src/start.ts require fixes before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/deeplink_actions.rs | Adds PauseRecording, ResumeRecording, SwitchMicrophone, and SwitchCamera variants to the DeepLinkAction enum and wires them to existing recording commands; Rust side looks correct. |
| apps/raycast/src/switch-camera.ts | Sends camera ID as a bare string, but Rust's DeviceOrModelID enum requires {"DeviceID": "..."} format; switch_camera will always fail for non-null values. |
| apps/raycast/src/start.ts | Hardcodes "Built-in Retina Display" as the capture target; this exact name only exists on some Apple Macs and will fail on most machines. |
| apps/raycast/src/utils.ts | Correctly builds the JSON payload matching Rust's serde enum format; contains prohibited code comments and the success HUD message is misleading. |
| apps/raycast/src/switch-mic.ts | Correctly serializes mic_label as a string or null, matching the Rust Option<String> expectation. |
| apps/raycast/src/pause.ts | Simple unit-variant deeplink for pause_recording; correct. |
| apps/raycast/src/resume.ts | Simple unit-variant deeplink for resume_recording; correct. |
| apps/raycast/src/stop.ts | Simple unit-variant deeplink for stop_recording; correct. |
| apps/raycast/package.json | Valid Raycast extension manifest; registers all six commands with correct modes and argument definitions. |
| apps/raycast/tsconfig.json | Standard Raycast extension TypeScript config; no issues. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Raycast Command
    participant U as utils.sendCapCommand
    participant OS as macOS URL Handler
    participant T as Tauri deeplink_actions
    participant RC as Recording Core

    R->>U: sendCapCommand("pause_recording")
    U->>U: Build valuePayload = '"pause_recording"'
    U->>OS: open("cap://action?value=...")
    OS->>T: handle(urls)
    T->>T: DeepLinkAction::try_from(url) → serde_json::from_str
    T->>RC: pause_recording(app, state)
    RC-->>T: Ok(())
    T-->>OS: done
    U->>R: showHUD("Cap: Action Executed")

    Note over R,U: switch-camera path (broken)
    R->>U: sendCapCommand("switch_camera", {camera: "raw_string"})
    U->>OS: open("cap://action?value=...")
    OS->>T: handle(urls)
    T->>T: serde_json::from_str → ParseFailed (expects {"DeviceID":"..."})
    T-->>OS: eprintln error, silent failure
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/raycast/src/switch-camera.ts
Line: 10

Comment:
**Wrong serialization format for `DeviceOrModelID`**

A plain string will always fail to deserialize on the Rust side. `DeviceOrModelID` is a Rust enum with two tuple variants — serde serializes it as `{"DeviceID": "..."}` or `{"ModelID": {...}}`, not as a bare string. Passing `props.arguments.cameraId` directly means any non-`"none"` input will produce a `ParseFailed` deep-link error and the camera switch will silently do nothing.

```ts
camera: props.arguments.cameraId === "none" ? null : { DeviceID: props.arguments.cameraId }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/raycast/src/start.ts
Line: 5

Comment:
**Hardcoded macOS-only display name**

`"Built-in Retina Display"` is only a valid screen name on Apple Retina Macs. On non-Retina Macs the name differs (e.g. `"Built-in Display"`), on external-only setups it won't exist at all, and on Windows the display name format is entirely different. The `StartRecording` handler does an exact string match against `cap_recording::screen_capture::list_displays()`, so this will produce a `"No screen with name"` error on most machines.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/raycast/src/utils.ts
Line: 4-8

Comment:
**Code comments violate project convention**

The project prohibits all code comments (single-line `//`, multi-line `/* */`, JSDoc, etc.) — code should be self-explanatory through naming and types. These comment blocks should be removed. The same pattern appears in `apps/raycast/src/start.ts` (line 5) and `apps/raycast/src/switch-camera.ts` (lines 5–8).

**Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/raycast/src/utils.ts
Line: 14

Comment:
**Misleading success HUD**

`showHUD("Cap: Action Executed")` fires immediately after `open(url)` resolves, which only confirms the URL was handed to the OS — not that Cap received or processed it. A recording may be in the wrong state, or Cap may not even be running. A more accurate message like `"Sent to Cap"` would prevent users from assuming the action succeeded when it may not have.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: implement deep links for Pause/Res..."](https://github.com/capsoftware/cap/commit/4eead891485135aaa4782521179a0acf667130b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28011386)</sub>

> Greptile also left **4 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->

/claim #1540