### PR TITLE
Improve desktop recording performance and reliability

### DIFF
--- a/apps/desktop/src-tauri/src/camera.rs
+++ b/apps/desktop/src-tauri/src/camera.rs
@@ -32,6 +32,14 @@ static TOOLBAR_HEIGHT: f32 = 56.0;
 
 static GPU_SURFACE_SCALE: u32 = 2;
 
+#[cfg(target_os = "macos")]
+const QOS_CLASS_USER_INTERACTIVE: u32 = 0x21;
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    fn pthread_set_qos_class_self_np(qos_class: u32, relative_priority: i32) -> i32;
+}
+
 pub const MIN_CAMERA_SIZE: f32 = 150.0;
 pub const MAX_CAMERA_SIZE: f32 = 600.0;
 pub const DEFAULT_CAMERA_SIZE: f32 = 230.0;
@@ -260,6 +268,10 @@ impl CameraPreviewManager {
         });
 
         thread::spawn(move || {
+            #[cfg(target_os = "macos")]
+            unsafe {
+                pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+            }
             LocalSet::new().block_on(
                 &rt,
                 renderer.run(window.clone(), default_state, reconfigure_rx, camera_rx),

--- a/apps/desktop/src-tauri/src/camera.rs
+++ b/apps/desktop/src-tauri/src/camera.rs
@@ -3,6 +3,8 @@ use cap_recording::{
     FFmpegVideoFrame,
     feeds::{self, camera::CameraFeed},
 };
+#[cfg(target_os = "macos")]
+use cap_utils::macos_qos::{MacOsQosClass, set_current_thread_qos};
 use ffmpeg::{
     format::{self, Pixel},
     frame,
@@ -31,14 +33,6 @@ use wgpu::{CompositeAlphaMode, SurfaceTexture};
 static TOOLBAR_HEIGHT: f32 = 56.0;
 
 static GPU_SURFACE_SCALE: u32 = 2;
-
-#[cfg(target_os = "macos")]
-const QOS_CLASS_USER_INTERACTIVE: u32 = 0x21;
-
-#[cfg(target_os = "macos")]
-unsafe extern "C" {
-    fn pthread_set_qos_class_self_np(qos_class: u32, relative_priority: i32) -> i32;
-}
 
 pub const MIN_CAMERA_SIZE: f32 = 150.0;
 pub const MAX_CAMERA_SIZE: f32 = 600.0;
@@ -269,8 +263,11 @@ impl CameraPreviewManager {
 
         thread::spawn(move || {
             #[cfg(target_os = "macos")]
-            unsafe {
-                pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+            {
+                let result = set_current_thread_qos(MacOsQosClass::UserInteractive);
+                if result != 0 {
+                    warn!(result, "pthread_set_qos_class_self_np failed");
+                }
             }
             LocalSet::new().block_on(
                 &rt,

--- a/apps/desktop/src-tauri/src/camera_legacy.rs
+++ b/apps/desktop/src-tauri/src/camera_legacy.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use cap_recording::FFmpegVideoFrame;
 use flume::Sender;
@@ -25,6 +25,7 @@ struct WsReadback {
 
 const WS_PREVIEW_MAX_WIDTH: u32 = 640;
 const WS_PREVIEW_MAX_HEIGHT: u32 = 360;
+const WS_PREVIEW_FRAME_INTERVAL: Duration = Duration::from_millis(33);
 
 pub async fn create_camera_preview_ws(
     blur_rx: watch::Receiver<cap_project::BackgroundBlurMode>,
@@ -40,6 +41,7 @@ pub async fn create_camera_preview_ws(
         let mut blur_rx = blur_rx;
 
         let mut blur_state = WsBlurState::new();
+        let mut next_preview_at = Instant::now();
 
         while let Ok(raw_frame) = camera_rx.recv() {
             let mut frame = raw_frame.inner;
@@ -47,6 +49,12 @@ pub async fn create_camera_preview_ws(
             while let Ok(newer) = camera_rx.try_recv() {
                 frame = newer.inner;
             }
+
+            let now = Instant::now();
+            if now < next_preview_at {
+                continue;
+            }
+            next_preview_at = now + WS_PREVIEW_FRAME_INTERVAL;
 
             let blur_mode = *blur_rx.borrow_and_update();
             let blur_enabled = blur_mode != cap_project::BackgroundBlurMode::Off;

--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -42,12 +42,37 @@ pub enum EditorPreviewQuality {
     Full,
 }
 
-#[derive(Default, Serialize, Deserialize, Type, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Type, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum StudioRecordingQuality {
-    #[default]
+    Compatibility,
     Balanced,
     Ultra,
+}
+
+impl Default for StudioRecordingQuality {
+    fn default() -> Self {
+        default_studio_recording_quality()
+    }
+}
+
+fn detect_total_memory_bytes() -> Option<u64> {
+    let system = sysinfo::System::new_with_specifics(
+        sysinfo::RefreshKind::nothing()
+            .with_memory(sysinfo::MemoryRefreshKind::nothing().with_ram()),
+    );
+    Some(system.total_memory()).filter(|m| *m > 0)
+}
+
+const COMPATIBILITY_MEMORY_THRESHOLD_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+
+pub fn default_studio_recording_quality() -> StudioRecordingQuality {
+    match detect_total_memory_bytes() {
+        Some(memory) if memory < COMPATIBILITY_MEMORY_THRESHOLD_BYTES => {
+            StudioRecordingQuality::Compatibility
+        }
+        _ => StudioRecordingQuality::Balanced,
+    }
 }
 
 impl MainWindowRecordingStartBehaviour {
@@ -247,7 +272,7 @@ impl Default for GeneralSettingsStore {
             max_fps: 60,
             transcription_hints: default_transcription_hints(),
             editor_preview_quality: EditorPreviewQuality::Half,
-            studio_recording_quality: StudioRecordingQuality::Balanced,
+            studio_recording_quality: default_studio_recording_quality(),
             main_window_position: None,
             camera_window_position: None,
             camera_window_positions_by_monitor_name: BTreeMap::new(),

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1588,6 +1588,11 @@ pub struct RequestScreenCapturePrewarm {
 pub struct NewNotification {
     title: String,
     body: String,
+#[derive(Deserialize, specta::Type, Serialize, tauri_specta::Event, Debug, Clone)]
+pub struct RequestScrollToSettingsSection {
+    pub section: String,
+}
+
     is_error: bool,
 }
 
@@ -3675,6 +3680,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
         .typ::<presets::PresetsStore>()
         .typ::<hotkeys::HotkeysStore>()
         .typ::<general_settings::GeneralSettingsStore>()
+            RequestScrollToSettingsSection,
         .typ::<recording_settings::RecordingSettingsStore>()
         .typ::<cap_flags::Flags>()
         .typ::<crate::window_exclusion::WindowExclusion>();

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -746,19 +746,29 @@ async fn set_camera_input(
                 .map_err(|e| e.to_string())?;
         }
         Some(id) => {
-            let camera_ws_sender = {
+            let (camera_ws_sender, native_preview_active) = {
                 let app = &mut *state.write().await;
                 app.selected_camera_id = Some(id.clone());
                 app.camera_in_use = true;
                 app.camera_cleanup_done = false;
                 #[allow(deprecated)]
-                app.camera_ws_sender.clone()
+                (
+                    app.camera_ws_sender.clone(),
+                    app.camera_preview.is_initialized(),
+                )
             };
 
-            #[allow(deprecated)]
-            let _ = camera_feed
-                .ask(feeds::camera::AddSender(camera_ws_sender))
-                .await;
+            if native_preview_active {
+                #[allow(deprecated)]
+                let _ = camera_feed
+                    .ask(feeds::camera::RemoveSender(camera_ws_sender))
+                    .await;
+            } else {
+                #[allow(deprecated)]
+                let _ = camera_feed
+                    .ask(feeds::camera::AddSender(camera_ws_sender))
+                    .await;
+            }
 
             let mut attempts = 0;
             let init_result: Result<(), String> = loop {
@@ -1579,6 +1589,11 @@ pub struct RequestOpenSettings {
 }
 
 #[derive(Deserialize, specta::Type, Serialize, tauri_specta::Event, Debug, Clone)]
+pub struct RequestScrollToSettingsSection {
+    pub section: String,
+}
+
+#[derive(Deserialize, specta::Type, Serialize, tauri_specta::Event, Debug, Clone)]
 pub struct RequestScreenCapturePrewarm {
     #[serde(default)]
     pub force: bool,
@@ -1588,11 +1603,6 @@ pub struct RequestScreenCapturePrewarm {
 pub struct NewNotification {
     title: String,
     body: String,
-#[derive(Deserialize, specta::Type, Serialize, tauri_specta::Event, Debug, Clone)]
-pub struct RequestScrollToSettingsSection {
-    pub section: String,
-}
-
     is_error: bool,
 }
 
@@ -3417,20 +3427,29 @@ async fn refresh_camera_feed(state: MutableState<'_, App>) -> Result<(), String>
     let camera_ws_sender = app.camera_ws_sender.clone();
 
     let camera_preview_sender = app.camera_preview.sender();
+    let native_preview_active = app.camera_preview.is_initialized();
 
     drop(app);
 
-    #[allow(deprecated)]
-    camera_feed
-        .ask(feeds::camera::AddSender(camera_ws_sender))
-        .await
-        .map_err(|err| format!("error re-adding camera ws sender: {err}"))?;
-
     if let Some(sender) = camera_preview_sender {
+        if native_preview_active {
+            #[allow(deprecated)]
+            camera_feed
+                .ask(feeds::camera::RemoveSender(camera_ws_sender))
+                .await
+                .map_err(|err| format!("error removing camera ws sender: {err}"))?;
+        }
+
         camera_feed
             .ask(feeds::camera::AddSender(sender))
             .await
             .map_err(|err| format!("error re-adding camera preview sender: {err}"))?;
+    } else {
+        #[allow(deprecated)]
+        camera_feed
+            .ask(feeds::camera::AddSender(camera_ws_sender))
+            .await
+            .map_err(|err| format!("error re-adding camera ws sender: {err}"))?;
     }
 
     Ok(())
@@ -3661,6 +3680,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             RequestOpenRecordingPicker,
             RequestSetTargetMode,
             RequestOpenSettings,
+            RequestScrollToSettingsSection,
             RequestScreenCapturePrewarm,
             NewNotification,
             audio_meter::AudioInputLevelChange,
@@ -3680,7 +3700,6 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
         .typ::<presets::PresetsStore>()
         .typ::<hotkeys::HotkeysStore>()
         .typ::<general_settings::GeneralSettingsStore>()
-            RequestScrollToSettingsSection,
         .typ::<recording_settings::RecordingSettingsStore>()
         .typ::<cap_flags::Flags>()
         .typ::<crate::window_exclusion::WindowExclusion>();

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -760,14 +760,20 @@ async fn set_camera_input(
 
             if native_preview_active {
                 #[allow(deprecated)]
-                let _ = camera_feed
+                let result = camera_feed
                     .ask(feeds::camera::RemoveSender(camera_ws_sender))
                     .await;
+                if let Err(err) = result {
+                    warn!(error = %err, "Failed to remove camera sender");
+                }
             } else {
                 #[allow(deprecated)]
-                let _ = camera_feed
+                let result = camera_feed
                     .ask(feeds::camera::AddSender(camera_ws_sender))
                     .await;
+                if let Err(err) = result {
+                    warn!(error = %err, "Failed to add camera sender");
+                }
             }
 
             let mut attempts = 0;
@@ -3427,18 +3433,15 @@ async fn refresh_camera_feed(state: MutableState<'_, App>) -> Result<(), String>
     let camera_ws_sender = app.camera_ws_sender.clone();
 
     let camera_preview_sender = app.camera_preview.sender();
-    let native_preview_active = app.camera_preview.is_initialized();
 
     drop(app);
 
     if let Some(sender) = camera_preview_sender {
-        if native_preview_active {
-            #[allow(deprecated)]
-            camera_feed
-                .ask(feeds::camera::RemoveSender(camera_ws_sender))
-                .await
-                .map_err(|err| format!("error removing camera ws sender: {err}"))?;
-        }
+        #[allow(deprecated)]
+        camera_feed
+            .ask(feeds::camera::RemoveSender(camera_ws_sender))
+            .await
+            .map_err(|err| format!("error removing camera ws sender: {err}"))?;
 
         camera_feed
             .ask(feeds::camera::AddSender(sender))

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -948,6 +948,13 @@ pub async fn start_recording(
                 let actor_result: Result<InProgressRecording, anyhow::Error> = async {
                     match inputs.mode {
                         RecordingMode::Studio => {
+                            let max_fps =
+                                general_settings.as_ref().map(|s| s.max_fps).unwrap_or(60);
+                            let max_fps = if camera_feed.is_some() {
+                                max_fps.min(30)
+                            } else {
+                                max_fps
+                            };
                             let mut builder = studio_recording::Actor::builder(
                                 recording_dir.clone(),
                                 inputs.capture_target.clone(),
@@ -977,15 +984,16 @@ pub async fn start_recording(
                                     .map(|s| s.out_of_process_muxer)
                                     .unwrap_or(false),
                             )
-                            .with_max_fps(
-                                general_settings.as_ref().map(|s| s.max_fps).unwrap_or(60),
-                            )
+                            .with_max_fps(max_fps)
                             .with_quality(
                                 match general_settings
                                     .as_ref()
                                     .map(|s| s.studio_recording_quality)
                                     .unwrap_or_default()
                                 {
+                                    crate::general_settings::StudioRecordingQuality::Compatibility => {
+                                        cap_recording::StudioQuality::Compatibility
+                                    }
                                     crate::general_settings::StudioRecordingQuality::Balanced => {
                                         cap_recording::StudioQuality::Balanced
                                     }

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -1553,7 +1553,7 @@ where
 pub async fn stop_recording(app: AppHandle, state: MutableState<'_, App>) -> Result<(), String> {
     let mut state = state.write().await;
     let Some(current_recording) = state.clear_current_recording() else {
-        return Err("Recording not in progress".to_string())?;
+        return Ok(());
     };
 
     let recording_dir = current_recording.recording_dir().clone();

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -1561,6 +1561,7 @@ where
 pub async fn stop_recording(app: AppHandle, state: MutableState<'_, App>) -> Result<(), String> {
     let mut state = state.write().await;
     let Some(current_recording) = state.clear_current_recording() else {
+        warn!("Stop recording requested without active recording");
         return Ok(());
     };
 

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -193,13 +193,17 @@ async fn restore_main_window_inputs(app: &AppHandle) {
             )
         };
 
-        #[allow(deprecated)]
-        let _ = camera_feed
-            .ask(feeds::camera::AddSender(camera_ws_sender))
-            .await;
-
         if let Some(sender) = native_sender {
+            #[allow(deprecated)]
+            let _ = camera_feed
+                .ask(feeds::camera::RemoveSender(camera_ws_sender))
+                .await;
             let _ = camera_feed.ask(feeds::camera::AddSender(sender)).await;
+        } else {
+            #[allow(deprecated)]
+            let _ = camera_feed
+                .ask(feeds::camera::AddSender(camera_ws_sender))
+                .await;
         }
 
         let mut attempts = 0;
@@ -1902,6 +1906,11 @@ impl ShowCapWindow {
 
                     if enable_native_camera_preview {
                         let camera_feed = state.camera_feed.clone();
+                        #[allow(deprecated)]
+                        let camera_ws_sender = state.camera_ws_sender.clone();
+                        let _ = camera_feed
+                            .ask(feeds::camera::RemoveSender(camera_ws_sender))
+                            .await;
                         if let Err(err) = state
                             .camera_preview
                             .init_window(window.clone(), camera_feed)

--- a/apps/desktop/src/components/Mode.tsx
+++ b/apps/desktop/src/components/Mode.tsx
@@ -1,16 +1,54 @@
-import { createSignal } from "solid-js";
+import { HoverCard } from "@kobalte/core/hover-card";
+import { cx } from "cva";
+import { type JSX, Show } from "solid-js";
 
-import Tooltip from "~/components/Tooltip";
 import { useRecordingOptions } from "~/routes/(window-chrome)/OptionsContext";
-import { commands } from "~/utils/tauri";
+import { commands, events, type RecordingMode } from "~/utils/tauri";
 
 interface ModeProps {
 	onInfoClick?: () => void;
 }
 
+type ModeButtonConfig = {
+	mode: RecordingMode;
+	label: string;
+	description: string;
+	settingsSection: "instant-quality" | "studio-quality" | null;
+	icon: (props: { class?: string }) => JSX.Element;
+	iconClass: string;
+};
+
+const MODE_BUTTONS: ModeButtonConfig[] = [
+	{
+		mode: "instant",
+		label: "Instant mode",
+		description:
+			"No rendering required — uploads on the fly so you can share the link the moment you stop.",
+		settingsSection: "instant-quality",
+		icon: (p) => <IconCapInstant {...p} />,
+		iconClass: "size-4 invert dark:invert-0",
+	},
+	{
+		mode: "studio",
+		label: "Studio mode",
+		description:
+			"Records at the highest quality for local rendering later. Opens the Cap editor when you're done.",
+		settingsSection: "studio-quality",
+		icon: (p) => <IconCapFilmCut {...p} />,
+		iconClass: "size-[0.9rem] invert dark:invert-0",
+	},
+	{
+		mode: "screenshot",
+		label: "Screenshot mode",
+		description: "Capture and annotate stills.",
+		settingsSection: null,
+		icon: (p) => <IconCapScreenshot {...p} />,
+		iconClass: "size-[0.9rem] invert dark:invert-0",
+	},
+];
+
 const Mode = (props: ModeProps) => {
 	const { rawOptions, setOptions } = useRecordingOptions();
-	const [isInfoHovered, setIsInfoHovered] = createSignal(false);
 
 	const handleInfoClick = () => {
 		if (props.onInfoClick) {
@@ -20,131 +58,82 @@ const Mode = (props: ModeProps) => {
 		}
 	};
 
+	const openQualitySettings = async (
+		section: "instant-quality" | "studio-quality",
+	) => {
+		try {
+			localStorage.setItem("cap.settings.scrollToSection", section);
+		} catch {}
+		await commands.showWindow({ Settings: { page: "general" } });
+		await events.requestScrollToSettingsSection.emit({ section });
+	};
+
 	return (
-		<div class="flex gap-2 relative justify-end items-center p-1.5 rounded-full border border-gray-5 bg-gray-3 w-fit">
-			<div
-				class="absolute -left-1.5 -top-2 p-1 rounded-full w-fit bg-gray-5 group"
+		<div class="flex relative gap-2 items-center p-1.5 rounded-full border border-gray-5 bg-gray-3 w-fit">
+			<button
+				type="button"
 				onClick={handleInfoClick}
-				onMouseEnter={() => setIsInfoHovered(true)}
-				onMouseLeave={() => setIsInfoHovered(false)}
+				class="absolute -left-1.5 -top-2 p-1 rounded-full w-fit bg-gray-5 group focus:outline-none"
+				aria-label="Recording mode info"
 			>
 				<IconCapInfo class="invert transition-opacity duration-200 cursor-pointer size-2.5 dark:invert-0 group-hover:opacity-50" />
-			</div>
+			</button>
 
-			{!isInfoHovered() && (
-				<Tooltip
-					placement="top"
-					content="Instant mode"
-					openDelay={0}
-					closeDelay={0}
-				>
-					<div
-						onClick={() => {
-							setOptions({ mode: "instant" });
-							commands.setRecordingMode("instant");
-						}}
-						class={`flex justify-center items-center transition-all duration-200 rounded-full size-7 hover:cursor-pointer ${
-							rawOptions.mode === "instant"
-								? "ring-2 ring-offset-1 ring-offset-gray-1 bg-gray-7 hover:bg-gray-7 ring-blue-500"
-								: "bg-gray-3 hover:bg-gray-7"
-						}`}
-					>
-						<IconCapInstant class="invert size-4 dark:invert-0" />
-					</div>
-				</Tooltip>
-			)}
+			{MODE_BUTTONS.map((button) => {
+				const isSelected = () => rawOptions.mode === button.mode;
 
-			{!isInfoHovered() && (
-				<Tooltip
-					placement="top"
-					content="Studio mode"
-					openDelay={0}
-					closeDelay={0}
-				>
-					<div
-						onClick={() => {
-							setOptions({ mode: "studio" });
-							commands.setRecordingMode("studio");
-						}}
-						class={`flex justify-center items-center transition-all duration-200 rounded-full size-7 hover:cursor-pointer ${
-							rawOptions.mode === "studio"
-								? "ring-2 ring-offset-1 ring-offset-gray-1 bg-gray-7 hover:bg-gray-7 ring-blue-500"
-								: "bg-gray-3 hover:bg-gray-7"
-						}`}
+				return (
+					<HoverCard
+						openDelay={120}
+						closeDelay={80}
+						placement="bottom-end"
+						gutter={12}
 					>
-						<IconCapFilmCut class="size-3.5 invert dark:invert-0" />
-					</div>
-				</Tooltip>
-			)}
-
-			{!isInfoHovered() && (
-				<Tooltip
-					placement="top"
-					content="Screenshot mode"
-					openDelay={0}
-					closeDelay={0}
-				>
-					<div
-						onClick={() => {
-							setOptions({ mode: "screenshot" });
-							commands.setRecordingMode("screenshot");
-						}}
-						class={`flex justify-center items-center transition-all duration-200 rounded-full size-7 hover:cursor-pointer ${
-							rawOptions.mode === "screenshot"
-								? "ring-2 ring-offset-1 ring-offset-gray-1 bg-gray-7 hover:bg-gray-7 ring-blue-500"
-								: "bg-gray-3 hover:bg-gray-7"
-						}`}
-					>
-						<IconCapScreenshot class="size-3.5 invert dark:invert-0" />
-					</div>
-				</Tooltip>
-			)}
-
-			{isInfoHovered() && (
-				<>
-					<div
-						onClick={() => {
-							setOptions({ mode: "instant" });
-							commands.setRecordingMode("instant");
-						}}
-						class={`flex justify-center items-center transition-all duration-200 rounded-full size-7 hover:cursor-pointer ${
-							rawOptions.mode === "instant"
-								? "ring-2 ring-offset-1 ring-offset-gray-1 bg-gray-5 hover:bg-gray-7 ring-blue-500"
-								: "bg-gray-3 hover:bg-gray-7"
-						}`}
-					>
-						<IconCapInstant class="invert size-4 dark:invert-0" />
-					</div>
-
-					<div
-						onClick={() => {
-							setOptions({ mode: "studio" });
-							commands.setRecordingMode("studio");
-						}}
-						class={`flex justify-center items-center transition-all duration-200 rounded-full size-7 hover:cursor-pointer ${
-							rawOptions.mode === "studio"
-								? "ring-2 ring-offset-1 ring-offset-gray-1 bg-gray-5 hover:bg-gray-7 ring-blue-10"
-								: "bg-gray-3 hover:bg-gray-7"
-						}`}
-					>
-						<IconCapFilmCut class="size-3.5 invert dark:invert-0" />
-					</div>
-
-					<div
-						onClick={() => {
-							setOptions({ mode: "screenshot" });
-							commands.setRecordingMode("screenshot");
-						}}
-						class={`flex justify-center items-center transition-all duration-200 rounded-full size-7 hover:cursor-pointer ${
-							rawOptions.mode === "screenshot"
-								? "ring-2 ring-offset-1 ring-offset-gray-1 bg-gray-5 hover:bg-gray-7 ring-blue-10"
-								: "bg-gray-3 hover:bg-gray-7"
-						}`}
-					>
-						<IconCapScreenshot class="size-3.5 invert dark:invert-0" />
-					</div>
-				</>
-			)}
+						<HoverCard.Trigger
+							as="div"
+							onClick={() => {
+								setOptions({ mode: button.mode });
+								commands.setRecordingMode(button.mode);
+							}}
+							class={cx(
+								"relative flex justify-center items-center rounded-full transition-all duration-200 cursor-pointer size-7",
+								isSelected()
+									? "ring-2 ring-offset-1 ring-offset-gray-1 bg-gray-7 hover:bg-gray-7 ring-blue-500"
+									: "bg-gray-3 hover:bg-gray-7",
+							)}
+						>
+							<button.icon class={button.iconClass} />
+						</HoverCard.Trigger>
+						<HoverCard.Portal>
+							<HoverCard.Content class="z-50 outline-none animate-in fade-in slide-in-from-top-1 duration-100">
+								<div class="flex flex-col gap-2 px-3 py-2.5 rounded-lg border shadow-lg bg-gray-12 text-gray-1 border-gray-3 min-w-[12rem] max-w-[15rem]">
+									<div class="flex flex-col gap-0.5">
+										<span class="text-xs font-medium">{button.label}</span>
+										<span class="text-[10px] text-gray-4 leading-snug">
+											{button.description}
+										</span>
+									</div>
+									<Show when={button.settingsSection}>
+										{(section) => (
+											<button
+												type="button"
+												onClick={(e) => {
+													e.stopPropagation();
+													void openQualitySettings(section());
+												}}
+												class="flex gap-1.5 items-center px-2 py-1 -mx-1 text-[11px] rounded-md transition-colors text-gray-4 hover:bg-gray-11 hover:text-gray-1"
+											>
+												<IconCapSettings class="size-3" />
+												<span>Quality settings</span>
+											</button>
+										)}
+									</Show>
+								</div>
+							</HoverCard.Content>
+						</HoverCard.Portal>
+					</HoverCard>
+				);
+			})}
 		</div>
 	);
 };

--- a/apps/desktop/src/routes/(window-chrome)/settings/Setting.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/Setting.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from "solid-js";
+import { Show } from "solid-js";
 import { Toggle } from "~/components/Toggle";
 
 export function SettingItem(props: {
@@ -8,16 +9,14 @@ export function SettingItem(props: {
 	children: JSX.Element;
 }) {
 	return (
-		<div class="flex flex-row gap-2 justify-between items-center py-3 text-sm">
-			<div class="flex flex-col justify-between items-start space-y-1">
-				<div class="flex gap-2 items-center">
-					<p class="text-gray-12">{props.label}</p>
-				</div>
-				{props.description && (
-					<p class="text-xs text-gray-11">{props.description}</p>
-				)}
+		<div class="flex flex-row gap-4 justify-between items-center px-4 py-3.5">
+			<div class="flex flex-col flex-1 min-w-0 gap-0.5">
+				<p class="text-[13px] text-gray-12">{props.label}</p>
+				<Show when={props.description}>
+					<p class="text-xs leading-snug text-gray-10">{props.description}</p>
+				</Show>
 			</div>
-			{props.children}
+			<div class="flex shrink-0 items-center">{props.children}</div>
 		</div>
 	);
 }

--- a/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/experimental.tsx
@@ -49,50 +49,58 @@ function Inner(props: {
 
 	return (
 		<div class="flex flex-col h-full custom-scroll">
-			<div class="p-4 space-y-4">
-				<div class="flex flex-col pb-4 border-b border-gray-2">
-					<h2 class="text-lg font-medium text-gray-12">
-						Experimental Features
+			<div class="px-6 py-6 space-y-7 max-w-[42rem]">
+				<div class="flex flex-col gap-1 px-1">
+					<h2 class="text-base font-semibold tracking-tight text-gray-12">
+						Experimental
 					</h2>
-					<p class="text-sm text-gray-10">
-						These features are still in development and may not work as
-						expected.
+					<p class="text-xs leading-relaxed text-gray-10">
+						In-development features that may not work as expected.
 					</p>
 				</div>
+
 				<Show
 					when={props.osType !== "windows"}
 					fallback={
-						<p class="text-sm text-gray-10">
+						<p class="text-xs text-gray-10 px-1">
 							No experimental features are currently available on this platform.
 						</p>
 					}
 				>
-					<div class="space-y-3">
-						<h3 class="text-sm text-gray-12 w-fit">Preview</h3>
-						<div class="px-3 rounded-xl border divide-y divide-gray-3 border-gray-3 bg-gray-2">
+					<section class="space-y-2.5">
+						<header class="px-1">
+							<h3 class="text-sm font-semibold tracking-tight text-gray-12">
+								Preview
+							</h3>
+						</header>
+						<div class="overflow-hidden rounded-xl border border-gray-3 bg-gray-2">
 							<ToggleSettingItem
 								label="Native camera preview"
-								description="Show the camera preview using a native GPU surface instead of rendering it within the webview. This is not functional on certain Windows systems so your mileage may vary."
+								description="Render the camera preview using a native GPU surface instead of through the webview. Not stable on certain Windows systems."
 								value={!!settings.enableNativeCameraPreview}
 								onChange={(value) =>
 									handleChange("enableNativeCameraPreview", value)
 								}
 							/>
 						</div>
-					</div>
+					</section>
 				</Show>
 
-				<div class="space-y-3">
-					<h3 class="text-sm text-gray-12 w-fit">Reliability</h3>
-					<div class="px-3 rounded-xl border divide-y divide-gray-3 border-gray-3 bg-gray-2">
+				<section class="space-y-2.5">
+					<header class="px-1">
+						<h3 class="text-sm font-semibold tracking-tight text-gray-12">
+							Reliability
+						</h3>
+					</header>
+					<div class="overflow-hidden rounded-xl border border-gray-3 bg-gray-2">
 						<ToggleSettingItem
 							label="Out-of-process muxer"
-							description="Run the fragmented-MP4 muxer in an isolated subprocess so a muxer crash or codec assertion can no longer take down your recording. Requires the bundled cap-muxer binary. Early-access — please report issues if your recordings fail to finalize."
+							description="Run the fragmented-MP4 muxer in an isolated subprocess so muxer crashes can't take down your recording. Requires the bundled cap-muxer binary."
 							value={!!settings.outOfProcessMuxer}
 							onChange={(value) => handleChange("outOfProcessMuxer", value)}
 						/>
 					</div>
-				</div>
+				</section>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -16,6 +16,8 @@ import {
 	createResource,
 	createSignal,
 	For,
+	type JSX,
+	onCleanup,
 	onMount,
 	type ParentProps,
 	Show,
@@ -70,16 +72,6 @@ const getWindowOptionLabel = (window: CaptureWindow) => {
 
 type ExtendedGeneralSettingsStore = GeneralSettingsStore;
 
-const INSTANT_MODE_RESOLUTION_OPTIONS = [
-	{ value: 1280, label: "720p" },
-	{ value: 1920, label: "1080p" },
-	{ value: 2560, label: "1440p" },
-	{ value: 3840, label: "4K" },
-] satisfies {
-	value: number;
-	label: string;
-}[];
-
 const MAX_FPS_OPTIONS = [
 	{ value: 30, label: "30 FPS" },
 	{ value: 60, label: "60 FPS (Recommended)" },
@@ -107,18 +99,9 @@ function AppearanceSection(props: {
 	onThemeChange: (theme: AppTheme) => void;
 }) {
 	const options = [
-		{
-			id: "system",
-			name: "System",
-		},
-		{
-			id: "light",
-			name: "Light",
-		},
-		{
-			id: "dark",
-			name: "Dark",
-		},
+		{ id: "system", name: "System" },
+		{ id: "light", name: "Light" },
+		{ id: "dark", name: "Dark" },
 	] satisfies { id: AppTheme; name: string }[];
 
 	const previews = {
@@ -128,65 +111,60 @@ function AppearanceSection(props: {
 	};
 
 	return (
-		<div class="flex flex-col gap-4">
-			<div class="flex flex-col border-b border-gray-2">
-				<h2 class="text-lg font-medium text-gray-12">General Settings</h2>
-			</div>
-			<div
-				class="flex justify-start items-center text-gray-12"
-				onContextMenu={(e) => e.preventDefault()}
-			>
-				<div class="flex flex-col gap-3">
-					<p class="text-sm text-gray-12">Appearance</p>
-					<div class="flex justify-between m-1 min-w-[20rem] w-[22.2rem] flex-nowrap">
-						<For each={options}>
-							{(theme) => (
+		<Section
+			title="Appearance"
+			description="Match Cap to your system theme or pick a fixed look."
+		>
+			<SectionCard padded>
+				<div
+					class="grid grid-cols-3 gap-3"
+					onContextMenu={(e) => e.preventDefault()}
+				>
+					<For each={options}>
+						{(theme) => {
+							const isSelected = () => props.currentTheme === theme.id;
+							return (
 								<button
 									type="button"
-									aria-checked={props.currentTheme === theme.id}
-									class="flex flex-col items-center rounded-md group focus:outline-none focus-visible:ring-gray-300 focus-visible:ring-offset-gray-50 focus-visible:ring-offset-2 focus-visible:ring-4"
+									aria-checked={isSelected()}
+									aria-label={`Select theme: ${theme.name}`}
 									onClick={() => props.onThemeChange(theme.id)}
+									class="flex flex-col gap-2 items-center group focus:outline-none"
 								>
 									<div
 										class={cx(
-											`w-24 h-[4.8rem] rounded-md overflow-hidden focus:outline-none ring-offset-gray-50 transition-all duration-200`,
-											{
-												"ring-2 ring-gray-12 ring-offset-2":
-													props.currentTheme === theme.id,
-												"group-hover:ring-2 ring-offset-2 group-hover:ring-gray-5":
-													props.currentTheme !== theme.id,
-											},
+											"w-full aspect-[5/3] rounded-lg overflow-hidden border-2 transition-all duration-150",
+											isSelected()
+												? "border-blue-9"
+												: "border-gray-4 group-hover:border-gray-6",
 										)}
-										aria-label={`Select theme: ${theme.name}`}
 									>
-										<div class="flex justify-center items-center w-full h-full">
-											<Show when={previews[theme.id]} keyed>
-												{(preview) => (
-													<img
-														class="animate-in fade-in duration-300"
-														draggable={false}
-														src={preview}
-														alt={`Preview of ${theme.name} theme`}
-													/>
-												)}
-											</Show>
-										</div>
+										<Show when={previews[theme.id]} keyed>
+											{(preview) => (
+												<img
+													class="object-cover w-full h-full animate-in fade-in duration-200"
+													draggable={false}
+													src={preview}
+													alt={`Preview of ${theme.name} theme`}
+												/>
+											)}
+										</Show>
 									</div>
 									<span
-										class={cx(`mt-2 text-sm transition-color duration-200`, {
-											"text-gray-12": props.currentTheme === theme.id,
-											"text-gray-10": props.currentTheme !== theme.id,
-										})}
+										class={cx(
+											"text-xs font-medium transition-colors",
+											isSelected() ? "text-gray-12" : "text-gray-10",
+										)}
 									>
 										{theme.name}
 									</span>
 								</button>
-							)}
-						</For>
-					</div>
+							);
+						}}
+					</For>
 				</div>
-			</div>
-		</div>
+			</SectionCard>
+		</Section>
 	);
 }
 
@@ -197,6 +175,51 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 
 	createEffect(() => {
 		setSettings(reconcile(deriveGeneralSettings(props.initialStore)));
+	});
+
+	let scrollContainerRef: HTMLDivElement | undefined;
+
+	const scrollToSection = (section: string) => {
+		try {
+			localStorage.removeItem("cap.settings.scrollToSection");
+		} catch {}
+		const attempt = (remaining: number) => {
+			const target = document.getElementById(`settings-section-${section}`);
+			const container = scrollContainerRef;
+			if (!target || !container) {
+				if (remaining > 0) {
+					window.setTimeout(() => attempt(remaining - 1), 50);
+				}
+				return;
+			}
+			const containerRect = container.getBoundingClientRect();
+			const targetRect = target.getBoundingClientRect();
+			const offset =
+				targetRect.top - containerRect.top + container.scrollTop - 8;
+			container.scrollTo({ top: offset, behavior: "smooth" });
+			target.classList.add("settings-section-pulse");
+			window.setTimeout(() => {
+				target.classList.remove("settings-section-pulse");
+			}, 1600);
+		};
+		attempt(10);
+	};
+
+	onMount(() => {
+		let pending: string | null = null;
+		try {
+			pending = localStorage.getItem("cap.settings.scrollToSection");
+		} catch {}
+		if (pending) {
+			scrollToSection(pending);
+		}
+
+		const unlisten = events.requestScrollToSettingsSection.listen((event) => {
+			scrollToSection(event.payload.section);
+		});
+		onCleanup(() => {
+			unlisten.then((cb) => cb()).catch(() => {});
+		});
 	});
 
 	const [windows, { refetch: refetchWindows }] = createResource(
@@ -342,7 +365,7 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 			<SettingItem label={props.label} description={props.description}>
 				<button
 					type="button"
-					class="flex flex-row gap-1 text-xs bg-gray-3 items-center px-2.5 py-1.5 rounded-md border border-gray-4"
+					class="flex flex-row gap-1.5 text-xs items-center px-2.5 py-1.5 rounded-lg border transition-colors bg-gray-3 hover:bg-gray-4 text-gray-12 border-gray-4"
 					onClick={async () => {
 						const currentValue = props.value;
 						const items = props.options.map((option) =>
@@ -366,15 +389,15 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 						);
 						return option ? option.text : currentValue;
 					})()}
-					<IconCapChevronDown class="size-4" />
+					<IconCapChevronDown class="size-3.5 text-gray-10" />
 				</button>
 			</SettingItem>
 		);
 	};
 
 	return (
-		<div class="flex flex-col h-full custom-scroll">
-			<div class="p-4 space-y-6">
+		<div ref={scrollContainerRef} class="flex flex-col h-full custom-scroll">
+			<div class="px-6 py-6 space-y-7 max-w-[42rem]">
 				<AppearanceSection
 					currentTheme={settings.theme ?? "system"}
 					onThemeChange={(newTheme) => {
@@ -384,157 +407,144 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 				/>
 
 				{ostype === "macos" && (
-					<SettingGroup title="App">
-						<ToggleSettingItem
-							label="Always show dock icon"
-							description="Show Cap in the dock even when there are no windows available to close."
-							value={!settings.hideDockIcon}
-							onChange={(v) => handleChange("hideDockIcon", !v)}
-						/>
-						<ToggleSettingItem
-							label="Enable system notifications"
-							description="Show system notifications for events like copying to clipboard, saving files, and more. You may need to manually allow Cap access via your system's notification settings."
-							value={!!settings.enableNotifications}
-							onChange={async (value) => {
-								if (value) {
-									// Check current permission state
-									console.log("Checking notification permission status");
-									const permissionGranted = await isPermissionGranted();
-									console.log(
-										`Current permission status: ${permissionGranted}`,
-									);
-
-									if (!permissionGranted) {
-										// Request permission if not granted
-										console.log(
-											"Permission not granted, requesting permission",
-										);
-										const permission = await requestPermission();
-										console.log(`Permission request result: ${permission}`);
-										if (permission !== "granted") {
-											// If permission denied, don't enable the setting
-											console.log("Permission denied, aborting setting change");
-											return;
+					<Section
+						title="App"
+						description="Choose how Cap shows up on your system."
+					>
+						<SectionRows>
+							<ToggleSettingItem
+								label="Always show dock icon"
+								description="Keep Cap in the dock even when no windows are open."
+								value={!settings.hideDockIcon}
+								onChange={(v) => handleChange("hideDockIcon", !v)}
+							/>
+							<ToggleSettingItem
+								label="System notifications"
+								description="Show notifications for clipboard copies, saved files, and more. You may need to allow Cap in your system's notification settings."
+								value={!!settings.enableNotifications}
+								onChange={async (value) => {
+									if (value) {
+										const permissionGranted = await isPermissionGranted();
+										if (!permissionGranted) {
+											const permission = await requestPermission();
+											if (permission !== "granted") return;
 										}
 									}
-								}
-								handleChange("enableNotifications", value);
-							}}
-						/>
-					</SettingGroup>
+									handleChange("enableNotifications", value);
+								}}
+							/>
+						</SectionRows>
+					</Section>
 				)}
 
-				<SettingGroup title="Recording">
-					<SelectSettingItem
-						label="Studio mode quality"
-						description="Balanced uses less storage and CPU. Ultra records at higher bitrate for maximum quality."
-						value={settings.studioRecordingQuality ?? "balanced"}
-						onChange={(value) => handleChange("studioRecordingQuality", value)}
-						options={[
-							{ text: "Balanced", value: "balanced" as StudioRecordingQuality },
-							{ text: "Ultra", value: "ultra" as StudioRecordingQuality },
-						]}
-					/>
-					<SelectSettingItem
-						label="Instant mode max resolution"
-						description="Choose the maximum resolution for Instant Mode recordings."
-						value={settings.instantModeMaxResolution ?? 1920}
-						onChange={(value) =>
-							handleChange("instantModeMaxResolution", value)
-						}
-						options={INSTANT_MODE_RESOLUTION_OPTIONS.map((option) => ({
-							text: option.label,
-							value: option.value,
-						}))}
-					/>
-					<SelectSettingItem
-						label="Recording countdown"
-						description="Countdown before recording starts"
-						value={settings.recordingCountdown ?? 0}
-						onChange={(value) => handleChange("recordingCountdown", value)}
-						options={[
-							{ text: "Off", value: 0 },
-							{ text: "3 seconds", value: 3 },
-							{ text: "5 seconds", value: 5 },
-							{ text: "10 seconds", value: 10 },
-						]}
-					/>
-					<SelectSettingItem
-						label="Main window recording start behaviour"
-						description="The main window recording start behaviour"
-						value={settings.mainWindowRecordingStartBehaviour ?? "close"}
-						onChange={(value) =>
-							handleChange("mainWindowRecordingStartBehaviour", value)
-						}
-						options={[
-							{ text: "Close", value: "close" },
-							{ text: "Minimise", value: "minimise" },
-						]}
-					/>
-					<SelectSettingItem
-						label="Studio recording finish behaviour"
-						description="The studio recording finish behaviour"
-						value={settings.postStudioRecordingBehaviour ?? "openEditor"}
-						onChange={(value) =>
-							handleChange("postStudioRecordingBehaviour", value)
-						}
-						options={[
-							{ text: "Open editor", value: "openEditor" },
-							{
-								text: "Show in overlay",
-								value: "showOverlay",
-							},
-						]}
-					/>
-					<SelectSettingItem
-						label="After deleting recording behaviour"
-						description="Should Cap reopen after deleting an in progress recording?"
-						value={settings.postDeletionBehaviour ?? "doNothing"}
-						onChange={(value) => handleChange("postDeletionBehaviour", value)}
-						options={[
-							{ text: "Do Nothing", value: "doNothing" },
-							{
-								text: "Reopen Recording Window",
-								value: "reopenRecordingWindow",
-							},
-						]}
-					/>
-					<ToggleSettingItem
-						label="Delete instant mode recordings after upload"
-						description="After finishing an instant recording, should Cap will delete it from your device?"
-						value={settings.deleteInstantRecordingsAfterUpload ?? false}
-						onChange={(v) =>
-							handleChange("deleteInstantRecordingsAfterUpload", v)
-						}
-					/>
-					<ToggleSettingItem
-						label="Crash-recoverable recording"
-						description="Records in fragmented segments that can be recovered if the app crashes or your system loses power. May have slightly higher storage usage during recording."
-						value={settings.crashRecoveryRecording ?? true}
-						onChange={(value) => handleChange("crashRecoveryRecording", value)}
-					/>
-					<ToggleSettingItem
-						label="Custom cursor capture in Studio Mode"
-						description="Studio Mode recordings capture cursor state separately so you can adjust cursor size and smoothing later in the editor."
-						value={!!settings.custom_cursor_capture2}
-						onChange={(value) => handleChange("custom_cursor_capture2", value)}
-					/>
-					<ToggleSettingItem
-						label="Auto zoom on clicks"
-						description="Automatically generate zoom segments around mouse clicks during Studio Mode recordings."
-						value={!!settings.autoZoomOnClicks}
-						onChange={(value) => handleChange("autoZoomOnClicks", value)}
-					/>
-					<ToggleSettingItem
-						label="Capture keyboard presses for the editor"
-						description="Records keyboard presses during Studio Mode so you can generate keyboard overlays in the editor. This data is only used in the editor."
-						value={!!settings.captureKeyboardEvents}
-						onChange={(value) => handleChange("captureKeyboardEvents", value)}
-					/>
-					<div class="flex flex-col gap-1">
+				<QualitySection
+					studioQuality={settings.studioRecordingQuality ?? "balanced"}
+					onStudioQualityChange={(value) =>
+						handleChange("studioRecordingQuality", value)
+					}
+					instantResolution={settings.instantModeMaxResolution ?? 1920}
+					onInstantResolutionChange={(value) =>
+						handleChange("instantModeMaxResolution", value)
+					}
+				/>
+
+				<Section
+					title="Recording"
+					description="Behaviour while you record and after you stop."
+				>
+					<SectionRows>
+						<SelectSettingItem
+							label="Countdown"
+							description="Wait before the recording starts."
+							value={settings.recordingCountdown ?? 0}
+							onChange={(value) => handleChange("recordingCountdown", value)}
+							options={[
+								{ text: "Off", value: 0 },
+								{ text: "3 seconds", value: 3 },
+								{ text: "5 seconds", value: 5 },
+								{ text: "10 seconds", value: 10 },
+							]}
+						/>
+						<SelectSettingItem
+							label="Main window when recording starts"
+							description="What happens to the main window once a recording begins."
+							value={settings.mainWindowRecordingStartBehaviour ?? "close"}
+							onChange={(value) =>
+								handleChange("mainWindowRecordingStartBehaviour", value)
+							}
+							options={[
+								{ text: "Close", value: "close" },
+								{ text: "Minimise", value: "minimise" },
+							]}
+						/>
+						<SelectSettingItem
+							label="After a Studio recording"
+							description="What happens once you stop a Studio recording."
+							value={settings.postStudioRecordingBehaviour ?? "openEditor"}
+							onChange={(value) =>
+								handleChange("postStudioRecordingBehaviour", value)
+							}
+							options={[
+								{ text: "Open editor", value: "openEditor" },
+								{ text: "Show in overlay", value: "showOverlay" },
+							]}
+						/>
+						<SelectSettingItem
+							label="After deleting a recording"
+							description="Whether the recording window should reopen."
+							value={settings.postDeletionBehaviour ?? "doNothing"}
+							onChange={(value) => handleChange("postDeletionBehaviour", value)}
+							options={[
+								{ text: "Do nothing", value: "doNothing" },
+								{
+									text: "Reopen recording window",
+									value: "reopenRecordingWindow",
+								},
+							]}
+						/>
+						<ToggleSettingItem
+							label="Delete Instant recordings after upload"
+							description="Cap removes the local file once it has uploaded successfully."
+							value={settings.deleteInstantRecordingsAfterUpload ?? false}
+							onChange={(v) =>
+								handleChange("deleteInstantRecordingsAfterUpload", v)
+							}
+						/>
+						<ToggleSettingItem
+							label="Crash-recoverable recording"
+							description="Record in fragments that can be recovered after a crash or power loss. Slightly larger files during capture."
+							value={settings.crashRecoveryRecording ?? true}
+							onChange={(value) =>
+								handleChange("crashRecoveryRecording", value)
+							}
+						/>
+						<ToggleSettingItem
+							label="Custom cursor capture (Studio)"
+							description="Capture cursor state separately so you can adjust size and smoothing in the editor."
+							value={!!settings.custom_cursor_capture2}
+							onChange={(value) =>
+								handleChange("custom_cursor_capture2", value)
+							}
+						/>
+						<ToggleSettingItem
+							label="Auto zoom on clicks"
+							description="Automatically add zoom segments around mouse clicks in Studio recordings."
+							value={!!settings.autoZoomOnClicks}
+							onChange={(value) => handleChange("autoZoomOnClicks", value)}
+						/>
+						<ToggleSettingItem
+							label="Capture keyboard presses"
+							description="Record key presses so you can add keyboard overlays in the editor."
+							value={!!settings.captureKeyboardEvents}
+							onChange={(value) => handleChange("captureKeyboardEvents", value)}
+						/>
 						<SelectSettingItem
 							label="Max capture framerate"
-							description="Maximum framerate for screen capture. Higher values may cause instability on some systems."
+							description={
+								(settings.maxFps ?? 60) > 60
+									? "Maximum framerate for screen capture. Higher values may cause drops or increased CPU usage on some systems."
+									: "Maximum framerate for screen capture."
+							}
 							value={settings.maxFps ?? 60}
 							onChange={(value) => handleChange("maxFps", value)}
 							options={MAX_FPS_OPTIONS.map((option) => ({
@@ -542,26 +552,23 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 								value: option.value,
 							}))}
 						/>
-						{(settings.maxFps ?? 60) > 60 && (
-							<p class="text-xs text-amber-500 px-1 pb-2">
-								⚠️ Higher framerates may cause frame drops or increased CPU usage
-								on some systems.
-							</p>
-						)}
-					</div>
-				</SettingGroup>
+					</SectionRows>
+				</Section>
 
-				<SettingGroup
-					title="Cap Pro Settings"
-					titleStyling="bg-blue-500 py-1.5 mb-4 text-white text-xs px-2 rounded-lg"
+				<Section
+					title="Cap Pro"
+					description="Settings available with a Cap Pro license."
+					pro
 				>
-					<ToggleSettingItem
-						label="Automatically open shareable links"
-						description="Whether Cap should automatically open instant recordings in your browser"
-						value={!settings.disableAutoOpenLinks}
-						onChange={(v) => handleChange("disableAutoOpenLinks", !v)}
-					/>
-				</SettingGroup>
+					<SectionRows>
+						<ToggleSettingItem
+							label="Auto-open shareable links"
+							description="Open the share link in your browser as soon as the upload finishes."
+							value={!settings.disableAutoOpenLinks}
+							onChange={(v) => handleChange("disableAutoOpenLinks", !v)}
+						/>
+					</SectionRows>
+				</Section>
 
 				<DefaultProjectNameCard
 					onChange={(value) =>
@@ -614,47 +621,252 @@ function TelemetryCard(props: {
 	onChange: (value: boolean) => void;
 }) {
 	return (
-		<div class="flex flex-col gap-3 mt-6">
-			<h3 class="text-sm text-gray-12 w-fit">Privacy</h3>
-			<div class="flex flex-col gap-3 px-4 py-3 rounded-xl border border-gray-3 bg-gray-2">
-				<div class="flex items-center justify-between gap-6">
-					<div class="flex flex-col gap-1">
-						<p class="text-sm text-gray-12">Share anonymous telemetry</p>
-						<p class="text-xs text-gray-10 max-w-[34rem]">
-							Cap uses anonymous telemetry to improve recording reliability,
-							upload accuracy, and bug fixes. We <strong>never</strong> collect
-							recording contents, window titles, file paths, or any personal
-							information. Events only include aggregate counts like frame
-							drops, A/V drift, and crash recovery outcomes.
-						</p>
-					</div>
-					<label class="relative inline-flex items-center cursor-pointer flex-shrink-0">
-						<input
-							type="checkbox"
-							class="sr-only peer"
-							checked={props.value}
-							onChange={(e) => props.onChange(e.currentTarget.checked)}
-						/>
-						<div class="w-9 h-5 bg-gray-5 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-gray-1 after:border-gray-6 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-blue-500" />
-					</label>
+		<Section title="Privacy">
+			<SectionRows>
+				<ToggleSettingItem
+					label="Share anonymous telemetry"
+					description="Cap uses anonymous telemetry to improve reliability and fix bugs. We never collect recording contents, window titles, file paths, or personal information."
+					value={props.value}
+					onChange={props.onChange}
+				/>
+			</SectionRows>
+		</Section>
+	);
+}
+
+type StudioQualityTier = {
+	value: StudioRecordingQuality;
+	label: string;
+	summary: string;
+	bestFor: string;
+};
+
+const STUDIO_QUALITY_TIERS: StudioQualityTier[] = [
+	{
+		value: "compatibility",
+		label: "Compatibility",
+		summary: "Lower bitrate to keep older or low-power machines smooth.",
+		bestFor: "Older Intel Macs, 8GB MacBook Air, weaker laptops.",
+	},
+	{
+		value: "balanced",
+		label: "Balanced",
+		summary: "Sharp footage with sensible CPU and disk usage.",
+		bestFor: "Most modern Macs and PCs with 16GB+ RAM.",
+	},
+	{
+		value: "ultra",
+		label: "Ultra",
+		summary: "Maximum detail for color-graded, large-display edits.",
+		bestFor: "M-series Pro/Max, discrete GPUs, 32GB+ RAM, NVMe.",
+	},
+];
+
+type InstantResolutionTier = {
+	value: number;
+	label: string;
+	summary: string;
+};
+
+const INSTANT_RESOLUTION_TIERS: InstantResolutionTier[] = [
+	{ value: 1280, label: "720p", summary: "Smallest size, low bandwidth." },
+	{
+		value: 1920,
+		label: "1080p",
+		summary: "Recommended. Sharp on most networks.",
+	},
+	{ value: 2560, label: "1440p", summary: "More detail for desktop content." },
+	{ value: 3840, label: "4K", summary: "Max clarity. Needs fast upload." },
+];
+
+function SegmentedControl<T extends string | number>(props: {
+	value: T;
+	onChange: (value: T) => void;
+	options: { value: T; label: string }[];
+}) {
+	return (
+		<div class="inline-flex p-0.5 rounded-lg border border-gray-3 bg-gray-3">
+			<For each={props.options}>
+				{(option) => {
+					const isSelected = () => props.value === option.value;
+					return (
+						<button
+							type="button"
+							onClick={() => props.onChange(option.value)}
+							class={cx(
+								"px-3 py-1 text-xs font-medium rounded-md transition-all",
+								isSelected()
+									? "bg-gray-1 text-gray-12 shadow-sm"
+									: "text-gray-10 hover:text-gray-12",
+							)}
+						>
+							{option.label}
+						</button>
+					);
+				}}
+			</For>
+		</div>
+	);
+}
+
+function StudioQualitySubsection(props: {
+	value: StudioRecordingQuality;
+	onChange: (value: StudioRecordingQuality) => void;
+}) {
+	const currentTier = createMemo(
+		() =>
+			STUDIO_QUALITY_TIERS.find((t) => t.value === props.value) ??
+			STUDIO_QUALITY_TIERS[1],
+	);
+
+	return (
+		<div
+			id="settings-section-studio-quality"
+			class="flex flex-col gap-3 px-4 py-4"
+		>
+			<div class="flex justify-between items-start gap-4">
+				<div class="flex flex-col gap-0.5 min-w-0">
+					<p class="text-[13px] font-medium text-gray-12">Studio mode</p>
+					<p class="text-xs leading-snug text-gray-10">
+						Encoder profile for local Studio recordings.
+					</p>
 				</div>
+				<SegmentedControl
+					value={props.value}
+					onChange={props.onChange}
+					options={STUDIO_QUALITY_TIERS.map((tier) => ({
+						value: tier.value,
+						label: tier.label,
+					}))}
+				/>
+			</div>
+			<div class="flex flex-col gap-1.5 px-3 py-2.5 rounded-lg bg-gray-3">
+				<p class="text-xs text-gray-12">{currentTier().summary}</p>
+				<p class="text-[11px] text-gray-10 leading-snug">
+					<span class="text-gray-11">Best for:</span> {currentTier().bestFor}
+				</p>
 			</div>
 		</div>
 	);
 }
 
-function SettingGroup(
-	props: ParentProps<{ title: string; titleStyling?: string }>,
-) {
+function InstantQualitySubsection(props: {
+	value: number;
+	onChange: (value: number) => void;
+}) {
+	const currentTier = createMemo(
+		() =>
+			INSTANT_RESOLUTION_TIERS.find((t) => t.value === props.value) ??
+			INSTANT_RESOLUTION_TIERS[1],
+	);
+
 	return (
-		<div>
-			<h3 class={cx("mb-3 text-sm text-gray-12 w-fit", props.titleStyling)}>
-				{props.title}
-			</h3>
-			<div class="px-3 rounded-xl border divide-y divide-gray-3 border-gray-3 bg-gray-2">
-				{props.children}
+		<div
+			id="settings-section-instant-quality"
+			class="flex flex-col gap-3 px-4 py-4"
+		>
+			<div class="flex justify-between items-start gap-4">
+				<div class="flex flex-col gap-0.5 min-w-0">
+					<p class="text-[13px] font-medium text-gray-12">Instant mode</p>
+					<p class="text-xs leading-snug text-gray-10">
+						Maximum upload resolution for Instant recordings.
+					</p>
+				</div>
+				<SegmentedControl
+					value={props.value}
+					onChange={props.onChange}
+					options={INSTANT_RESOLUTION_TIERS.map((tier) => ({
+						value: tier.value,
+						label: tier.label,
+					}))}
+				/>
+			</div>
+			<div class="flex flex-col gap-1.5 px-3 py-2.5 rounded-lg bg-gray-3">
+				<p class="text-xs text-gray-12">{currentTier().summary}</p>
 			</div>
 		</div>
+	);
+}
+
+function QualitySection(props: {
+	studioQuality: StudioRecordingQuality;
+	onStudioQualityChange: (value: StudioRecordingQuality) => void;
+	instantResolution: number;
+	onInstantResolutionChange: (value: number) => void;
+}) {
+	return (
+		<Section
+			title="Quality"
+			description="Pick the right profile for each recording mode."
+		>
+			<SectionCard class="divide-y divide-gray-3">
+				<StudioQualitySubsection
+					value={props.studioQuality}
+					onChange={props.onStudioQualityChange}
+				/>
+				<InstantQualitySubsection
+					value={props.instantResolution}
+					onChange={props.onInstantResolutionChange}
+				/>
+			</SectionCard>
+		</Section>
+	);
+}
+
+function Section(
+	props: ParentProps<{
+		title: string;
+		description?: string;
+		right?: JSX.Element;
+		pro?: boolean;
+	}>,
+) {
+	return (
+		<section class="space-y-2.5">
+			<header class="flex justify-between items-end gap-3 px-1">
+				<div class="flex flex-col gap-0.5 min-w-0">
+					<div class="flex gap-2 items-center">
+						<h3 class="text-sm font-semibold tracking-tight text-gray-12">
+							{props.title}
+						</h3>
+						<Show when={props.pro}>
+							<span class="text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded-md bg-blue-9 text-white">
+								Pro
+							</span>
+						</Show>
+					</div>
+					<Show when={props.description}>
+						<p class="text-xs leading-relaxed text-gray-10">
+							{props.description}
+						</p>
+					</Show>
+				</div>
+				<Show when={props.right}>
+					<div class="flex shrink-0 gap-2 items-center">{props.right}</div>
+				</Show>
+			</header>
+			{props.children}
+		</section>
+	);
+}
+
+function SectionCard(props: ParentProps<{ class?: string; padded?: boolean }>) {
+	return (
+		<div
+			class={cx(
+				"overflow-hidden rounded-xl border border-gray-3 bg-gray-2",
+				props.padded && "px-4 py-4",
+				props.class,
+			)}
+		>
+			{props.children}
+		</div>
+	);
+}
+
+function SectionRows(props: ParentProps) {
+	return (
+		<SectionCard class="divide-y divide-gray-3">{props.children}</SectionCard>
 	);
 }
 
@@ -665,22 +877,23 @@ function ServerURLSetting(props: {
 	const [value, setValue] = createWritableMemo(() => props.value);
 
 	return (
-		<div class="flex flex-col gap-3">
-			<h3 class="text-sm text-gray-12 w-fit">Self host</h3>
-			<div class="flex flex-col gap-2 px-4 rounded-xl border border-gray-3 bg-gray-2">
-				<SettingItem
-					label="Cap Server URL"
-					description="This setting should only be changed if you are self hosting your own instance of Cap Web."
-				>
-					<div class="flex flex-col gap-2 items-end">
+		<Section
+			title="Self-host"
+			description="Only change this if you are running your own instance of Cap Web."
+		>
+			<SectionCard padded>
+				<div class="flex flex-col gap-3">
+					<label class="flex flex-col gap-1.5">
+						<span class="text-[13px] text-gray-12">Cap Server URL</span>
 						<Input
 							class="bg-gray-3"
 							value={value()}
 							onInput={(e) => setValue(e.currentTarget.value)}
 						/>
+					</label>
+					<div class="flex justify-end">
 						<Button
 							size="sm"
-							class="mt-2"
 							variant="dark"
 							disabled={props.value === value()}
 							onClick={() => props.onChange(value())}
@@ -688,9 +901,9 @@ function ServerURLSetting(props: {
 							Update
 						</Button>
 					</div>
-				</SettingItem>
-			</div>
-		</div>
+				</div>
+			</SectionCard>
+		</Section>
 	);
 }
 
@@ -762,24 +975,20 @@ function DefaultProjectNameCard(props: {
 			<button
 				type="button"
 				title="Click to copy"
-				class="bg-gray-1 hover:bg-gray-5 rounded-md m-0.5 p-0.5 cursor-pointer transition-[color,background-color,transform] ease-out duration-200 active:scale-95"
+				class="px-1.5 py-0.5 mx-0.5 font-mono text-[11px] rounded-md transition-all duration-150 ease-out cursor-pointer bg-gray-3 hover:bg-gray-4 active:scale-95 text-gray-12"
 				onClick={() => commands.writeClipboardString(props.children)}
 			>
-				<code>{props.children}</code>
+				{props.children}
 			</button>
 		);
 	}
 
 	return (
-		<div class="flex flex-col gap-3 px-4 py-3 mt-6 rounded-xl border border-gray-3 bg-gray-2">
-			<div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-				<div class="flex flex-col gap-1">
-					<p class="text-sm text-gray-12">Default Project Name</p>
-					<p class="text-xs text-gray-10">
-						Choose the template to use as the default project and file name.
-					</p>
-				</div>
-				<div class="flex flex-shrink-0 gap-2">
+		<Section
+			title="Default project name"
+			description="Template used for new recordings and exported files."
+			right={
+				<>
 					<Button
 						size="sm"
 						variant="gray"
@@ -797,7 +1006,6 @@ function DefaultProjectNameCard(props: {
 					>
 						Reset
 					</Button>
-
 					<Button
 						size="sm"
 						variant="dark"
@@ -809,91 +1017,83 @@ function DefaultProjectNameCard(props: {
 					>
 						Save
 					</Button>
+				</>
+			}
+		>
+			<SectionCard padded>
+				<div class="flex flex-col gap-3">
+					<Input
+						autocorrect="off"
+						ref={inputRef}
+						type="text"
+						class="bg-gray-3 font-mono"
+						value={inputValue()}
+						onInput={(e) => {
+							setInputValue(e.currentTarget.value);
+							updatePreview(e.currentTarget.value);
+						}}
+					/>
+
+					<div class="flex gap-2 items-center px-3 py-2 rounded-lg border border-dashed bg-gray-3 border-gray-5">
+						<IconCapLogo class="pointer-events-none size-4 shrink-0" />
+						<p class="text-xs text-gray-12 whitespace-pre-wrap">{preview()}</p>
+					</div>
+
+					<Collapsible class="w-full rounded-lg">
+						<Collapsible.Trigger class="inline-flex gap-1 items-center text-xs transition-colors text-gray-10 hover:text-gray-12 group">
+							<IconCapChevronDown class="size-3.5 ui-group-expanded:rotate-180 transition-transform duration-200" />
+							<span>Available placeholders</span>
+						</Collapsible.Trigger>
+
+						<Collapsible.Content class="space-y-3 pt-3 text-xs text-gray-12 opacity-0 transition animate-collapsible-up ui-expanded:animate-collapsible-down ui-expanded:opacity-100">
+							<p class="text-gray-10">
+								Click any placeholder to copy it. Time supports custom formats
+								via <code class="text-gray-12">{"{moment:HH:mm}"}</code>.
+							</p>
+
+							<div class="space-y-1">
+								<p class="font-medium text-gray-12">Recording mode</p>
+								<p>
+									<CodeView>{"{recording_mode}"}</CodeView> → "Studio",
+									"Instant", or "Screenshot"
+								</p>
+								<p>
+									<CodeView>{"{mode}"}</CodeView> → "studio", "instant", or
+									"screenshot"
+								</p>
+							</div>
+
+							<div class="space-y-1">
+								<p class="font-medium text-gray-12">Target</p>
+								<p>
+									<CodeView>{"{target_kind}"}</CodeView> → "Display", "Window",
+									or "Area"
+								</p>
+								<p>
+									<CodeView>{"{target_name}"}</CodeView> → Monitor name or
+									window title.
+								</p>
+							</div>
+
+							<div class="space-y-1">
+								<p class="font-medium text-gray-12">Date &amp; time</p>
+								<p>
+									<CodeView>{"{date}"}</CodeView> → {dateString}
+								</p>
+								<p>
+									<CodeView>{"{time}"}</CodeView> →{" "}
+									{macos ? "09:41 AM" : "12:00 PM"}
+								</p>
+								<p class="flex flex-col items-start pt-1">
+									<CodeView>{MOMENT_EXAMPLE_TEMPLATE}</CodeView> →{" "}
+									{momentExample()}
+								</p>
+							</div>
+						</Collapsible.Content>
+					</Collapsible>
 				</div>
-			</div>
-
-			<div class="flex flex-col gap-2 w-full">
-				<Input
-					autocorrect="off"
-					ref={inputRef}
-					type="text"
-					class="bg-gray-3 font-mono"
-					value={inputValue()}
-					onInput={(e) => {
-						setInputValue(e.currentTarget.value);
-						updatePreview(e.currentTarget.value);
-					}}
-				/>
-
-				<div class="w-full flex items-center py-2 px-2 rounded-lg bg-gray-transparent-50 border border-dashed border-gray-5">
-					<IconCapLogo class="size-4 pointer-events-none mr-2" />
-					<p class="whitespace-pre-wrap">{preview()}</p>
-				</div>
-
-				<Collapsible class="w-full rounded-lg">
-					<Collapsible.Trigger class="group inline-flex items-center w-full text-xs rounded-lg outline-none px-0.5 py-1">
-						<IconCapChevronDown class="size-4 ui-group-expanded:rotate-180 transition-transform duration-300 ease-in-out" />
-						<p class="py-0.5 px-1">How to customize?</p>
-					</Collapsible.Trigger>
-
-					<Collapsible.Content class="opacity-0 transition animate-collapsible-up ui-expanded:animate-collapsible-down ui-expanded:opacity-100 text-xs text-gray-12 space-y-3 px-1 pb-2">
-						<p class="border-t pt-3">
-							Use placeholders in your template that will be automatically
-							filled in.
-						</p>
-
-						<div class="space-y-1">
-							<p class="font-medium text-foreground">Recording Mode</p>
-							<p>
-								<CodeView>{"{recording_mode}"}</CodeView> → "Studio", "Instant",
-								or "Screenshot"
-							</p>
-							<p>
-								<CodeView>{"{mode}"}</CodeView> → "studio", "instant", or
-								"screenshot"
-							</p>
-						</div>
-
-						<div class="space-y-1">
-							<p class="font-medium text-foreground">Target</p>
-							<p>
-								<CodeView>{"{target_kind}"}</CodeView> → "Display", "Window", or
-								"Area"
-							</p>
-							<p>
-								<CodeView>{"{target_name}"}</CodeView> → The name of the monitor
-								or the title of the app depending on the recording mode.
-							</p>
-						</div>
-
-						<div class="space-y-1">
-							<p class="font-medium text-foreground">Date &amp; Time</p>
-							<p>
-								<CodeView>{"{date}"}</CodeView> → {dateString}
-							</p>
-							<p>
-								<CodeView>{"{time}"}</CodeView> →{" "}
-								{macos ? "09:41 AM" : "12:00 PM"}
-							</p>
-						</div>
-
-						<div class="space-y-1">
-							<p class="font-medium text-foreground">Custom Formats</p>
-							<p>
-								You can also use a custom format for time. The placeholders are
-								case-sensitive. For 24-hour time, use{" "}
-								<CodeView>{"{moment:HH:mm}"}</CodeView> or use lower cased{" "}
-								<code>hh</code> for 12-hour format.
-							</p>
-							<p class="flex flex-col items-start pt-1">
-								<CodeView>{MOMENT_EXAMPLE_TEMPLATE}</CodeView> →{" "}
-								{momentExample()}
-							</p>
-						</div>
-					</Collapsible.Content>
-				</Collapsible>
-			</div>
-		</div>
+			</SectionCard>
+		</Section>
 	);
 }
 
@@ -964,22 +1164,15 @@ function ExcludedWindowsCard(props: {
 	};
 
 	return (
-		<div class="flex flex-col gap-3 px-4 py-3 mt-6 rounded-xl border border-gray-3 bg-gray-2">
-			<div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
-				<div class="flex flex-col gap-1">
-					<p class="text-sm text-gray-12">Excluded Windows</p>
-					<p class="text-xs text-gray-10">
-						Choose which windows Cap hides from your recordings.
-					</p>
-					<Show when={props.isWindows}>
-						<p class="text-xs text-gray-9">
-							<span class="font-medium text-gray-11">Note:</span> Only Cap
-							related windows can be excluded on Windows due to technical
-							limitations.
-						</p>
-					</Show>
-				</div>
-				<div class="flex flex-shrink-0 gap-2">
+		<Section
+			title="Excluded windows"
+			description={
+				props.isWindows
+					? "Hide windows from recordings. On Windows, only Cap-related windows can be excluded."
+					: "Hide windows from recordings."
+			}
+			right={
+				<>
 					<Button
 						variant="gray"
 						size="sm"
@@ -989,76 +1182,77 @@ function ExcludedWindowsCard(props: {
 							void props.onReset();
 						}}
 					>
-						Reset to Default
+						Reset
 					</Button>
 					<Button
 						variant="dark"
 						size="sm"
 						disabled={!canAdd()}
 						onClick={(e) => void handleAddClick(e)}
-						class="flex items-center gap-2"
+						class="flex gap-1.5 items-center"
 					>
-						<IconLucidePlus class="size-4" />
+						<IconLucidePlus class="size-3.5" />
 						Add
 					</Button>
-				</div>
-			</div>
-			<Show when={!props.isLoading} fallback={<ExcludedWindowsSkeleton />}>
-				<Show
-					when={hasExclusions()}
-					fallback={
-						<p class="text-xs text-gray-10">
-							No windows are currently excluded.
-						</p>
-					}
-				>
-					<div class="flex flex-wrap gap-2">
-						<For each={props.excludedWindows}>
-							{(entry, index) => (
-								<div class="group flex items-center gap-2 rounded-full border border-gray-4 bg-gray-3 px-3 py-1.5">
-									<div class="flex flex-col leading-tight">
-										<span class="text-sm text-gray-12">
-											{getExclusionPrimaryLabel(entry)}
-										</span>
-										<Show when={getExclusionSecondaryLabel(entry)}>
-											{(label) => (
-												<span class="text-[0.65rem] text-gray-9">
-													{label()}
-												</span>
-											)}
-										</Show>
+				</>
+			}
+		>
+			<SectionCard padded>
+				<Show when={!props.isLoading} fallback={<ExcludedWindowsSkeleton />}>
+					<Show
+						when={hasExclusions()}
+						fallback={
+							<p class="text-xs text-gray-10">
+								No windows are currently excluded.
+							</p>
+						}
+					>
+						<div class="flex flex-wrap gap-2">
+							<For each={props.excludedWindows}>
+								{(entry, index) => (
+									<div class="flex gap-2 items-center pr-1 pl-3 py-1.5 rounded-full border bg-gray-3 border-gray-4">
+										<div class="flex flex-col leading-tight">
+											<span class="text-xs text-gray-12">
+												{getExclusionPrimaryLabel(entry)}
+											</span>
+											<Show when={getExclusionSecondaryLabel(entry)}>
+												{(label) => (
+													<span class="text-[10px] text-gray-9">{label()}</span>
+												)}
+											</Show>
+										</div>
+										<button
+											type="button"
+											class="flex justify-center items-center rounded-full transition-colors size-5 text-gray-10 hover:bg-gray-5 hover:text-gray-12"
+											onClick={() => void props.onRemove(index())}
+											aria-label="Remove excluded window"
+										>
+											<IconLucideX class="size-3" />
+										</button>
 									</div>
-									<button
-										type="button"
-										class="flex items-center justify-center rounded-full bg-gray-4/70 text-gray-11 transition-colors hover:bg-gray-5 hover:text-gray-12 size-6"
-										onClick={() => void props.onRemove(index())}
-										aria-label="Remove excluded window"
-									>
-										<IconLucideX class="size-3" />
-									</button>
-								</div>
-							)}
-						</For>
-					</div>
+								)}
+							</For>
+						</div>
+					</Show>
 				</Show>
-			</Show>
-		</div>
+			</SectionCard>
+		</Section>
 	);
 }
 
 function ExcludedWindowsSkeleton() {
-	const chipWidths = ["w-32", "w-28", "w-36"] as const;
+	const chipWidths = ["w-28", "w-24", "w-32"] as const;
 
 	return (
 		<div class="flex flex-wrap gap-2" aria-hidden="true">
 			<For each={chipWidths}>
 				{(width) => (
-					<div class="flex items-center gap-2 rounded-full border border-gray-4 bg-gray-3 px-3 py-1.5 animate-pulse">
+					<div class="flex gap-2 items-center pr-1 pl-3 py-1.5 rounded-full border bg-gray-3 border-gray-4 animate-pulse">
 						<div class="flex flex-col gap-1 leading-tight">
-							<div class={cx("h-3 rounded bg-gray-4", width)} />
-							<div class="h-2 w-16 rounded bg-gray-4" />
+							<div class={cx("h-2.5 rounded bg-gray-4", width)} />
+							<div class="w-14 h-2 rounded bg-gray-4" />
 						</div>
-						<div class="size-6 rounded-full bg-gray-4" />
+						<div class="rounded-full size-5 bg-gray-4" />
 					</div>
 				)}
 			</For>

--- a/apps/desktop/src/routes/camera.tsx
+++ b/apps/desktop/src/routes/camera.tsx
@@ -798,6 +798,7 @@ function LegacyCameraPreviewPage(props: { disconnected: Accessor<boolean> }) {
 			if (!isWindowVisible()) return;
 
 			lastFrameTime = Date.now();
+			if (pendingRender) return;
 
 			const buffer = event.data as ArrayBuffer;
 			const clamped = new Uint8ClampedArray(buffer);

--- a/apps/desktop/src/routes/editor/ConfigSidebar.tsx
+++ b/apps/desktop/src/routes/editor/ConfigSidebar.tsx
@@ -45,6 +45,8 @@ import type {
 	BackgroundBlurMode,
 	BackgroundSource,
 	CameraShape,
+	CameraXPosition,
+	CameraYPosition,
 	CaptionTrackSegment,
 	ClipOffsets,
 	CursorAnimationStyle,
@@ -210,6 +212,13 @@ const CAMERA_SHAPES = [
 		value: "source",
 	},
 ] satisfies Array<{ name: string; value: CameraShape }>;
+
+const CAMERA_X_POSITIONS = [
+	"left",
+	"center",
+	"right",
+] satisfies CameraXPosition[];
+const CAMERA_Y_POSITIONS = ["top", "bottom"] satisfies CameraYPosition[];
 
 const CORNER_STYLE_OPTIONS = [
 	{ name: "Squircle", value: "squircle" },
@@ -403,9 +412,8 @@ export function ConfigSidebar() {
 						{
 							id: TAB_IDS.cursor,
 							icon: IconCapCursor,
-							disabled: !(
-								meta().type === "multiple" && (meta() as any).segments[0].cursor
-							),
+							disabled:
+								meta().type !== "multiple" || !meta().segments[0]?.cursor,
 						},
 						{
 							id: TAB_IDS.keyboard,
@@ -674,7 +682,7 @@ export function ConfigSidebar() {
 										value={[cursorIdleDelay()]}
 										onChange={(v) => {
 											const rounded = clampIdleDelay(v[0]);
-											setProject("cursor", "hideWhenIdleDelay" as any, rounded);
+											setProject("cursor", "hideWhenIdleDelay", rounded);
 										}}
 										minValue={0.5}
 										maxValue={5}
@@ -770,9 +778,9 @@ export function ConfigSidebar() {
 							icon={<IconLucideSparkles />}
 							value={
 								<Toggle
-									checked={(project.cursor as any).useSvg ?? true}
+									checked={project.cursor.useSvg ?? true}
 									onChange={(value) => {
-										setProject("cursor", "useSvg" as any, value);
+										setProject("cursor", "useSvg", value);
 									}}
 								/>
 							}
@@ -1235,59 +1243,68 @@ export function ConfigSidebar() {
 											segment: project.timeline?.sceneSegments?.[idx],
 											index: idx,
 										}))
-										.filter((s) => s.segment !== undefined);
+										.filter(
+											(
+												s,
+											): s is { segment: SceneSegment; index: number } =>
+												s.segment !== undefined,
+										);
 
 									if (segments.length === 0) return;
 									return { selection: sceneSelection, segments };
 								})()}
 							>
 								{(value) => (
-									<Show
-										when={value().segments.length > 1}
-										fallback={
-											<SceneSegmentConfig
-												segment={value().segments[0].segment!}
-												segmentIndex={value().segments[0].index}
-											/>
-										}
-									>
-										<div class="space-y-4">
-											<div class="flex flex-row justify-between items-center">
-												<div class="flex gap-2 items-center">
-													<EditorButton
-														onClick={() =>
-															setEditorState("timeline", "selection", null)
-														}
-														leftIcon={<IconLucideCheck />}
-													>
-														Done
-													</EditorButton>
-													<span class="text-sm text-gray-10">
-														{value().segments.length} scene{" "}
-														{value().segments.length === 1
-															? "segment"
-															: "segments"}{" "}
-														selected
-													</span>
-												</div>
-												<EditorButton
-													variant="danger"
-													onClick={() => {
-														const indices = value().selection.indices;
+									<Show when={value().segments[0]}>
+										{(firstSegment) => (
+											<Show
+												when={value().segments.length > 1}
+												fallback={
+													<SceneSegmentConfig
+														segment={firstSegment().segment}
+														segmentIndex={firstSegment().index}
+													/>
+												}
+											>
+												<div class="space-y-4">
+													<div class="flex flex-row justify-between items-center">
+														<div class="flex gap-2 items-center">
+															<EditorButton
+																onClick={() =>
+																	setEditorState("timeline", "selection", null)
+																}
+																leftIcon={<IconLucideCheck />}
+															>
+																Done
+															</EditorButton>
+															<span class="text-sm text-gray-10">
+																{value().segments.length} scene{" "}
+																{value().segments.length === 1
+																	? "segment"
+																	: "segments"}{" "}
+																selected
+															</span>
+														</div>
+														<EditorButton
+															variant="danger"
+															onClick={() => {
+																const indices = value().selection.indices;
 
-														// Delete segments in reverse order to maintain indices
-														[...indices]
-															.sort((a, b) => b - a)
-															.forEach((idx) => {
-																projectActions.deleteSceneSegment(idx);
-															});
-													}}
-													leftIcon={<IconCapTrash />}
-												>
-													Delete
-												</EditorButton>
-											</div>
-										</div>
+																// Delete segments in reverse order to maintain indices
+																[...indices]
+																	.sort((a, b) => b - a)
+																	.forEach((idx) => {
+																		projectActions.deleteSceneSegment(idx);
+																	});
+															}}
+															leftIcon={<IconCapTrash />}
+														>
+															Delete
+														</EditorButton>
+													</div>
+												</div>
+											</Show>
+										)}
 									</Show>
 								)}
 							</Show>
@@ -1301,59 +1318,68 @@ export function ConfigSidebar() {
 											segment: project.timeline?.segments?.[idx],
 											index: idx,
 										}))
-										.filter((s) => s.segment !== undefined);
+										.filter(
+											(
+												s,
+											): s is { segment: TimelineSegment; index: number } =>
+												s.segment !== undefined,
+										);
 
 									if (segments.length === 0) return;
 									return { selection: clipSelection, segments };
 								})()}
 							>
 								{(value) => (
-									<Show
-										when={value().segments.length > 1}
-										fallback={
-											<ClipSegmentConfig
-												segment={value().segments[0].segment!}
-												segmentIndex={value().segments[0].index}
-											/>
-										}
-									>
-										<div class="space-y-4">
-											<div class="flex flex-row justify-between items-center">
-												<div class="flex gap-2 items-center">
-													<EditorButton
-														onClick={() =>
-															setEditorState("timeline", "selection", null)
-														}
-														leftIcon={<IconLucideCheck />}
-													>
-														Done
-													</EditorButton>
-													<span class="text-sm text-gray-10">
-														{value().segments.length} clip{" "}
-														{value().segments.length === 1
-															? "segment"
-															: "segments"}{" "}
-														selected
-													</span>
-												</div>
-												<EditorButton
-													variant="danger"
-													onClick={() => {
-														const indices = value().selection.indices;
+									<Show when={value().segments[0]}>
+										{(firstSegment) => (
+											<Show
+												when={value().segments.length > 1}
+												fallback={
+													<ClipSegmentConfig
+														segment={firstSegment().segment}
+														segmentIndex={firstSegment().index}
+													/>
+												}
+											>
+												<div class="space-y-4">
+													<div class="flex flex-row justify-between items-center">
+														<div class="flex gap-2 items-center">
+															<EditorButton
+																onClick={() =>
+																	setEditorState("timeline", "selection", null)
+																}
+																leftIcon={<IconLucideCheck />}
+															>
+																Done
+															</EditorButton>
+															<span class="text-sm text-gray-10">
+																{value().segments.length} clip{" "}
+																{value().segments.length === 1
+																	? "segment"
+																	: "segments"}{" "}
+																selected
+															</span>
+														</div>
+														<EditorButton
+															variant="danger"
+															onClick={() => {
+																const indices = value().selection.indices;
 
-														// Delete segments in reverse order to maintain indices
-														[...indices]
-															.sort((a, b) => b - a)
-															.forEach((idx) => {
-																projectActions.deleteClipSegment(idx);
-															});
-													}}
-													leftIcon={<IconCapTrash />}
-												>
-													Delete
-												</EditorButton>
-											</div>
-										</div>
+																// Delete segments in reverse order to maintain indices
+																[...indices]
+																	.sort((a, b) => b - a)
+																	.forEach((idx) => {
+																		projectActions.deleteClipSegment(idx);
+																	});
+															}}
+															leftIcon={<IconCapTrash />}
+														>
+															Delete
+														</EditorButton>
+													</div>
+												</div>
+											</Show>
+										)}
 									</Show>
 								)}
 							</Show>
@@ -1387,11 +1413,11 @@ function BackgroundConfig(props: { scrollRef: HTMLDivElement }) {
 		const initialPaths = await Promise.all(visibleWallpaperPaths);
 
 		return initialPaths
-			.filter((p) => p.path !== null)
+			.filter((p): p is { id: string; path: string } => p.path !== null)
 			.map(({ id, path }) => ({
 				id,
-				url: convertFileSrc(path!),
-				rawPath: path!,
+				url: convertFileSrc(path),
+				rawPath: path,
 			}));
 	});
 
@@ -1790,13 +1816,13 @@ function BackgroundConfig(props: { scrollRef: HTMLDivElement }) {
 								<For each={filteredWallpapers().slice(0, 21)}>
 									{(photo) => (
 										<KRadioGroup.Item
-											value={photo.url!}
+											value={photo.url}
 											class="relative aspect-square group"
 										>
 											<KRadioGroup.ItemInput class="peer" />
 											<KRadioGroup.ItemControl class="overflow-hidden w-full h-full rounded-lg transition cursor-pointer ui-not-checked:ring-offset-1 ui-not-checked:ring-offset-gray-200 ui-not-checked:hover:ring-1 ui-not-checked:hover:ring-gray-400 ui-checked:ring-2 ui-checked:ring-gray-500 ui-checked:ring-offset-2 ui-checked:ring-offset-gray-200">
 												<img
-													src={photo.url!}
+													src={photo.url}
 													loading="eager"
 													class="object-cover w-full h-full"
 													alt="Wallpaper option"
@@ -1811,13 +1837,13 @@ function BackgroundConfig(props: { scrollRef: HTMLDivElement }) {
 											<For each={filteredWallpapers()}>
 												{(photo) => (
 													<KRadioGroup.Item
-														value={photo.url!}
+														value={photo.url}
 														class="relative aspect-square group"
 													>
 														<KRadioGroup.ItemInput class="peer" />
 														<KRadioGroup.ItemControl class="overflow-hidden w-full h-full rounded-lg border cursor-pointer border-gray-5 ui-checked:border-blue-9 ui-checked:ring-2 ui-checked:ring-blue-9 peer-focus-visible:border-2 peer-focus-visible:border-blue-9">
 															<img
-																src={photo.url!}
+																src={photo.url}
 																alt="Wallpaper option"
 																class="object-cover w-full h-full"
 																loading="lazy"
@@ -2054,7 +2080,7 @@ function BackgroundConfig(props: { scrollRef: HTMLDivElement }) {
 			<Field name="Motion Blur" icon={<IconLucideWind class="size-4" />}>
 				<Slider
 					value={[project.cursor.motionBlur ?? DEFAULT_CURSOR_MOTION_BLUR]}
-					onChange={(v) => setProject("cursor", "motionBlur" as any, v[0])}
+					onChange={(v) => setProject("cursor", "motionBlur", v[0])}
 					minValue={0}
 					maxValue={1}
 					step={0.01}
@@ -2161,7 +2187,7 @@ function BackgroundConfig(props: { scrollRef: HTMLDivElement }) {
 			</KCollapsible>
 			<Field name="Shadow" icon={<IconCapShadow class="size-4" />}>
 				<Slider
-					value={[project.background.shadow!]}
+					value={[project.background.shadow ?? 0]}
 					onChange={(v) => {
 						batch(() => {
 							setProject("background", "shadow", v[0]);
@@ -2255,7 +2281,17 @@ function CameraConfig(props: { scrollRef: HTMLDivElement }) {
 							value={`${project.camera.position.x}:${project.camera.position.y}`}
 							onChange={(v) => {
 								const [x, y] = v.split(":");
-								setProject("camera", "position", { x, y } as any);
+								const xPosition = CAMERA_X_POSITIONS.find(
+									(position) => position === x,
+								);
+								const yPosition = CAMERA_Y_POSITIONS.find(
+									(position) => position === y,
+								);
+								if (!xPosition || !yPosition) return;
+								setProject("camera", "position", {
+									x: xPosition,
+									y: yPosition,
+								});
 							}}
 							class="mt-[0.75rem] rounded-[0.5rem] border border-gray-3 bg-gray-2 w-full h-[7.5rem] relative"
 						>
@@ -2456,7 +2492,7 @@ function CameraConfig(props: { scrollRef: HTMLDivElement }) {
 			<Field name="Rounded Corners" icon={<IconCapCorners class="size-4" />}>
 				<div class="flex flex-col gap-3">
 					<Slider
-						value={[project.camera.rounding!]}
+						value={[project.camera.rounding ?? 0]}
 						onChange={(v) => setProject("camera", "rounding", v[0])}
 						minValue={0}
 						maxValue={100}
@@ -2473,7 +2509,7 @@ function CameraConfig(props: { scrollRef: HTMLDivElement }) {
 			<Field name="Shadow" icon={<IconCapShadow class="size-4" />}>
 				<div class="space-y-8">
 					<Slider
-						value={[project.camera.shadow!]}
+						value={[project.camera.shadow ?? 0]}
 						onChange={(v) => setProject("camera", "shadow", v[0])}
 						minValue={0}
 						maxValue={100}
@@ -2772,7 +2808,7 @@ function TextSegmentConfig(props: {
 						)}
 					>
 						<KSelect.Trigger class="flex w-full items-center justify-between rounded-md border border-gray-3 bg-gray-2 px-3 py-2 text-sm text-gray-12 transition-colors hover:border-gray-4 hover:bg-gray-3 focus:border-blue-9 focus:outline-none focus:ring-1 focus:ring-blue-9">
-							<KSelect.Value<any> class="truncate">
+							<KSelect.Value<{ label: string; value: number }> class="truncate">
 								{(state) => {
 									const selected = state.selectedOption();
 									if (selected) return selected.label;
@@ -3352,13 +3388,8 @@ function ZoomSegmentConfig(props: {
 	segment: ZoomSegment;
 }) {
 	const generalSettings = generalSettingsStore.createQuery();
-	const {
-		project,
-		setProject,
-		editorInstance,
-		setEditorState,
-		projectHistory,
-	} = useEditorContext();
+	const { project, setProject, editorInstance, projectHistory } =
+		useEditorContext();
 
 	const states = {
 		manual:
@@ -3521,8 +3552,8 @@ function ZoomSegmentConfig(props: {
 										croppedSize().y,
 										0,
 										0,
-										canvasRef.width!,
-										canvasRef.height!,
+										canvasRef.width,
+										canvasRef.height,
 									);
 								};
 
@@ -3566,7 +3597,7 @@ function ZoomSegmentConfig(props: {
 								};
 
 								const visualHeight = () =>
-									(bounds.width! / croppedSize().x) * croppedSize().y;
+									((bounds.width ?? 0) / croppedSize().x) * croppedSize().y;
 
 								return (
 									<div
@@ -3666,7 +3697,8 @@ function ClipSegmentConfig(props: {
 
 		setProject(
 			produce((proj) => {
-				const clips = (proj.clips ??= []);
+				if (!proj.clips) proj.clips = [];
+				const clips = proj.clips;
 				let clip = clips.find(
 					(clip) => clip.index === (props.segment.recordingSegment ?? 0),
 				);

--- a/apps/desktop/src/routes/editor/ConfigSidebar.tsx
+++ b/apps/desktop/src/routes/editor/ConfigSidebar.tsx
@@ -412,8 +412,7 @@ export function ConfigSidebar() {
 						{
 							id: TAB_IDS.cursor,
 							icon: IconCapCursor,
-							disabled:
-								meta().type !== "multiple" || !meta().segments[0]?.cursor,
+							disabled: !meta().hasRecordedCursorData,
 						},
 						{
 							id: TAB_IDS.keyboard,
@@ -1244,9 +1243,7 @@ export function ConfigSidebar() {
 											index: idx,
 										}))
 										.filter(
-											(
-												s,
-											): s is { segment: SceneSegment; index: number } =>
+											(s): s is { segment: SceneSegment; index: number } =>
 												s.segment !== undefined,
 										);
 
@@ -1319,9 +1316,7 @@ export function ConfigSidebar() {
 											index: idx,
 										}))
 										.filter(
-											(
-												s,
-											): s is { segment: TimelineSegment; index: number } =>
+											(s): s is { segment: TimelineSegment; index: number } =>
 												s.segment !== undefined,
 										);
 
@@ -1412,13 +1407,14 @@ function BackgroundConfig(props: { scrollRef: HTMLDivElement }) {
 		// Load initial batch
 		const initialPaths = await Promise.all(visibleWallpaperPaths);
 
-		return initialPaths
-			.filter((p): p is { id: string; path: string } => p.path !== null)
-			.map(({ id, path }) => ({
+		return initialPaths.flatMap(({ id, path }) => {
+			if (path === null) return [];
+			return {
 				id,
 				url: convertFileSrc(path),
 				rawPath: path,
-			}));
+			};
+		});
 	});
 
 	// set padding if background is selected

--- a/apps/desktop/src/routes/editor/TextOverlay.tsx
+++ b/apps/desktop/src/routes/editor/TextOverlay.tsx
@@ -314,7 +314,7 @@ function TextSegmentOverlay(props: {
 				startSize: { ...seg.size },
 			};
 		},
-		(e, { startPos, startSize }, initialMouse) => {
+		(e, { startPos }, initialMouse) => {
 			const dx = (e.clientX - initialMouse.x) / props.size.width;
 			const dy = (e.clientY - initialMouse.y) / props.size.height;
 

--- a/apps/desktop/src/routes/in-progress-recording.tsx
+++ b/apps/desktop/src/routes/in-progress-recording.tsx
@@ -108,6 +108,7 @@ function InProgressRecordingInner() {
 	const [issueKey, setIssueKey] = createSignal("");
 	const [cameraWindowOpen, setCameraWindowOpen] = createSignal(false);
 	const [startingDismissed, setStartingDismissed] = createSignal(false);
+	const [stopRequested, setStopRequested] = createSignal(false);
 	const [interactiveAreaRef, setInteractiveAreaRef] =
 		createSignal<HTMLDivElement | null>(null);
 	let settingsButtonRef: HTMLButtonElement | undefined;
@@ -189,6 +190,7 @@ function InProgressRecordingInner() {
 				setRecordingFailure(null);
 				setDegradedReason(null);
 				setPauseResumes([]);
+				setStopRequested(false);
 				setState({
 					variant: "countdown",
 					from: payload.value,
@@ -202,6 +204,7 @@ function InProgressRecordingInner() {
 				setRecordingFailure(null);
 				setDegradedReason(null);
 				setPauseResumes([]);
+				setStopRequested(false);
 				aborted = false;
 				setState({ variant: "recording" });
 				setStart(Date.now());
@@ -262,6 +265,7 @@ function InProgressRecordingInner() {
 			setRecordingFailure(null);
 			setDegradedReason(null);
 			setPauseResumes([]);
+			setStopRequested(false);
 			aborted = false;
 			if (recording.status === "recording") {
 				setState({ variant: "recording" });
@@ -382,10 +386,20 @@ function InProgressRecordingInner() {
 
 	const stopRecording = createMutation(() => ({
 		mutationFn: async () => {
+			setStopRequested(true);
 			setState({ variant: "stopped" });
+			void getCurrentWindow().hide();
 			await commands.stopRecording();
 		},
+		onError: () => {
+			setStopRequested(false);
+		},
 	}));
+
+	const requestStopRecording = () => {
+		if (isCountdown() || stopRequested() || stopRecording.isPending) return;
+		stopRecording.mutate();
+	};
 
 	const togglePause = createMutation(() => ({
 		mutationFn: async () => {
@@ -669,10 +683,20 @@ function InProgressRecordingInner() {
 									}
 								>
 									<button
-										disabled={stopRecording.isPending || isCountdown()}
+										disabled={
+											stopRequested() ||
+											stopRecording.isPending ||
+											isCountdown()
+										}
 										class="flex flex-row items-center gap-[0.25rem] rounded-lg py-[0.25rem] px-[0.5rem] text-red-300 transition-colors duration-100 hover:bg-red-500/[0.08] active:bg-red-500/[0.12] disabled:opacity-60 disabled:hover:bg-transparent"
 										type="button"
-										onClick={() => stopRecording.mutate()}
+										onPointerDown={(event) => {
+											if (event.button !== 0) return;
+											event.preventDefault();
+											event.stopPropagation();
+											requestStopRecording();
+										}}
+										onClick={requestStopRecording}
 										title="Stop recording"
 										aria-label="Stop recording"
 									>

--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -1293,6 +1293,8 @@ function CameraPreviewInline() {
 
 		socket.onmessage = (event) => {
 			lastFrameTime = Date.now();
+			if (pendingRender) return;
+
 			const buffer = event.data as ArrayBuffer;
 			const clamped = new Uint8ClampedArray(buffer);
 			if (clamped.length < 24) return;

--- a/apps/desktop/src/styles/theme.css
+++ b/apps/desktop/src/styles/theme.css
@@ -261,8 +261,6 @@
 		stroke-dasharray: 100;
 		stroke-dashoffset: 100;
 	}
-	50% {
-	}
 	100% {
 		stroke-dashoffset: 0;
 	}

--- a/apps/desktop/src/styles/theme.css
+++ b/apps/desktop/src/styles/theme.css
@@ -237,6 +237,23 @@
 	animation-iteration-count: infinite;
 }
 
+@keyframes settings-section-pulse {
+	0% {
+		box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+	}
+	30% {
+		box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.45);
+	}
+	100% {
+		box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+	}
+}
+
+.settings-section-pulse {
+	animation: settings-section-pulse 1.6s ease-out forwards;
+	border-radius: 0.75rem;
+}
+
 /* SVG path animation */
 
 @keyframes svgpathframes {

--- a/apps/desktop/src/utils/socket.ts
+++ b/apps/desktop/src/utils/socket.ts
@@ -210,6 +210,7 @@ export function createImageDataWS(
 	let mainThreadWebGPU: WebGPURenderer | null = null;
 	let mainThreadWebGPUInitializing = false;
 	let pendingNv12Frame: ArrayBuffer | null = null;
+	let pendingNv12RafId: number | null = null;
 
 	let lastRenderedFrameData: {
 		data: Uint8ClampedArray;
@@ -280,6 +281,10 @@ export function createImageDataWS(
 
 		mainThreadWebGPUInitializing = false;
 		pendingNv12Frame = null;
+		if (pendingNv12RafId !== null) {
+			cancelAnimationFrame(pendingNv12RafId);
+			pendingNv12RafId = null;
+		}
 		mainThreadNv12Buffer = null;
 		mainThreadNv12BufferSize = 0;
 		cachedDirectImageData = null;
@@ -342,8 +347,19 @@ export function createImageDataWS(
 			);
 
 			storeRenderedFrame(frameData, width, height, yStride, true);
+			actualRendersCount++;
 			onmessage({ width, height });
 		}
+	}
+
+	function schedulePendingNv12Frame(buffer: ArrayBuffer) {
+		pendingNv12Frame = buffer;
+		if (pendingNv12RafId !== null) return;
+
+		pendingNv12RafId = requestAnimationFrame(() => {
+			pendingNv12RafId = null;
+			renderPendingNv12Frame();
+		});
 	}
 
 	function renderPendingFrameCanvas2D() {
@@ -616,12 +632,7 @@ export function createImageDataWS(
 	let frameCount = 0;
 	let frameTimeSum = 0;
 	let totalBytesReceived = 0;
-	let lastLogTime = 0;
-	let framesReceived = 0;
-	let framesDropped = 0;
-	let framesSentToWorker = 0;
 	let actualRendersCount = 0;
-	let renderFrameCount = 0;
 	let minFrameTime = Number.MAX_VALUE;
 	let maxFrameTime = 0;
 	const getLocalFpsStats = (): FpsStats => ({
@@ -646,7 +657,6 @@ export function createImageDataWS(
 		const buffer = event.data as ArrayBuffer;
 		const now = performance.now();
 		totalBytesReceived += buffer.byteLength;
-		framesReceived++;
 
 		let isNv12Format = false;
 		if (buffer.byteLength >= 28) {
@@ -662,32 +672,13 @@ export function createImageDataWS(
 			maxFrameTime = Math.max(maxFrameTime, delta);
 
 			if (frameCount % 60 === 0) {
-				const avgDelta = frameTimeSum / 60;
-				const elapsedSec = (now - lastLogTime) / 1000;
-				const mbPerSec = totalBytesReceived / 1_000_000 / elapsedSec;
-				const recvFps = framesReceived / elapsedSec;
-				const sentFps = framesSentToWorker / elapsedSec;
-				const actualFps = actualRendersCount / elapsedSec;
-				const dropRate =
-					framesReceived > 0 ? (framesDropped / framesReceived) * 100 : 0;
-
-				console.log(
-					`[Frame] recv: ${recvFps.toFixed(1)}/s, sent: ${sentFps.toFixed(1)}/s, ACTUAL: ${actualFps.toFixed(1)}/s, dropped: ${dropRate.toFixed(0)}%, delta: ${avgDelta.toFixed(1)}ms, ${mbPerSec.toFixed(1)} MB/s, ${isNv12Format ? "NV12" : "RGBA"}`,
-				);
-
 				frameCount = 0;
 				frameTimeSum = 0;
 				totalBytesReceived = 0;
-				lastLogTime = now;
-				framesReceived = 0;
-				framesDropped = 0;
-				framesSentToWorker = 0;
 				actualRendersCount = 0;
 				minFrameTime = Number.MAX_VALUE;
 				maxFrameTime = 0;
 			}
-		} else {
-			lastLogTime = now;
 		}
 		lastFrameTime = now;
 
@@ -695,34 +686,16 @@ export function createImageDataWS(
 			if (mainThreadWebGPU && directCanvas) {
 				const metadataOffset = buffer.byteLength - 28;
 				const meta = new DataView(buffer, metadataOffset, 28);
-				const yStride = meta.getUint32(0, true);
 				const height = meta.getUint32(4, true);
 				const width = meta.getUint32(8, true);
 
 				if (width > 0 && height > 0) {
-					const ySize = yStride * height;
-					const uvSize = yStride * (height / 2);
-					const totalSize = ySize + uvSize;
-
-					const frameData = new Uint8ClampedArray(buffer, 0, totalSize);
-
 					if (directCanvas.width !== width || directCanvas.height !== height) {
 						directCanvas.width = width;
 						directCanvas.height = height;
 					}
 
-					renderNv12FrameWebGPU(
-						mainThreadWebGPU,
-						frameData,
-						width,
-						height,
-						yStride,
-					);
-					actualRendersCount++;
-					renderFrameCount++;
-
-					storeRenderedFrame(frameData, width, height, yStride, true);
-					onmessage({ width, height });
+					schedulePendingNv12Frame(buffer);
 				}
 				return;
 			}
@@ -796,7 +769,6 @@ export function createImageDataWS(
 
 					storeRenderedFrame(nv12Data, width, height, yStride, true);
 					actualRendersCount++;
-					renderFrameCount++;
 
 					onmessage({ width, height });
 				}
@@ -804,10 +776,8 @@ export function createImageDataWS(
 			}
 
 			if (isProcessing) {
-				framesDropped++;
 				nextFrame = buffer;
 			} else {
-				framesSentToWorker++;
 				pendingFrame = buffer;
 				processNextFrame();
 			}
@@ -838,7 +808,6 @@ export function createImageDataWS(
 					strideBytes,
 				);
 				actualRendersCount++;
-				renderFrameCount++;
 
 				storeRenderedFrame(frameData, width, height, strideBytes, false);
 				onmessage({ width, height });
@@ -865,22 +834,11 @@ export function createImageDataWS(
 						minFrameTime = Math.min(minFrameTime, delta);
 						maxFrameTime = Math.max(maxFrameTime, delta);
 						if (frameCount % 60 === 0) {
-							const avgDelta = frameTimeSum / 60;
-							const elapsedSec = (now - lastLogTime) / 1000;
-							const mbPerSec = totalBytesReceived / 1_000_000 / elapsedSec;
-							const actualRenderFps = renderFrameCount / elapsedSec;
-							console.log(
-								`[Frame] recv_fps: ${(1000 / avgDelta).toFixed(1)}, render_fps: ${actualRenderFps.toFixed(1)}, mb/s: ${mbPerSec.toFixed(1)}, frame_ms: ${avgDelta.toFixed(1)} (min: ${minFrameTime.toFixed(1)}, max: ${maxFrameTime.toFixed(1)}), size: ${(buffer.byteLength / 1024).toFixed(0)}KB, format: ${isNv12Format ? "NV12" : "RGBA"}`,
-							);
 							frameTimeSum = 0;
 							totalBytesReceived = 0;
-							lastLogTime = now;
-							renderFrameCount = 0;
 							minFrameTime = Number.MAX_VALUE;
 							maxFrameTime = 0;
 						}
-					} else {
-						lastLogTime = now;
 					}
 					lastFrameTime = now;
 
@@ -918,8 +876,6 @@ export function createImageDataWS(
 							width * 4,
 							false,
 						);
-						renderFrameCount++;
-
 						onmessage({ width, height });
 					} else {
 						strideWorker.postMessage(

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -388,6 +388,7 @@ renderFrameEvent: RenderFrameEvent,
 requestOpenRecordingPicker: RequestOpenRecordingPicker,
 requestOpenSettings: RequestOpenSettings,
 requestScreenCapturePrewarm: RequestScreenCapturePrewarm,
+requestScrollToSettingsSection: RequestScrollToSettingsSection,
 requestSetTargetMode: RequestSetTargetMode,
 requestStartRecording: RequestStartRecording,
 setCaptureAreaPending: SetCaptureAreaPending,
@@ -413,6 +414,7 @@ renderFrameEvent: "render-frame-event",
 requestOpenRecordingPicker: "request-open-recording-picker",
 requestOpenSettings: "request-open-settings",
 requestScreenCapturePrewarm: "request-screen-capture-prewarm",
+requestScrollToSettingsSection: "request-scroll-to-settings-section",
 requestSetTargetMode: "request-set-target-mode",
 requestStartRecording: "request-start-recording",
 setCaptureAreaPending: "set-capture-area-pending",
@@ -568,6 +570,7 @@ export type RenderFrameEvent = { frame_number: number; fps: number; resolution_b
 export type RequestOpenRecordingPicker = { target_mode: RecordingTargetMode | null }
 export type RequestOpenSettings = { page: string }
 export type RequestScreenCapturePrewarm = { force?: boolean }
+export type RequestScrollToSettingsSection = { section: string }
 export type RequestSetTargetMode = { target_mode: RecordingTargetMode | null; display_id: string | null }
 export type RequestStartRecording = { mode: RecordingMode }
 export type S3UploadMeta = { id: string }
@@ -586,7 +589,7 @@ export type SingleSegment = { display: VideoMeta; camera?: VideoMeta | null; aud
 export type StartRecordingInputs = { capture_target: ScreenCaptureTarget; capture_system_audio?: boolean; mode: RecordingMode; organization_id?: string | null }
 export type StereoMode = "stereo" | "monoL" | "monoR"
 export type StudioRecordingMeta = { segment: SingleSegment } | { inner: MultipleSegments }
-export type StudioRecordingQuality = "balanced" | "ultra"
+export type StudioRecordingQuality = "compatibility" | "balanced" | "ultra"
 export type StudioRecordingStatus = { status: "InProgress" } | { status: "NeedsRemux" } | { status: "Failed"; error: string } | { status: "Complete" }
 export type SystemDiagnostics = { macosVersion: MacOSVersionInfo | null; availableEncoders: string[]; screenCaptureSupported: boolean; metalSupported: boolean; gpuName: string | null }
 export type TargetUnderCursor = { display_id: DisplayId | null; window: WindowUnderCursor | null }

--- a/apps/media-server/src/routes/video.ts
+++ b/apps/media-server/src/routes/video.ts
@@ -1027,7 +1027,7 @@ video.post("/mux-segments", async (c) => {
 				phase: "error",
 				error: err instanceof Error ? err.message : String(err),
 			});
-			sendWebhook(getJob(jobId)!);
+			sendCurrentJobWebhook(jobId);
 		}
 	});
 
@@ -1147,6 +1147,11 @@ async function downloadSegmentsBatchTracked(
 	return failed;
 }
 
+function sendCurrentJobWebhook(jobId: string): void {
+	const job = getJob(jobId);
+	if (job) sendWebhook(job);
+}
+
 async function muxSegmentsAsync(
 	jobId: string,
 	videoId: string,
@@ -1170,7 +1175,7 @@ async function muxSegmentsAsync(
 	try {
 		await ensureTempDir();
 		updateJob(jobId, { phase: "downloading", progress: 0 });
-		sendWebhook(getJob(jobId)!);
+		sendCurrentJobWebhook(jobId);
 
 		await mkdir(workDir, { recursive: true });
 		const videoDir = join(workDir, "video");
@@ -1180,7 +1185,7 @@ async function muxSegmentsAsync(
 
 		await downloadUrlToFile(videoInitUrl, join(videoDir, "init.mp4"));
 		updateJob(jobId, { phase: "downloading", progress: 5 });
-		sendWebhook(getJob(jobId)!);
+		sendCurrentJobWebhook(jobId);
 
 		const videoFailed = await downloadSegmentsBatchTracked(
 			videoSegmentUrls,
@@ -1202,36 +1207,38 @@ async function muxSegmentsAsync(
 			);
 		}
 
-		let hasAudio =
+		let audioInput =
 			audioInitUrl !== null &&
 			audioSegmentUrls !== null &&
-			audioSegmentUrls.length > 0;
-		if (hasAudio) {
-			await downloadUrlToFile(audioInitUrl!, join(audioDir, "init.mp4"));
+			audioSegmentUrls.length > 0
+				? { initUrl: audioInitUrl, segmentUrls: audioSegmentUrls }
+				: null;
+		if (audioInput) {
+			await downloadUrlToFile(audioInput.initUrl, join(audioDir, "init.mp4"));
 			const audioFailed = await downloadSegmentsBatchTracked(
-				audioSegmentUrls!,
+				audioInput.segmentUrls,
 				audioDir,
 				jobId,
 				50,
 				10,
 			);
 			if (audioFailed > 0) {
-				const audioFailRatio = audioFailed / audioSegmentUrls!.length;
+				const audioFailRatio = audioFailed / audioInput.segmentUrls.length;
 				if (audioFailRatio >= 0.5) {
 					console.warn(
-						`[mux-segments] ${audioFailed}/${audioSegmentUrls!.length} audio segments failed for ${videoId} (${Math.round(audioFailRatio * 100)}%), proceeding without audio`,
+						`[mux-segments] ${audioFailed}/${audioInput.segmentUrls.length} audio segments failed for ${videoId} (${Math.round(audioFailRatio * 100)}%), proceeding without audio`,
 					);
-					hasAudio = false;
+					audioInput = null;
 				} else {
 					console.warn(
-						`[mux-segments] ${audioFailed}/${audioSegmentUrls!.length} audio segments failed to download for ${videoId}`,
+						`[mux-segments] ${audioFailed}/${audioInput.segmentUrls.length} audio segments failed to download for ${videoId}`,
 					);
 				}
 			}
 		}
 
 		updateJob(jobId, { phase: "processing", progress: 60 });
-		sendWebhook(getJob(jobId)!);
+		sendCurrentJobWebhook(jobId);
 
 		const combinedVideoPath = join(workDir, "combined_video.mp4");
 		const videoInitPath = join(videoDir, "init.mp4");
@@ -1257,7 +1264,7 @@ async function muxSegmentsAsync(
 
 		let resultPath: string;
 
-		if (hasAudio) {
+		if (audioInput) {
 			const combinedAudioPath = join(workDir, "combined_audio.mp4");
 			const audioInitPath = join(audioDir, "init.mp4");
 			const audioSegmentFiles = (await readdir(audioDir))
@@ -1298,7 +1305,7 @@ async function muxSegmentsAsync(
 		}
 
 		updateJob(jobId, { phase: "uploading", progress: 80 });
-		sendWebhook(getJob(jobId)!);
+		sendCurrentJobWebhook(jobId);
 
 		await uploadFileToS3(resultPath, outputPresignedUrl, "video/mp4");
 
@@ -1319,7 +1326,7 @@ async function muxSegmentsAsync(
 				progress: 90,
 				message: "Generating thumbnail...",
 			});
-			sendWebhook(getJob(jobId)!);
+			sendCurrentJobWebhook(jobId);
 
 			try {
 				const duration = metadata?.duration ?? 0;
@@ -1338,7 +1345,7 @@ async function muxSegmentsAsync(
 			progress: 100,
 			metadata,
 		});
-		sendWebhook(getJob(jobId)!);
+		sendCurrentJobWebhook(jobId);
 
 		setTimeout(() => deleteJob(jobId), 5 * 60 * 1000);
 	} catch (error: unknown) {
@@ -1347,7 +1354,7 @@ async function muxSegmentsAsync(
 			phase: "error",
 			error: error instanceof Error ? error.message : "Unknown error",
 		});
-		sendWebhook(getJob(jobId)!);
+		sendCurrentJobWebhook(jobId);
 	} finally {
 		const { rm } = await import("node:fs/promises");
 		await rm(workDir, { recursive: true, force: true }).catch(() => {});

--- a/apps/media-server/src/routes/video.ts
+++ b/apps/media-server/src/routes/video.ts
@@ -1149,7 +1149,11 @@ async function downloadSegmentsBatchTracked(
 
 function sendCurrentJobWebhook(jobId: string): void {
 	const job = getJob(jobId);
-	if (job) sendWebhook(job);
+	if (!job) {
+		console.warn(`[mux-segments] Job ${jobId} not found for webhook`);
+		return;
+	}
+	sendWebhook(job);
 }
 
 async function muxSegmentsAsync(

--- a/apps/web-cluster/src/cluster/container-metadata.ts
+++ b/apps/web-cluster/src/cluster/container-metadata.ts
@@ -1,6 +1,8 @@
 import { Config, Data, Effect, Option } from "effect";
 
-export class FetchIpError extends Data.TaggedError("FetchIpError")<{}> {}
+export class FetchIpError extends Data.TaggedError("FetchIpError")<
+	Record<never, never>
+> {}
 
 class EcsContainerMetadata extends Effect.Service<EcsContainerMetadata>()(
 	"EcsContainerMetadata",

--- a/apps/web/__tests__/unit/async-video-code-reviews-page.test.ts
+++ b/apps/web/__tests__/unit/async-video-code-reviews-page.test.ts
@@ -146,7 +146,7 @@ describe("AsyncVideoCodeReviewsPage FAQ schema", () => {
 	it("maps each FAQ to a Question entity with acceptedAnswer", () => {
 		const schema = createFAQSchema(faqs);
 
-		expect(schema.mainEntity[0]!).toEqual({
+		expect(schema.mainEntity[0]).toEqual({
 			"@type": "Question",
 			name: "What is an async video code review?",
 			acceptedAnswer: {

--- a/apps/web/__tests__/unit/avi-to-mp4-page.test.ts
+++ b/apps/web/__tests__/unit/avi-to-mp4-page.test.ts
@@ -114,7 +114,7 @@ describe("AVI to MP4 FAQ schema validity", () => {
 	it("maps each FAQ to a Question entity with acceptedAnswer", () => {
 		const schema = createFAQSchema(faqs);
 
-		expect(schema.mainEntity[0]!).toEqual({
+		expect(schema.mainEntity[0]).toEqual({
 			"@type": "Question",
 			name: "How do I convert AVI to MP4 online?",
 			acceptedAnswer: {

--- a/apps/web/__tests__/unit/best-screen-recorder-page.test.ts
+++ b/apps/web/__tests__/unit/best-screen-recorder-page.test.ts
@@ -138,7 +138,7 @@ describe("BestScreenRecorderPage FAQ schema", () => {
 	it("maps each FAQ to a Question entity with acceptedAnswer", () => {
 		const schema = createFAQSchema(faqs);
 
-		expect(schema.mainEntity[0]!).toEqual({
+		expect(schema.mainEntity[0]).toEqual({
 			"@type": "Question",
 			name: "What is the best screen recorder?",
 			acceptedAnswer: {

--- a/apps/web/__tests__/unit/breadcrumb-schema.test.ts
+++ b/apps/web/__tests__/unit/breadcrumb-schema.test.ts
@@ -44,9 +44,11 @@ describe("createBreadcrumbSchema", () => {
 			{ name: "Home", url: "https://cap.so" },
 			{ name: "Current Page" },
 		]);
+		const currentPageItem = schema.itemListElement[1];
 
 		expect(schema.itemListElement[0]?.item).toBe("https://cap.so");
-		expect("item" in schema.itemListElement[1]!).toBe(false);
+		expect(currentPageItem).toBeDefined();
+		expect(currentPageItem && "item" in currentPageItem).toBe(false);
 	});
 
 	it("handles single item breadcrumb", () => {
@@ -165,7 +167,7 @@ describe("Breadcrumb structured data in tools pages", () => {
 		const content = readPage("(site)/tools/convert/[conversionPath]/page.tsx");
 		expect(content).toContain("createBreadcrumbSchema");
 		expect(content).toContain(
-			"`https://cap.so/tools/convert/${conversionPath}`",
+			"`https://cap.so/tools/convert/$" + "{conversionPath}`",
 		);
 	});
 });

--- a/apps/web/__tests__/unit/developer-credit-math.test.ts
+++ b/apps/web/__tests__/unit/developer-credit-math.test.ts
@@ -25,6 +25,10 @@ function balanceAfterCharge(balance: number, charge: number): number {
 	return Math.max(0, balance - charge);
 }
 
+function isBelowMinimumPurchase(amountCents: number): boolean {
+	return amountCents < 500;
+}
+
 describe("Purchase Credits Conversion", () => {
 	it("converts $5.00 (500 cents) to 500,000 micro-credits", () => {
 		expect(purchaseCreditsFormula(500)).toBe(500_000);
@@ -52,9 +56,9 @@ describe("Purchase Credits Conversion", () => {
 	});
 
 	it("rejects purchases below $5.00 minimum (amountCents < 500)", () => {
-		expect(499 < 500).toBe(true);
-		expect(500 < 500).toBe(false);
-		expect(0 < 500).toBe(true);
+		expect(isBelowMinimumPurchase(499)).toBe(true);
+		expect(isBelowMinimumPurchase(500)).toBe(false);
+		expect(isBelowMinimumPurchase(0)).toBe(true);
 	});
 });
 

--- a/apps/web/__tests__/unit/developer-cron-storage.test.ts
+++ b/apps/web/__tests__/unit/developer-cron-storage.test.ts
@@ -5,8 +5,8 @@ const mockDb = vi.fn();
 type DbRow = Record<string, unknown>;
 type JsonBody = Record<string, unknown>;
 type TransactionValues = {
-	type?: string;
-	amountMicroCredits?: number;
+	type: string;
+	amountMicroCredits: number;
 };
 type MockDbChain = {
 	select: ReturnType<typeof vi.fn>;
@@ -136,7 +136,19 @@ function setupDbSequence(
 }
 
 function isTransactionValues(value: unknown): value is TransactionValues {
-	return typeof value === "object" && value !== null;
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		typeof value.type === "string" &&
+		"amountMicroCredits" in value &&
+		typeof value.amountMicroCredits === "number"
+	);
+}
+
+function getCapturedJsonBody() {
+	if (capturedJsonBody === null) throw new Error("Expected JSON response body");
+	return capturedJsonBody;
 }
 
 beforeEach(() => {
@@ -199,7 +211,7 @@ describe("developer-storage cron job", () => {
 				success: true,
 				appsProcessed: 1,
 			});
-			expect(capturedJsonBody.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+			expect(getCapturedJsonBody().date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 		});
 
 		it("skips already-processed apps", async () => {
@@ -257,7 +269,7 @@ describe("developer-storage cron job", () => {
 	describe("transaction behavior", () => {
 		it("creates negative transaction for storage_daily", async () => {
 			const GET = await importGET();
-			let insertValues: TransactionValues | null = null;
+			let insertValues: unknown = null;
 
 			setupDbSequence(
 				[
@@ -281,7 +293,8 @@ describe("developer-storage cron job", () => {
 
 			await GET(makeRequest(`Bearer ${CRON_SECRET}`));
 
-			expect(insertValues).not.toBeNull();
+			if (!isTransactionValues(insertValues))
+				throw new Error("Expected storage transaction");
 			expect(insertValues.type).toBe("storage_daily");
 			expect(insertValues.amountMicroCredits).toBe(-33);
 		});
@@ -324,11 +337,12 @@ describe("developer-storage cron job", () => {
 
 			await GET(makeRequest(`Bearer ${CRON_SECRET}`));
 
-			expect(capturedJsonBody).toHaveProperty("success", true);
-			expect(capturedJsonBody).toHaveProperty("date");
-			expect(capturedJsonBody).toHaveProperty("appsProcessed");
-			expect(capturedJsonBody.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-			expect(typeof capturedJsonBody.appsProcessed).toBe("number");
+			const body = getCapturedJsonBody();
+			expect(body).toHaveProperty("success", true);
+			expect(body).toHaveProperty("date");
+			expect(body).toHaveProperty("appsProcessed");
+			expect(body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+			expect(typeof body.appsProcessed).toBe("number");
 		});
 	});
 

--- a/apps/web/__tests__/unit/developer-cron-storage.test.ts
+++ b/apps/web/__tests__/unit/developer-cron-storage.test.ts
@@ -2,6 +2,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockDb = vi.fn();
 
+type DbRow = Record<string, unknown>;
+type JsonBody = Record<string, unknown>;
+type TransactionValues = {
+	type?: string;
+	amountMicroCredits?: number;
+};
+type MockDbChain = {
+	select: ReturnType<typeof vi.fn>;
+	from: ReturnType<typeof vi.fn>;
+	where: ReturnType<typeof vi.fn>;
+	groupBy?: ReturnType<typeof vi.fn>;
+	limit: ReturnType<typeof vi.fn>;
+	insert: ReturnType<typeof vi.fn>;
+	values: ReturnType<typeof vi.fn>;
+	update: ReturnType<typeof vi.fn>;
+	set: ReturnType<typeof vi.fn>;
+	transaction?: ReturnType<typeof vi.fn>;
+};
+
 vi.mock("@cap/database", () => ({
 	db: mockDb,
 }));
@@ -32,19 +51,19 @@ vi.mock("@cap/database/schema", () => ({
 }));
 
 vi.mock("drizzle-orm", () => ({
-	and: vi.fn((...args: any[]) => args),
-	eq: vi.fn((a: any, b: any) => ({ eq: [a, b] })),
-	inArray: vi.fn((a: any, b: any) => ({ inArray: [a, b] })),
-	isNull: vi.fn((a: any) => ({ isNull: a })),
+	and: vi.fn((...args: unknown[]) => args),
+	eq: vi.fn((a: unknown, b: unknown) => ({ eq: [a, b] })),
+	inArray: vi.fn((a: unknown, b: unknown) => ({ inArray: [a, b] })),
+	isNull: vi.fn((a: unknown) => ({ isNull: a })),
 	sql: vi.fn(),
 }));
 
-let capturedJsonBody: any = null;
+let capturedJsonBody: JsonBody | null = null;
 let capturedStatus: number | undefined;
 
 vi.mock("next/server", () => ({
 	NextResponse: {
-		json: vi.fn((body: any, init?: any) => {
+		json: vi.fn((body: JsonBody, init?: ResponseInit) => {
 			capturedJsonBody = body;
 			capturedStatus = init?.status;
 			return { body, status: init?.status ?? 200 };
@@ -55,10 +74,11 @@ vi.mock("next/server", () => ({
 const CRON_SECRET = "test-cron-secret";
 
 function makeChain(
-	result: any[],
-	options?: { onTransaction?: (tx: any) => void },
+	result: DbRow[],
+	options?: { onTransaction?: (tx: MockDbChain) => void },
 ) {
-	const chain: any = {
+	const chain = Promise.resolve(result) as Promise<DbRow[]> & MockDbChain;
+	Object.assign(chain, {
 		select: vi.fn(() => chain),
 		from: vi.fn(() => chain),
 		where: vi.fn(() => chain),
@@ -68,9 +88,9 @@ function makeChain(
 		values: vi.fn(() => Promise.resolve()),
 		update: vi.fn(() => chain),
 		set: vi.fn(() => chain),
-		transaction: vi.fn(async (cb: any) => {
+		transaction: vi.fn(async (cb: (tx: MockDbChain) => Promise<unknown>) => {
 			let currentOperation: "select" | "update" | "insert" | null = null;
-			const txChain: any = {
+			const txChain = {
 				select: vi.fn(() => {
 					currentOperation = "select";
 					return txChain;
@@ -99,21 +119,24 @@ function makeChain(
 			}
 			await cb(txChain);
 		}),
-	};
-	chain.then = (resolve: any) => resolve(result);
+	});
 	return chain;
 }
 
 function setupDbSequence(
-	responses: any[][],
-	txOptions?: { onTransaction?: (tx: any) => void },
+	responses: DbRow[][],
+	txOptions?: { onTransaction?: (tx: MockDbChain) => void },
 ) {
 	let callIndex = 0;
 	mockDb.mockImplementation(() => {
 		const idx = callIndex++;
-		const result = idx < responses.length ? responses[idx]! : [];
+		const result = responses[idx] ?? [];
 		return makeChain(result, txOptions);
 	});
+}
+
+function isTransactionValues(value: unknown): value is TransactionValues {
+	return typeof value === "object" && value !== null;
 }
 
 beforeEach(() => {
@@ -234,7 +257,7 @@ describe("developer-storage cron job", () => {
 	describe("transaction behavior", () => {
 		it("creates negative transaction for storage_daily", async () => {
 			const GET = await importGET();
-			let insertValues: any = null;
+			let insertValues: TransactionValues | null = null;
 
 			setupDbSequence(
 				[
@@ -246,8 +269,8 @@ describe("developer-storage cron job", () => {
 				],
 				{
 					onTransaction: (tx) => {
-						tx.values.mockImplementation((vals: any) => {
-							if (vals?.type === "storage_daily") {
+						tx.values.mockImplementation((vals: unknown) => {
+							if (isTransactionValues(vals) && vals.type === "storage_daily") {
 								insertValues = vals;
 							}
 							return Promise.resolve();
@@ -277,8 +300,8 @@ describe("developer-storage cron job", () => {
 				],
 				{
 					onTransaction: (tx) => {
-						tx.values.mockImplementation((vals: any) => {
-							if (vals?.type === "storage_daily") {
+						tx.values.mockImplementation((vals: unknown) => {
+							if (isTransactionValues(vals) && vals.type === "storage_daily") {
 								capturedAmount = vals.amountMicroCredits;
 							}
 							return Promise.resolve();

--- a/apps/web/__tests__/unit/developer-documentation-videos-page.test.ts
+++ b/apps/web/__tests__/unit/developer-documentation-videos-page.test.ts
@@ -155,7 +155,7 @@ describe("DeveloperDocumentationVideosPage FAQ schema", () => {
 	it("maps each FAQ to a Question entity with acceptedAnswer", () => {
 		const schema = createFAQSchema(faqs);
 
-		expect(schema.mainEntity[0]!).toEqual({
+		expect(schema.mainEntity[0]).toEqual({
 			"@type": "Question",
 			name: "What is a developer documentation video?",
 			acceptedAnswer: {

--- a/apps/web/__tests__/unit/hipaa-compliant-screen-recording-page.test.ts
+++ b/apps/web/__tests__/unit/hipaa-compliant-screen-recording-page.test.ts
@@ -146,7 +146,7 @@ describe("HipaaCompliantScreenRecordingPage FAQ schema", () => {
 	it("maps each FAQ to a Question entity with acceptedAnswer", () => {
 		const schema = createFAQSchema(faqs);
 
-		expect(schema.mainEntity[0]!).toEqual({
+		expect(schema.mainEntity[0]).toEqual({
 			"@type": "Question",
 			name: "Can Cap be used for HIPAA-compliant screen recording?",
 			acceptedAnswer: {

--- a/apps/web/__tests__/unit/mac-screen-recording-with-audio-page.test.ts
+++ b/apps/web/__tests__/unit/mac-screen-recording-with-audio-page.test.ts
@@ -171,7 +171,7 @@ describe("MacScreenRecordingWithAudioPage FAQ schema", () => {
 	it("maps each FAQ to a Question entity with acceptedAnswer", () => {
 		const schema = createFAQSchema(faqs);
 
-		expect(schema.mainEntity[0]!).toEqual({
+		expect(schema.mainEntity[0]).toEqual({
 			"@type": "Question",
 			name: "Why doesn't macOS record internal audio by default?",
 			acceptedAnswer: {

--- a/apps/web/__tests__/unit/mov-to-mp4-page.test.ts
+++ b/apps/web/__tests__/unit/mov-to-mp4-page.test.ts
@@ -109,7 +109,7 @@ describe("MOV to MP4 FAQ schema validity", () => {
 	it("maps each FAQ to a Question entity with acceptedAnswer", () => {
 		const schema = createFAQSchema(faqs);
 
-		expect(schema.mainEntity[0]!).toEqual({
+		expect(schema.mainEntity[0]).toEqual({
 			"@type": "Question",
 			name: "How do I convert MOV to MP4 online?",
 			acceptedAnswer: {

--- a/apps/web/__tests__/unit/mp4-to-gif-page.test.ts
+++ b/apps/web/__tests__/unit/mp4-to-gif-page.test.ts
@@ -109,7 +109,7 @@ describe("MP4 to GIF FAQ schema validity", () => {
 	it("maps each FAQ to a Question entity with acceptedAnswer", () => {
 		const schema = createFAQSchema(faqs);
 
-		expect(schema.mainEntity[0]!).toEqual({
+		expect(schema.mainEntity[0]).toEqual({
 			"@type": "Question",
 			name: "How do I convert MP4 to GIF?",
 			acceptedAnswer: {

--- a/apps/web/__tests__/unit/obs-alternative-page.test.ts
+++ b/apps/web/__tests__/unit/obs-alternative-page.test.ts
@@ -148,7 +148,7 @@ describe("ObsAlternativePage FAQ schema", () => {
 	it("maps each FAQ to a Question entity with acceptedAnswer", () => {
 		const schema = createFAQSchema(faqs);
 
-		expect(schema.mainEntity[0]!).toEqual({
+		expect(schema.mainEntity[0]).toEqual({
 			"@type": "Question",
 			name: "Why would I use Cap instead of OBS Studio?",
 			acceptedAnswer: {

--- a/apps/web/__tests__/unit/open-source-screen-recorder-page.test.ts
+++ b/apps/web/__tests__/unit/open-source-screen-recorder-page.test.ts
@@ -144,7 +144,7 @@ describe("OpenSourceScreenRecorderPage FAQ schema", () => {
 	it("maps each FAQ to a Question entity with acceptedAnswer", () => {
 		const schema = createFAQSchema(faqs);
 
-		expect(schema.mainEntity[0]!).toEqual({
+		expect(schema.mainEntity[0]).toEqual({
 			"@type": "Question",
 			name: "Is Cap really open source?",
 			acceptedAnswer: {

--- a/apps/web/__tests__/unit/self-hosted-screen-recording-page.test.ts
+++ b/apps/web/__tests__/unit/self-hosted-screen-recording-page.test.ts
@@ -147,7 +147,7 @@ describe("SelfHostedScreenRecordingPage FAQ schema", () => {
 	it("maps each FAQ to a Question entity with acceptedAnswer", () => {
 		const schema = createFAQSchema(faqs);
 
-		expect(schema.mainEntity[0]!).toEqual({
+		expect(schema.mainEntity[0]).toEqual({
 			"@type": "Question",
 			name: "Can Cap be self-hosted?",
 			acceptedAnswer: {

--- a/apps/web/__tests__/unit/video-frame-thumbnail.test.ts
+++ b/apps/web/__tests__/unit/video-frame-thumbnail.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-	type CaptureVideoFrameDeps,
-	captureVideoFrameDataUrl,
-} from "@/app/s/[videoId]/_components/video-frame-thumbnail";
+import { captureVideoFrameDataUrl } from "@/app/s/[videoId]/_components/video-frame-thumbnail";
 
 function createMockCanvas(options?: {
 	contextReturnsNull?: boolean;

--- a/apps/web/__tests__/unit/video-recording-software-page.test.ts
+++ b/apps/web/__tests__/unit/video-recording-software-page.test.ts
@@ -143,7 +143,7 @@ describe("VideoRecordingSoftwarePage FAQ schema", () => {
 	it("maps each FAQ to a Question entity with acceptedAnswer", () => {
 		const schema = createFAQSchema(faqs);
 
-		expect(schema.mainEntity[0]!).toEqual({
+		expect(schema.mainEntity[0]).toEqual({
 			"@type": "Question",
 			name: "What is video recording software?",
 			acceptedAnswer: {

--- a/apps/web/__tests__/unit/video-speed-controller-page.test.ts
+++ b/apps/web/__tests__/unit/video-speed-controller-page.test.ts
@@ -109,7 +109,7 @@ describe("Video Speed Controller FAQ schema validity", () => {
 	it("maps each FAQ to a Question entity with acceptedAnswer", () => {
 		const schema = createFAQSchema(faqs);
 
-		expect(schema.mainEntity[0]!).toEqual({
+		expect(schema.mainEntity[0]).toEqual({
 			"@type": "Question",
 			name: "How do I change the speed of a video online?",
 			acceptedAnswer: {

--- a/apps/web/__tests__/unit/webm-to-mp4-page.test.ts
+++ b/apps/web/__tests__/unit/webm-to-mp4-page.test.ts
@@ -114,7 +114,7 @@ describe("WebM to MP4 FAQ schema validity", () => {
 	it("maps each FAQ to a Question entity with acceptedAnswer", () => {
 		const schema = createFAQSchema(faqs);
 
-		expect(schema.mainEntity[0]!).toEqual({
+		expect(schema.mainEntity[0]).toEqual({
 			"@type": "Question",
 			name: "How do I convert WebM to MP4 online?",
 			acceptedAnswer: {

--- a/apps/web/app/(org)/dashboard/_components/Navbar/SpaceDialog.tsx
+++ b/apps/web/app/(org)/dashboard/_components/Navbar/SpaceDialog.tsx
@@ -223,14 +223,19 @@ export const NewSpaceForm: React.FC<NewSpaceFormProps> = (props) => {
 						form.reset();
 						setSelectedFile(null);
 						props.onSpaceCreated();
-					} catch (error: any) {
+					} catch (error) {
 						console.error(
 							edit ? "Error updating space:" : "Error creating space:",
 							error,
 						);
+						const message =
+							error instanceof Error
+								? error.message
+								: edit
+									? "Failed to update space"
+									: "Failed to create space";
 						toast.error(
-							error?.message ||
-								error?.error ||
+							message ||
 								(edit ? "Failed to update space" : "Failed to create space"),
 						);
 					} finally {

--- a/apps/web/app/(site)/(seo)/async-video-code-reviews/page.tsx
+++ b/apps/web/app/(site)/(seo)/async-video-code-reviews/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import {
 	AsyncVideoCodeReviewsPage,
 	asyncVideoCodeReviewsContent,
@@ -42,15 +41,9 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(
-						createFAQSchema(asyncVideoCodeReviewsContent.faqs),
-					),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(createFAQSchema(asyncVideoCodeReviewsContent.faqs))}
+			</script>
 			<AsyncVideoCodeReviewsPage />
 		</>
 	);

--- a/apps/web/app/(site)/(seo)/best-screen-recorder/page.tsx
+++ b/apps/web/app/(site)/(seo)/best-screen-recorder/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import {
 	BestScreenRecorderPage,
 	bestScreenRecorderContent,
@@ -44,15 +43,9 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(
-						createFAQSchema(bestScreenRecorderContent.faqs),
-					),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(createFAQSchema(bestScreenRecorderContent.faqs))}
+			</script>
 			<BestScreenRecorderPage />
 		</>
 	);

--- a/apps/web/app/(site)/(seo)/developer-documentation-videos/page.tsx
+++ b/apps/web/app/(site)/(seo)/developer-documentation-videos/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import {
 	DeveloperDocumentationVideosPage,
 	developerDocumentationVideosContent,
@@ -45,15 +44,11 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(
-						createFAQSchema(developerDocumentationVideosContent.faqs),
-					),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(
+					createFAQSchema(developerDocumentationVideosContent.faqs),
+				)}
+			</script>
 			<DeveloperDocumentationVideosPage />
 		</>
 	);

--- a/apps/web/app/(site)/(seo)/free-screen-recorder/page.tsx
+++ b/apps/web/app/(site)/(seo)/free-screen-recorder/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import {
 	FreeScreenRecorderPage,
 	freeScreenRecorderContent,
@@ -42,15 +41,9 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(
-						createFAQSchema(freeScreenRecorderContent.faqs),
-					),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(createFAQSchema(freeScreenRecorderContent.faqs))}
+			</script>
 			<FreeScreenRecorderPage />
 		</>
 	);

--- a/apps/web/app/(site)/(seo)/hipaa-compliant-screen-recording/page.tsx
+++ b/apps/web/app/(site)/(seo)/hipaa-compliant-screen-recording/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import {
 	HipaaCompliantScreenRecordingPage,
 	hipaaCompliantScreenRecordingContent,
@@ -45,15 +44,11 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(
-						createFAQSchema(hipaaCompliantScreenRecordingContent.faqs),
-					),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(
+					createFAQSchema(hipaaCompliantScreenRecordingContent.faqs),
+				)}
+			</script>
 			<HipaaCompliantScreenRecordingPage />
 		</>
 	);

--- a/apps/web/app/(site)/(seo)/how-to-screen-record/page.tsx
+++ b/apps/web/app/(site)/(seo)/how-to-screen-record/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import {
 	HowToScreenRecordPage,
 	howToScreenRecordContent,
@@ -61,30 +60,20 @@ const howToSteps = [
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(
-						createFAQSchema(howToScreenRecordContent.faqs),
-					),
-				}}
-			/>
-			<Script
-				id="howto-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(
-						createHowToSchema({
-							name: "How to Screen Record on Mac, Windows & Chrome",
-							description:
-								"Learn how to screen record with audio on Mac, Windows, or in your browser using Cap, the free open-source screen recorder.",
-							totalTime: "PT2M",
-							steps: howToSteps,
-						}),
-					),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(createFAQSchema(howToScreenRecordContent.faqs))}
+			</script>
+			<script type="application/ld+json">
+				{JSON.stringify(
+					createHowToSchema({
+						name: "How to Screen Record on Mac, Windows & Chrome",
+						description:
+							"Learn how to screen record with audio on Mac, Windows, or in your browser using Cap, the free open-source screen recorder.",
+						totalTime: "PT2M",
+						steps: howToSteps,
+					}),
+				)}
+			</script>
 			<HowToScreenRecordPage />
 		</>
 	);

--- a/apps/web/app/(site)/(seo)/mac-screen-recording-with-audio/page.tsx
+++ b/apps/web/app/(site)/(seo)/mac-screen-recording-with-audio/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import {
 	MacScreenRecordingWithAudioPage,
 	macScreenRecordingWithAudioContent,
@@ -42,15 +41,11 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(
-						createFAQSchema(macScreenRecordingWithAudioContent.faqs),
-					),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(
+					createFAQSchema(macScreenRecordingWithAudioContent.faqs),
+				)}
+			</script>
 			<MacScreenRecordingWithAudioPage />
 		</>
 	);

--- a/apps/web/app/(site)/(seo)/obs-alternative/page.tsx
+++ b/apps/web/app/(site)/(seo)/obs-alternative/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import {
 	ObsAlternativePage,
 	obsAlternativeContent,
@@ -44,13 +43,9 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(createFAQSchema(obsAlternativeContent.faqs)),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(createFAQSchema(obsAlternativeContent.faqs))}
+			</script>
 			<ObsAlternativePage />
 		</>
 	);

--- a/apps/web/app/(site)/(seo)/open-source-screen-recorder/page.tsx
+++ b/apps/web/app/(site)/(seo)/open-source-screen-recorder/page.tsx
@@ -42,9 +42,7 @@ export default function Page() {
 	return (
 		<>
 			<script type="application/ld+json">
-				{JSON.stringify(
-					createFAQSchema(openSourceScreenRecorderContent.faqs),
-				)}
+				{JSON.stringify(createFAQSchema(openSourceScreenRecorderContent.faqs))}
 			</script>
 			<OpenSourceScreenRecorderPage />
 		</>

--- a/apps/web/app/(site)/(seo)/open-source-screen-recorder/page.tsx
+++ b/apps/web/app/(site)/(seo)/open-source-screen-recorder/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import {
 	OpenSourceScreenRecorderPage,
 	openSourceScreenRecorderContent,
@@ -42,15 +41,11 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(
-						createFAQSchema(openSourceScreenRecorderContent.faqs),
-					),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(
+					createFAQSchema(openSourceScreenRecorderContent.faqs),
+				)}
+			</script>
 			<OpenSourceScreenRecorderPage />
 		</>
 	);

--- a/apps/web/app/(site)/(seo)/record-screen/page.tsx
+++ b/apps/web/app/(site)/(seo)/record-screen/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import {
 	RecordScreenPage,
 	recordScreenContent,
@@ -42,13 +41,9 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(createFAQSchema(recordScreenContent.faqs)),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(createFAQSchema(recordScreenContent.faqs))}
+			</script>
 			<RecordScreenPage />
 		</>
 	);

--- a/apps/web/app/(site)/(seo)/screen-recorder/page.tsx
+++ b/apps/web/app/(site)/(seo)/screen-recorder/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import {
 	ScreenRecorderPage,
 	screenRecorderContent,
@@ -44,13 +43,9 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(createFAQSchema(screenRecorderContent.faqs)),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(createFAQSchema(screenRecorderContent.faqs))}
+			</script>
 			<ScreenRecorderPage />
 		</>
 	);

--- a/apps/web/app/(site)/(seo)/screen-recording/page.tsx
+++ b/apps/web/app/(site)/(seo)/screen-recording/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import {
 	ScreenRecordingPage,
 	screenRecordingContent,
@@ -42,13 +41,9 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(createFAQSchema(screenRecordingContent.faqs)),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(createFAQSchema(screenRecordingContent.faqs))}
+			</script>
 			<ScreenRecordingPage />
 		</>
 	);

--- a/apps/web/app/(site)/(seo)/self-hosted-screen-recording/page.tsx
+++ b/apps/web/app/(site)/(seo)/self-hosted-screen-recording/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import {
 	SelfHostedScreenRecordingPage,
 	selfHostedScreenRecordingContent,
@@ -45,15 +44,11 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(
-						createFAQSchema(selfHostedScreenRecordingContent.faqs),
-					),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(
+					createFAQSchema(selfHostedScreenRecordingContent.faqs),
+				)}
+			</script>
 			<SelfHostedScreenRecordingPage />
 		</>
 	);

--- a/apps/web/app/(site)/(seo)/self-hosted-screen-recording/page.tsx
+++ b/apps/web/app/(site)/(seo)/self-hosted-screen-recording/page.tsx
@@ -45,9 +45,7 @@ export default function Page() {
 	return (
 		<>
 			<script type="application/ld+json">
-				{JSON.stringify(
-					createFAQSchema(selfHostedScreenRecordingContent.faqs),
-				)}
+				{JSON.stringify(createFAQSchema(selfHostedScreenRecordingContent.faqs))}
 			</script>
 			<SelfHostedScreenRecordingPage />
 		</>

--- a/apps/web/app/(site)/(seo)/video-recording-software/page.tsx
+++ b/apps/web/app/(site)/(seo)/video-recording-software/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import {
 	VideoRecordingSoftwarePage,
 	videoRecordingSoftwareContent,
@@ -42,15 +41,9 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(
-						createFAQSchema(videoRecordingSoftwareContent.faqs),
-					),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(createFAQSchema(videoRecordingSoftwareContent.faqs))}
+			</script>
 			<VideoRecordingSoftwarePage />
 		</>
 	);

--- a/apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx
+++ b/apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx
@@ -481,7 +481,7 @@ export function CapVideoPlayer({
 	const generateVideoFrameThumbnail = useCallback(
 		(_time: number): string | undefined =>
 			captureVideoFrameDataUrl({ video: videoRef.current }),
-		[],
+		[videoRef.current],
 	);
 
 	const isUploadFailed = uploadProgress?.status === "failed";

--- a/biome.json
+++ b/biome.json
@@ -8,6 +8,8 @@
 	"files": {
 		"includes": [
 			"**",
+			"!**/tauri.ts",
+			"!**/queries.ts",
 			"!apps/desktop/src/utils/tauri.ts",
 			"!apps/desktop/src/global.d.ts",
 			"!apps/web/public/gif.worker.js",

--- a/crates/camera/src/macos.rs
+++ b/crates/camera/src/macos.rs
@@ -116,6 +116,7 @@ pub(super) fn start_capturing_impl(
     let mut output = av::capture::VideoDataOutput::new();
     let mut session = av::capture::Session::new();
     let mut added_input = false;
+    let pixel_format = format.native().format_desc().media_sub_type();
 
     session.configure(|s| {
         if s.can_add_input(&input) {
@@ -134,6 +135,16 @@ pub(super) fn start_capturing_impl(
         )
         .into());
     }
+
+    let video_settings = ns::Dictionary::with_keys_values(
+        &[cv::pixel_buffer_keys::pixel_format().as_ns()],
+        &[ns::Number::with_u32(pixel_format).as_id_ref()],
+    );
+    output
+        .set_video_settings(Some(video_settings.as_ref()))
+        .map_err(|err| {
+            AVFoundationError::Message(format!("Failed to set camera video settings: {err}"))
+        })?;
 
     output.set_sample_buf_delegate(Some(delegate.as_ref()), Some(&queue));
 

--- a/crates/editor/src/audio.rs
+++ b/crates/editor/src/audio.rs
@@ -619,6 +619,11 @@ impl<T: FromSampleBytes> PrerenderedAudioBuffer<T> {
         self.read_position = sample_position.min(self.samples.len());
     }
 
+    pub fn current_audible_playhead(&self, device_latency_secs: f64) -> f64 {
+        let generated_secs = (self.read_position / self.channels) as f64 / self.sample_rate as f64;
+        (generated_secs - device_latency_secs.max(0.0)).max(0.0)
+    }
+
     #[allow(dead_code)]
     pub fn current_playhead_secs(&self) -> f64 {
         (self.read_position / self.channels) as f64 / self.sample_rate as f64

--- a/crates/editor/src/audio.rs
+++ b/crates/editor/src/audio.rs
@@ -797,6 +797,21 @@ mod tests {
     }
 
     #[test]
+    fn prerendered_audio_reports_audible_playhead_after_output_latency() {
+        let mut buffer = PrerenderedAudioBuffer::<f32> {
+            samples: vec![0.0; AudioData::SAMPLE_RATE as usize * 2],
+            read_position: 0,
+            sample_rate: AudioData::SAMPLE_RATE,
+            channels: 2,
+        };
+
+        buffer.set_playhead(0.5);
+
+        assert!((buffer.current_audible_playhead(0.2) - 0.3).abs() < 0.000_1);
+        assert_eq!(buffer.current_audible_playhead(1.0), 0.0);
+    }
+
+    #[test]
     fn speed_segment_start_cuts_audio_inside_a_single_request() {
         let (_dir, mut renderer, project) = build_renderer_fixture();
         let boundary = 1.0 + 0.25 + 1.0 + 1.0;

--- a/crates/editor/src/playback.rs
+++ b/crates/editor/src/playback.rs
@@ -1379,14 +1379,13 @@ impl AudioPlayback {
 
         let mut output_info = AudioInfo::from_stream_config(&supported_config);
         output_info.sample_format = output_info.sample_format.packed();
-        // Clamp output info for FFmpeg compatibility (max 8 channels)
         output_info = output_info.for_ffmpeg_output();
 
         let mut config = supported_config.config();
-        // Match stream config channels to clamped output info
         config.channels = output_info.channels as u16;
 
         let sample_rate = output_info.sample_rate;
+        let buffer_size = output_info.buffer_size;
 
         let playhead = f64::from(start_frame_number) / f64::from(fps);
 
@@ -1405,7 +1404,32 @@ impl AudioPlayback {
             duration_secs,
         );
 
-        audio_buffer.set_playhead(playhead);
+        #[cfg(not(target_os = "windows"))]
+        let mut latency_corrector = {
+            let hint = default_output_latency_hint(sample_rate, buffer_size);
+            if let Some(hint) = hint
+                && hint.latency_secs > 0.0
+            {
+                if hint.transport.is_wireless() {
+                    info!(
+                        "Applying wireless pre-rendered audio output latency hint: {:.1} ms",
+                        hint.latency_secs * 1_000.0
+                    );
+                } else {
+                    info!(
+                        "Applying pre-rendered audio output latency hint: {:.1} ms",
+                        hint.latency_secs * 1_000.0
+                    );
+                }
+            }
+            LatencyCorrector::new(hint, LatencyCorrectionConfig::default())
+        };
+        #[cfg(not(target_os = "windows"))]
+        let initial_compensation_secs = latency_corrector.initial_compensation_secs();
+        #[cfg(target_os = "windows")]
+        let initial_compensation_secs = 0.0;
+
+        audio_buffer.set_playhead(playhead + initial_compensation_secs);
 
         let mut playhead_rx_for_stream = playhead_rx.clone();
         let mut last_video_playhead = playhead;
@@ -1413,13 +1437,23 @@ impl AudioPlayback {
         let stream = device
             .build_output_stream(
                 &config,
-                move |buffer: &mut [T], _info| {
+                move |buffer: &mut [T], info| {
+                    #[cfg(not(target_os = "windows"))]
+                    let latency_secs = latency_corrector.update_from_callback(info);
+                    #[cfg(target_os = "windows")]
+                    let latency_secs = {
+                        let _ = info;
+                        0.0
+                    };
+
                     if playhead_rx_for_stream.has_changed().unwrap_or(false) {
                         let video_playhead = *playhead_rx_for_stream.borrow_and_update();
                         let jump = (video_playhead - last_video_playhead).abs();
+                        let audible_playhead = audio_buffer.current_audible_playhead(latency_secs);
+                        let drift = (video_playhead - audible_playhead).abs();
 
-                        if jump > 0.05 {
-                            audio_buffer.set_playhead(video_playhead);
+                        if jump > 0.05 || drift > 0.04 {
+                            audio_buffer.set_playhead(video_playhead + latency_secs);
                         }
 
                         last_video_playhead = video_playhead;

--- a/crates/editor/src/playback.rs
+++ b/crates/editor/src/playback.rs
@@ -1384,7 +1384,9 @@ impl AudioPlayback {
         let mut config = supported_config.config();
         config.channels = output_info.channels as u16;
 
+        #[cfg(not(target_os = "windows"))]
         let sample_rate = output_info.sample_rate;
+        #[cfg(not(target_os = "windows"))]
         let buffer_size = output_info.buffer_size;
 
         let playhead = f64::from(start_frame_number) / f64::from(fps);
@@ -1392,7 +1394,7 @@ impl AudioPlayback {
         info!(
             duration_secs = duration_secs,
             start_playhead = playhead,
-            sample_rate = sample_rate,
+            sample_rate = output_info.sample_rate,
             "Creating pre-rendered audio stream"
         );
 

--- a/crates/enc-avfoundation/src/mp4.rs
+++ b/crates/enc-avfoundation/src/mp4.rs
@@ -861,6 +861,8 @@ impl MP4Encoder {
         let nanos = (numerator / denominator).max(1);
 
         Duration::from_nanos(nanos as u64)
+    }
+
     fn minimum_video_pts_step(&self) -> Duration {
         let nanos = (self.video_frame_duration().as_nanos() / 4).max(1);
         Duration::from_nanos(nanos.min(u64::MAX as u128) as u64)

--- a/crates/enc-avfoundation/src/mp4.rs
+++ b/crates/enc-avfoundation/src/mp4.rs
@@ -868,8 +868,6 @@ impl MP4Encoder {
         Duration::from_nanos(nanos.min(u64::MAX as u128) as u64)
     }
 
-    }
-
     pub fn pause(&mut self) {
         if self.is_paused || !self.is_writing {
             return;
@@ -1018,9 +1016,6 @@ fn timescale_value_to_duration(value: i64, timescale: i32) -> Duration {
 
 const MIN_STUDIO_BITRATE: f32 = 8_000_000.0;
 const MAX_ULTRA_BITRATE: f32 = 120_000_000.0;
-
-fn get_average_bitrate(width: f32, height: f32, fps: f32) -> f32 {
-    let pixels = width * height;
 const MIN_COMPATIBILITY_BITRATE: f32 = 2_500_000.0;
 const MAX_COMPATIBILITY_BITRATE: f32 = 10_000_000.0;
 
@@ -1031,6 +1026,9 @@ pub enum BitrateProfile {
     Balanced,
     Ultra,
 }
+
+fn get_average_bitrate(width: f32, height: f32, fps: f32) -> f32 {
+    let pixels = width * height;
     let fps_factor = fps.min(60.0) / 30.0;
     (pixels * fps_factor * 5.0).max(MIN_STUDIO_BITRATE)
 }
@@ -1041,15 +1039,15 @@ fn get_ultra_bitrate(width: f32, height: f32, fps: f32) -> f32 {
     (pixels * fps_factor * 10.0).clamp(MIN_STUDIO_BITRATE, MAX_ULTRA_BITRATE)
 }
 
-fn get_instant_mode_bitrate(width: f32, height: f32, fps: f32) -> f32 {
-    let pixel_ratio = width * height / (1920.0 * 1080.0);
-    let fps_ratio = fps.min(60.0) / 30.0;
 fn get_compatibility_bitrate(width: f32, height: f32, fps: f32) -> f32 {
     let pixels = width * height;
     let fps_factor = fps.min(60.0) / 30.0;
     (pixels * fps_factor * 2.5).clamp(MIN_COMPATIBILITY_BITRATE, MAX_COMPATIBILITY_BITRATE)
 }
 
+fn get_instant_mode_bitrate(width: f32, height: f32, fps: f32) -> f32 {
+    let pixel_ratio = width * height / (1920.0 * 1080.0);
+    let fps_ratio = fps.min(60.0) / 30.0;
     1_500_000.0 + pixel_ratio * 1_500_000.0 + fps_ratio * 500_000.0
 }
 
@@ -3515,6 +3513,49 @@ mod tests {
         );
 
         let _ = encoder.finish(Some(Duration::from_secs(15)));
+        let _ = std::fs::remove_file(&output);
+    }
+
+    #[test]
+    fn regression_tiny_positive_pts_step_is_expanded() {
+        let output = test_output_path("tiny_positive_pts_step");
+        let video = valid_video_config();
+
+        let mut encoder = MP4Encoder::init(output.clone(), video, None, None).unwrap();
+        let pool = create_pixel_buffer_pool(1920, 1080);
+
+        let timestamps = [0u64, 33_333, 33_334, 66_666, 100_000, 133_333];
+        let mut errors = Vec::new();
+
+        for ts_us in timestamps {
+            let frame = create_test_video_frame(&pool, ts_us as i64, 33_333);
+            match encoder.queue_video_frame(frame, Duration::from_micros(ts_us)) {
+                Ok(()) => {}
+                Err(QueueFrameError::WriterFailed(e)) => {
+                    errors.push(format!("WriterFailed at {ts_us}: {e}"));
+                    break;
+                }
+                Err(QueueFrameError::Failed) => {
+                    errors.push(format!("Failed at {ts_us}"));
+                    break;
+                }
+                Err(QueueFrameError::Finished) => {
+                    errors.push(format!("Finished at {ts_us}"));
+                    break;
+                }
+                Err(_) => {}
+            }
+        }
+
+        assert!(
+            errors.is_empty(),
+            "Tiny positive PTS steps should not reach AVFoundation: {:?}",
+            errors
+        );
+
+        let result = encoder.finish(Some(Duration::from_micros(166_666)));
+        assert!(result.is_ok(), "Finish failed: {result:?}");
+
         let _ = std::fs::remove_file(&output);
     }
 

--- a/crates/enc-avfoundation/src/mp4.rs
+++ b/crates/enc-avfoundation/src/mp4.rs
@@ -799,10 +799,8 @@ impl MP4Encoder {
             dts: cm::Time::invalid(),
         };
 
-        let timed_frame = match pending
-            .raw_frame
-            .copy_with_new_timing(&[timing])
-            .or_else(|_| rebuild_video_sample_buf(&pending.raw_frame, timing))
+        let timed_frame = match rebuild_video_sample_buf(&pending.raw_frame, timing)
+            .or_else(|_| pending.raw_frame.copy_with_new_timing(&[timing]))
         {
             Ok(f) => f,
             Err(e) => {

--- a/crates/enc-avfoundation/src/mp4.rs
+++ b/crates/enc-avfoundation/src/mp4.rs
@@ -534,7 +534,7 @@ impl MP4Encoder {
         let effective_last_pts = self.effective_video_pts();
 
         if let Some(last_pts) = effective_last_pts
-            && pts_duration <= last_pts
+            && pts_duration <= last_pts.saturating_add(self.minimum_video_pts_step())
         {
             let frame_duration = self.video_frame_duration();
             let adjusted_pts = last_pts + frame_duration;
@@ -863,6 +863,11 @@ impl MP4Encoder {
         let nanos = (numerator / denominator).max(1);
 
         Duration::from_nanos(nanos as u64)
+    fn minimum_video_pts_step(&self) -> Duration {
+        let nanos = (self.video_frame_duration().as_nanos() / 4).max(1);
+        Duration::from_nanos(nanos.min(u64::MAX as u128) as u64)
+    }
+
     }
 
     pub fn pause(&mut self) {

--- a/crates/enc-avfoundation/src/mp4.rs
+++ b/crates/enc-avfoundation/src/mp4.rs
@@ -124,7 +124,7 @@ impl MP4Encoder {
             video_config,
             audio_config,
             output_height,
-            false,
+            BitrateProfile::Balanced,
             false,
         )
     }
@@ -140,8 +140,24 @@ impl MP4Encoder {
             video_config,
             audio_config,
             output_height,
+            BitrateProfile::Ultra,
             false,
-            true,
+        )
+    }
+
+    pub fn init_compatibility(
+        output: PathBuf,
+        video_config: VideoInfo,
+        audio_config: Option<AudioInfo>,
+        output_height: Option<u32>,
+    ) -> Result<Self, InitError> {
+        Self::init_with_options(
+            output,
+            video_config,
+            audio_config,
+            output_height,
+            BitrateProfile::Compatibility,
+            false,
         )
     }
 
@@ -156,8 +172,8 @@ impl MP4Encoder {
             video_config,
             audio_config,
             output_height,
+            BitrateProfile::Balanced,
             true,
-            false,
         )
     }
 
@@ -166,9 +182,10 @@ impl MP4Encoder {
         video_config: VideoInfo,
         audio_config: Option<AudioInfo>,
         output_height: Option<u32>,
+        bitrate_profile: BitrateProfile,
         instant_mode: bool,
-        ultra_quality: bool,
     ) -> Result<Self, InitError> {
+        let ultra_quality = matches!(bitrate_profile, BitrateProfile::Ultra);
         info!(
             width = video_config.width,
             height = video_config.height,
@@ -258,19 +275,27 @@ impl MP4Encoder {
 
             let bitrate = if instant_mode {
                 get_instant_mode_bitrate(output_width as f32, output_height as f32, fps)
-            } else if ultra_quality {
-                get_ultra_bitrate(output_width as f32, output_height as f32, fps)
             } else {
-                get_average_bitrate(output_width as f32, output_height as f32, fps)
+                match bitrate_profile {
+                    BitrateProfile::Ultra => {
+                        get_ultra_bitrate(output_width as f32, output_height as f32, fps)
+                    }
+                    BitrateProfile::Balanced => {
+                        get_average_bitrate(output_width as f32, output_height as f32, fps)
+                    }
+                    BitrateProfile::Compatibility => {
+                        get_compatibility_bitrate(output_width as f32, output_height as f32, fps)
+                    }
+                }
             };
 
-            debug!(instant_mode, ultra_quality, "recording bitrate: {bitrate}");
+            debug!(
+                instant_mode,
+                ?bitrate_profile,
+                "recording bitrate: {bitrate}"
+            );
 
-            let keyframe_interval = if instant_mode {
-                fps as i32
-            } else {
-                (fps * 2.0) as i32
-            };
+            let keyframe_interval = fps as i32;
 
             let allow_frame_reordering = ultra_quality && !instant_mode;
 
@@ -991,6 +1016,16 @@ const MAX_ULTRA_BITRATE: f32 = 120_000_000.0;
 
 fn get_average_bitrate(width: f32, height: f32, fps: f32) -> f32 {
     let pixels = width * height;
+const MIN_COMPATIBILITY_BITRATE: f32 = 2_500_000.0;
+const MAX_COMPATIBILITY_BITRATE: f32 = 10_000_000.0;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub enum BitrateProfile {
+    Compatibility,
+    #[default]
+    Balanced,
+    Ultra,
+}
     let fps_factor = fps.min(60.0) / 30.0;
     (pixels * fps_factor * 5.0).max(MIN_STUDIO_BITRATE)
 }
@@ -1004,6 +1039,12 @@ fn get_ultra_bitrate(width: f32, height: f32, fps: f32) -> f32 {
 fn get_instant_mode_bitrate(width: f32, height: f32, fps: f32) -> f32 {
     let pixel_ratio = width * height / (1920.0 * 1080.0);
     let fps_ratio = fps.min(60.0) / 30.0;
+fn get_compatibility_bitrate(width: f32, height: f32, fps: f32) -> f32 {
+    let pixels = width * height;
+    let fps_factor = fps.min(60.0) / 30.0;
+    (pixels * fps_factor * 2.5).clamp(MIN_COMPATIBILITY_BITRATE, MAX_COMPATIBILITY_BITRATE)
+}
+
     1_500_000.0 + pixel_ratio * 1_500_000.0 + fps_ratio * 500_000.0
 }
 

--- a/crates/export/tests/export_benchmark.rs
+++ b/crates/export/tests/export_benchmark.rs
@@ -137,7 +137,7 @@ pub fn list_recordings() -> Vec<PathBuf> {
         })
         .collect();
 
-    recordings.sort_by(|a, b| b.0.cmp(&a.0));
+    recordings.sort_by_key(|entry| std::cmp::Reverse(entry.0));
 
     recordings.into_iter().map(|(_, path)| path).collect()
 }

--- a/crates/recording/examples/quality-comparison.rs
+++ b/crates/recording/examples/quality-comparison.rs
@@ -62,6 +62,7 @@ async fn run_recording(
     max_fps: u32,
 ) -> Result<RecordingResult, Box<dyn std::error::Error>> {
     let quality_label = match quality {
+        StudioQuality::Compatibility => "Compatibility",
         StudioQuality::Balanced => "Balanced",
         StudioQuality::Ultra => "Ultra",
     };
@@ -185,6 +186,7 @@ fn print_comparison(results: &[RecordingResult]) {
 
     for r in results {
         let quality_label = match r.quality {
+            StudioQuality::Compatibility => "Compatibility",
             StudioQuality::Balanced => "Balanced",
             StudioQuality::Ultra => "Ultra",
         };
@@ -216,6 +218,7 @@ fn print_comparison(results: &[RecordingResult]) {
                 let a_label = format!(
                     "{} ({})",
                     match a.quality {
+                        StudioQuality::Compatibility => "Compatibility",
                         StudioQuality::Balanced => "Balanced",
                         StudioQuality::Ultra => "Ultra",
                     },
@@ -224,6 +227,7 @@ fn print_comparison(results: &[RecordingResult]) {
                 let b_label = format!(
                     "{} ({})",
                     match b.quality {
+                        StudioQuality::Compatibility => "Compatibility",
                         StudioQuality::Balanced => "Balanced",
                         StudioQuality::Ultra => "Ultra",
                     },
@@ -250,6 +254,7 @@ fn print_comparison(results: &[RecordingResult]) {
     println!("Output paths:");
     for r in results {
         let quality_label = match r.quality {
+            StudioQuality::Compatibility => "Compatibility",
             StudioQuality::Balanced => "Balanced",
             StudioQuality::Ultra => "Ultra",
         };

--- a/crates/recording/src/capture_pipeline.rs
+++ b/crates/recording/src/capture_pipeline.rs
@@ -93,10 +93,12 @@ impl MakeCapturePipeline for screen_capture::CMSampleBufferCapture {
         quality: StudioQuality,
     ) -> anyhow::Result<OutputPipeline> {
         let ultra = quality == StudioQuality::Ultra;
+        let compatibility = quality == StudioQuality::Compatibility;
 
         tracing::debug!(
             ?quality,
             ultra,
+            compatibility,
             fragmented,
             use_oop_muxer,
             "Studio mode capture pipeline quality selection"
@@ -110,6 +112,8 @@ impl MakeCapturePipeline for screen_capture::CMSampleBufferCapture {
 
             let bpp = if ultra {
                 H264EncoderBuilder::ULTRA_BPP
+            } else if compatibility {
+                H264EncoderBuilder::QUALITY_BPP * 0.5
             } else {
                 H264EncoderBuilder::QUALITY_BPP
             };
@@ -186,6 +190,7 @@ impl MakeCapturePipeline for screen_capture::CMSampleBufferCapture {
                     output_height: output_size.map(|(_, h)| h),
                     instant_mode: false,
                     ultra_quality: ultra,
+                    compatibility_quality: compatibility,
                 })
                 .await
         }

--- a/crates/recording/src/feeds/camera.rs
+++ b/crates/recording/src/feeds/camera.rs
@@ -235,6 +235,10 @@ pub struct AddSender(pub flume::Sender<FFmpegVideoFrame>);
 
 pub struct AddNativeSender(pub flume::Sender<NativeCameraFrame>);
 
+pub struct RemoveSender(pub flume::Sender<FFmpegVideoFrame>);
+
+pub struct RemoveNativeSender(pub flume::Sender<NativeCameraFrame>);
+
 pub struct ListenForReady(pub oneshot::Sender<()>);
 
 pub struct OnFeedDisconnect(pub Box<dyn Fn() + Send>);
@@ -844,6 +848,31 @@ impl Message<OnFeedDisconnect> for CameraFeed {
         _: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         self.on_disconnect.push(msg.0);
+    }
+}
+
+impl Message<RemoveSender> for CameraFeed {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: RemoveSender,
+        _: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.senders.retain(|sender| !sender.same_channel(&msg.0));
+    }
+}
+
+impl Message<RemoveNativeSender> for CameraFeed {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: RemoveNativeSender,
+        _: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.native_senders
+            .retain(|sender| !sender.same_channel(&msg.0));
     }
 }
 

--- a/crates/recording/src/feeds/camera.rs
+++ b/crates/recording/src/feeds/camera.rs
@@ -453,6 +453,10 @@ struct SetupCameraResult {
 }
 
 static CAMERA_CALLBACK_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+const TARGET_CAMERA_WIDTH: u32 = 1280;
+const TARGET_CAMERA_HEIGHT: u32 = 720;
+const TARGET_CAMERA_FRAME_RATE: f32 = 30.0;
+const MIN_CAMERA_FRAME_RATE: f32 = 24.0;
 
 fn select_camera_format(
     camera: &cap_camera::CameraInfo,
@@ -465,8 +469,36 @@ fn select_camera_format(
     let mut ideal_formats = formats
         .clone()
         .into_iter()
-        .filter(|f| f.frame_rate() >= 30.0 && f.width() < 2000 && f.height() < 2000)
+        .filter(|f| {
+            f.frame_rate() >= MIN_CAMERA_FRAME_RATE
+                && f.frame_rate() <= TARGET_CAMERA_FRAME_RATE
+                && f.width() <= TARGET_CAMERA_WIDTH
+                && f.height() <= TARGET_CAMERA_HEIGHT
+        })
         .collect::<Vec<_>>();
+
+    if ideal_formats.is_empty() {
+        ideal_formats = formats
+            .clone()
+            .into_iter()
+            .filter(|f| {
+                f.frame_rate() >= MIN_CAMERA_FRAME_RATE
+                    && f.frame_rate() <= TARGET_CAMERA_FRAME_RATE
+                    && f.width() < 2000
+                    && f.height() < 2000
+            })
+            .collect::<Vec<_>>();
+    }
+
+    if ideal_formats.is_empty() {
+        ideal_formats = formats
+            .clone()
+            .into_iter()
+            .filter(|f| {
+                f.frame_rate() >= MIN_CAMERA_FRAME_RATE && f.width() < 2000 && f.height() < 2000
+            })
+            .collect::<Vec<_>>();
+    }
 
     if ideal_formats.is_empty() {
         ideal_formats = formats;
@@ -483,12 +515,14 @@ fn select_camera_format(
 
         let aspect_cmp = aspect_cmp_a.partial_cmp(&aspect_cmp_b);
         let resolution_cmp = (a.width() * a.height()).cmp(&(b.width() * b.height()));
-        let fr_cmp = a.frame_rate().partial_cmp(&b.frame_rate());
+        let fr_cmp_a = (a.frame_rate() - TARGET_CAMERA_FRAME_RATE).abs();
+        let fr_cmp_b = (b.frame_rate() - TARGET_CAMERA_FRAME_RATE).abs();
+        let fr_cmp = fr_cmp_a.partial_cmp(&fr_cmp_b);
 
         aspect_cmp
             .unwrap_or(Ordering::Equal)
             .then(resolution_cmp.reverse())
-            .then(fr_cmp.unwrap_or(Ordering::Equal).reverse())
+            .then(fr_cmp.unwrap_or(Ordering::Equal))
     });
 
     Ok(ideal_formats.swap_remove(0))
@@ -817,6 +851,31 @@ impl Message<AddNativeSender> for CameraFeed {
     }
 }
 
+impl Message<RemoveSender> for CameraFeed {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: RemoveSender,
+        _: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.senders.retain(|sender| !sender.same_channel(&msg.0));
+    }
+}
+
+impl Message<RemoveNativeSender> for CameraFeed {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: RemoveNativeSender,
+        _: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.native_senders
+            .retain(|sender| !sender.same_channel(&msg.0));
+    }
+}
+
 impl Message<ListenForReady> for CameraFeed {
     type Reply = ();
 
@@ -848,31 +907,6 @@ impl Message<OnFeedDisconnect> for CameraFeed {
         _: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         self.on_disconnect.push(msg.0);
-    }
-}
-
-impl Message<RemoveSender> for CameraFeed {
-    type Reply = ();
-
-    async fn handle(
-        &mut self,
-        msg: RemoveSender,
-        _: &mut Context<Self, Self::Reply>,
-    ) -> Self::Reply {
-        self.senders.retain(|sender| !sender.same_channel(&msg.0));
-    }
-}
-
-impl Message<RemoveNativeSender> for CameraFeed {
-    type Reply = ();
-
-    async fn handle(
-        &mut self,
-        msg: RemoveNativeSender,
-        _: &mut Context<Self, Self::Reply>,
-    ) -> Self::Reply {
-        self.native_senders
-            .retain(|sender| !sender.same_channel(&msg.0));
     }
 }
 

--- a/crates/recording/src/instant_recording.rs
+++ b/crates/recording/src/instant_recording.rs
@@ -567,6 +567,7 @@ pub async fn spawn_instant_recording_actor(
                 crop_bounds,
                 true,
                 30,
+                None,
                 timestamps.system_time(),
                 inputs.capture_system_audio,
                 #[cfg(windows)]

--- a/crates/recording/src/lib.rs
+++ b/crates/recording/src/lib.rs
@@ -45,6 +45,7 @@ pub enum RecordingMode {
 
 #[derive(Clone, Debug, Copy, Default, PartialEq, Eq)]
 pub enum StudioQuality {
+    Compatibility,
     #[default]
     Balanced,
     Ultra,

--- a/crates/recording/src/output_pipeline/macos.rs
+++ b/crates/recording/src/output_pipeline/macos.rs
@@ -9,6 +9,7 @@ use anyhow::anyhow;
 use cap_enc_avfoundation::QueueFrameError;
 use cap_media_info::{AudioInfo, VideoInfo};
 use cap_timestamp::Timestamp;
+use cap_utils::macos_qos::{MacOsQosClass, set_current_thread_qos};
 use cidre::arc;
 use std::{
     path::PathBuf,
@@ -31,17 +32,11 @@ const DISK_SPACE_MIN_START_MB: u64 = 500;
 const DISK_SPACE_CRITICAL_MB: u64 = 200;
 const DISK_SPACE_CHECK_INTERVAL: Duration = Duration::from_secs(10);
 
-#[cfg(target_os = "macos")]
-const QOS_CLASS_USER_INITIATED: u32 = 0x19;
-
-#[cfg(target_os = "macos")]
-unsafe extern "C" {
-    fn pthread_set_qos_class_self_np(qos_class: u32, relative_priority: i32) -> i32;
-}
-
-#[cfg(target_os = "macos")]
 fn boost_encoder_thread_qos() {
-    unsafe { pthread_set_qos_class_self_np(QOS_CLASS_USER_INITIATED, 0) };
+    let result = set_current_thread_qos(MacOsQosClass::UserInitiated);
+    if result != 0 {
+        warn!(result, "pthread_set_qos_class_self_np failed");
+    }
 }
 
 fn get_available_disk_space_mb(path: &std::path::Path) -> Option<u64> {

--- a/crates/recording/src/output_pipeline/macos.rs
+++ b/crates/recording/src/output_pipeline/macos.rs
@@ -273,6 +273,7 @@ impl Muxer for AVFoundationMp4Muxer {
         pause_flag: Arc<AtomicBool>,
         _tasks: &mut TaskPool,
     ) -> anyhow::Result<Self> {
+    pub compatibility_quality: bool,
         let video_config =
             video_config.ok_or_else(|| anyhow!("Invariant: No video source provided"))?;
 
@@ -326,6 +327,13 @@ impl Muxer for AVFoundationMp4Muxer {
         let encoder = Arc::new(Mutex::new(encoder));
         let encoder_clone = encoder.clone();
         let fatal_error = Arc::new(Mutex::new(None));
+        } else if config.compatibility_quality {
+            cap_enc_avfoundation::MP4Encoder::init_compatibility(
+                output_path.clone(),
+                video_config,
+                audio_config,
+                config.output_height,
+            )
         let video_fatal_error = fatal_error.clone();
         let disk_check_path = output_path.clone();
         let is_instant = config.instant_mode;
@@ -892,17 +900,27 @@ impl Muxer for AVFoundationCameraMuxer {
             video_config.ok_or_else(|| anyhow!("Invariant: No video source provided"))?;
 
         let buffer_size = get_mp4_muxer_buffer_size(false);
+    pub compatibility_quality: bool,
         debug!(buffer_size, "Camera MP4 muxer encoder channel buffer size");
 
         let (video_tx, video_rx) = sync_channel::<Option<CameraFrameMessage>>(buffer_size);
         let (ready_tx, ready_rx) = sync_channel::<anyhow::Result<()>>(1);
 
-        let encoder = cap_enc_avfoundation::MP4Encoder::init(
-            output_path.clone(),
-            video_config,
-            None,
-            config.output_height,
-        )
+        let encoder = if config.compatibility_quality {
+            cap_enc_avfoundation::MP4Encoder::init_compatibility(
+                output_path.clone(),
+                video_config,
+                None,
+                config.output_height,
+            )
+        } else {
+            cap_enc_avfoundation::MP4Encoder::init(
+                output_path.clone(),
+                video_config,
+                None,
+                config.output_height,
+            )
+        }
         .map_err(|e| anyhow!("{e}"))?;
 
         let encoder = Arc::new(Mutex::new(encoder));

--- a/crates/recording/src/output_pipeline/macos.rs
+++ b/crates/recording/src/output_pipeline/macos.rs
@@ -347,13 +347,6 @@ impl Muxer for AVFoundationMp4Muxer {
         let encoder = Arc::new(Mutex::new(encoder));
         let encoder_clone = encoder.clone();
         let fatal_error = Arc::new(Mutex::new(None));
-        } else if config.compatibility_quality {
-            cap_enc_avfoundation::MP4Encoder::init_compatibility(
-                output_path.clone(),
-                video_config,
-                audio_config,
-                config.output_height,
-            )
         let video_fatal_error = fatal_error.clone();
         let disk_check_path = output_path.clone();
         let is_instant = config.instant_mode;
@@ -379,6 +372,8 @@ impl Muxer for AVFoundationMp4Muxer {
         let encoder_handle = std::thread::Builder::new()
             .name("mp4-video-encoder".to_string())
             .spawn(move || {
+                #[cfg(target_os = "macos")]
+                boost_encoder_thread_qos();
                 if ready_tx.send(Ok(())).is_err() {
                     return Err(anyhow!("Failed to send ready signal - receiver dropped"));
                 }
@@ -523,6 +518,8 @@ impl Muxer for AVFoundationMp4Muxer {
             let audio_handle = std::thread::Builder::new()
                 .name("mp4-audio-encoder".to_string())
                 .spawn(move || {
+                    #[cfg(target_os = "macos")]
+                    boost_encoder_thread_qos();
                     if audio_ready_tx.send(Ok(())).is_err() {
                         return Err(anyhow!("Failed to send audio ready signal"));
                     }
@@ -903,6 +900,7 @@ pub struct AVFoundationCameraMuxer {
 #[derive(Default)]
 pub struct AVFoundationCameraMuxerConfig {
     pub output_height: Option<u32>,
+    pub compatibility_quality: bool,
 }
 
 impl Muxer for AVFoundationCameraMuxer {
@@ -920,7 +918,6 @@ impl Muxer for AVFoundationCameraMuxer {
             video_config.ok_or_else(|| anyhow!("Invariant: No video source provided"))?;
 
         let buffer_size = get_mp4_muxer_buffer_size(false);
-    pub compatibility_quality: bool,
         debug!(buffer_size, "Camera MP4 muxer encoder channel buffer size");
 
         let (video_tx, video_rx) = sync_channel::<Option<CameraFrameMessage>>(buffer_size);
@@ -951,6 +948,8 @@ impl Muxer for AVFoundationCameraMuxer {
         let encoder_handle = std::thread::Builder::new()
             .name("mp4-camera-encoder".to_string())
             .spawn(move || {
+                #[cfg(target_os = "macos")]
+                boost_encoder_thread_qos();
                 if ready_tx.send(Ok(())).is_err() {
                     return Err(anyhow!("Failed to send ready signal - receiver dropped"));
                 }

--- a/crates/recording/src/output_pipeline/macos.rs
+++ b/crates/recording/src/output_pipeline/macos.rs
@@ -31,6 +31,19 @@ const DISK_SPACE_MIN_START_MB: u64 = 500;
 const DISK_SPACE_CRITICAL_MB: u64 = 200;
 const DISK_SPACE_CHECK_INTERVAL: Duration = Duration::from_secs(10);
 
+#[cfg(target_os = "macos")]
+const QOS_CLASS_USER_INITIATED: u32 = 0x19;
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    fn pthread_set_qos_class_self_np(qos_class: u32, relative_priority: i32) -> i32;
+}
+
+#[cfg(target_os = "macos")]
+fn boost_encoder_thread_qos() {
+    unsafe { pthread_set_qos_class_self_np(QOS_CLASS_USER_INITIATED, 0) };
+}
+
 fn get_available_disk_space_mb(path: &std::path::Path) -> Option<u64> {
     use std::ffi::CString;
     let c_path = CString::new(path.parent().unwrap_or(path).to_str()?).ok()?;
@@ -260,6 +273,7 @@ pub struct AVFoundationMp4MuxerConfig {
     pub output_height: Option<u32>,
     pub instant_mode: bool,
     pub ultra_quality: bool,
+    pub compatibility_quality: bool,
 }
 
 impl Muxer for AVFoundationMp4Muxer {
@@ -273,7 +287,6 @@ impl Muxer for AVFoundationMp4Muxer {
         pause_flag: Arc<AtomicBool>,
         _tasks: &mut TaskPool,
     ) -> anyhow::Result<Self> {
-    pub compatibility_quality: bool,
         let video_config =
             video_config.ok_or_else(|| anyhow!("Invariant: No video source provided"))?;
 
@@ -309,6 +322,13 @@ impl Muxer for AVFoundationMp4Muxer {
             )
         } else if config.ultra_quality {
             cap_enc_avfoundation::MP4Encoder::init_ultra(
+                output_path.clone(),
+                video_config,
+                audio_config,
+                config.output_height,
+            )
+        } else if config.compatibility_quality {
+            cap_enc_avfoundation::MP4Encoder::init_compatibility(
                 output_path.clone(),
                 video_config,
                 audio_config,

--- a/crates/recording/src/sources/screen_capture/macos.rs
+++ b/crates/recording/src/sources/screen_capture/macos.rs
@@ -99,34 +99,6 @@ fn create_pixel_buffer_pool(width: usize, height: usize) -> Option<arc::R<cv::Pi
     cv::PixelBufPool::new(Some(pool_attrs.as_ref()), Some(pixel_buf_attrs.as_ref())).ok()
 }
 
-struct PixelBufferCopier {
-    session: arc::R<cidre::vt::PixelTransferSession>,
-    pool: arc::R<cv::PixelBufPool>,
-}
-
-unsafe impl Send for PixelBufferCopier {}
-
-impl PixelBufferCopier {
-    fn new(width: usize, height: usize) -> Option<Self> {
-        let mut session = cidre::vt::PixelTransferSession::new().ok()?;
-        session.set_realtime(true).ok()?;
-        let pool = create_pixel_buffer_pool(width, height)?;
-        Some(Self { session, pool })
-    }
-
-    fn copy_frame(&self, src_sample_buf: &cm::SampleBuf) -> Option<arc::R<cm::SampleBuf>> {
-        let src_image_buf = src_sample_buf.image_buf()?;
-        let dst_buf = self.pool.pixel_buf().ok()?;
-
-        self.session.transfer(src_image_buf, &dst_buf).ok()?;
-
-        let format_desc = cm::VideoFormatDesc::with_image_buf(&dst_buf).ok()?;
-        let timing = src_sample_buf.timing_info(0).ok()?;
-
-        cm::SampleBuf::with_image_buf(&dst_buf, true, None, ptr::null(), &format_desc, &timing).ok()
-    }
-}
-
 fn get_screen_buffer_size() -> usize {
     std::env::var("CAP_SCREEN_BUFFER_SIZE")
         .ok()
@@ -229,27 +201,7 @@ impl ScreenCaptureConfig<CMSampleBufferCapture> {
 
         debug!("SCK content filter: {:?}", content_filter);
 
-        let size = {
-            let logical_size = self
-                .config
-                .crop_bounds
-                .map(|bounds| bounds.size())
-                .or_else(|| display.logical_size())
-                .ok_or_else(|| anyhow!("Display has no logical size"))?;
-
-            let physical_size = display
-                .physical_size()
-                .ok_or_else(|| anyhow!("Display has no physical size"))?;
-            let display_logical_size = display
-                .logical_size()
-                .ok_or_else(|| anyhow!("Display has no logical size for scale computation"))?;
-
-            let scale = physical_size.width() / display_logical_size.width();
-
-            let width = ensure_even((logical_size.width() * scale) as u32) as f64;
-            let height = ensure_even((logical_size.height() * scale) as u32) as f64;
-            PhysicalSize::new(width, height)
-        };
+        let size = PhysicalSize::new(self.video_info.width as f64, self.video_info.height as f64);
 
         debug!("size: {:?}", size);
 
@@ -296,10 +248,6 @@ impl ScreenCaptureConfig<CMSampleBufferCapture> {
         let scaling_logged = Arc::new(AtomicBool::new(false));
         let scaled_frame_count = Arc::new(AtomicU64::new(0));
 
-        let pixel_buffer_copier: Arc<Mutex<Option<PixelBufferCopier>>> = Arc::new(Mutex::new(
-            PixelBufferCopier::new(expected_width, expected_height),
-        ));
-
         let (stall_health_tx, stall_health_rx) =
             tokio::sync::mpsc::channel::<output_pipeline::PipelineHealthEvent>(32);
 
@@ -319,7 +267,6 @@ impl ScreenCaptureConfig<CMSampleBufferCapture> {
             frame_scaler: frame_scaler.clone(),
             scaling_logged: scaling_logged.clone(),
             scaled_frame_count: scaled_frame_count.clone(),
-            pixel_buffer_copier: pixel_buffer_copier.clone(),
             stall_health_tx: stall_health_tx.clone(),
         });
 
@@ -410,23 +357,7 @@ impl ScreenCaptureConfig<CMSampleBufferCapture> {
                                         }
                                     }
 
-                                    let copied = if let Ok(copier_guard) = pixel_buffer_copier.lock() {
-                                        if let Some(copier) = copier_guard.as_ref() {
-                                            copier.copy_frame(sample_buffer)
-                                        } else {
-                                            None
-                                        }
-                                    } else {
-                                        None
-                                    };
-
-                                    match copied {
-                                        Some(buf) => buf,
-                                        None => {
-                                            drop_counter.fetch_add(1, atomic::Ordering::Relaxed);
-                                            return;
-                                        }
-                                    }
+                                    sample_buffer.retained()
                                 };
 
                             cap_fail::fail_ret!("screen_capture video frame skip");
@@ -938,7 +869,6 @@ struct CapturerRebuildParams {
     frame_scaler: Arc<Mutex<Option<FrameScaler>>>,
     scaling_logged: Arc<AtomicBool>,
     scaled_frame_count: Arc<AtomicU64>,
-    pixel_buffer_copier: Arc<Mutex<Option<PixelBufferCopier>>>,
     stall_health_tx: output_pipeline::HealthSender,
 }
 
@@ -973,26 +903,10 @@ async fn rebuild_capturer(params: &CapturerRebuildParams) -> anyhow::Result<Capt
         .as_content_filter_excluding_windows(shareable_content, excluded_sc_windows)
         .ok_or_else(|| anyhow!("Failed to create content filter during restart"))?;
 
-    let size = {
-        let logical_size = params
-            .config
-            .crop_bounds
-            .map(|bounds| bounds.size())
-            .or_else(|| display.logical_size())
-            .ok_or_else(|| anyhow!("Display has no logical size during restart"))?;
-
-        let physical_size = display
-            .physical_size()
-            .ok_or_else(|| anyhow!("Display has no physical size during restart"))?;
-        let display_logical_size = display.logical_size().ok_or_else(|| {
-            anyhow!("Display has no logical size for scale computation during restart")
-        })?;
-
-        let scale = physical_size.width() / display_logical_size.width();
-        let width = ensure_even((logical_size.width() * scale) as u32) as f64;
-        let height = ensure_even((logical_size.height() * scale) as u32) as f64;
-        PhysicalSize::new(width, height)
-    };
+    let size = PhysicalSize::new(
+        params.video_info.width as f64,
+        params.video_info.height as f64,
+    );
 
     let max_queue_depth = get_max_queue_depth();
     let queue_depth =
@@ -1033,7 +947,6 @@ async fn rebuild_capturer(params: &CapturerRebuildParams) -> anyhow::Result<Capt
             let frame_scaler = params.frame_scaler.clone();
             let scaling_logged = params.scaling_logged.clone();
             let scaled_frame_count = params.scaled_frame_count.clone();
-            let pixel_buffer_copier = params.pixel_buffer_copier.clone();
             let sys_audio_drop_counter = params.system_audio_drop_counter.clone();
             let sys_audio_frame_counter = params.system_audio_frame_counter.clone();
             let stall_health_tx = params.stall_health_tx.clone();
@@ -1115,24 +1028,7 @@ async fn rebuild_capturer(params: &CapturerRebuildParams) -> anyhow::Result<Capt
                                     }
                                 }
 
-                                let copied =
-                                    if let Ok(copier_guard) = pixel_buffer_copier.lock() {
-                                        if let Some(copier) = copier_guard.as_ref() {
-                                            copier.copy_frame(sample_buffer)
-                                        } else {
-                                            None
-                                        }
-                                    } else {
-                                        None
-                                    };
-
-                                match copied {
-                                    Some(buf) => buf,
-                                    None => {
-                                        drop_counter.fetch_add(1, atomic::Ordering::Relaxed);
-                                        return;
-                                    }
-                                }
+                                    sample_buffer.retained()
                             };
 
                         cap_fail::fail_ret!("screen_capture video frame skip");

--- a/crates/recording/src/sources/screen_capture/mod.rs
+++ b/crates/recording/src/sources/screen_capture/mod.rs
@@ -1,9 +1,7 @@
 #[cfg(target_os = "macos")]
 use crate::SendableShareableContent;
 use cap_cursor_capture::CursorCropBounds;
-#[cfg(target_os = "macos")]
-use cap_media_info::ensure_even;
-use cap_media_info::{AudioInfo, VideoInfo};
+use cap_media_info::{AudioInfo, VideoInfo, ensure_even};
 use scap_targets::{Display, DisplayId, Window, WindowId, bounds::*};
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -227,6 +225,36 @@ pub struct ScreenCaptureConfig<TCaptureFormat: ScreenCaptureFormat> {
     pub excluded_windows: Vec<WindowId>,
 }
 
+fn constrain_capture_size(size: PhysicalSize, max_size: Option<(u32, u32)>) -> PhysicalSize {
+    let width = size.width() as u32;
+    let height = size.height() as u32;
+    let Some((max_width, max_height)) = max_size else {
+        return PhysicalSize::new(ensure_even(width) as f64, ensure_even(height) as f64);
+    };
+
+    if width <= max_width && height <= max_height {
+        return PhysicalSize::new(ensure_even(width) as f64, ensure_even(height) as f64);
+    }
+
+    let width_scale = max_width as f64 / width as f64;
+    let height_scale = max_height as f64 / height as f64;
+    let scale = width_scale.min(height_scale);
+    let constrained_width = ensure_even((width as f64 * scale).round() as u32);
+    let constrained_height = ensure_even((height as f64 * scale).round() as u32);
+
+    tracing::info!(
+        input_width = width,
+        input_height = height,
+        output_width = constrained_width,
+        output_height = constrained_height,
+        max_width,
+        max_height,
+        "Screen capture input constrained for camera recording"
+    );
+
+    PhysicalSize::new(constrained_width as f64, constrained_height as f64)
+}
+
 impl<T: ScreenCaptureFormat> std::fmt::Debug for ScreenCaptureConfig<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ScreenCaptureSource")
@@ -304,6 +332,7 @@ impl<TCaptureFormat: ScreenCaptureFormat> ScreenCaptureConfig<TCaptureFormat> {
         crop_bounds: Option<CropBounds>,
         show_cursor: bool,
         max_fps: u32,
+        max_capture_size: Option<(u32, u32)>,
         start_time: SystemTime,
         system_audio: bool,
         #[cfg(windows)] d3d_device: ::windows::Win32::Graphics::Direct3D11::ID3D11Device,
@@ -315,7 +344,7 @@ impl<TCaptureFormat: ScreenCaptureFormat> ScreenCaptureConfig<TCaptureFormat> {
         let target_refresh = validated_refresh_rate(display.refresh_rate());
         let fps = std::cmp::max(1, std::cmp::min(max_fps, target_refresh));
 
-        let output_size: PhysicalSize = {
+        let native_output_size: PhysicalSize = {
             #[cfg(target_os = "macos")]
             {
                 crop_bounds.and_then(|b| {
@@ -334,6 +363,7 @@ impl<TCaptureFormat: ScreenCaptureFormat> ScreenCaptureConfig<TCaptureFormat> {
         }
         .or_else(|| display.physical_size())
         .ok_or(ScreenCaptureInitError::NoBounds)?;
+        let output_size = constrain_capture_size(native_output_size, max_capture_size);
 
         Ok(Self {
             config: Config {

--- a/crates/recording/src/studio_recording.rs
+++ b/crates/recording/src/studio_recording.rs
@@ -44,6 +44,11 @@ use std::{
 use tokio::{sync::watch, task::JoinHandle};
 use tracing::{Instrument, debug, error_span, info, trace, warn};
 
+const CAMERA_ACTIVE_MAX_SCREEN_WIDTH: u32 = 1920;
+const CAMERA_ACTIVE_MAX_SCREEN_HEIGHT: u32 = 1200;
+const COMPATIBILITY_CAMERA_ACTIVE_MAX_SCREEN_WIDTH: u32 = 1600;
+const COMPATIBILITY_CAMERA_ACTIVE_MAX_SCREEN_HEIGHT: u32 = 1000;
+
 #[allow(clippy::large_enum_variant)]
 enum ActorState {
     Recording {
@@ -1279,17 +1284,17 @@ async fn create_segment_pipeline(
 
     trace!("preparing segment pipeline {index}");
 
-    #[cfg(target_os = "macos")]
-    let shared_pause_state = if segment_fragmented {
-        Some(SharedPauseState::new(Arc::new(
-            std::sync::atomic::AtomicBool::new(false),
-        )))
     let camera_active = base_inputs.camera_feed.is_some();
     #[cfg(target_os = "macos")]
     let segment_fragmented = fragmented && !camera_active;
     #[cfg(not(target_os = "macos"))]
     let segment_fragmented = fragmented;
 
+    #[cfg(target_os = "macos")]
+    let shared_pause_state = if segment_fragmented {
+        Some(SharedPauseState::new(Arc::new(
+            std::sync::atomic::AtomicBool::new(false),
+        )))
     } else {
         None
     };
@@ -1348,12 +1353,34 @@ async fn create_segment_pipeline(
 
         let (display, crop) =
             target_to_display_and_crop(&capture_target).context("target_display_crop")?;
+        let compatibility_quality = matches!(quality, crate::StudioQuality::Compatibility);
+        let max_capture_size = if camera_active {
+            if compatibility_quality {
+                Some((
+                    COMPATIBILITY_CAMERA_ACTIVE_MAX_SCREEN_WIDTH,
+                    COMPATIBILITY_CAMERA_ACTIVE_MAX_SCREEN_HEIGHT,
+                ))
+            } else {
+                Some((
+                    CAMERA_ACTIVE_MAX_SCREEN_WIDTH,
+                    CAMERA_ACTIVE_MAX_SCREEN_HEIGHT,
+                ))
+            }
+        } else {
+            None
+        };
+        let effective_max_fps = if compatibility_quality && camera_active {
+            max_fps.min(24)
+        } else {
+            max_fps
+        };
 
         let screen_config = ScreenCaptureConfig::<ScreenCaptureMethod>::init(
             display,
             crop,
             !custom_cursor_capture,
-            max_fps,
+            effective_max_fps,
+            max_capture_size,
             start_time.system_time(),
             base_inputs.capture_system_audio,
             #[cfg(windows)]
@@ -1416,7 +1443,10 @@ async fn create_segment_pipeline(
             OutputPipeline::builder(dir.join("camera.mp4"))
                 .with_video::<sources::NativeCamera>(camera_feed)
                 .with_timestamps(start_time)
-                .build::<AVFoundationCameraMuxer>(AVFoundationCameraMuxerConfig::default())
+                .build::<AVFoundationCameraMuxer>(AVFoundationCameraMuxerConfig {
+                    compatibility_quality: matches!(quality, crate::StudioQuality::Compatibility),
+                    ..Default::default()
+                })
                 .instrument(error_span!("camera-out"))
                 .await
         };

--- a/crates/recording/src/studio_recording.rs
+++ b/crates/recording/src/studio_recording.rs
@@ -1280,16 +1280,22 @@ async fn create_segment_pipeline(
     trace!("preparing segment pipeline {index}");
 
     #[cfg(target_os = "macos")]
-    let shared_pause_state = if fragmented {
+    let shared_pause_state = if segment_fragmented {
         Some(SharedPauseState::new(Arc::new(
             std::sync::atomic::AtomicBool::new(false),
         )))
+    let camera_active = base_inputs.camera_feed.is_some();
+    #[cfg(target_os = "macos")]
+    let segment_fragmented = fragmented && !camera_active;
+    #[cfg(not(target_os = "macos"))]
+    let segment_fragmented = fragmented;
+
     } else {
         None
     };
 
     #[cfg(windows)]
-    let shared_pause_state = if fragmented {
+    let shared_pause_state = if segment_fragmented {
         Some(SharedPauseState::new(Arc::new(
             std::sync::atomic::AtomicBool::new(false),
         )))
@@ -1376,7 +1382,7 @@ async fn create_segment_pipeline(
             capture_source,
             screen_output_path.clone(),
             start_time,
-            fragmented,
+            segment_fragmented,
             use_oop_muxer,
             shared_pause_state.clone(),
             output_size,
@@ -1395,7 +1401,7 @@ async fn create_segment_pipeline(
     let camera = if camera_only {
         None
     } else if let Some(camera_feed) = base_inputs.camera_feed {
-        let pipeline = if fragmented {
+        let pipeline = if segment_fragmented {
             let fragments_dir = dir.join("camera");
             OutputPipeline::builder(fragments_dir)
                 .with_video::<sources::NativeCamera>(camera_feed)
@@ -1423,7 +1429,7 @@ async fn create_segment_pipeline(
     let camera = if camera_only {
         None
     } else if let Some(camera_feed) = base_inputs.camera_feed {
-        let pipeline = if fragmented {
+        let pipeline = if segment_fragmented {
             let fragments_dir = dir.join("camera");
             OutputPipeline::builder(fragments_dir)
                 .with_video::<sources::NativeCamera>(camera_feed)
@@ -1451,7 +1457,7 @@ async fn create_segment_pipeline(
     };
 
     let microphone = if let Some(mic_feed) = base_inputs.mic_feed {
-        let pipeline = if fragmented {
+        let pipeline = if segment_fragmented {
             let output_path = dir.join("audio-input.m4a");
             OutputPipeline::builder(output_path)
                 .with_audio_source::<sources::Microphone>(mic_feed)
@@ -1475,7 +1481,7 @@ async fn create_segment_pipeline(
     };
 
     let system_audio = if let Some(system_audio_source) = system_audio {
-        let pipeline = if fragmented {
+        let pipeline = if segment_fragmented {
             let output_path = dir.join("system_audio.m4a");
             OutputPipeline::builder(output_path)
                 .with_audio_source::<screen_capture::SystemAudioSource>(system_audio_source)

--- a/crates/rendering/src/decoder/avassetreader.rs
+++ b/crates/rendering/src/decoder/avassetreader.rs
@@ -19,6 +19,8 @@ use super::frame_converter::{copy_bgra_to_rgba, copy_rgba_plane};
 use super::multi_position::{DecoderPoolManager, MultiPositionDecoderConfig, ScrubDetector};
 use super::{DecoderInitResult, DecoderType, FRAME_CACHE_SIZE, VideoDecoderMessage, pts_to_frame};
 
+const MAX_RELAXED_FALLBACK_DISTANCE: u32 = 8;
+
 #[derive(Clone)]
 struct FrameData {
     data: Arc<Vec<u8>>,
@@ -565,6 +567,7 @@ impl AVAssetReaderDecoder {
 
         struct PendingRequest {
             frame: u32,
+            max_fallback_distance: u32,
             sender: oneshot::Sender<DecodedFrame>,
         }
 
@@ -572,20 +575,32 @@ impl AVAssetReaderDecoder {
             let mut pending_requests: Vec<PendingRequest> = Vec::with_capacity(8);
 
             match r {
-                VideoDecoderMessage::GetFrame(requested_time, sender) => {
+                VideoDecoderMessage::GetFrame(requested_time, max_fallback_distance, sender) => {
                     let frame = (requested_time * fps as f32).floor() as u32;
                     if !sender.is_closed() {
-                        pending_requests.push(PendingRequest { frame, sender });
+                        pending_requests.push(PendingRequest {
+                            frame,
+                            max_fallback_distance,
+                            sender,
+                        });
                     }
                 }
             }
 
             while let Ok(msg) = rx.try_recv() {
                 match msg {
-                    VideoDecoderMessage::GetFrame(requested_time, sender) => {
+                    VideoDecoderMessage::GetFrame(
+                        requested_time,
+                        max_fallback_distance,
+                        sender,
+                    ) => {
                         let frame = (requested_time * fps as f32).floor() as u32;
                         if !sender.is_closed() {
-                            pending_requests.push(PendingRequest { frame, sender });
+                            pending_requests.push(PendingRequest {
+                                frame,
+                                max_fallback_distance,
+                                sender,
+                            });
                         }
                     }
                 }
@@ -725,22 +740,6 @@ impl AVAssetReaderDecoder {
                                     *last_sent_frame.borrow_mut() = Some(data.clone());
                                     let _ = req.sender.send(data.to_decoded_frame());
                                 } else {
-                                    // IMPORTANT: When the decoder advances past a requested frame
-                                    // and that frame isn't cached, fall back to the nearest cached
-                                    // frame (backward preferred). This happens during parallel
-                                    // prefetch decoding when multiple GetFrame requests arrive
-                                    // concurrently — the decoder may process later frames first,
-                                    // advancing past earlier requests. Without a generous fallback,
-                                    // the oneshot sender is silently dropped (returning None to the
-                                    // prefetch pipeline), creating permanent gaps in the frame
-                                    // sequence that cause visible playback stalls and frame skips.
-                                    //
-                                    // Previously this was restricted to forward-only fallback
-                                    // within 1 frame (MAX_FORWARD_FALLBACK_DISTANCE=1), which was
-                                    // far too restrictive for 60fps playback of lower-fps
-                                    // recordings (e.g. 46fps) where frame number gaps are common.
-                                    const MAX_FALLBACK_DISTANCE: u32 = 90;
-
                                     let nearest = cache
                                         .range(..=req.frame)
                                         .next_back()
@@ -748,7 +747,7 @@ impl AVAssetReaderDecoder {
 
                                     if let Some((&frame_num, cached)) = nearest {
                                         let distance = req.frame.abs_diff(frame_num);
-                                        if distance <= MAX_FALLBACK_DISTANCE {
+                                        if distance <= req.max_fallback_distance {
                                             let _ =
                                                 req.sender.send(cached.data().to_decoded_frame());
                                         }
@@ -856,26 +855,15 @@ impl AVAssetReaderDecoder {
                     let data = cached.data().clone();
                     let _ = req.sender.send(data.to_decoded_frame());
                 } else {
-                    // See the matching comment in the decode-loop fallback above for full
-                    // context. Both sites must use the same generous fallback policy:
-                    // backward-preferred, distance up to 90 frames. Restricting to
-                    // forward-only within 1 frame silently drops senders for frames the
-                    // decoder skipped, producing None in the prefetch pipeline.
-                    const MAX_FALLBACK_DISTANCE: u32 = 90;
-                    const MAX_FALLBACK_DISTANCE_EOF: u32 = 300;
-                    const MAX_FALLBACK_DISTANCE_NEAR_END: u32 = 180;
-
                     let allow_relaxed_fallback = is_scrubbing
                         || near_video_end
                         || decoder_at_eof
                         || decoder_returned_no_frames;
 
-                    let fallback_distance = if decoder_at_eof || decoder_returned_no_frames {
-                        MAX_FALLBACK_DISTANCE_EOF
-                    } else if near_video_end {
-                        MAX_FALLBACK_DISTANCE_NEAR_END
+                    let fallback_distance = if allow_relaxed_fallback {
+                        req.max_fallback_distance.max(MAX_RELAXED_FALLBACK_DISTANCE)
                     } else {
-                        MAX_FALLBACK_DISTANCE
+                        req.max_fallback_distance
                     };
 
                     let nearest = cache

--- a/crates/rendering/src/decoder/ffmpeg.rs
+++ b/crates/rendering/src/decoder/ffmpeg.rs
@@ -316,14 +316,14 @@ impl FfmpegDecoder {
                         };
 
                     match r {
-                        VideoDecoderMessage::GetFrame(requested_time, reply) => {
+                        VideoDecoderMessage::GetFrame(requested_time, _, reply) => {
                             push_request(requested_time, reply);
                         }
                     }
 
                     while let Ok(msg) = rx.try_recv() {
                         match msg {
-                            VideoDecoderMessage::GetFrame(requested_time, reply) => {
+                            VideoDecoderMessage::GetFrame(requested_time, _, reply) => {
                                 push_request(requested_time, reply);
                             }
                         }
@@ -627,14 +627,14 @@ impl FfmpegDecoder {
                     };
 
                 match r {
-                    VideoDecoderMessage::GetFrame(requested_time, reply) => {
+                    VideoDecoderMessage::GetFrame(requested_time, _, reply) => {
                         push_request(requested_time, reply);
                     }
                 }
 
                 while let Ok(msg) = rx.try_recv() {
                     match msg {
-                        VideoDecoderMessage::GetFrame(requested_time, reply) => {
+                        VideoDecoderMessage::GetFrame(requested_time, _, reply) => {
                             push_request(requested_time, reply);
                         }
                     }

--- a/crates/rendering/src/decoder/media_foundation.rs
+++ b/crates/rendering/src/decoder/media_foundation.rs
@@ -251,14 +251,14 @@ impl MFDecoder {
                     };
 
                 match r {
-                    VideoDecoderMessage::GetFrame(requested_time, sender) => {
+                    VideoDecoderMessage::GetFrame(requested_time, _, sender) => {
                         push_request(requested_time, sender);
                     }
                 }
 
                 while let Ok(msg) = rx.try_recv() {
                     match msg {
-                        VideoDecoderMessage::GetFrame(requested_time, sender) => {
+                        VideoDecoderMessage::GetFrame(requested_time, _, sender) => {
                             push_request(requested_time, sender);
                         }
                     }

--- a/crates/rendering/src/decoder/mod.rs
+++ b/crates/rendering/src/decoder/mod.rs
@@ -438,7 +438,7 @@ impl DecodedFrame {
 }
 
 pub enum VideoDecoderMessage {
-    GetFrame(f32, tokio::sync::oneshot::Sender<DecodedFrame>),
+    GetFrame(f32, u32, tokio::sync::oneshot::Sender<DecodedFrame>),
 }
 
 pub fn pts_to_frame(pts: i64, time_base: Rational, fps: u32) -> u32 {
@@ -447,12 +447,14 @@ pub fn pts_to_frame(pts: i64, time_base: Rational, fps: u32) -> u32 {
 }
 
 pub const FRAME_CACHE_SIZE: usize = 90;
+const DEFAULT_MAX_FALLBACK_DISTANCE: u32 = 90;
 
 #[derive(Clone)]
 pub struct AsyncVideoDecoderHandle {
     sender: mpsc::Sender<VideoDecoderMessage>,
     offset: f64,
     status: DecoderStatus,
+    max_fallback_distance: u32,
 }
 
 impl AsyncVideoDecoderHandle {
@@ -485,7 +487,11 @@ impl AsyncVideoDecoderHandle {
 
         if self
             .sender
-            .send(VideoDecoderMessage::GetFrame(adjusted_time, tx))
+            .send(VideoDecoderMessage::GetFrame(
+                adjusted_time,
+                self.max_fallback_distance,
+                tx,
+            ))
             .is_err()
         {
             return None;
@@ -527,6 +533,11 @@ impl AsyncVideoDecoderHandle {
     pub fn fallback_reason(&self) -> Option<&str> {
         self.status.fallback_reason.as_deref()
     }
+
+    pub fn with_max_fallback_distance(mut self, max_fallback_distance: u32) -> Self {
+        self.max_fallback_distance = max_fallback_distance;
+        self
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -560,6 +571,7 @@ async fn spawn_ffmpeg_decoder(
                 sender: tx,
                 offset,
                 status,
+                max_fallback_distance: DEFAULT_MAX_FALLBACK_DISTANCE,
             })
         }
         Ok(Ok(Err(e))) => Err(format!(
@@ -615,6 +627,7 @@ pub async fn spawn_decoder(
                         sender: tx,
                         offset,
                         status,
+                        max_fallback_distance: DEFAULT_MAX_FALLBACK_DISTANCE,
                     })
                 }
                 Ok(Ok(Err(e))) => Err(format!("AVAssetReader initialization failed: {e}")),
@@ -659,6 +672,7 @@ pub async fn spawn_decoder(
                             sender: tx,
                             offset,
                             status,
+                            max_fallback_distance: DEFAULT_MAX_FALLBACK_DISTANCE,
                         })
                     }
                     Ok(Ok(Err(e))) => Err(format!(
@@ -704,6 +718,7 @@ pub async fn spawn_decoder(
                         sender: tx,
                         offset,
                         status,
+                        max_fallback_distance: DEFAULT_MAX_FALLBACK_DISTANCE,
                     })
                 }
                 Ok(Ok(Err(e))) => Err(format!(
@@ -737,6 +752,7 @@ pub async fn spawn_decoder(
                             sender: tx,
                             offset,
                             status,
+                            max_fallback_distance: DEFAULT_MAX_FALLBACK_DISTANCE,
                         })
                     }
                     Ok(Ok(Err(e))) => Err(format!(
@@ -789,6 +805,7 @@ pub async fn spawn_decoder(
                             sender: tx,
                             offset,
                             status,
+                            max_fallback_distance: DEFAULT_MAX_FALLBACK_DISTANCE,
                         })
                     }
                     Ok(Ok(Err(e))) => Err(format!(
@@ -830,6 +847,7 @@ pub async fn spawn_decoder(
                     sender: tx,
                     offset,
                     status,
+                    max_fallback_distance: DEFAULT_MAX_FALLBACK_DISTANCE,
                 })
             }
             Ok(Ok(Err(e))) => Err(format!("'{name}' decoder initialization failed: {e}")),

--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -311,6 +311,7 @@ impl RecordingSegmentDecoders {
                 force_ffmpeg,
             )
             .await
+            .map(|decoder| decoder.with_max_fallback_distance(2))
             .map_err(|e| format!("Camera:{e}"))?;
             Ok(Some(camera))
         };

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -10,6 +10,8 @@ use aho_corasick::{AhoCorasickBuilder, MatchKind};
 use tracing::Instrument;
 
 pub mod disk_space;
+#[cfg(target_os = "macos")]
+pub mod macos_qos;
 
 /// Wrapper around tokio::spawn that inherits the current tracing subscriber and span.
 pub fn spawn_actor<F>(future: F) -> tokio::task::JoinHandle<F::Output>

--- a/crates/utils/src/macos_qos.rs
+++ b/crates/utils/src/macos_qos.rs
@@ -1,3 +1,5 @@
+use libc::qos_class_t::{QOS_CLASS_USER_INITIATED, QOS_CLASS_USER_INTERACTIVE};
+
 #[derive(Clone, Copy, Debug)]
 pub enum MacOsQosClass {
     UserInteractive,
@@ -7,8 +9,8 @@ pub enum MacOsQosClass {
 impl MacOsQosClass {
     fn as_raw(self) -> libc::qos_class_t {
         match self {
-            Self::UserInteractive => libc::QOS_CLASS_USER_INTERACTIVE,
-            Self::UserInitiated => libc::QOS_CLASS_USER_INITIATED,
+            Self::UserInteractive => QOS_CLASS_USER_INTERACTIVE,
+            Self::UserInitiated => QOS_CLASS_USER_INITIATED,
         }
     }
 }

--- a/crates/utils/src/macos_qos.rs
+++ b/crates/utils/src/macos_qos.rs
@@ -1,0 +1,18 @@
+#[derive(Clone, Copy, Debug)]
+pub enum MacOsQosClass {
+    UserInteractive,
+    UserInitiated,
+}
+
+impl MacOsQosClass {
+    fn as_raw(self) -> libc::qos_class_t {
+        match self {
+            Self::UserInteractive => libc::QOS_CLASS_USER_INTERACTIVE,
+            Self::UserInitiated => libc::QOS_CLASS_USER_INITIATED,
+        }
+    }
+}
+
+pub fn set_current_thread_qos(qos_class: MacOsQosClass) -> i32 {
+    unsafe { libc::pthread_set_qos_class_self_np(qos_class.as_raw(), 0) }
+}

--- a/packages/database/crypto.ts
+++ b/packages/database/crypto.ts
@@ -81,9 +81,9 @@ export async function encrypt(text: string): Promise<string> {
 		);
 
 		const result = Buffer.concat([
-			Buffer.from(salt as any) as any,
-			Buffer.from(iv as any) as any,
-			Buffer.from(encrypted as any) as any,
+			Buffer.from(salt),
+			Buffer.from(iv),
+			Buffer.from(encrypted),
 		]);
 
 		return result.toString("base64");
@@ -107,7 +107,7 @@ export async function decrypt(encryptedText: string): Promise<string> {
 		const iv = encrypted.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
 		const content = encrypted.subarray(SALT_LENGTH + IV_LENGTH);
 
-		const key = await deriveKey(salt as Uint8Array);
+		const key = await deriveKey(salt);
 
 		const decrypted = await crypto.subtle.decrypt(
 			{
@@ -156,10 +156,7 @@ export async function hashPassword(password: string): Promise<string> {
 		PASSWORD_KEY_LENGTH * 8,
 	);
 
-	const result = Buffer.concat([
-		Buffer.from(salt as any) as any,
-		Buffer.from(derived as any) as any,
-	]);
+	const result = Buffer.concat([Buffer.from(salt), Buffer.from(derived)]);
 
 	return result.toString("base64");
 }

--- a/packages/database/emails/config.ts
+++ b/packages/database/emails/config.ts
@@ -18,7 +18,7 @@ export const sendEmail = async ({
 }: {
 	email: string;
 	subject: string;
-	react: ReactElement<any, string | JSXElementConstructor<any>>;
+	react: ReactElement<unknown, string | JSXElementConstructor<unknown>>;
 	marketing?: boolean;
 	test?: boolean;
 	scheduledAt?: string;
@@ -32,7 +32,7 @@ export const sendEmail = async ({
 	}
 
 	if (marketing && !buildEnv.NEXT_PUBLIC_IS_CAP) return;
-	let from;
+	let from: string;
 
 	if (fromOverride) from = fromOverride;
 	else if (marketing) from = "Richie from Cap <richie@send.cap.so>";
@@ -48,5 +48,5 @@ export const sendEmail = async ({
 		scheduledAt,
 		cc: test ? undefined : cc,
 		replyTo: replyTo,
-	}) as any;
+	});
 };

--- a/packages/env/build.ts
+++ b/packages/env/build.ts
@@ -34,6 +34,6 @@ export const buildEnv = new Proxy({} as typeof _env, {
 	get(_, key) {
 		if (!_env) _env = create();
 
-		return (_env as any)[key];
+		return _env[key as keyof typeof _env];
 	},
 });

--- a/packages/env/build.ts
+++ b/packages/env/build.ts
@@ -28,10 +28,9 @@ const create = () =>
 		},
 	});
 
-// Environment variables that are needed in the build process, and may be incorrect on the client.
-// Some are only provided by `NEXT_PUBLIC`, but others can be provdied at runtime
 export const buildEnv = new Proxy({} as typeof _env, {
 	get(_, key) {
+		if (typeof key !== "string") return undefined;
 		if (!_env) _env = create();
 
 		return _env[key as keyof typeof _env];

--- a/packages/web-backend/src/Auth.ts
+++ b/packages/web-backend/src/Auth.ts
@@ -4,6 +4,7 @@ import {
 	CurrentUser,
 	type DatabaseError,
 	HttpAuthMiddleware,
+	UserId,
 } from "@cap/web-domain";
 import { HttpApiError, HttpServerRequest } from "@effect/platform";
 import * as Dz from "drizzle-orm";
@@ -23,7 +24,12 @@ export const getCurrentUser = Effect.gen(function* () {
 					db
 						.select()
 						.from(Db.users)
-						.where(Dz.eq(Db.users.id, (session.user as { id: string }).id)),
+						.where(
+							Dz.eq(
+								Db.users.id,
+								UserId.make((session.user as { id: string }).id),
+							),
+						),
 				);
 
 				return Option.fromNullable(currentUser);

--- a/packages/web-backend/src/Auth.ts
+++ b/packages/web-backend/src/Auth.ts
@@ -23,7 +23,7 @@ export const getCurrentUser = Effect.gen(function* () {
 					db
 						.select()
 						.from(Db.users)
-						.where(Dz.eq(Db.users.id, (session.user as any).id)),
+						.where(Dz.eq(Db.users.id, (session.user as { id: string }).id)),
 				);
 
 				return Option.fromNullable(currentUser);
@@ -60,7 +60,7 @@ export const HttpAuthMiddlewareLive = Layer.effect(
 				);
 				const authHeader = headers.authorization?.split(" ")[1];
 
-				let user;
+				let user: Option.Option<typeof Db.users.$inferSelect>;
 
 				if (authHeader?.length === 36) {
 					user = yield* database

--- a/packages/web-domain/src/Policy.ts
+++ b/packages/web-domain/src/Policy.ts
@@ -58,7 +58,9 @@ export const publicPolicy = <E, R>(
 		);
 	}) as PublicPolicy<E, R>;
 
-export class DenyAccess extends Data.TaggedError("DenyAccess")<{}> {}
+export class DenyAccess extends Data.TaggedError("DenyAccess")<
+	Record<never, never>
+> {}
 
 /**
  * Applies a policy as a pre-check to an effect.


### PR DESCRIPTION
Optimizes macOS desktop recording based on MacBook Neo testing, including compatibility quality profiles, reduced camera/screen capture load, coalesced preview rendering, AVFoundation muxing fixes, decoder fallback tuning, and safer stop-recording behavior. Also refreshes the related quality/settings UI and cleans up playback, media serving, tests, and benchmark handling.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR optimizes macOS desktop recording performance and reliability through several interconnected changes: a new Compatibility quality tier (auto-selected for devices with < 16 GB RAM), removal of the per-frame `PixelBufferCopier` VTPixelTransferSession copy in favour of `sample_buffer.retained()`, centralized macOS QoS thread boosting via a new `cap_utils::macos_qos` module, per-request fallback distance tuning in the decoder pipeline, and `BitrateProfile`-based encoder selection. Supporting changes include AVFoundation muxing fixes (rebuild-first for timing, keyframe interval normalisation), camera-active screen-size caps, FPS limits, and TypeScript null-safety cleanups in the media server.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style/observability suggestions with no blocking defects.

No P0 or P1 issues found. The four P2 comments cover: FFmpeg/MF decoders silently ignoring max_fallback_distance (behavioural inconsistency but not a crash), silent FPS cap without a log, sysinfo probe on every Default call, and the dual-bool muxer config risk. Core recording logic, the new Compatibility tier, QoS boosting, and the media-server null-safety cleanup all look correct.

crates/rendering/src/decoder/ffmpeg.rs and media_foundation.rs (ignored fallback distance), crates/enc-avfoundation/src/mp4.rs (PTS cascade noted in previous review), crates/recording/src/output_pipeline/macos.rs (dual-bool config)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/enc-avfoundation/src/mp4.rs | Adds BitrateProfile enum (Compatibility/Balanced/Ultra), PTS near-duplicate guard with minimum step, and swaps rebuild vs copy_with_new_timing order; keyframe interval now always fps (was 2×fps for normal mode) |
| crates/recording/src/output_pipeline/macos.rs | Adds compatibility_quality flag to muxer configs and centralises QoS thread boosting via cap_utils; dual-bool ultra/compatibility pattern is error-prone |
| crates/rendering/src/decoder/mod.rs | Introduces per-handle max_fallback_distance propagated through VideoDecoderMessage; default is 90 frames, camera uses 2 — but FFmpeg/MF decoders silently ignore the field |
| crates/rendering/src/decoder/avassetreader.rs | AVAssetReader now reads max_fallback_distance per request; replaces large hardcoded fallback constants with per-request values; MAX_RELAXED_FALLBACK_DISTANCE=8 used as floor for relaxed fallback scenarios |
| crates/recording/src/sources/screen_capture/macos.rs | Removes PixelBufferCopier (VTPixelTransferSession copy per frame) in favour of sample_buffer.retained(); eliminates a significant source of frame drops; uses video_info dimensions directly instead of recomputing from display scale |
| apps/desktop/src-tauri/src/general_settings.rs | Adds Compatibility quality tier; default now auto-detected from RAM (< 16 GB → Compatibility); sysinfo probe runs on each Default::default() call |
| apps/desktop/src-tauri/src/recording.rs | Caps recording FPS to 30 when camera is active (no log emitted); adds Compatibility quality branch; stop_recording now returns Ok instead of Err when no active recording |
| crates/utils/src/macos_qos.rs | New module centralising macOS QoS class helpers (UserInteractive/UserInitiated), replacing duplicate inline extern declarations |
| crates/recording/src/studio_recording.rs | Adds camera-active screen size constraints (1920×1200 normal, 1600×1000 compatibility) and disables fragmented muxing when camera is active; threads compatibility_quality to camera muxer config |
| apps/media-server/src/routes/video.ts | Replaces non-null assertions on getJob() with sendCurrentJobWebhook helper; refactors hasAudio mutable boolean to audioInput nullable object eliminating non-null assertions |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[start_recording] --> B{Camera active?}
    B -- Yes --> C[cap max_fps to 30]
    B -- No --> D[use configured max_fps]
    C --> E{Quality mode?}
    D --> E
    E -- Compatibility --> F[cap screen to 1600x1000\ncap fps to 24\nBitrateProfile::Compatibility]
    E -- Balanced --> G[cap screen to 1920x1200\nBitrateProfile::Balanced]
    E -- Ultra --> H[BitrateProfile::Ultra\nframe reordering enabled]
    F & G & H --> I[ScreenCaptureConfig::init\nwith max_capture_size]
    I --> J[AVFoundationMp4Muxer\nor AVFoundationCameraMuxer]
    J --> K[encoder threads\nboosted to UserInitiated QoS]
    K --> L[MP4Encoder::init_with_options\nBitrateProfile selects bitrate fn]
    L --> M[queue_video_frame\nPTS near-duplicate guard\nrebuild_video_sample_buf first]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/enc-avfoundation/src/mp4.rs`, line 536-548 ([link](https://github.com/capsoftware/cap/blob/a9e909efec895d277fb6b74c0533f11790bbdc42/crates/enc-avfoundation/src/mp4.rs#L536-L548)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **PTS near-duplicate check cascades to subsequent legitimate frames**

   The new `minimum_video_pts_step()` guard (1/4 frame duration ≈ 8 ms at 30 fps) treats any incoming PTS within that window of `last_pts` as a near-duplicate and advances it by one full `frame_duration`. Once one such adjustment fires, the new `last_pts` is exactly one `frame_duration` later than expected. The very next legitimate frame — which was supposed to arrive at that same new `last_pts` — then also satisfies the condition and is advanced again, creating a permanent +1 frame cascade for the rest of the recording.

   The regression test at `regression_tiny_positive_pts_step_is_expanded` only checks that no errors occur, not that the PTS values after the second frame are correct. For a continuous recording this means all frames after the first glitch are time-shifted by ~33 ms (one frame period), which may be acceptable, but the intent should be documented. The detailed comment explaining the fallback policy was removed in the same PR, leaving the reasoning implicit.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/enc-avfoundation/src/mp4.rs
   Line: 536-548

   Comment:
   **PTS near-duplicate check cascades to subsequent legitimate frames**

   The new `minimum_video_pts_step()` guard (1/4 frame duration ≈ 8 ms at 30 fps) treats any incoming PTS within that window of `last_pts` as a near-duplicate and advances it by one full `frame_duration`. Once one such adjustment fires, the new `last_pts` is exactly one `frame_duration` later than expected. The very next legitimate frame — which was supposed to arrive at that same new `last_pts` — then also satisfies the condition and is advanced again, creating a permanent +1 frame cascade for the rest of the recording.

   The regression test at `regression_tiny_positive_pts_step_is_expanded` only checks that no errors occur, not that the PTS values after the second frame are correct. For a continuous recording this means all frames after the first glitch are time-shifted by ~33 ms (one frame period), which may be acceptable, but the intent should be documented. The detailed comment explaining the fallback policy was removed in the same PR, leaving the reasoning implicit.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
crates/rendering/src/decoder/ffmpeg.rs:799
**`max_fallback_distance` silently ignored in FFmpeg and MediaFoundation decoders**

`VideoDecoderMessage::GetFrame` now carries a `max_fallback_distance` field, and `lib.rs` applies `.with_max_fallback_distance(2)` specifically to the camera decoder to keep playback from using stale frames. Both `FfmpegDecoder` and `MFDecoder` discard this field with `_`, so the tight 2-frame limit has no effect for camera segments decoded by those paths (Windows always, macOS FFmpeg fallback). The camera could serve frames up to `DEFAULT_MAX_FALLBACK_DISTANCE` (90) frames away, undermining the intent of the per-decoder setting.

### Issue 2 of 4
apps/desktop/src-tauri/src/recording.rs:134-138
**Silent FPS cap when camera is active lacks a user-visible diagnostic**

The cap to 30 fps whenever a camera feed is present is applied without any `info!` or `warn!` log. A user who configured 60 fps in settings will silently record at 30 fps with no indication in logs or UI. Adding a trace-level log (or surfacing it in the recording-started event) would make performance debugging much easier.

### Issue 3 of 4
apps/desktop/src-tauri/src/general_settings.rs:55-65
**`sysinfo` RAM probe runs on every `StudioRecordingQuality::default()` call**

`detect_total_memory_bytes()` constructs a fresh `sysinfo::System` instance (with a memory refresh) each time it is called. Because `StudioRecordingQuality`'s `Default` impl delegates here, any serde deserialization of an older settings file missing the `studio_recording_quality` key will invoke this probe. Consider caching the result with `std::sync::OnceLock` or computing it once at application start and storing it, so repeated calls don't incur the `sysinfo` overhead.

### Issue 4 of 4
crates/recording/src/output_pipeline/macos.rs:268-270
**Dual boolean flags `ultra_quality` / `compatibility_quality` can silently conflict**

`AVFoundationMp4MuxerConfig` now has two independent `bool` fields that are meant to be mutually exclusive. If both are set to `true`, the if-else chain silently picks `ultra_quality`. Replacing the two booleans with a single `BitrateProfile` (already exported from `cap_enc_avfoundation`) would make the intent explicit and eliminate the ambiguous state. `AVFoundationCameraMuxerConfig` has the same pattern.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["clippy"](https://github.com/capsoftware/cap/commit/f6a0f534d1ab6656ed637b836977b7e6c45fc264) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30419087)</sub>

<!-- /greptile_comment -->