### PR TITLE
fix(web): detect cross-origin support from probe redirect, fix broken thumbnail tooltip

### DIFF
--- a/apps/web/__tests__/unit/playback-source.test.ts
+++ b/apps/web/__tests__/unit/playback-source.test.ts
@@ -32,7 +32,7 @@ function createResponse(
 }
 
 describe("detectCrossOriginSupport", () => {
-	it("disables cross-origin for S3 and R2 URLs", () => {
+	it("disables cross-origin for S3 and R2 URLs when not redirected", () => {
 		expect(
 			detectCrossOriginSupport(
 				"https://cap-assets.r2.cloudflarestorage.com/video.mp4",
@@ -44,6 +44,30 @@ describe("detectCrossOriginSupport", () => {
 			),
 		).toBe(false);
 		expect(detectCrossOriginSupport("/api/playlist?videoType=mp4")).toBe(true);
+	});
+
+	it("enables cross-origin for S3/R2 URLs when probe was redirected", () => {
+		expect(
+			detectCrossOriginSupport(
+				"https://cap-assets.r2.cloudflarestorage.com/video.mp4",
+				true,
+			),
+		).toBe(true);
+		expect(
+			detectCrossOriginSupport(
+				"https://bucket.s3.eu-west-2.amazonaws.com/video.mp4",
+				true,
+			),
+		).toBe(true);
+	});
+
+	it("falls back to hostname heuristic when not redirected", () => {
+		expect(
+			detectCrossOriginSupport(
+				"https://cap-assets.r2.cloudflarestorage.com/video.mp4",
+				false,
+			),
+		).toBe(false);
 	});
 });
 
@@ -103,7 +127,7 @@ describe("resolvePlaybackSource", () => {
 		expect(result).toEqual({
 			url: "https://bucket.s3.amazonaws.com/result.mp4",
 			type: "mp4",
-			supportsCrossOrigin: false,
+			supportsCrossOrigin: true,
 		});
 	});
 

--- a/apps/web/__tests__/unit/video-frame-thumbnail.test.ts
+++ b/apps/web/__tests__/unit/video-frame-thumbnail.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	type CaptureVideoFrameDeps,
+	captureVideoFrameDataUrl,
+} from "@/app/s/[videoId]/_components/video-frame-thumbnail";
+
+function createMockCanvas(options?: {
+	contextReturnsNull?: boolean;
+	drawImageThrows?: boolean;
+	toDataURLThrows?: boolean;
+}) {
+	const ctx = {
+		drawImage: options?.drawImageThrows
+			? vi.fn(() => {
+					throw new DOMException("Tainted canvas", "SecurityError");
+				})
+			: vi.fn(),
+	};
+
+	return {
+		canvas: {
+			width: 0,
+			height: 0,
+			getContext: options?.contextReturnsNull
+				? vi.fn().mockReturnValue(null)
+				: vi.fn().mockReturnValue(ctx),
+			toDataURL: options?.toDataURLThrows
+				? vi.fn(() => {
+						throw new DOMException("Tainted canvas", "SecurityError");
+					})
+				: vi.fn().mockReturnValue("data:image/jpeg;base64,abc123"),
+		} as unknown as HTMLCanvasElement,
+		ctx,
+	};
+}
+
+function createMockVideo(readyState = 3): HTMLVideoElement {
+	return { readyState } as unknown as HTMLVideoElement;
+}
+
+describe("captureVideoFrameDataUrl", () => {
+	it("returns undefined when video is null", () => {
+		const result = captureVideoFrameDataUrl({ video: null });
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined when video.readyState < 2", () => {
+		const result = captureVideoFrameDataUrl({
+			video: createMockVideo(1),
+		});
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined when the 2D context is null", () => {
+		const { canvas } = createMockCanvas({ contextReturnsNull: true });
+		const result = captureVideoFrameDataUrl({
+			video: createMockVideo(),
+			createCanvas: () => canvas,
+		});
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined when drawImage throws (tainted canvas)", () => {
+		const { canvas } = createMockCanvas({ drawImageThrows: true });
+		const result = captureVideoFrameDataUrl({
+			video: createMockVideo(),
+			createCanvas: () => canvas,
+		});
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined when toDataURL throws (tainted canvas)", () => {
+		const { canvas } = createMockCanvas({ toDataURLThrows: true });
+		const result = captureVideoFrameDataUrl({
+			video: createMockVideo(),
+			createCanvas: () => canvas,
+		});
+		expect(result).toBeUndefined();
+	});
+
+	it("returns a data URL on the happy path", () => {
+		const { canvas, ctx } = createMockCanvas();
+		const video = createMockVideo();
+		const result = captureVideoFrameDataUrl({
+			video,
+			createCanvas: () => canvas,
+		});
+		expect(result).toBe("data:image/jpeg;base64,abc123");
+		expect(ctx.drawImage).toHaveBeenCalledWith(video, 0, 0, 224, 128);
+		expect(canvas.toDataURL).toHaveBeenCalledWith("image/jpeg", 0.8);
+	});
+
+	it("respects custom width and height", () => {
+		const { canvas, ctx } = createMockCanvas();
+		const video = createMockVideo();
+		captureVideoFrameDataUrl({
+			video,
+			createCanvas: () => canvas,
+			width: 320,
+			height: 180,
+		});
+		expect(canvas.width).toBe(320);
+		expect(canvas.height).toBe(180);
+		expect(ctx.drawImage).toHaveBeenCalledWith(video, 0, 0, 320, 180);
+	});
+
+	it("uses the injected createCanvas factory", () => {
+		const { canvas } = createMockCanvas();
+		const factory = vi.fn().mockReturnValue(canvas);
+		captureVideoFrameDataUrl({
+			video: createMockVideo(),
+			createCanvas: factory,
+		});
+		expect(factory).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx
+++ b/apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx
@@ -45,6 +45,7 @@ import {
 	MediaPlayerVolumeIndicator,
 } from "./video/media-player";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./video/tooltip";
+import { captureVideoFrameDataUrl } from "./video-frame-thumbnail";
 
 const { circumference } = getProgressCircleConfig();
 
@@ -402,29 +403,9 @@ export function CapVideoPlayer({
 	]);
 
 	const generateVideoFrameThumbnail = useCallback(
-		(time: number): string => {
-			const video = videoRef.current;
-
-			if (!video) {
-				return `https://placeholder.pics/svg/224x128/1f2937/ffffff/Loading ${Math.floor(time)}s`;
-			}
-
-			const canvas = document.createElement("canvas");
-			canvas.width = 224;
-			canvas.height = 128;
-			const ctx = canvas.getContext("2d");
-
-			if (ctx) {
-				try {
-					ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-					return canvas.toDataURL("image/jpeg", 0.8);
-				} catch (_error) {
-					return `https://placeholder.pics/svg/224x128/dc2626/ffffff/Error`;
-				}
-			}
-			return `https://placeholder.pics/svg/224x128/dc2626/ffffff/Error`;
-		},
-		[videoRef.current],
+		(_time: number): string | undefined =>
+			captureVideoFrameDataUrl({ video: videoRef.current }),
+		[],
 	);
 
 	const isUploadFailed = uploadProgress?.status === "failed";
@@ -756,7 +737,7 @@ export function CapVideoPlayer({
 				<MediaPlayerSeek
 					fallbackDuration={playerDuration}
 					tooltipThumbnailSrc={
-						isMobile || !resolvedSrc.isSuccess
+						isMobile || !resolvedSrc.data?.supportsCrossOrigin
 							? undefined
 							: generateVideoFrameThumbnail
 					}

--- a/apps/web/app/s/[videoId]/_components/playback-source.ts
+++ b/apps/web/app/s/[videoId]/_components/playback-source.ts
@@ -63,7 +63,11 @@ async function probePlaybackSource(
 	}
 }
 
-export function detectCrossOriginSupport(url: string): boolean {
+export function detectCrossOriginSupport(
+	url: string,
+	probeWasRedirected = false,
+): boolean {
+	if (probeWasRedirected) return true;
 	try {
 		const hostname = new URL(url, "https://cap.so").hostname;
 		const isR2OrS3 =
@@ -135,7 +139,8 @@ export async function resolvePlaybackSource({
 			url: rawResult.url,
 			type: "raw",
 			supportsCrossOrigin:
-				enableCrossOrigin && detectCrossOriginSupport(rawResult.url),
+				enableCrossOrigin &&
+				detectCrossOriginSupport(rawResult.url, rawResult.response.redirected),
 		};
 	};
 
@@ -150,7 +155,8 @@ export async function resolvePlaybackSource({
 			url: mp4Result.url,
 			type: "mp4",
 			supportsCrossOrigin:
-				enableCrossOrigin && detectCrossOriginSupport(mp4Result.url),
+				enableCrossOrigin &&
+				detectCrossOriginSupport(mp4Result.url, mp4Result.response.redirected),
 		};
 	}
 

--- a/apps/web/app/s/[videoId]/_components/video-frame-thumbnail.ts
+++ b/apps/web/app/s/[videoId]/_components/video-frame-thumbnail.ts
@@ -1,0 +1,27 @@
+export interface CaptureVideoFrameDeps {
+	video: HTMLVideoElement | null;
+	createCanvas?: () => HTMLCanvasElement;
+	width?: number;
+	height?: number;
+}
+
+export function captureVideoFrameDataUrl(
+	deps: CaptureVideoFrameDeps,
+): string | undefined {
+	const { video, width = 224, height = 128 } = deps;
+	if (!video) return undefined;
+	if (video.readyState < 2) return undefined;
+	const createCanvas =
+		deps.createCanvas ?? (() => document.createElement("canvas"));
+	const canvas = createCanvas();
+	canvas.width = width;
+	canvas.height = height;
+	const ctx = canvas.getContext("2d");
+	if (!ctx) return undefined;
+	try {
+		ctx.drawImage(video, 0, 0, width, height);
+		return canvas.toDataURL("image/jpeg", 0.8);
+	} catch {
+		return undefined;
+	}
+}

--- a/apps/web/app/s/[videoId]/_components/video/media-player.tsx
+++ b/apps/web/app/s/[videoId]/_components/video/media-player.tsx
@@ -1535,7 +1535,7 @@ interface MediaPlayerSeekProps
 	withoutChapter?: boolean;
 	withoutTooltip?: boolean;
 	fallbackDuration?: number | null;
-	tooltipThumbnailSrc?: string | ((time: number) => string);
+	tooltipThumbnailSrc?: string | ((time: number) => string | undefined | null);
 	tooltipTimeVariant?: "current" | "progress";
 	tooltipSideOffset?: number;
 	tooltipCollisionBoundary?: Element | Element[];
@@ -1703,6 +1703,7 @@ function MediaPlayerSeek(props: MediaPlayerSeekProps) {
 					typeof tooltipThumbnailSrc === "function"
 						? tooltipThumbnailSrc(time)
 						: tooltipThumbnailSrc;
+				if (!src) return null;
 				return { src, coords: null };
 			}
 


### PR DESCRIPTION
## Summary

Cap Pro users with custom R2/S3 buckets see a red "Error" thumbnail when hovering over the video progress bar. Their CORS is configured correctly — the fetch probe follows a cross-origin redirect and the browser enforces CORS on the response — but `detectCrossOriginSupport` ignores the runtime signal and returns `false` based on a hostname blocklist, preventing `crossOrigin="anonymous"` from being set on the `<video>` element.

- **Runtime CORS detection**: Use `response.redirected` from the probe as a definitive signal that CORS works, short-circuiting the hostname blocklist for redirected responses
- **Extract canvas capture helper**: New `captureVideoFrameDataUrl` function returns `undefined` on all failure paths instead of red placeholder URLs (`placeholder.pics/.../Error`)
- **Graceful tooltip degradation**: Widen `MediaPlayerSeek.tooltipThumbnailSrc` type and add null guard so the tooltip falls back to time-only display when capture fails

### Root cause (HAR-verified)

The probe fetch to `/api/playlist` returns `302` redirecting to a presigned R2 URL. The browser enforces CORS on the cross-origin response — `Access-Control-Allow-Origin` is present and correct. But `detectCrossOriginSupport` checks `hostname.includes("r2.cloudflarestorage.com")` → returns `false` → `crossOrigin` attribute omitted → canvas taints on `drawImage` → `toDataURL` throws `SecurityError` → catch returns red placeholder URL.

### Defense in depth

1. If CORS probe fails → no video renders → no thumbnail attempt
2. If `supportsCrossOrigin` is false → `tooltipThumbnailSrc` is `undefined` → no canvas capture attempted
3. If canvas capture fails anyway → returns `undefined` (not a red error image)
4. If `getThumbnail` receives `undefined` → returns `null` → tooltip shows time only

### Pre-existing issue (out of scope)

`generateVideoFrameThumbnail` ignores its `time` parameter and always captures `video.currentTime`. Proper scrub previews need server-side sprite sheets + WebVTT — separate, larger future PR.

## Test plan

- [x] `pnpm --filter=@cap/web test` — 783/783 pass (10 new/updated test cases)
- [x] `pnpm typecheck` — no new errors (pre-existing PageProps issues unrelated)
- [x] `pnpm lint` — no errors in changed files
- [x] `pnpm format` — clean
- [x] Local smoke test: run `pnpm dev:web`, upload video, hover progress bar — no red "Error"
- [ ] R2 integration test: point local dev at real R2 bucket with CORS configured, verify thumbnail renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where Cap Pro users with custom R2/S3 buckets get a red \"Error\" thumbnail on video hover because `detectCrossOriginSupport` was using a hostname blocklist that ignored a successful CORS-validated redirect. The fix uses `response.redirected` from the probe fetch as a definitive runtime signal to bypass the blocklist, and also extracts canvas capture into a testable helper that returns `undefined` (rather than a red placeholder URL) on all failure paths.

The logic is correct: if the probe `fetch` follows a cross-origin redirect and still returns a successful response, the browser has already validated that CORS headers are present, so `crossOrigin=\"anonymous\"` on the `<video>` element will work.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is logically sound, well-tested, and only affects thumbnail behaviour for Pro users with custom buckets.

All findings are P2 (pre-existing acknowledged limitation and a style note about unused parameter). No regressions introduced; the CORS detection logic correctly uses `response.redirected` as a definitive runtime signal, and the canvas extraction refactor removes a UX-visible red error URL. 783 tests passing, types clean.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/s/[videoId]/_components/playback-source.ts | Core fix: `detectCrossOriginSupport` now accepts `probeWasRedirected` and short-circuits to `true`, correctly enabling cross-origin mode when the probe fetch confirmed a valid CORS-redirected response. |
| apps/web/app/s/[videoId]/_components/video-frame-thumbnail.ts | New extracted helper returns `undefined` on all failure paths instead of placeholder error URLs; includes `readyState < 2` guard and dependency injection for testability. |
| apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx | Replaces inline canvas/placeholder logic with `captureVideoFrameDataUrl`; condition for enabling thumbnails correctly changed to `resolvedSrc.data?.supportsCrossOrigin` for precise cross-origin gating. |
| apps/web/app/s/[videoId]/_components/video/media-player.tsx | Type widened for `tooltipThumbnailSrc` callback return to `string | undefined | null`; null guard added to gracefully fall back to time-only tooltip display. |
| apps/web/__tests__/unit/playback-source.test.ts | Tests updated with `redirected: true` on mock response and new cases for the `probeWasRedirected` parameter; S3 URL assertion correctly updated from `false` to `true`. |
| apps/web/__tests__/unit/video-frame-thumbnail.test.ts | New test file with comprehensive coverage of all `captureVideoFrameDataUrl` failure paths and the happy path, using dependency injection for canvas and video mocks. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant ProbeAPI as "/api/playlist (same-origin)"
    participant R2 as "R2/S3 Bucket (cross-origin)"
    participant Canvas

    Browser->>ProbeAPI: fetch(url, range bytes=0-0)
    ProbeAPI-->>Browser: 302 redirect to presigned R2 URL
    Browser->>R2: follow redirect in cors mode with Origin header
    R2-->>Browser: 206 Partial + Access-Control-Allow-Origin OK

    Note over Browser: response.redirected = true

    Browser->>Browser: detectCrossOriginSupport(url, true) returns true
    Note over Browser: video element gets crossOrigin=anonymous

    Browser->>Canvas: drawImage(video, 0, 0, w, h)
    Canvas-->>Browser: toDataURL returns jpeg data URL
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx
Line: 406-409

Comment:
**`_time` parameter is permanently unused**

`generateVideoFrameThumbnail` ignores the hovered `time` entirely and always captures `videoRef.current` (the current playback frame). The underscore prefix correctly signals the intent, and this is acknowledged in the PR description as a pre-existing issue. The consequence is that hover previews will always show the live playback frame, not the position being hovered over.

For future reference, when proper scrub previews are implemented (server-side sprite sheets + WebVTT), the parameter name and implementation will need to change.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/app/s/[videoId]/_components/playback-source.ts
Line: 66-70

Comment:
**Direct S3/R2 URLs without a redirect still blocked**

When `videoSrc` points directly at a presigned S3 or R2 URL (no initial redirect through `/api/playlist`), `response.redirected` is `false`, and the hostname blocklist still returns `false`, so thumbnails remain disabled even if CORS headers are correctly set on that bucket.

This is a narrow remaining gap: it affects users whose `videoSrc` is a bare presigned URL rather than a same-origin proxy. Not a regression introduced here, but worth a follow-up when expanding cross-origin support beyond the proxy-redirect path.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): detect cross-origin support fr..."](https://github.com/capsoftware/cap/commit/e8bf31a67602106f93ef93566da2a22edb7c98cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28214784)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->