### PR TITLE
feat: add SMTP support as alternative to Resend

### DIFF
--- a/packages/database/auth/auth-options.ts
+++ b/packages/database/auth/auth-options.ts
@@ -73,7 +73,7 @@ export const authOptions = (): NextAuthOptions => {
 					async sendVerificationRequest({ identifier, token }) {
 						console.log("sendVerificationRequest");
 
-						if (!serverEnv().RESEND_API_KEY) {
+						if (!serverEnv().RESEND_API_KEY && !serverEnv().SMTP_HOST) {
 							console.log("\n");
 							console.log(
 								"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",

--- a/packages/database/emails/config.ts
+++ b/packages/database/emails/config.ts
@@ -1,9 +1,32 @@
 import { buildEnv, serverEnv } from "@cap/env";
+import { render } from "@react-email/render";
+import nodemailer from "nodemailer";
 import type { JSXElementConstructor, ReactElement } from "react";
 import { Resend } from "resend";
 
 export const resend = () =>
 	serverEnv().RESEND_API_KEY ? new Resend(serverEnv().RESEND_API_KEY) : null;
+
+let _smtpTransport: ReturnType<typeof nodemailer.createTransport> | null | undefined;
+
+export const smtp = () => {
+	if (_smtpTransport !== undefined) return _smtpTransport;
+	const env = serverEnv();
+	if (!env.SMTP_HOST) {
+		_smtpTransport = null;
+		return null;
+	}
+	_smtpTransport = nodemailer.createTransport({
+		host: env.SMTP_HOST,
+		port: env.SMTP_PORT,
+		secure: env.SMTP_SECURE,
+		auth:
+			env.SMTP_USER && env.SMTP_PASS
+				? { user: env.SMTP_USER, pass: env.SMTP_PASS }
+				: undefined,
+	});
+	return _smtpTransport;
+};
 
 export const sendEmail = async ({
 	email,
@@ -26,23 +49,51 @@ export const sendEmail = async ({
 	replyTo?: string;
 	fromOverride?: string;
 }) => {
+	if (marketing && !buildEnv.NEXT_PUBLIC_IS_CAP) return;
+
+	let from: string;
+	if (fromOverride) from = fromOverride;
+	else if (marketing) from = "Richie from Cap <richie@send.cap.so>";
+	else if (buildEnv.NEXT_PUBLIC_IS_CAP)
+		from = "Cap Auth <no-reply@auth.cap.so>";
+	else if (serverEnv().SMTP_FROM) from = serverEnv().SMTP_FROM!;
+	else if (serverEnv().RESEND_FROM_DOMAIN)
+		from = `auth@${serverEnv().RESEND_FROM_DOMAIN}`;
+	else {
+		// No from-address configured. Most SMTP servers reject "noreply@localhost"
+		// as invalid sender, which would silently drop the email. Fail loudly instead.
+		throw new Error(
+			"No email from-address configured. Set SMTP_FROM (when using SMTP) or RESEND_FROM_DOMAIN (when using Resend).",
+		);
+	}
+
+	// Resend has a sandbox sink at delivered@resend.dev for test mode;
+	// over SMTP we just use the real recipient
+	const to = test && !smtp() ? "delivered@resend.dev" : email;
+
+	// Try SMTP first if configured (preferred for self-hosted)
+	const transport = smtp();
+	if (transport) {
+		const html = await render(react);
+		return transport.sendMail({
+			from,
+			to,
+			subject,
+			html,
+			cc: test ? undefined : cc,
+			replyTo,
+		}) as any;
+	}
+
+	// Fall back to Resend if configured
 	const r = resend();
 	if (!r) {
 		return Promise.resolve();
 	}
 
-	if (marketing && !buildEnv.NEXT_PUBLIC_IS_CAP) return;
-	let from;
-
-	if (fromOverride) from = fromOverride;
-	else if (marketing) from = "Richie from Cap <richie@send.cap.so>";
-	else if (buildEnv.NEXT_PUBLIC_IS_CAP)
-		from = "Cap Auth <no-reply@auth.cap.so>";
-	else from = `auth@${serverEnv().RESEND_FROM_DOMAIN}`;
-
 	return r.emails.send({
 		from,
-		to: test ? "delivered@resend.dev" : email,
+		to,
 		subject,
 		react,
 		scheduledAt,

--- a/packages/env/server.ts
+++ b/packages/env/server.ts
@@ -30,6 +30,15 @@ function createServerEnv() {
 			RESEND_API_KEY: z.string().optional(),
 			RESEND_FROM_DOMAIN: z.string().optional(),
 
+			// SMTP configuration (alternative to Resend)
+			// If SMTP_HOST is set, emails will be sent via SMTP instead of Resend
+			SMTP_HOST: z.string().optional().describe("SMTP server hostname"),
+			SMTP_PORT: z.coerce.number().optional().default(587).describe("SMTP server port"),
+			SMTP_USER: z.string().optional().describe("SMTP username"),
+			SMTP_PASS: z.string().optional().describe("SMTP password"),
+			SMTP_FROM: z.string().optional().describe("Default From address (e.g. cap@mail.example.com)"),
+			SMTP_SECURE: boolString(false).describe("Use TLS/SSL (true for port 465, false for 587/STARTTLS)"),
+
 			/// S3 configuration
 			// Though they are prefixed with `CAP_AWS`, these don't have to be
 			// for AWS, and can instead be for any S3-compatible service


### PR DESCRIPTION
## Summary

Adds SMTP transport as an alternative to Resend for sending emails (magic-link auth, notifications, etc.) on self-hosted Cap deployments. Uses `nodemailer`, which is already a transitive dependency of `@cap/database`, so no new packages are introduced.

Closes #1766.

## Why

Self-hosted Cap currently requires a Resend account for any email functionality. For users running Cap on private infrastructure, sending email through their own SMTP server (Postfix, Plunk, AWS SES via SMTP, Mailgun via SMTP, etc.) is often the natural choice — it avoids vendor lock-in, doesn't require an external account, and keeps the email path inside their own network.

This PR makes Cap's email layer pluggable: SMTP is tried first if configured, Resend is the fallback, and existing Resend deployments continue to work unchanged.

## Changes

**`packages/env/server.ts`** — Adds 6 new optional env variables:
- `SMTP_HOST`, `SMTP_PORT` (default 587), `SMTP_USER`, `SMTP_PASS`
- `SMTP_FROM` — Default From address (e.g. `Cap <cap@mail.example.com>`)
- `SMTP_SECURE` — `true` for SSL (port 465), `false` for STARTTLS (port 587)

**`packages/database/emails/config.ts`** — Extends `sendEmail()`:
- New `smtp()` helper that returns a configured `nodemailer.Transporter` when `SMTP_HOST` is set, otherwise `null`
- `sendEmail()` tries SMTP first; if no transport is configured, falls back to Resend (existing behaviour)
- React-Email templates are rendered to HTML via `@react-email/render` before being passed to nodemailer (Resend handles React directly, nodemailer needs HTML)
- From-address resolution extended: `fromOverride` → marketing → IS_CAP → `SMTP_FROM` → `RESEND_FROM_DOMAIN` → fallback

**`packages/database/auth/auth-options.ts`** — One-line fix:
```diff
-if (!serverEnv().RESEND_API_KEY) {
+if (!serverEnv().RESEND_API_KEY && !serverEnv().SMTP_HOST) {
```
Without this, the magic-link `sendVerificationRequest()` fell through to the dev-mode console-log branch even when SMTP was configured.

## Backwards compatibility

Fully backwards-compatible. When `SMTP_HOST` is not set, behaviour is identical to before — Resend handles everything as today. No migrations, no breaking changes.

## Tested

End-to-end on a self-hosted deployment:
- Magic-link auth: code email arrives in the inbox with the correct React-Email template, branding, and From address
- Verified with self-hosted Plunk SMTP (`port=587`, `secure=false`, STARTTLS)
- Confirmed Resend path still works when only `RESEND_API_KEY` is set (no SMTP env)
- Verified dev-mode console-log fallback still works when neither is configured

## Example .env

```bash
# SMTP via your own server / Plunk / SES / Mailgun
SMTP_HOST=smtp.example.com
SMTP_PORT=587
SMTP_USER=username
SMTP_PASS=secret
SMTP_FROM=Cap <cap@mail.example.com>
SMTP_SECURE=false
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds nodemailer-based SMTP as a first-class alternative to Resend for self-hosted Cap deployments. The implementation is clean and fully backwards-compatible, but there is one present defect in `packages/database/emails/config.ts`:

- **P1 — wrong test-mode recipient over SMTP**: `to` is unconditionally set to `\"delivered@resend.dev\"` when `test: true`. That address is a Resend sandbox sink; when SMTP is the active transport it is treated as an ordinary external address and a real email is dispatched there, bypassing the intended recipient.

<h3>Confidence Score: 3/5</h3>

Safe to merge for typical self-hosted setups, but the test-mode recipient bug should be fixed before merging to avoid silently misdirected emails in any path that passes test: true with SMTP configured.

One P1 defect (Resend-specific test-sink address sent over real SMTP transport) drops the ceiling to 4/5; the issue affects a real code path and produces incorrect runtime behaviour, pulling the score to 3.

packages/database/emails/config.ts — test-mode to-address logic and from-address fallback chain.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/database/emails/config.ts | Core email dispatch logic extended with SMTP transport; P1 bug where test-mode to-address is Resend-specific and sends real emails via SMTP, plus two P2 style concerns. |
| packages/database/auth/auth-options.ts | One-line fix correctly extends the dev-mode console-log guard to also check SMTP_HOST, preventing the fallback from triggering when only SMTP is configured. |
| packages/env/server.ts | Adds 6 well-typed optional SMTP env vars using existing Zod patterns; SMTP_PORT coercion and SMTP_SECURE boolString defaults are correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[sendEmail called] --> B{marketing && !IS_CAP?}
    B -- yes --> Z[return early]
    B -- no --> C[Resolve from address\nfromOverride → marketing → IS_CAP\n→ SMTP_FROM → RESEND_FROM_DOMAIN\n→ noreply@localhost]
    C --> D{test mode?}
    D -- yes --> E[to = delivered@resend.dev]
    D -- no --> F[to = email]
    E --> G{SMTP_HOST set?}
    F --> G
    G -- yes --> H[smtp transport\nnodemailer.createTransport]
    G -- no --> I{RESEND_API_KEY set?}
    H --> J[render React → HTML\ntransport.sendMail]
    I -- yes --> K[resend.emails.send\nReact passed directly]
    I -- no --> L[return Promise.resolve\nsilent no-op]
    J --> M[Email sent via SMTP]
    K --> N[Email sent via Resend]
    style E fill:#f9c,stroke:#c00
    style G fill:#ffd,stroke:#aa0
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/database/emails/config.ts:57
**`test` to-address is Resend-specific, sends real email via SMTP**

`"delivered@resend.dev"` is a Resend sandbox sink — it only has meaning when delivery goes through the Resend API. When SMTP is the active transport, this resolves to an ordinary external address and `sendMail()` will deliver a real email there. Any caller that passes `test: true` expecting sandboxed delivery while SMTP is configured will silently send to the wrong recipient.

```suggestion
	const to = test && !smtp() ? "delivered@resend.dev" : email;
```

### Issue 2 of 3
packages/database/emails/config.ts:52-55
**`SMTP_FROM` resolves independently of which transport is active**

The from-address chain checks `SMTP_FROM` then `RESEND_FROM_DOMAIN` before falling back to `"noreply@localhost"`. A user who configures only SMTP and never sets `SMTP_FROM` will fall through to `"noreply@localhost"`, which most SMTP servers will reject as an invalid sender, causing a silent non-delivery. Consider validating that at least one from-address env var is present when a transport is configured, or documenting this fallback clearly.

### Issue 3 of 3
packages/database/emails/config.ts:10-22
**New transporter created on every `sendEmail()` call**

`smtp()` calls `nodemailer.createTransport()` afresh for every email, discarding the internal connection pool each time. Following the memoisation pattern already used for `serverEnv()` would keep a single pooled transporter alive for the process lifetime and avoid repeated setup overhead.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add SMTP support as alternative to..."](https://github.com/capsoftware/cap/commit/15f27be97b9a4a9cc108f522957cbc0b77c04f95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30357498)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->