### PR TITLE
fix(auth): disable NextAuth debug mode in production

### DIFF
--- a/packages/database/auth/auth-options.ts
+++ b/packages/database/auth/auth-options.ts
@@ -26,7 +26,7 @@ export const authOptions = (): NextAuthOptions => {
 			_adapter = DrizzleAdapter(db());
 			return _adapter;
 		},
-		debug: true,
+		debug: process.env.NODE_ENV !== "production",
 		session: {
 			strategy: "jwt",
 		},

--- a/packages/database/auth/auth-options.ts
+++ b/packages/database/auth/auth-options.ts
@@ -53,7 +53,7 @@ export const authOptions = (): NextAuthOptions => {
 			_adapter = DrizzleAdapter(db());
 			return _adapter;
 		},
-		debug: true,
+		debug: process.env.NODE_ENV !== "production",
 		session: {
 			strategy: "jwt",
 		},

--- a/packages/database/auth/auth-options.ts
+++ b/packages/database/auth/auth-options.ts
@@ -101,8 +101,6 @@ export const authOptions = (): NextAuthOptions => {
 						return crypto.randomInt(100000, 1000000).toString();
 					},
 					async sendVerificationRequest({ identifier, token }) {
-						console.log("sendVerificationRequest");
-
 						if (!serverEnv().RESEND_API_KEY) {
 							console.log("\n");
 							console.log(
@@ -120,10 +118,8 @@ export const authOptions = (): NextAuthOptions => {
 							);
 							console.log("\n");
 						} else {
-							console.log({ identifier, token });
 							const { OTPEmail } = await import("../emails/otp-email");
 							const email = OTPEmail({ code: token, email: identifier });
-							console.log({ email });
 							await sendEmail({
 								email: identifier,
 								subject: `Your Cap Verification Code`,

--- a/packages/database/auth/auth-options.ts
+++ b/packages/database/auth/auth-options.ts
@@ -53,7 +53,7 @@ export const authOptions = (): NextAuthOptions => {
 			_adapter = DrizzleAdapter(db());
 			return _adapter;
 		},
-		debug: process.env.NODE_ENV !== "production",
+		debug: process.env.NODE_ENV === "development",
 		session: {
 			strategy: "jwt",
 		},


### PR DESCRIPTION
## Summary
- \`debug: true\` was hardcoded unconditionally in \`authOptions()\`, causing NextAuth to log full JWT contents, session data, and user objects in production
- Changed to \`process.env.NODE_ENV !== \"production\"\` so debug logging only activates in development
- Removed three production-path \`console.log\` statements in \`sendVerificationRequest\` that logged raw OTP tokens and recipient emails to stdout on every auth request

## Changes

### 1. NextAuth debug flag
\`\`\`ts
- debug: true,
+ debug: process.env.NODE_ENV !== "production",
\`\`\`

### 2. OTP logging in production email path
Removed from the \`RESEND_API_KEY\` (production) branch of \`sendVerificationRequest\`:
- \`console.log("sendVerificationRequest")\` — unconditional, fires in all environments
- \`console.log({ identifier, token })\` — logged raw OTP code + recipient email
- \`console.log({ email })\` — logged rendered OTP email JSX

The dev fallback path (\`!RESEND_API_KEY\`) is unchanged — OTP codes still print to console in development.

## Security Impact
NextAuth debug mode exposes session tokens and OAuth token data in stdout logs. In any hosted deployment, these logs are retained in log aggregation systems (Vercel, Datadog, CloudWatch, etc.), making every session token readable to anyone with log access.

The \`console.log({ identifier, token })\` statement had the same exposure profile: raw OTP code + user email written to prod stdout on every magic-link auth attempt.

## Test plan
- [ ] Dev environment: verify OTP codes still appear in console (debug active, dev fallback path intact)
- [ ] Production build (\`NODE_ENV=production\`): verify no JWT/session data in logs
- [ ] Production build: verify no OTP tokens or emails in logs from \`sendVerificationRequest\`