### PR TITLE
macOS desktop crash hardening

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1277,7 +1277,10 @@ async fn cleanup_app_resources_for_exit(app: &AppHandle) {
     close_target_select_overlays(app);
 
     let (mic_feed, camera_feed, camera_shutdown) = {
-        let state = app.state::<ArcLock<App>>();
+        let Some(state) = app.try_state::<ArcLock<App>>() else {
+            warn!("App state unavailable during exit cleanup");
+            return;
+        };
         let mut app_state = state.write().await;
         let camera_shutdown = app_state.camera_preview.begin_shutdown();
         app_state.camera_in_use = false;
@@ -1333,7 +1336,14 @@ fn finalize_app_exit(app: &AppHandle, exit_code: i32) {
 }
 
 pub async fn request_app_exit(app: AppHandle) {
-    if !app.state::<AppExitState>().begin() {
+    let Some(exit_state) = app.try_state::<AppExitState>() else {
+        warn!("Exit state unavailable while requesting app exit");
+        finalize_app_exit(&app, 0);
+        #[cfg(not(target_os = "macos"))]
+        return;
+    };
+
+    if !exit_state.begin() {
         return;
     }
 
@@ -4073,18 +4083,22 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
                     if let Ok(window_id) = CapWindowId::from_str(label) {
                         match window_id {
                             CapWindowId::Camera => {
-                                let close_gate = app.state::<CameraWindowCloseGate>();
-                                if close_gate.allow_close() {
+                                if app
+                                    .try_state::<CameraWindowCloseGate>()
+                                    .is_some_and(|close_gate| close_gate.allow_close())
+                                {
                                     return;
                                 }
 
                                 api.prevent_close();
                                 let _ = window.hide();
                                 tracing::warn!("Camera window CloseRequested event received!");
-                                let session_id =
-                                    app.state::<Arc<AtomicU64>>().load(Ordering::Acquire);
+                                let session_id = app
+                                    .try_state::<Arc<AtomicU64>>()
+                                    .map(|state| state.load(Ordering::Acquire))
+                                    .unwrap_or(0);
                                 let app = app.clone();
-                                tokio::spawn(async move {
+                                spawn_on_runtime(async move {
                                     cleanup_camera_window(app, session_id).await;
                                 });
                             }
@@ -4092,7 +4106,10 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
                                 api.prevent_close();
                                 let _ = window.hide();
 
-                                let state = app.state::<ArcLock<App>>();
+                                let Some(state) = app.try_state::<ArcLock<App>>() else {
+                                    warn!("App state unavailable during main window close request");
+                                    return;
+                                };
                                 let is_recording = state
                                     .try_read()
                                     .map(|s| s.is_recording_active_or_pending())
@@ -4106,8 +4123,11 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
                                     close_target_select_overlays(app);
 
                                     let app = app.clone();
-                                    tokio::spawn(async move {
-                                        let state = app.state::<ArcLock<App>>();
+                                    spawn_on_runtime(async move {
+                                        let Some(state) = app.try_state::<ArcLock<App>>() else {
+                                            warn!("App state unavailable during main window close cleanup");
+                                            return;
+                                        };
 
                                         let (mic_feed, camera_feed) = {
                                             let mut app_state = state.write().await;
@@ -4158,8 +4178,11 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
                                     let _ = camera.hide();
                                 }
 
-                                tokio::spawn(async move {
-                                    let state = app.state::<ArcLock<App>>();
+                                spawn_on_runtime(async move {
+                                    let Some(state) = app.try_state::<ArcLock<App>>() else {
+                                        warn!("App state unavailable during main window destroyed cleanup");
+                                        return;
+                                    };
 
                                     let feeds = {
                                         let app_state = state.read().await;
@@ -4196,30 +4219,38 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
                             }
                             CapWindowId::Editor { id } => {
                                 let window_ids = EditorWindowIds::get(window.app_handle());
-                                window_ids.ids.lock().unwrap().retain(|(_, _id)| *_id != id);
+                                match window_ids.ids.lock() {
+                                    Ok(mut ids) => ids.retain(|(_, _id)| *_id != id),
+                                    Err(err) => warn!(error = %err, "Editor window ids lock poisoned"),
+                                }
 
                                 let label = window.label().to_string();
                                 let pending = editor_window::PendingEditorInstances::get(app);
-                                tokio::spawn(async move {
+                                spawn_on_runtime(async move {
                                     pending.cancel_prewarm(&label).await;
                                 });
 
-                                tokio::spawn(EditorInstances::remove(window.clone()));
+                                spawn_on_runtime(EditorInstances::remove(window.clone()));
 
                                 restore_main_windows_if_no_editors(app);
                             }
                             CapWindowId::ScreenshotEditor { id } => {
                                 let window_ids =
                                     ScreenshotEditorWindowIds::get(window.app_handle());
-                                window_ids.ids.lock().unwrap().retain(|(_, _id)| *_id != id);
+                                match window_ids.ids.lock() {
+                                    Ok(mut ids) => ids.retain(|(_, _id)| *_id != id),
+                                    Err(err) => {
+                                        warn!(error = %err, "Screenshot editor window ids lock poisoned");
+                                    }
+                                }
 
                                 let label = window.label().to_string();
                                 let pending = PendingScreenshotEditorInstances::get(app);
-                                tokio::spawn(async move {
+                                spawn_on_runtime(async move {
                                     pending.cancel_prewarm(&label).await;
                                 });
 
-                                tokio::spawn(ScreenshotEditorInstances::remove(window.clone()));
+                                spawn_on_runtime(ScreenshotEditorInstances::remove(window.clone()));
 
                                 restore_main_windows_if_no_editors(app);
                             }
@@ -4267,11 +4298,16 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
                                 return;
                             }
                             CapWindowId::TargetSelectOverlay { display_id } => {
-                                app.state::<target_select_overlay::WindowFocusManager>()
-                                    .destroy(&display_id, app.global_shortcut());
-                                let session_id =
-                                    app.state::<Arc<AtomicU64>>().load(Ordering::Acquire);
-                                tokio::spawn(cleanup_camera_after_overlay_close(
+                                if let Some(focus_manager) =
+                                    app.try_state::<target_select_overlay::WindowFocusManager>()
+                                {
+                                    focus_manager.destroy(&display_id, app.global_shortcut());
+                                }
+                                let session_id = app
+                                    .try_state::<Arc<AtomicU64>>()
+                                    .map(|state| state.load(Ordering::Acquire))
+                                    .unwrap_or(0);
+                                spawn_on_runtime(cleanup_camera_after_overlay_close(
                                     app.clone(),
                                     session_id,
                                 ));
@@ -4280,17 +4316,21 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
                                 tracing::info!(
                                     "Camera window Destroyed event - resetting panel state"
                                 );
-                                let session_id =
-                                    app.state::<Arc<AtomicU64>>().load(Ordering::Acquire);
+                                let session_id = app
+                                    .try_state::<Arc<AtomicU64>>()
+                                    .map(|state| state.load(Ordering::Acquire))
+                                    .unwrap_or(0);
                                 let app = app.clone();
-                                tokio::spawn(async move {
+                                spawn_on_runtime(async move {
                                     #[cfg(target_os = "macos")]
                                     {
-                                        let panel_manager =
-                                            app.state::<panel_manager::PanelManager>();
-                                        panel_manager
-                                            .force_reset(panel_manager::PanelWindowType::Camera)
-                                            .await;
+                                        if let Some(panel_manager) =
+                                            app.try_state::<panel_manager::PanelManager>()
+                                        {
+                                            panel_manager
+                                                .force_reset(panel_manager::PanelWindowType::Camera)
+                                                .await;
+                                        }
                                     }
                                     cleanup_camera_window(app, session_id).await;
                                 });
@@ -4365,82 +4405,131 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
         })
         .build(tauri_context)
         .expect("error while running tauri application")
-        .run(move |_handle, event| match event {
-            #[cfg(target_os = "macos")]
-            tauri::RunEvent::Reopen { .. } => {
-                let should_focus_onboarding = should_show_onboarding(_handle);
+        .run(move |_handle, event| {
+            let handle = _handle.clone();
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                handle_run_event(&handle, event);
+            }));
 
-                if should_focus_onboarding
-                    && let Some(onboarding) = CapWindowId::Onboarding.get(_handle)
+            if let Err(panic) = result {
+                let message = panic_payload_message(&panic);
+                tracing::error!(panic = %message, "Suppressed panic in Tauri RunEvent handler");
+                sentry::capture_message(
+                    &format!("Tauri RunEvent panic suppressed: {message}"),
+                    sentry::Level::Error,
+                );
+            }
+        });
+}
+
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}
+
+fn handle_run_event(_handle: &AppHandle, event: tauri::RunEvent) {
+    match event {
+        #[cfg(target_os = "macos")]
+        tauri::RunEvent::Reopen { .. } => {
+            let should_focus_onboarding = should_show_onboarding(_handle);
+
+            if should_focus_onboarding
+                && let Some(onboarding) = CapWindowId::Onboarding.get(_handle)
+            {
+                onboarding.show().ok();
+                onboarding.set_focus().ok();
+                return;
+            }
+
+            let has_window = _handle.webview_windows().iter().any(|(label, _)| {
+                label.starts_with("editor-")
+                    || label.starts_with("screenshot-editor-")
+                    || label.as_str() == "settings"
+                    || label.as_str() == "signin"
+                    || (should_focus_onboarding && label.as_str() == "onboarding")
+            });
+
+            if has_window {
+                if let Some(window) = _handle
+                    .webview_windows()
+                    .iter()
+                    .find(|(label, _)| {
+                        label.starts_with("editor-")
+                            || label.starts_with("screenshot-editor-")
+                            || label.as_str() == "settings"
+                            || label.as_str() == "signin"
+                            || (should_focus_onboarding && label.as_str() == "onboarding")
+                    })
+                    .map(|(_, window)| window.clone())
                 {
-                    onboarding.show().ok();
-                    onboarding.set_focus().ok();
-                    return;
+                    window.set_focus().ok();
                 }
-
-                let has_window = _handle.webview_windows().iter().any(|(label, _)| {
-                    label.starts_with("editor-")
-                        || label.starts_with("screenshot-editor-")
-                        || label.as_str() == "settings"
-                        || label.as_str() == "signin"
-                        || (should_focus_onboarding && label.as_str() == "onboarding")
-                });
-
-                if has_window {
-                    if let Some(window) = _handle
-                        .webview_windows()
-                        .iter()
-                        .find(|(label, _)| {
-                            label.starts_with("editor-")
-                                || label.starts_with("screenshot-editor-")
-                                || label.as_str() == "settings"
-                                || label.as_str() == "signin"
-                                || (should_focus_onboarding && label.as_str() == "onboarding")
-                        })
-                        .map(|(_, window)| window.clone())
-                    {
-                        window.set_focus().ok();
+            } else {
+                let handle = _handle.clone();
+                spawn_on_runtime(async move {
+                    let _ = ShowCapWindow::Main {
+                        init_target_mode: None,
                     }
-                } else {
-                    let handle = _handle.clone();
-                    tokio::spawn(async move {
-                        let _ = ShowCapWindow::Main {
-                            init_target_mode: None,
-                        }
-                        .show(&handle)
-                        .await;
-                    });
-                }
-            }
-            tauri::RunEvent::ExitRequested { code, api, .. } => {
-                if _handle.state::<AppExitState>().is_exiting() {
-                    return;
-                }
-
-                api.prevent_exit();
-
-                let _ = code;
-                let handle = _handle.clone();
-                tokio::spawn(async move {
-                    request_app_exit(handle).await;
-                });
-            }
-            tauri::RunEvent::Exit => {
-                if !_handle.state::<AppExitState>().begin() {
-                    return;
-                }
-
-                let handle = _handle.clone();
-                tokio::spawn(async move {
-                    let _ = tokio::time::timeout(
-                        Duration::from_secs(2),
-                        cleanup_app_resources_for_exit(&handle),
-                    )
+                    .show(&handle)
                     .await;
                 });
             }
-            _ => {}
-        });
+        }
+        tauri::RunEvent::ExitRequested { code, api, .. } => {
+            if _handle
+                .try_state::<AppExitState>()
+                .is_some_and(|state| state.is_exiting())
+            {
+                return;
+            }
+
+            api.prevent_exit();
+
+            let _ = code;
+            let handle = _handle.clone();
+            spawn_on_runtime(async move {
+                request_app_exit(handle).await;
+            });
+        }
+        tauri::RunEvent::Exit => {
+            let already_exiting = match _handle.try_state::<AppExitState>() {
+                Some(state) => !state.begin(),
+                None => false,
+            };
+            if already_exiting {
+                return;
+            }
+
+            let handle = _handle.clone();
+            spawn_on_runtime(async move {
+                let _ = tokio::time::timeout(
+                    Duration::from_secs(2),
+                    cleanup_app_resources_for_exit(&handle),
+                )
+                .await;
+            });
+        }
+        _ => {}
+    }
+}
+
+fn spawn_on_runtime<F>(future: F)
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => {
+            handle.spawn(future);
+        }
+        Err(err) => {
+            tracing::warn!(error = %err, "No tokio runtime available; dropping background task");
+        }
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -4467,21 +4556,28 @@ fn restore_main_windows_if_no_editors(app: &AppHandle) {
             restore_camera_window(app);
         }
 
-        tokio::spawn(captions::release_ml_models());
+        spawn_on_runtime(captions::release_ml_models());
     }
 }
 
 fn restore_camera_window(app: &AppHandle) {
     let should_restore_camera = app
-        .state::<ArcLock<App>>()
-        .try_read()
-        .map(|state| state.selected_camera_id.is_some() && !state.camera_cleanup_done)
+        .try_state::<ArcLock<App>>()
+        .and_then(|state| {
+            state
+                .try_read()
+                .ok()
+                .map(|state| state.selected_camera_id.is_some() && !state.camera_cleanup_done)
+        })
         .unwrap_or(false);
 
     if should_restore_camera {
         let app = app.clone();
-        tokio::spawn(async move {
-            let operation_lock = app.state::<CameraWindowOperationLock>();
+        spawn_on_runtime(async move {
+            let Some(operation_lock) = app.try_state::<CameraWindowOperationLock>() else {
+                warn!("Camera window operation lock unavailable during restore");
+                return;
+            };
             let _operation_guard = operation_lock.lock().await;
             let _ = ShowCapWindow::Camera { centered: false }.show(&app).await;
         });
@@ -4489,18 +4585,20 @@ fn restore_camera_window(app: &AppHandle) {
 }
 
 fn close_target_select_overlays(app: &AppHandle) {
-    let focus_manager = app.state::<target_select_overlay::WindowFocusManager>();
+    let focus_manager = app.try_state::<target_select_overlay::WindowFocusManager>();
     let mut saw_overlay = false;
 
     for (label, window) in app.webview_windows() {
         if let Ok(CapWindowId::TargetSelectOverlay { display_id }) = CapWindowId::from_str(&label) {
             saw_overlay = true;
             hide_overlay(&window);
-            focus_manager.destroy(&display_id, app.global_shortcut());
+            if let Some(focus_manager) = focus_manager.as_ref() {
+                focus_manager.destroy(&display_id, app.global_shortcut());
+            }
         }
     }
 
-    if !saw_overlay {
+    if !saw_overlay && let Some(focus_manager) = focus_manager {
         focus_manager.shutdown(app);
     }
 }

--- a/apps/desktop/src-tauri/src/permissions.rs
+++ b/apps/desktop/src-tauri/src/permissions.rs
@@ -7,10 +7,18 @@ use cidre::av;
 #[cfg(target_os = "macos")]
 use objc2_app_kit::{NSApplicationActivationOptions, NSRunningApplication};
 #[cfg(target_os = "macos")]
-use std::{future::Future, str::FromStr, time::Duration};
+use std::{
+    future::Future,
+    str::FromStr,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
 #[cfg(target_os = "macos")]
 use tauri::Manager;
 use tracing::instrument;
+
+#[cfg(target_os = "macos")]
+static MACOS_DOCK_VISIBILITY_SYNC_GENERATION: AtomicU64 = AtomicU64::new(0);
 
 #[cfg(target_os = "macos")]
 #[link(name = "ApplicationServices", kind = "framework")]
@@ -134,6 +142,13 @@ fn macos_sync_activation_policy(app: &tauri::AppHandle, should_show_dock: bool) 
 }
 
 #[cfg(target_os = "macos")]
+pub(crate) fn prepare_macos_panel_window(app: &tauri::AppHandle) {
+    if let Err(err) = app.set_activation_policy(tauri::ActivationPolicy::Accessory) {
+        tracing::warn!("Failed to prepare macOS panel activation policy: {err}");
+    }
+}
+
+#[cfg(target_os = "macos")]
 pub(crate) fn sync_macos_dock_visibility(app: &tauri::AppHandle) {
     let should_hide_dock = GeneralSettingsStore::get(app)
         .ok()
@@ -152,6 +167,18 @@ pub(crate) fn sync_macos_dock_visibility(app: &tauri::AppHandle) {
     if let Err(err) = app.set_dock_visibility(should_show_dock) {
         tracing::warn!("Failed to update dock visibility: {err}");
     }
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn schedule_macos_dock_visibility_sync(app: &tauri::AppHandle) {
+    let generation = MACOS_DOCK_VISIBILITY_SYNC_GENERATION.fetch_add(1, Ordering::Relaxed) + 1;
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if MACOS_DOCK_VISIBILITY_SYNC_GENERATION.load(Ordering::Relaxed) == generation {
+            sync_macos_dock_visibility(&app);
+        }
+    });
 }
 
 #[cfg(target_os = "macos")]

--- a/apps/desktop/src-tauri/src/platform/macos/delegates.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/delegates.rs
@@ -95,24 +95,37 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
         func(ptr);
     }
 
+    fn suppress_delegate_panic<T, F>(selector: &'static str, fallback: T, operation: F) -> T
+    where
+        F: FnOnce() -> T,
+    {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(operation)) {
+            Ok(value) => value,
+            Err(_) => {
+                tracing::error!(selector, "Suppressed panic in macOS window delegate");
+                fallback
+            }
+        }
+    }
+
     unsafe {
         let ns_win_id = ns_win as id;
         let current_delegate: id = ns_win_id.delegate();
 
         extern "C" fn on_window_should_close(this: &Object, _cmd: Sel, sender: id) -> BOOL {
-            unsafe {
+            suppress_delegate_panic("windowShouldClose:", cocoa::base::NO, || unsafe {
                 let super_del: id = *this.get_ivar("super_delegate");
                 msg_send![super_del, windowShouldClose: sender]
-            }
+            })
         }
         extern "C" fn on_window_will_close(this: &Object, _cmd: Sel, notification: id) {
-            unsafe {
+            suppress_delegate_panic("windowWillClose:", (), || unsafe {
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, windowWillClose: notification];
-            }
+            });
         }
         extern "C" fn on_window_did_resize<R: Runtime>(this: &Object, _cmd: Sel, notification: id) {
-            unsafe {
+            suppress_delegate_panic("windowDidResize:", (), || unsafe {
                 with_window_state(this, |state: &mut WindowState<R>| {
                     if let Ok(window_handle) = state.window.ns_window() {
                         position_window_controls(
@@ -126,69 +139,69 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
 
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, windowDidResize: notification];
-            }
+            });
         }
         extern "C" fn on_window_did_move(this: &Object, _cmd: Sel, notification: id) {
-            unsafe {
+            suppress_delegate_panic("windowDidMove:", (), || unsafe {
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, windowDidMove: notification];
-            }
+            });
         }
         extern "C" fn on_window_did_change_backing_properties(
             this: &Object,
             _cmd: Sel,
             notification: id,
         ) {
-            unsafe {
+            suppress_delegate_panic("windowDidChangeBackingProperties:", (), || unsafe {
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, windowDidChangeBackingProperties: notification];
-            }
+            });
         }
         extern "C" fn on_window_did_become_key(this: &Object, _cmd: Sel, notification: id) {
-            unsafe {
+            suppress_delegate_panic("windowDidBecomeKey:", (), || unsafe {
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, windowDidBecomeKey: notification];
-            }
+            });
         }
         extern "C" fn on_window_did_resign_key(this: &Object, _cmd: Sel, notification: id) {
-            unsafe {
+            suppress_delegate_panic("windowDidResignKey:", (), || unsafe {
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, windowDidResignKey: notification];
-            }
+            });
         }
         extern "C" fn on_dragging_entered(this: &Object, _cmd: Sel, notification: id) -> BOOL {
-            unsafe {
+            suppress_delegate_panic("draggingEntered:", cocoa::base::NO, || unsafe {
                 let super_del: id = *this.get_ivar("super_delegate");
                 msg_send![super_del, draggingEntered: notification]
-            }
+            })
         }
         extern "C" fn on_prepare_for_drag_operation(
             this: &Object,
             _cmd: Sel,
             notification: id,
         ) -> BOOL {
-            unsafe {
+            suppress_delegate_panic("prepareForDragOperation:", cocoa::base::NO, || unsafe {
                 let super_del: id = *this.get_ivar("super_delegate");
                 msg_send![super_del, prepareForDragOperation: notification]
-            }
+            })
         }
         extern "C" fn on_perform_drag_operation(this: &Object, _cmd: Sel, sender: id) -> BOOL {
-            unsafe {
+            suppress_delegate_panic("performDragOperation:", cocoa::base::NO, || unsafe {
                 let super_del: id = *this.get_ivar("super_delegate");
                 msg_send![super_del, performDragOperation: sender]
-            }
+            })
         }
         extern "C" fn on_conclude_drag_operation(this: &Object, _cmd: Sel, notification: id) {
-            unsafe {
+            suppress_delegate_panic("concludeDragOperation:", (), || unsafe {
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, concludeDragOperation: notification];
-            }
+            });
         }
         extern "C" fn on_dragging_exited(this: &Object, _cmd: Sel, notification: id) {
-            unsafe {
+            suppress_delegate_panic("draggingExited:", (), || unsafe {
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, draggingExited: notification];
-            }
+            });
         }
         extern "C" fn on_window_will_use_full_screen_presentation_options(
             this: &Object,
@@ -196,17 +209,21 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
             window: id,
             proposed_options: NSUInteger,
         ) -> NSUInteger {
-            unsafe {
-                let super_del: id = *this.get_ivar("super_delegate");
-                msg_send![super_del, window: window willUseFullScreenPresentationOptions: proposed_options]
-            }
+            suppress_delegate_panic(
+                "window:willUseFullScreenPresentationOptions:",
+                proposed_options,
+                || unsafe {
+                    let super_del: id = *this.get_ivar("super_delegate");
+                    msg_send![super_del, window: window willUseFullScreenPresentationOptions: proposed_options]
+                },
+            )
         }
         extern "C" fn on_window_did_enter_full_screen<R: Runtime>(
             this: &Object,
             _cmd: Sel,
             notification: id,
         ) {
-            unsafe {
+            suppress_delegate_panic("windowDidEnterFullScreen:", (), || unsafe {
                 with_window_state(this, |state: &mut WindowState<R>| {
                     if let Err(err) = state.window.emit("did-enter-fullscreen", ()) {
                         tracing::warn!("Failed to emit did-enter-fullscreen: {err}");
@@ -215,14 +232,14 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
 
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, windowDidEnterFullScreen: notification];
-            }
+            });
         }
         extern "C" fn on_window_will_enter_full_screen<R: Runtime>(
             this: &Object,
             _cmd: Sel,
             notification: id,
         ) {
-            unsafe {
+            suppress_delegate_panic("windowWillEnterFullScreen:", (), || unsafe {
                 with_window_state(this, |state: &mut WindowState<R>| {
                     if let Err(err) = state.window.emit("will-enter-fullscreen", ()) {
                         tracing::warn!("Failed to emit will-enter-fullscreen: {err}");
@@ -231,14 +248,14 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
 
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, windowWillEnterFullScreen: notification];
-            }
+            });
         }
         extern "C" fn on_window_did_exit_full_screen<R: Runtime>(
             this: &Object,
             _cmd: Sel,
             notification: id,
         ) {
-            unsafe {
+            suppress_delegate_panic("windowDidExitFullScreen:", (), || unsafe {
                 with_window_state(this, |state: &mut WindowState<R>| {
                     if let Err(err) = state.window.emit("did-exit-fullscreen", ()) {
                         tracing::warn!("Failed to emit did-exit-fullscreen: {err}");
@@ -256,14 +273,14 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
 
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, windowDidExitFullScreen: notification];
-            }
+            });
         }
         extern "C" fn on_window_will_exit_full_screen<R: Runtime>(
             this: &Object,
             _cmd: Sel,
             notification: id,
         ) {
-            unsafe {
+            suppress_delegate_panic("windowWillExitFullScreen:", (), || unsafe {
                 with_window_state(this, |state: &mut WindowState<R>| {
                     if let Err(err) = state.window.emit("will-exit-fullscreen", ()) {
                         tracing::warn!("Failed to emit will-exit-fullscreen: {err}");
@@ -272,40 +289,44 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
 
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, windowWillExitFullScreen: notification];
-            }
+            });
         }
         extern "C" fn on_window_did_fail_to_enter_full_screen(
             this: &Object,
             _cmd: Sel,
             window: id,
         ) {
-            unsafe {
+            suppress_delegate_panic("windowDidFailToEnterFullScreen:", (), || unsafe {
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, windowDidFailToEnterFullScreen: window];
-            }
+            });
         }
         extern "C" fn on_effective_appearance_did_change(
             this: &Object,
             _cmd: Sel,
             notification: id,
         ) {
-            unsafe {
+            suppress_delegate_panic("effectiveAppearanceDidChange:", (), || unsafe {
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, effectiveAppearanceDidChange: notification];
-            }
+            });
         }
         extern "C" fn on_effective_appearance_did_changed_on_main_thread(
             this: &Object,
             _cmd: Sel,
             notification: id,
         ) {
-            unsafe {
-                let super_del: id = *this.get_ivar("super_delegate");
-                let _: () = msg_send![
-                    super_del,
-                    effectiveAppearanceDidChangedOnMainThread: notification
-                ];
-            }
+            suppress_delegate_panic(
+                "effectiveAppearanceDidChangedOnMainThread:",
+                (),
+                || unsafe {
+                    let super_del: id = *this.get_ivar("super_delegate");
+                    let _: () = msg_send![
+                        super_del,
+                        effectiveAppearanceDidChangedOnMainThread: notification
+                    ];
+                },
+            );
         }
 
         let window_label = window.label().to_string();

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -1165,8 +1165,7 @@ impl ShowCapWindow {
                 let should_protect = should_protect_window(app, &title);
 
                 #[cfg(target_os = "macos")]
-                app.set_activation_policy(tauri::ActivationPolicy::Accessory)
-                    .ok();
+                permissions::prepare_macos_panel_window(app);
 
                 let window = self
                     .window_builder(app, "/")
@@ -1242,7 +1241,7 @@ impl ShowCapWindow {
 
                             crate::platform::apply_squircle_corners(&window, 16.0);
 
-                            crate::permissions::sync_macos_dock_visibility(&app);
+                            crate::permissions::schedule_macos_dock_visibility_sync(&app);
                         }
                     })
                     .ok();
@@ -1299,8 +1298,7 @@ impl ShowCapWindow {
                 };
 
                 #[cfg(target_os = "macos")]
-                app.set_activation_policy(tauri::ActivationPolicy::Accessory)
-                    .ok();
+                permissions::prepare_macos_panel_window(app);
 
                 let mut window_builder = self
                     .window_builder(
@@ -1411,7 +1409,7 @@ impl ShowCapWindow {
                             panel.order_front_regardless();
                             panel.show();
 
-                            crate::permissions::sync_macos_dock_visibility(&app);
+                            crate::permissions::schedule_macos_dock_visibility_sync(&app);
                         }
                     })
                     .ok();
@@ -1710,8 +1708,7 @@ impl ShowCapWindow {
                     let should_protect = should_protect_window(app, &title);
 
                     #[cfg(target_os = "macos")]
-                    app.set_activation_policy(tauri::ActivationPolicy::Accessory)
-                        .ok();
+                    permissions::prepare_macos_panel_window(app);
 
                     let mut window_builder = self
                         .window_builder(app, "/camera")
@@ -1883,7 +1880,7 @@ impl ShowCapWindow {
 
                                 panel.order_front_regardless();
                                 panel.show();
-                                crate::permissions::sync_macos_dock_visibility(&app);
+                                crate::permissions::schedule_macos_dock_visibility_sync(&app);
                                 let _ = panel_tx.send(true);
                             }
                         })
@@ -2037,8 +2034,7 @@ impl ShowCapWindow {
                 let should_protect = should_protect_window(app, &title);
 
                 #[cfg(target_os = "macos")]
-                app.set_activation_policy(tauri::ActivationPolicy::Accessory)
-                    .ok();
+                permissions::prepare_macos_panel_window(app);
 
                 #[cfg(target_os = "macos")]
                 let window = {
@@ -2153,7 +2149,7 @@ impl ShowCapWindow {
                             panel.order_front_regardless();
                             panel.show();
 
-                            crate::permissions::sync_macos_dock_visibility(&app);
+                            crate::permissions::schedule_macos_dock_visibility_sync(&app);
                         }
                     })
                     .ok();

--- a/crates/camera-avfoundation/src/lib.rs
+++ b/crates/camera-avfoundation/src/lib.rs
@@ -114,33 +114,39 @@ impl VideoDataOutputSampleBufDelegateImpl for CallbackOutputDelegate {
         sample_buf: &cm::SampleBuf,
         connection: &av::CaptureConnection,
     ) {
-        let pts = sample_buf.pts();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let pts = sample_buf.pts();
 
-        let capture_begin_time = pts
-            .is_valid()
-            .then(|| mach_time_to_microseconds(cm::Clock::convert_host_time_to_sys_units(pts)));
-        let pres_timestamp = capture_begin_time.unwrap_or(Duration::ZERO);
+            let capture_begin_time = pts
+                .is_valid()
+                .then(|| mach_time_to_microseconds(cm::Clock::convert_host_time_to_sys_units(pts)));
+            let pres_timestamp = capture_begin_time.unwrap_or(Duration::ZERO);
 
-        let stream_start = self
-            .inner_mut()
-            .stream_start
-            .get_or_insert_with(|| (Instant::now(), pres_timestamp));
+            let stream_start = self
+                .inner_mut()
+                .stream_start
+                .get_or_insert_with(|| (Instant::now(), pres_timestamp));
 
-        let Some(timestamp) = pres_timestamp.checked_sub(stream_start.1) else {
-            warn!("PTS {pres_timestamp:?} less than stream start {stream_start:?}");
+            let Some(timestamp) = pres_timestamp.checked_sub(stream_start.1) else {
+                warn!("PTS {pres_timestamp:?} less than stream start {stream_start:?}");
 
-            return;
-        };
+                return;
+            };
 
-        let capture_begin_time = stream_start.0 + capture_begin_time.unwrap_or(Duration::ZERO);
+            let capture_begin_time = stream_start.0 + capture_begin_time.unwrap_or(Duration::ZERO);
 
-        (self.inner_mut().callback)(CallbackData {
-            output,
-            sample_buf,
-            connection,
-            capture_begin_time,
-            timestamp,
-        });
+            (self.inner_mut().callback)(CallbackData {
+                output,
+                sample_buf,
+                connection,
+                capture_begin_time,
+                timestamp,
+            });
+        }));
+
+        if result.is_err() {
+            warn!("Suppressed panic in AVFoundation output delegate");
+        }
     }
 }
 
@@ -149,23 +155,14 @@ fn mach_time_to_microseconds(mach_time: u64) -> Duration {
     if timebase_info.numer == timebase_info.denom {
         return Duration::from_nanos(mach_time);
     }
-    let divisor = timebase_info.denom as u64 * 1000;
-    let mut microseconds = mach_time / divisor;
+    if timebase_info.denom == 0 {
+        warn!("Invalid mach timebase denominator");
+        return Duration::ZERO;
+    }
 
-    let mach_time_remainder = mach_time % divisor;
-
-    microseconds = microseconds
-        .checked_mul(timebase_info.numer as u64)
-        .expect("Multiplication overflow");
-
-    let least_significant_microseconds =
-        (mach_time_remainder * timebase_info.numer as u64) / divisor;
-
-    microseconds = microseconds
-        .checked_add(least_significant_microseconds)
-        .expect("Addition overflow");
-
-    Duration::from_micros(microseconds)
+    let microseconds =
+        (mach_time as u128 * timebase_info.numer as u128) / (timebase_info.denom as u128 * 1000);
+    Duration::from_micros(microseconds.min(u64::MAX as u128) as u64)
 }
 
 pub trait ImageBufExt {

--- a/crates/recording/src/sources/screen_capture/macos.rs
+++ b/crates/recording/src/sources/screen_capture/macos.rs
@@ -473,12 +473,21 @@ impl ScreenCaptureConfig<CMSampleBufferCapture> {
                                 ChannelLayout::STEREO,
                             );
                             frame.set_rate(48_000);
-                            let data_bytes_size = buf_list.list().buffers[0].data_bytes_size;
+                            let data_bytes_size =
+                                buf_list.list().buffers[0].data_bytes_size as usize;
                             for i in 0..frame.planes() {
-                                frame.data_mut(i).copy_from_slice(
-                                    &slice[i * data_bytes_size as usize
-                                        ..(i + 1) * data_bytes_size as usize],
-                                );
+                                let start = i.saturating_mul(data_bytes_size);
+                                let end = start.saturating_add(data_bytes_size);
+                                let Some(source) = slice.get(start..end) else {
+                                    warn!("Audio buffer slice too small for plane data, dropping audio chunk");
+                                    return;
+                                };
+                                let destination = frame.data_mut(i);
+                                if destination.len() != source.len() {
+                                    warn!("Audio frame plane size mismatch, dropping audio chunk");
+                                    return;
+                                }
+                                destination.copy_from_slice(source);
                             }
 
                             match output_pipeline::send_with_stall_budget_futures(

--- a/crates/scap-screencapturekit/src/capture.rs
+++ b/crates/scap-screencapturekit/src/capture.rs
@@ -21,20 +21,26 @@ impl sc::stream::OutputImpl for CapturerCallbacks {
         sample_buf: &mut cm::SampleBuf,
         kind: sc::OutputType,
     ) {
-        if let Some(cb) = &mut self.inner_mut().did_output_sample_buf_cb {
-            let sample_buf = sample_buf.retained();
-            let frame = match kind {
-                sc::OutputType::Screen => {
-                    if sample_buf.image_buf().is_none() {
-                        return;
-                    }
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if let Some(cb) = &mut self.inner_mut().did_output_sample_buf_cb {
+                let sample_buf = sample_buf.retained();
+                let frame = match kind {
+                    sc::OutputType::Screen => {
+                        if sample_buf.image_buf().is_none() {
+                            return;
+                        }
 
-                    Frame::Screen(VideoFrame { sample_buf })
-                }
-                sc::OutputType::Audio => Frame::Audio(AudioFrame { sample_buf }),
-                sc::OutputType::Mic => Frame::Mic(AudioFrame { sample_buf }),
-            };
-            (cb)(frame);
+                        Frame::Screen(VideoFrame { sample_buf })
+                    }
+                    sc::OutputType::Audio => Frame::Audio(AudioFrame { sample_buf }),
+                    sc::OutputType::Mic => Frame::Mic(AudioFrame { sample_buf }),
+                };
+                (cb)(frame);
+            }
+        }));
+
+        if result.is_err() {
+            tracing::warn!("Suppressed panic in ScreenCaptureKit output callback");
         }
     }
 }
@@ -49,8 +55,14 @@ impl sc::stream::DelegateImpl for CapturerCallbacks {
         stream: &sc::Stream,
         error: &ns::Error,
     ) {
-        if let Some(cb) = &mut self.inner_mut().did_stop_with_err_cb {
-            (cb)(stream, error)
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if let Some(cb) = &mut self.inner_mut().did_stop_with_err_cb {
+                (cb)(stream, error)
+            }
+        }));
+
+        if result.is_err() {
+            tracing::warn!("Suppressed panic in ScreenCaptureKit stop callback");
         }
     }
 }


### PR DESCRIPTION
Hardens desktop window lifecycle and macOS capture callbacks against panics and missing state during shutdown/cleanup. Also debounces macOS dock visibility sync and validates audio plane slices before copying.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the macOS desktop against panics and missing state during shutdown by replacing `.state()` with `.try_state()` across window lifecycle handlers, wrapping ObjC delegate callbacks and ScreenCaptureKit/AVFoundation output callbacks in `catch_unwind`, debouncing dock-visibility sync, and validating audio buffer slice bounds before copying.

The changes are well-targeted and the overall approach is sound; two P2 concerns are noted inline regarding the breadth of the `catch_unwind` in the Tauri run-event handler and the risk of operating on inconsistent mutable Obj-C state after a suppressed panic.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 suggestions with no blocking logic errors on the changed paths.

Only P2 findings present. The hardening changes are additive and conservative — `try_state` guards, bounded arithmetic, and bounds-checked slice copies all reduce crash surface without introducing new failure modes. The two flagged concerns (broad `catch_unwind` scope and post-panic mutable state) are valid quality suggestions but do not represent regressions.

`crates/scap-screencapturekit/src/capture.rs` and `apps/desktop/src-tauri/src/lib.rs` (run-event handler) for the `catch_unwind` scope questions.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/lib.rs | Systematic replacement of `.state()` with `.try_state()` across window lifecycle handlers; extracted `handle_run_event` wrapped in `catch_unwind`; introduced `spawn_on_runtime` guard helper. The blanket `catch_unwind` around the entire run-event handler is broader than necessary. |
| apps/desktop/src-tauri/src/permissions.rs | Added `schedule_macos_dock_visibility_sync` debounce helper using a generation counter; atomic ordering is Relaxed (flagged in a prior outside-diff review comment as needing AcqRel/Acquire on Apple Silicon). |
| apps/desktop/src-tauri/src/platform/macos/delegates.rs | Introduced `suppress_delegate_panic` wrapper around every ObjC window delegate selector. Fallback values are sensible (NO for BOOL selectors, pass-through for presentation options). |
| apps/desktop/src-tauri/src/windows.rs | Replaced four direct `sync_macos_dock_visibility` calls with `schedule_macos_dock_visibility_sync`, and three `set_activation_policy` call-sites with `prepare_macos_panel_window`. Clean refactor. |
| crates/camera-avfoundation/src/lib.rs | Sample-buffer callback wrapped in `catch_unwind`; `mach_time_to_microseconds` rewritten to use u128 arithmetic with a saturating u64 cast (saturation to u64::MAX producing a wildly incorrect timestamp is flagged in the prior outside-diff review comment). |
| crates/recording/src/sources/screen_capture/macos.rs | Added bounds-checked slice access and plane-size validation before `copy_from_slice` for audio buffer planes. Correct fix for the original panic. |
| crates/scap-screencapturekit/src/capture.rs | Both ScreenCaptureKit callbacks wrapped in `catch_unwind` + `AssertUnwindSafe`. Mutable Obj-C delegate state after a suppressed panic may be inconsistent for subsequent frames. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Tauri RunEvent] --> B[catch_unwind AssertUnwindSafe]
    B --> C{handle_run_event}
    C -->|Reopen| D[show/focus window]
    C -->|ExitRequested| E[try_state AppExitState\nprevent_exit + spawn request_app_exit]
    C -->|Exit| F[try_state AppExitState\nspawn cleanup_app_resources_for_exit]
    C -->|panic| G[log to tracing + sentry\ncontinue processing]

    subgraph Window CloseRequested
        H[try_state CameraWindowCloseGate] -->|None or deny| I[prevent_close + spawn_on_runtime cleanup]
        J[try_state ArcLock App] -->|None| K[warn + return]
        J -->|Some| L[check is_recording]
    end

    subgraph macOS ObjC Delegates
        M[suppress_delegate_panic] --> N{delegate fn}
        N -->|panic| O[log error\nreturn fallback value]
        N -->|ok| P[forward to super_delegate]
    end

    subgraph Capture Callbacks
        Q[did_output_sample_buf] --> R[catch_unwind AssertUnwindSafe]
        R -->|panic| S[warn + skip frame]
        R -->|ok| T[process frame / invoke cb]
    end

    subgraph Audio Buffer Validation
        U[buf_list buffers 0] --> V{slice.get start..end}
        V -->|None| W[warn + drop chunk]
        V -->|Some| X{dest.len == src.len}
        X -->|no| W
        X -->|yes| Y[copy_from_slice]
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/desktop/src-tauri/src/permissions.rs`, line 499-506 ([link](https://github.com/capsoftware/cap/blob/47e4d7a6867be2f0e5a3c4e5ccc9321fa7cc71e5/apps/desktop/src-tauri/src/permissions.rs#L499-L506)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Relaxed ordering insufficient for debounce correctness on ARM**

   The generation counter uses `Relaxed` for both the `fetch_add` (caller) and the `load` (spawned task). On weakly-ordered architectures like Apple Silicon, there is no guarantee the spawned task will observe the latest counter value written by a concurrent caller — two rapid callers could each observe a stale generation and both proceed to invoke `sync_macos_dock_visibility`. For a debounce intended to coalesce multiple rapid calls into one, `AcqRel` on the `fetch_add` and `Acquire` on the `load` would correctly enforce the happens-before relationship.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src-tauri/src/permissions.rs
   Line: 499-506

   Comment:
   **Relaxed ordering insufficient for debounce correctness on ARM**

   The generation counter uses `Relaxed` for both the `fetch_add` (caller) and the `load` (spawned task). On weakly-ordered architectures like Apple Silicon, there is no guarantee the spawned task will observe the latest counter value written by a concurrent caller — two rapid callers could each observe a stale generation and both proceed to invoke `sync_macos_dock_visibility`. For a debounce intended to coalesce multiple rapid calls into one, `AcqRel` on the `fetch_add` and `Acquire` on the `load` would correctly enforce the happens-before relationship.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `crates/camera-avfoundation/src/lib.rs`, line 959-961 ([link](https://github.com/capsoftware/cap/blob/47e4d7a6867be2f0e5a3c4e5ccc9321fa7cc71e5/crates/camera-avfoundation/src/lib.rs#L959-L961)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Clamping to `u64::MAX` produces a wildly incorrect timestamp**

   When the computed microseconds exceeds `u64::MAX` (≈ 584,542 years), `.min(u64::MAX as u128) as u64` silently saturates to `u64::MAX` and passes it upstream as a valid timestamp rather than returning `Duration::ZERO` or an error. Downstream code will interpret this as a ~584,542-year timestamp delta, likely corrupting any PTS-based synchronization logic. Returning `Duration::ZERO` (matching the existing `denom == 0` guard) would be safer.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/camera-avfoundation/src/lib.rs
   Line: 959-961

   Comment:
   **Clamping to `u64::MAX` produces a wildly incorrect timestamp**

   When the computed microseconds exceeds `u64::MAX` (≈ 584,542 years), `.min(u64::MAX as u128) as u64` silently saturates to `u64::MAX` and passes it upstream as a valid timestamp rather than returning `Duration::ZERO` or an error. Downstream code will interpret this as a ~584,542-year timestamp delta, likely corrupting any PTS-based synchronization logic. Returning `Duration::ZERO` (matching the existing `denom == 0` guard) would be safer.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
crates/scap-screencapturekit/src/capture.rs:21-40
**Mutable delegate state may be inconsistent after a suppressed panic**

`AssertUnwindSafe` tells the compiler "trust me, this is safe to unwind through", but it doesn't actually make the invariant true. If `(cb)(frame)` panics mid-execution, the closure unwinds while `self.inner_mut()` holds a live mutable borrow on the underlying `CapturerCallbacksInner`. For Obj-C-bridged types that use raw-pointer interior mutability, the object's internal state can be left partially written. Every subsequent frame callback then operates on that inconsistent state, potentially producing corrupted frames or a secondary panic. At minimum, consider setting a `poisoned` flag on the `CapturerCallbacks` after a caught panic and skipping future callbacks (returning early) until the stream is restarted.

### Issue 2 of 2
apps/desktop/src-tauri/src/lib.rs:4433-4446
**`catch_unwind` + `AssertUnwindSafe` on the Tauri event loop is broad**

Wrapping all of `handle_run_event` in `catch_unwind(AssertUnwindSafe(...))` suppresses any panic, including ones that indicate corrupted Tauri-internal state (e.g., a partially-updated window table). After such a panic the application continues processing future run-events against that corrupted state rather than crashing cleanly and giving the user a clear error report. Consider scoping the unwind boundary to the narrow call-sites actually known to panic (as was done in `delegates.rs`), rather than using a blanket catch over the entire event dispatch path.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into crashing-stuff"](https://github.com/capsoftware/cap/commit/0b9b12347544fd9aad319a1ea2e610bfbc67db56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30427760)</sub>

<!-- /greptile_comment -->