### PR TITLE
fix: add NSSupportsAutomaticGraphicsSwitching to Info.plist

### DIFF
--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -29,5 +29,7 @@
 	<string>Cap captures your screen as part of recording your Caps</string>
 	<key>NSCameraUseContinuityCameraDeviceType</key>
 	<true/>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <false/>
 </dict>
 </plist>


### PR DESCRIPTION
Addresses high CPU usage during recording (related to #586 and #1673). Without this key, macOS may default to the integrated GPU on dual-GPU MacBooks, preventing VTEncoder from engaging hardware acceleration properly. Setting to false prefers the discrete GPU for better encoding performance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `NSSupportsAutomaticGraphicsSwitching = false` to `Info.plist`, which prevents macOS from switching to the integrated GPU on Intel dual-GPU MacBooks, aiming to ensure VTEncoder can engage hardware acceleration during screen recording. The change is correct in intent — `false` does force the discrete GPU — but applies globally for the entire app lifetime rather than only during active recording sessions.

<h3>Confidence Score: 4/5</h3>

Safe to merge with minor concerns — only affects Intel dual-GPU MacBooks and has a known battery trade-off worth acknowledging.

Both findings are P2: one is a trivial indentation style issue, the other is a real but non-blocking power-consumption trade-off that the team should be aware of. The functional change is correct and the fix is targeted at a real reported issue.

apps/desktop/src-tauri/Info.plist — indentation style and always-on discrete GPU concern.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/Info.plist | Adds NSSupportsAutomaticGraphicsSwitching=false to force discrete GPU on Intel dual-GPU MacBooks; introduces indentation inconsistency (spaces vs. tabs) and forces discrete GPU for entire app lifetime rather than only during recording. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[App Launch] --> B{Dual-GPU Intel Mac?}
    B -- No / Apple Silicon --> C[Unified GPU - No Effect]
    B -- Yes --> D{NSSupportsAutomaticGraphicsSwitching}
    D -- true / absent --> E[macOS may select Integrated GPU]
    D -- false - this PR --> F[Discrete GPU forced ON]
    E --> G{During Recording}
    G -- Integrated GPU active --> H[VTEncoder may miss HW accel\nhigh CPU fallback]
    F --> I{During Recording}
    I --> J[VTEncoder uses HW accel\nlower CPU usage]
    F --> K{App Idle / Menu Bar}
    K --> L[Discrete GPU still ON\nincreased power draw]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src-tauri/Info.plist
Line: 32-33

Comment:
**Indentation inconsistency**

The new keys use 4 spaces for indentation while all existing keys in the file use tabs. This mixes whitespace styles within the same XML document.

```suggestion
	<key>NSSupportsAutomaticGraphicsSwitching</key>
	<false/>
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src-tauri/Info.plist
Line: 32-33

Comment:
**Discrete GPU forced for entire app lifetime, not just recording**

Setting `NSSupportsAutomaticGraphicsSwitching` to `false` prevents macOS from ever switching to the integrated GPU while Cap is running — including when it's idle in the menu bar between recordings. On Intel dual-GPU MacBooks this continuously activates the discrete GPU, which can noticeably increase power consumption and fan activity even when the app is not encoding. Consider whether this trade-off is intentional; a more targeted approach (e.g. invoking `CGLEnable(kCGLCEMPEngine)` or the Metal equivalent only during active recording) would avoid the always-on GPU cost.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add NSSupportsAutomaticGraphicsSwit..."](https://github.com/capsoftware/cap/commit/68a728ee04c9b5b02a415034380ec08cab247907) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29556893)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->