### PR TITLE
Organization-managed storage for desktop and dashboard

### DIFF
--- a/apps/desktop/src/routes/(window-chrome)/settings/integrations/google-drive-config.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/integrations/google-drive-config.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@cap/ui-solid";
 import { useMutation } from "@tanstack/solid-query";
 import { createResource, createSignal, Show, Suspense } from "solid-js";
+import { createSelectedOrganization } from "~/utils/organization-branding";
 import { commands } from "~/utils/tauri";
 import { apiClient, protectedHeaders } from "~/utils/web-api";
 import { IntegrationConfigHeader } from "./config-header";
@@ -42,9 +43,18 @@ const wait = (ms: number) =>
 		setTimeout(resolve, ms);
 	});
 
-const fetchStorageIntegrations = async (refreshStorageQuota = false) => {
+const fetchStorageIntegrations = async (
+	orgId: string | null,
+	refreshStorageQuota = false,
+) => {
 	const response = await apiClient.desktop.getStorageIntegrations({
-		query: refreshStorageQuota ? { refreshStorageQuota: true } : undefined,
+		query:
+			refreshStorageQuota || orgId
+				? {
+						...(refreshStorageQuota ? { refreshStorageQuota: true } : {}),
+						...(orgId ? { orgId } : {}),
+					}
+				: undefined,
 		headers: await protectedHeaders(),
 	});
 
@@ -54,44 +64,60 @@ const fetchStorageIntegrations = async (refreshStorageQuota = false) => {
 	return response.body;
 };
 
-const fetchS3Config = async () => {
+const fetchS3Config = async (orgId: string | null) => {
 	const response = await apiClient.desktop.getS3Config({
+		query: orgId ? { orgId } : undefined,
 		headers: await protectedHeaders(),
 	});
 
 	if (response.status !== 200) throw new Error("Failed to fetch S3 config");
 
-	return response.body.config;
+	return response.body;
 };
 
 export default function GoogleDriveConfigPage() {
+	const organizationSelection = createSelectedOrganization();
 	const [isWaitingForConnection, setIsWaitingForConnection] =
 		createSignal(false);
 	const [isRefreshing, setIsRefreshing] = createSignal(false);
-	const [storage, { mutate: setStorage }] = createResource(() =>
-		fetchStorageIntegrations(),
+	const [storage, { mutate: setStorage }] = createResource(
+		() => organizationSelection.selectedOrganizationId(),
+		(orgId) => fetchStorageIntegrations(orgId),
 	);
 
 	const googleDrive = () => storage()?.googleDrive;
 	const storageQuota = () => googleDrive()?.storageQuota ?? null;
 	const isConnected = () => googleDrive()?.connected === true;
 	const isActive = () => storage()?.activeProvider === "googleDrive";
+	const managedByOrganization = () => storage()?.managedByOrganization ?? null;
 
-	const [s3Config, { mutate: setS3Config }] = createResource(fetchS3Config);
+	const [s3Config, { mutate: setS3Config }] = createResource(
+		() => organizationSelection.selectedOrganizationId(),
+		(orgId) => fetchS3Config(orgId),
+	);
 
 	const hasS3Config = () => {
-		const config = s3Config();
-		return !!config?.accessKeyId && !!config.bucketName;
+		const result = s3Config();
+		return (
+			result?.source === "user" &&
+			!!result.config.accessKeyId &&
+			!!result.config.bucketName
+		);
 	};
 
 	const updateStorage = async (refreshStorageQuota = false) => {
-		const nextStorage = await fetchStorageIntegrations(refreshStorageQuota);
+		const nextStorage = await fetchStorageIntegrations(
+			organizationSelection.selectedOrganizationId(),
+			refreshStorageQuota,
+		);
 		setStorage(nextStorage);
 		return nextStorage;
 	};
 
 	const updateS3Config = async () => {
-		const nextConfig = await fetchS3Config();
+		const nextConfig = await fetchS3Config(
+			organizationSelection.selectedOrganizationId(),
+		);
 		setS3Config(nextConfig);
 		return nextConfig;
 	};
@@ -238,6 +264,7 @@ export default function GoogleDriveConfigPage() {
 	const busy = () =>
 		storage.loading ||
 		s3Config.loading ||
+		!!managedByOrganization() ||
 		isRefreshing() ||
 		connect.isPending ||
 		isWaitingForConnection() ||
@@ -264,6 +291,13 @@ export default function GoogleDriveConfigPage() {
 									your Drive. Existing Cap-hosted and S3 videos keep using their
 									current storage.
 								</p>
+								<Show when={managedByOrganization()}>
+									{(organization) => (
+										<p class="mt-3 text-sm font-medium text-gray-12">
+											Managed by your organization: {organization().name}
+										</p>
+									)}
+								</Show>
 							</div>
 
 							<div class="space-y-3">

--- a/apps/desktop/src/routes/(window-chrome)/settings/integrations/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/integrations/index.tsx
@@ -1,11 +1,13 @@
 import { Button } from "@cap/ui-solid";
 import { useNavigate } from "@solidjs/router";
-import { For, onMount } from "solid-js";
+import { createResource, For, onMount } from "solid-js";
 import IconLucideDatabase from "~icons/lucide/database";
 
 import "@total-typescript/ts-reset/filter-boolean";
 import { authStore } from "~/store";
+import { createSelectedOrganization } from "~/utils/organization-branding";
 import { commands } from "~/utils/tauri";
+import { apiClient, protectedHeaders } from "~/utils/web-api";
 
 const GoogleDriveIcon = (props: { class?: string }) => (
 	<svg
@@ -44,8 +46,23 @@ const GoogleDriveIcon = (props: { class?: string }) => (
 export default function AppsTab() {
 	const navigate = useNavigate();
 	const auth = authStore.createQuery();
+	const organizationSelection = createSelectedOrganization();
+	const [storage] = createResource(
+		() => organizationSelection.selectedOrganizationId(),
+		async (orgId) => {
+			if (!orgId) return null;
+			const response = await apiClient.desktop.getStorageIntegrations({
+				query: { orgId },
+				headers: await protectedHeaders(),
+			});
+
+			if (response.status !== 200) return null;
+			return response.body;
+		},
+	);
 
 	const isPro = () => auth.data?.plan?.upgraded;
+	const managedByOrganization = () => storage()?.managedByOrganization ?? null;
 
 	onMount(() => {
 		void commands.checkUpgradedAndUpdate();
@@ -72,6 +89,7 @@ export default function AppsTab() {
 
 	const handleAppClick = async (app: (typeof apps)[number]) => {
 		try {
+			if (managedByOrganization()) return;
 			if (app.pro && !isPro()) {
 				await commands.showWindow("Upgrade");
 				return;
@@ -102,9 +120,14 @@ export default function AppsTab() {
 							<Button
 								size="sm"
 								variant="primary"
+								disabled={!!managedByOrganization()}
 								onClick={() => handleAppClick(app)}
 							>
-								{app.pro && !isPro() ? "Upgrade to Pro" : "Configure"}
+								{managedByOrganization()
+									? "Managed by your organization"
+									: app.pro && !isPro()
+										? "Upgrade to Pro"
+										: "Configure"}
 							</Button>
 						</div>
 						<p class="text-[13px] text-gray-11">{app.description}</p>

--- a/apps/desktop/src/routes/(window-chrome)/settings/integrations/s3-config.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/integrations/s3-config.tsx
@@ -1,8 +1,9 @@
 import { Button } from "@cap/ui-solid";
 import { createWritableMemo } from "@solid-primitives/memo";
 import { useMutation } from "@tanstack/solid-query";
-import { createResource, Suspense } from "solid-js";
+import { createResource, Show, Suspense } from "solid-js";
 import { Input } from "~/routes/editor/ui";
+import { createSelectedOrganization } from "~/utils/organization-branding";
 import { commands } from "~/utils/tauri";
 import { apiClient, protectedHeaders } from "~/utils/web-api";
 import { IntegrationConfigHeader } from "./config-header";
@@ -26,17 +27,25 @@ const DEFAULT_CONFIG = {
 };
 
 export default function S3ConfigPage() {
-	const [_s3Config, { refetch }] = createResource(async () => {
-		const response = await apiClient.desktop.getS3Config({
-			headers: await protectedHeaders(),
-		});
+	const organizationSelection = createSelectedOrganization();
+	const [_s3Config, { refetch }] = createResource(
+		() => organizationSelection.selectedOrganizationId(),
+		async (orgId) => {
+			const response = await apiClient.desktop.getS3Config({
+				query: orgId ? { orgId } : undefined,
+				headers: await protectedHeaders(),
+			});
 
-		if (response.status !== 200) throw new Error("Failed to fetch S3 config");
+			if (response.status !== 200) throw new Error("Failed to fetch S3 config");
 
-		return response.body.config;
-	});
+			return response.body;
+		},
+	);
 
-	const hasConfig = () => !!_s3Config()?.accessKeyId;
+	const managedByOrganization = () =>
+		_s3Config()?.managedByOrganization ?? null;
+	const hasConfig = () =>
+		_s3Config()?.source === "user" && !!_s3Config()?.config.accessKeyId;
 
 	const saveConfig = useMutation(() => ({
 		mutationFn: async (config: S3Config) => {
@@ -113,7 +122,7 @@ export default function S3ConfigPage() {
 	}));
 
 	const [s3Config, setS3Config] = createWritableMemo(
-		() => _s3Config.latest ?? DEFAULT_CONFIG,
+		() => _s3Config.latest?.config ?? DEFAULT_CONFIG,
 	);
 
 	const renderInput = (
@@ -128,6 +137,7 @@ export default function S3ConfigPage() {
 				class="!bg-gray-3"
 				type={type}
 				value={s3Config()[key] ?? ""}
+				disabled={!!managedByOrganization()}
 				onInput={(e: InputEvent & { currentTarget: HTMLInputElement }) =>
 					setS3Config({
 						...s3Config(),
@@ -170,6 +180,13 @@ export default function S3ConfigPage() {
 									</a>{" "}
 									to get started.
 								</p>
+								<Show when={managedByOrganization()}>
+									{(organization) => (
+										<p class="mt-3 text-sm font-medium text-gray-12">
+											Managed by your organization: {organization().name}
+										</p>
+									)}
+								</Show>
 							</div>
 
 							<div class="space-y-2">
@@ -177,6 +194,7 @@ export default function S3ConfigPage() {
 								<div class="relative">
 									<select
 										value={s3Config().provider}
+										disabled={!!managedByOrganization()}
 										onChange={(e) =>
 											setS3Config((c) => ({
 												...c,
@@ -234,7 +252,8 @@ export default function S3ConfigPage() {
 						_s3Config.loading ||
 						saveConfig.isPending ||
 						deleteConfig.isPending ||
-						testConfig.isPending
+						testConfig.isPending ||
+						!!managedByOrganization()
 					}
 				>
 					<div class="flex gap-2">

--- a/apps/web/__tests__/unit/loom-import.test.ts
+++ b/apps/web/__tests__/unit/loom-import.test.ts
@@ -95,6 +95,10 @@ vi.mock("@/lib/server", async () => {
 	return { runPromise: Effect.runPromise };
 });
 
+vi.mock("@/actions/organization/authorization", () => ({
+	requireOrganizationAccess: vi.fn(),
+}));
+
 vi.mock("workflow/api", () => ({
 	start: startMock,
 }));

--- a/apps/web/actions/loom.ts
+++ b/apps/web/actions/loom.ts
@@ -14,6 +14,7 @@ import { and, eq } from "drizzle-orm";
 import { Option } from "effect";
 import { revalidatePath } from "next/cache";
 import { start } from "workflow/api";
+import { requireOrganizationAccess } from "@/actions/organization/authorization";
 import { runPromise } from "@/lib/server";
 import { importLoomVideoWorkflow } from "@/workflows/import-loom-video";
 
@@ -233,6 +234,8 @@ export async function importFromLoom({
 		};
 	}
 
+	await requireOrganizationAccess(user.id, orgId);
+
 	const loomVideoId = extractLoomVideoId(loomUrl.trim());
 	if (!loomVideoId) {
 		return {
@@ -295,7 +298,7 @@ export async function importFromLoom({
 		fetchLoomOEmbed(loomVideoId),
 	]);
 
-	const writable = await Storage.getWritableAccessForUser(user.id).pipe(
+	const writable = await Storage.getWritableAccessForUser(user.id, orgId).pipe(
 		runPromise,
 	);
 

--- a/apps/web/actions/organization/authorization.ts
+++ b/apps/web/actions/organization/authorization.ts
@@ -1,0 +1,33 @@
+import { db } from "@cap/database";
+import { organizationMembers, organizations } from "@cap/database/schema";
+import type { Organisation, User } from "@cap/web-domain";
+import { and, eq, isNull, or } from "drizzle-orm";
+
+export async function requireOrganizationAccess(
+	userId: User.UserId,
+	organizationId: Organisation.OrganisationId,
+) {
+	const [organization] = await db()
+		.select({ id: organizations.id })
+		.from(organizations)
+		.leftJoin(
+			organizationMembers,
+			and(
+				eq(organizationMembers.organizationId, organizations.id),
+				eq(organizationMembers.userId, userId),
+			),
+		)
+		.where(
+			and(
+				eq(organizations.id, organizationId),
+				isNull(organizations.tombstoneAt),
+				or(
+					eq(organizations.ownerId, userId),
+					eq(organizationMembers.userId, userId),
+				),
+			),
+		)
+		.limit(1);
+
+	if (!organization) throw new Error("Forbidden");
+}

--- a/apps/web/actions/organization/storage.ts
+++ b/apps/web/actions/organization/storage.ts
@@ -22,7 +22,7 @@ import {
 	getGoogleDriveUserEmail,
 } from "@cap/web-backend";
 import { type Organisation, S3Bucket, Storage } from "@cap/web-domain";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { runPromise } from "@/lib/server";
 
@@ -95,7 +95,12 @@ const requireOrganizationOwner = async (
 			ownerId: organizations.ownerId,
 		})
 		.from(organizations)
-		.where(eq(organizations.id, organizationId))
+		.where(
+			and(
+				eq(organizations.id, organizationId),
+				isNull(organizations.tombstoneAt),
+			),
+		)
 		.limit(1);
 
 	if (!organization) throw new Error("Organization not found");
@@ -106,11 +111,14 @@ const requireOrganizationOwner = async (
 	return { user, organization };
 };
 
-const decryptS3Config = async (bucket: typeof s3Buckets.$inferSelect) => ({
+const decryptS3Config = async (
+	bucket: typeof s3Buckets.$inferSelect,
+	exposeSecrets: boolean,
+) => ({
 	configured: true,
 	provider: bucket.provider,
-	accessKeyId: await decrypt(bucket.accessKeyId),
-	secretAccessKey: await decrypt(bucket.secretAccessKey),
+	accessKeyId: exposeSecrets ? await decrypt(bucket.accessKeyId) : "",
+	secretAccessKey: exposeSecrets ? await decrypt(bucket.secretAccessKey) : "",
 	endpoint: bucket.endpoint
 		? await decrypt(bucket.endpoint)
 		: "https://s3.amazonaws.com",
@@ -226,6 +234,34 @@ const getOrganizationBucket = async (
 	return bucket ?? null;
 };
 
+const getS3InputCredentials = async (input: S3ConfigInput) => {
+	const hasAccessKeyId = input.accessKeyId.trim().length > 0;
+	const hasSecretAccessKey = input.secretAccessKey.trim().length > 0;
+
+	if (hasAccessKeyId && hasSecretAccessKey) {
+		return {
+			accessKeyId: input.accessKeyId,
+			secretAccessKey: input.secretAccessKey,
+		};
+	}
+
+	const existingBucket = await getOrganizationBucket(input.organizationId);
+	if (!existingBucket) {
+		throw new Error("Access key ID and secret access key are required");
+	}
+
+	if (hasAccessKeyId || hasSecretAccessKey) {
+		throw new Error(
+			"Enter both access key ID and secret access key to change credentials",
+		);
+	}
+
+	return {
+		accessKeyId: await decrypt(existingBucket.accessKeyId),
+		secretAccessKey: await decrypt(existingBucket.secretAccessKey),
+	};
+};
+
 const revalidateStorageSettings = () => {
 	revalidatePath(settingsPath);
 	revalidatePath("/dashboard/settings/organization");
@@ -272,7 +308,7 @@ export async function getOrganizationStorageSettings(
 		activeProvider,
 		googleOAuthClientId: process.env.GOOGLE_CLIENT_ID ?? null,
 		googlePickerApiKey: process.env.NEXT_PUBLIC_GOOGLE_PICKER_API_KEY ?? null,
-		s3: bucket ? await decryptS3Config(bucket) : null,
+		s3: bucket ? await decryptS3Config(bucket, false) : null,
 		googleDrive:
 			drive && driveConfig
 				? {
@@ -293,10 +329,11 @@ export async function getOrganizationStorageSettings(
 
 export async function saveOrganizationS3Config(input: S3ConfigInput) {
 	const { user } = await requireOrganizationOwner(input.organizationId);
+	const credentials = await getS3InputCredentials(input);
 	const encryptedConfig = {
 		provider: input.provider,
-		accessKeyId: await encrypt(input.accessKeyId),
-		secretAccessKey: await encrypt(input.secretAccessKey),
+		accessKeyId: await encrypt(credentials.accessKeyId),
+		secretAccessKey: await encrypt(credentials.secretAccessKey),
 		endpoint: input.endpoint ? await encrypt(input.endpoint) : null,
 		bucketName: await encrypt(input.bucketName),
 		region: await encrypt(input.region),
@@ -334,14 +371,15 @@ export async function removeOrganizationS3Config(
 
 export async function testOrganizationS3Config(input: S3ConfigInput) {
 	await requireOrganizationOwner(input.organizationId);
+	const credentials = await getS3InputCredentials(input);
 	const controller = new AbortController();
 	const timeoutId = setTimeout(() => controller.abort(), 5000);
 	const s3Client = new S3Client({
 		endpoint: input.endpoint || undefined,
 		region: input.region,
 		credentials: {
-			accessKeyId: input.accessKeyId,
-			secretAccessKey: input.secretAccessKey,
+			accessKeyId: credentials.accessKeyId,
+			secretAccessKey: credentials.secretAccessKey,
 		},
 	});
 

--- a/apps/web/actions/organization/storage.ts
+++ b/apps/web/actions/organization/storage.ts
@@ -1,0 +1,596 @@
+"use server";
+
+import { createHmac } from "node:crypto";
+import { HeadBucketCommand, S3Client } from "@aws-sdk/client-s3";
+import { db } from "@cap/database";
+import { getCurrentUser } from "@cap/database/auth/session";
+import { decrypt, encrypt } from "@cap/database/crypto";
+import { nanoId } from "@cap/database/helpers";
+import {
+	organizations,
+	s3Buckets,
+	storageIntegrations,
+	storageObjects,
+	videos,
+} from "@cap/database/schema";
+import { serverEnv } from "@cap/env";
+import {
+	type GoogleDriveIntegrationConfig,
+	getGoogleDriveAccessToken,
+	getGoogleDriveAuthUrl,
+	getGoogleDriveFolderLocation,
+	getGoogleDriveUserEmail,
+} from "@cap/web-backend";
+import { type Organisation, S3Bucket, Storage } from "@cap/web-domain";
+import { and, desc, eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { runPromise } from "@/lib/server";
+
+const googleDriveProvider = "googleDrive";
+const settingsPath = "/dashboard/settings/organization/integrations";
+
+type OrganizationStorageProvider = "s3" | "googleDrive";
+
+export type OrganizationStorageSettings = {
+	organization: {
+		id: string;
+		name: string;
+	};
+	activeProvider: OrganizationStorageProvider | null;
+	googleOAuthClientId: string | null;
+	googlePickerApiKey: string | null;
+	s3: {
+		configured: boolean;
+		provider: string;
+		accessKeyId: string;
+		secretAccessKey: string;
+		endpoint: string;
+		bucketName: string;
+		region: string;
+	} | null;
+	googleDrive: {
+		id: string;
+		connected: boolean;
+		active: boolean;
+		status: "active" | "disconnected" | "error";
+		displayName: string | null;
+		email: string | null;
+		folderId: string | null;
+		folderName: string | null;
+		driveId: string | null;
+		driveName: string | null;
+	} | null;
+};
+
+type S3ConfigInput = {
+	organizationId: Organisation.OrganisationId;
+	provider: string;
+	accessKeyId: string;
+	secretAccessKey: string;
+	endpoint: string;
+	bucketName: string;
+	region: string;
+};
+
+export type OrganizationGoogleDriveFolder = {
+	id: string;
+	name: string;
+	driveId: string | null;
+	driveName: string | null;
+};
+
+const googleDriveFolderMimeType = "application/vnd.google-apps.folder";
+const driveApiBase = "https://www.googleapis.com/drive/v3";
+
+const requireOrganizationOwner = async (
+	organizationId: Organisation.OrganisationId,
+) => {
+	const user = await getCurrentUser();
+	if (!user) throw new Error("Unauthorized");
+
+	const [organization] = await db()
+		.select({
+			id: organizations.id,
+			name: organizations.name,
+			ownerId: organizations.ownerId,
+		})
+		.from(organizations)
+		.where(eq(organizations.id, organizationId))
+		.limit(1);
+
+	if (!organization) throw new Error("Organization not found");
+	if (organization.ownerId !== user.id) {
+		throw new Error("Only the owner can manage organization storage");
+	}
+
+	return { user, organization };
+};
+
+const decryptS3Config = async (bucket: typeof s3Buckets.$inferSelect) => ({
+	configured: true,
+	provider: bucket.provider,
+	accessKeyId: await decrypt(bucket.accessKeyId),
+	secretAccessKey: await decrypt(bucket.secretAccessKey),
+	endpoint: bucket.endpoint
+		? await decrypt(bucket.endpoint)
+		: "https://s3.amazonaws.com",
+	bucketName: await decrypt(bucket.bucketName),
+	region: await decrypt(bucket.region),
+});
+
+const parseDriveConfig = async (
+	integration: typeof storageIntegrations.$inferSelect,
+) =>
+	JSON.parse(
+		await decrypt(integration.encryptedConfig),
+	) as GoogleDriveIntegrationConfig;
+
+const hasDriveLocation = (config: GoogleDriveIntegrationConfig) =>
+	config.folderId.trim().length > 0;
+
+const escapeDriveQueryValue = (value: string) =>
+	value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+
+const parseDriveResponse = async <T>(response: Response) => {
+	const text = await response.text();
+	if (!response.ok) {
+		throw new Error(`Google Drive request failed: ${response.status} ${text}`);
+	}
+	return text ? (JSON.parse(text) as T) : ({} as T);
+};
+
+const toReadableError = (error: unknown) => {
+	if (error instanceof Error) return error;
+	if (error && typeof error === "object" && "cause" in error) {
+		const cause = (error as { cause?: unknown }).cause;
+		if (cause instanceof Error) return cause;
+	}
+	return new Error("Google Drive request failed");
+};
+
+const driveHasStoredData = async (
+	drive: typeof storageIntegrations.$inferSelect,
+) => {
+	const [object, video] = await Promise.all([
+		db()
+			.select({ id: storageObjects.id })
+			.from(storageObjects)
+			.where(eq(storageObjects.integrationId, drive.id))
+			.limit(1),
+		db()
+			.select({ id: videos.id })
+			.from(videos)
+			.where(eq(videos.storageIntegrationId, drive.id))
+			.limit(1),
+	]);
+
+	return object.length > 0 || video.length > 0;
+};
+
+const getOrganizationDrive = async (
+	organizationId: Organisation.OrganisationId,
+) => {
+	const [drive] = await db()
+		.select()
+		.from(storageIntegrations)
+		.where(
+			and(
+				eq(storageIntegrations.organizationId, organizationId),
+				eq(storageIntegrations.provider, googleDriveProvider),
+			),
+		)
+		.orderBy(
+			desc(storageIntegrations.active),
+			desc(storageIntegrations.updatedAt),
+		)
+		.limit(1);
+
+	return drive ?? null;
+};
+
+const getActiveOrganizationDrive = async (
+	organizationId: Organisation.OrganisationId,
+) => {
+	const [drive] = await db()
+		.select()
+		.from(storageIntegrations)
+		.where(
+			and(
+				eq(storageIntegrations.organizationId, organizationId),
+				eq(storageIntegrations.provider, googleDriveProvider),
+				eq(storageIntegrations.active, true),
+				eq(storageIntegrations.status, "active"),
+			),
+		)
+		.orderBy(desc(storageIntegrations.updatedAt))
+		.limit(1);
+
+	return drive ?? null;
+};
+
+const getOrganizationBucket = async (
+	organizationId: Organisation.OrganisationId,
+) => {
+	const [bucket] = await db()
+		.select()
+		.from(s3Buckets)
+		.where(
+			and(
+				eq(s3Buckets.organizationId, organizationId),
+				eq(s3Buckets.active, true),
+			),
+		)
+		.orderBy(desc(s3Buckets.updatedAt))
+		.limit(1);
+
+	return bucket ?? null;
+};
+
+const revalidateStorageSettings = () => {
+	revalidatePath(settingsPath);
+	revalidatePath("/dashboard/settings/organization");
+};
+
+const signStatePayload = (payload: string) => {
+	return createHmac("sha256", serverEnv().NEXTAUTH_SECRET)
+		.update(payload)
+		.digest("base64url");
+};
+
+const createGoogleDriveState = (
+	userId: string,
+	organizationId: Organisation.OrganisationId,
+) => {
+	const payload = Buffer.from(
+		JSON.stringify({
+			userId,
+			expiresAt: Date.now() + 10 * 60 * 1000,
+			scope: "organization",
+			organizationId,
+		}),
+	).toString("base64url");
+	return `${payload}.${signStatePayload(payload)}`;
+};
+
+export async function getOrganizationStorageSettings(
+	organizationId: Organisation.OrganisationId,
+): Promise<OrganizationStorageSettings> {
+	const { organization } = await requireOrganizationOwner(organizationId);
+	const [bucket, drive, activeDrive] = await Promise.all([
+		getOrganizationBucket(organizationId),
+		getOrganizationDrive(organizationId),
+		getActiveOrganizationDrive(organizationId),
+	]);
+	const driveConfig = drive ? await parseDriveConfig(drive) : null;
+	const activeProvider = activeDrive ? "googleDrive" : bucket ? "s3" : null;
+
+	return {
+		organization: {
+			id: organization.id,
+			name: organization.name,
+		},
+		activeProvider,
+		googleOAuthClientId: process.env.GOOGLE_CLIENT_ID ?? null,
+		googlePickerApiKey: process.env.NEXT_PUBLIC_GOOGLE_PICKER_API_KEY ?? null,
+		s3: bucket ? await decryptS3Config(bucket) : null,
+		googleDrive:
+			drive && driveConfig
+				? {
+						id: drive.id,
+						connected: drive.status === "active",
+						active: drive.active,
+						status: drive.status,
+						displayName: drive.displayName,
+						email: driveConfig.email ?? null,
+						folderId: driveConfig.folderId || null,
+						folderName: driveConfig.folderName ?? null,
+						driveId: driveConfig.driveId ?? null,
+						driveName: driveConfig.driveName ?? null,
+					}
+				: null,
+	};
+}
+
+export async function saveOrganizationS3Config(input: S3ConfigInput) {
+	const { user } = await requireOrganizationOwner(input.organizationId);
+	const encryptedConfig = {
+		provider: input.provider,
+		accessKeyId: await encrypt(input.accessKeyId),
+		secretAccessKey: await encrypt(input.secretAccessKey),
+		endpoint: input.endpoint ? await encrypt(input.endpoint) : null,
+		bucketName: await encrypt(input.bucketName),
+		region: await encrypt(input.region),
+		ownerId: user.id,
+		organizationId: input.organizationId,
+	};
+
+	await db().transaction(async (tx) => {
+		await tx
+			.update(s3Buckets)
+			.set({ active: false })
+			.where(eq(s3Buckets.organizationId, input.organizationId));
+		await tx.insert(s3Buckets).values({
+			id: S3Bucket.S3BucketId.make(nanoId()),
+			...encryptedConfig,
+			active: true,
+		});
+	});
+
+	revalidateStorageSettings();
+	return { success: true };
+}
+
+export async function removeOrganizationS3Config(
+	organizationId: Organisation.OrganisationId,
+) {
+	await requireOrganizationOwner(organizationId);
+	await db()
+		.update(s3Buckets)
+		.set({ active: false })
+		.where(eq(s3Buckets.organizationId, organizationId));
+	revalidateStorageSettings();
+	return { success: true };
+}
+
+export async function testOrganizationS3Config(input: S3ConfigInput) {
+	await requireOrganizationOwner(input.organizationId);
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), 5000);
+	const s3Client = new S3Client({
+		endpoint: input.endpoint || undefined,
+		region: input.region,
+		credentials: {
+			accessKeyId: input.accessKeyId,
+			secretAccessKey: input.secretAccessKey,
+		},
+	});
+
+	try {
+		await s3Client.send(new HeadBucketCommand({ Bucket: input.bucketName }), {
+			abortSignal: controller.signal,
+		});
+		return { success: true };
+	} finally {
+		clearTimeout(timeoutId);
+	}
+}
+
+export async function setOrganizationStorageProvider({
+	organizationId,
+	provider,
+}: {
+	organizationId: Organisation.OrganisationId;
+	provider: OrganizationStorageProvider;
+}) {
+	await requireOrganizationOwner(organizationId);
+
+	if (provider === "s3") {
+		const bucket = await getOrganizationBucket(organizationId);
+		if (!bucket) throw new Error("S3 is not configured");
+		await db()
+			.update(storageIntegrations)
+			.set({ active: false })
+			.where(eq(storageIntegrations.organizationId, organizationId));
+		revalidateStorageSettings();
+		return { success: true };
+	}
+
+	const drive = await getOrganizationDrive(organizationId);
+	if (!drive || drive.status !== "active") {
+		throw new Error("Google Drive is not connected");
+	}
+	const config = await parseDriveConfig(drive);
+	if (!hasDriveLocation(config)) {
+		throw new Error("Choose a Google Drive location before enabling it");
+	}
+
+	await db().transaction(async (tx) => {
+		await tx
+			.update(storageIntegrations)
+			.set({ active: false })
+			.where(eq(storageIntegrations.organizationId, organizationId));
+		await tx
+			.update(storageIntegrations)
+			.set({ active: true })
+			.where(eq(storageIntegrations.id, drive.id));
+	});
+
+	revalidateStorageSettings();
+	return { success: true };
+}
+
+export async function connectOrganizationGoogleDrive(
+	organizationId: Organisation.OrganisationId,
+) {
+	const { user } = await requireOrganizationOwner(organizationId);
+	const state = createGoogleDriveState(user.id, organizationId);
+	return { url: getGoogleDriveAuthUrl({ state }) };
+}
+
+export async function disconnectOrganizationGoogleDrive(
+	organizationId: Organisation.OrganisationId,
+) {
+	await requireOrganizationOwner(organizationId);
+	await db()
+		.update(storageIntegrations)
+		.set({
+			active: false,
+			status: "disconnected",
+			googleDriveAccessToken: null,
+			googleDriveAccessTokenExpiresAt: null,
+			googleDriveTokenRefreshLeaseId: null,
+			googleDriveTokenRefreshLeaseExpiresAt: null,
+			googleDriveStorageQuotaCache: null,
+		})
+		.where(
+			and(
+				eq(storageIntegrations.organizationId, organizationId),
+				eq(storageIntegrations.provider, googleDriveProvider),
+			),
+		);
+
+	revalidateStorageSettings();
+	return { success: true };
+}
+
+export async function getOrganizationGoogleDrivePickerToken(
+	organizationId: Organisation.OrganisationId,
+) {
+	await requireOrganizationOwner(organizationId);
+	const drive = await getOrganizationDrive(organizationId);
+	if (!drive || drive.status !== "active") {
+		throw new Error("Google Drive is not connected");
+	}
+
+	const config = await parseDriveConfig(drive);
+	const accessToken = await getGoogleDriveAccessToken(config)
+		.pipe(runPromise)
+		.catch((error: unknown) => {
+			throw toReadableError(error);
+		});
+
+	return {
+		accessToken,
+		clientId: process.env.GOOGLE_CLIENT_ID ?? null,
+		apiKey: process.env.NEXT_PUBLIC_GOOGLE_PICKER_API_KEY ?? null,
+	};
+}
+
+export async function listOrganizationGoogleDriveFolders({
+	organizationId,
+	parentId = "root",
+}: {
+	organizationId: Organisation.OrganisationId;
+	parentId?: string;
+}) {
+	await requireOrganizationOwner(organizationId);
+	const drive = await getOrganizationDrive(organizationId);
+	if (!drive || drive.status !== "active") {
+		throw new Error("Google Drive is not connected");
+	}
+
+	try {
+		const config = await parseDriveConfig(drive);
+		const accessToken =
+			await getGoogleDriveAccessToken(config).pipe(runPromise);
+		const query = [
+			`'${escapeDriveQueryValue(parentId)}' in parents`,
+			`mimeType='${googleDriveFolderMimeType}'`,
+			"trashed=false",
+		].join(" and ");
+		const url = new URL(`${driveApiBase}/files`);
+		url.searchParams.set("q", query);
+		url.searchParams.set("fields", "files(id,name,driveId)");
+		url.searchParams.set("spaces", "drive");
+		url.searchParams.set("supportsAllDrives", "true");
+		url.searchParams.set("includeItemsFromAllDrives", "true");
+		if (config.driveId) {
+			url.searchParams.set("corpora", "drive");
+			url.searchParams.set("driveId", config.driveId);
+		}
+
+		const response = await fetch(url, {
+			headers: { Authorization: `Bearer ${accessToken}` },
+		});
+		const body = await parseDriveResponse<{
+			files?: Array<{ id?: string; name?: string; driveId?: string | null }>;
+		}>(response);
+
+		return {
+			folders:
+				body.files
+					?.filter((folder) => folder.id && folder.name)
+					.map((folder) => ({
+						id: folder.id as string,
+						name: folder.name as string,
+						driveId: folder.driveId ?? null,
+						driveName: null,
+					})) ?? [],
+		};
+	} catch (error) {
+		throw toReadableError(error);
+	}
+}
+
+export async function setOrganizationGoogleDriveLocation({
+	organizationId,
+	folderId,
+	folderName,
+	driveId,
+	driveName,
+}: {
+	organizationId: Organisation.OrganisationId;
+	folderId: string;
+	folderName?: string | null;
+	driveId?: string | null;
+	driveName?: string | null;
+}) {
+	const { user } = await requireOrganizationOwner(organizationId);
+	const drive = await getOrganizationDrive(organizationId);
+	if (!drive || drive.status !== "active") {
+		throw new Error("Google Drive is not connected");
+	}
+
+	const config = await parseDriveConfig(drive);
+	const location =
+		folderId === "root"
+			? { id: "root", name: "My Drive", driveId: null }
+			: await getGoogleDriveFolderLocation(config, folderId)
+					.pipe(runPromise)
+					.catch((error: unknown) => {
+						throw toReadableError(error);
+					});
+	const nextConfig: GoogleDriveIntegrationConfig = {
+		...config,
+		folderId: location.id,
+		folderName: folderName ?? location.name,
+		driveId: driveId ?? location.driveId ?? null,
+		driveName: driveName ?? location.driveName ?? null,
+		folderLayout: "userVideo",
+	};
+	const email = await getGoogleDriveUserEmail(nextConfig)
+		.pipe(runPromise)
+		.catch((error: unknown) => {
+			throw toReadableError(error);
+		});
+	const displayName = email ? `Google Drive (${email})` : "Google Drive";
+	const encryptedConfig = await encrypt(
+		JSON.stringify({ ...nextConfig, email: email ?? undefined }),
+	);
+
+	if (await driveHasStoredData(drive)) {
+		await db().transaction(async (tx) => {
+			if (drive.active) {
+				await tx
+					.update(storageIntegrations)
+					.set({ active: false })
+					.where(eq(storageIntegrations.organizationId, organizationId));
+			}
+			await tx.insert(storageIntegrations).values({
+				id: Storage.StorageIntegrationId.make(nanoId()),
+				ownerId: user.id,
+				organizationId,
+				provider: googleDriveProvider,
+				displayName,
+				status: "active",
+				active: drive.active,
+				encryptedConfig,
+				googleDriveStorageQuotaCache: null,
+			});
+		});
+	} else {
+		await db()
+			.update(storageIntegrations)
+			.set({
+				active: drive.active,
+				status: "active",
+				displayName,
+				encryptedConfig,
+				googleDriveStorageQuotaCache: null,
+			})
+			.where(eq(storageIntegrations.id, drive.id));
+	}
+
+	revalidateStorageSettings();
+	return { success: true };
+}

--- a/apps/web/actions/organization/storage.ts
+++ b/apps/web/actions/organization/storage.ts
@@ -14,6 +14,7 @@ import {
 	videos,
 } from "@cap/database/schema";
 import { serverEnv } from "@cap/env";
+import { userIsPro } from "@cap/utils";
 import {
 	type GoogleDriveIntegrationConfig,
 	getGoogleDriveAccessToken,
@@ -28,6 +29,8 @@ import { runPromise } from "@/lib/server";
 
 const googleDriveProvider = "googleDrive";
 const settingsPath = "/dashboard/settings/organization/integrations";
+const proRequiredMessage =
+	"Cap Pro is required to manage organization integrations";
 
 type OrganizationStorageProvider = "s3" | "googleDrive";
 
@@ -111,6 +114,14 @@ const requireOrganizationOwner = async (
 	return { user, organization };
 };
 
+const requireOrganizationOwnerPro = async (
+	organizationId: Organisation.OrganisationId,
+) => {
+	const result = await requireOrganizationOwner(organizationId);
+	if (!userIsPro(result.user)) throw new Error(proRequiredMessage);
+	return result;
+};
+
 const decryptS3Config = async (
 	bucket: typeof s3Buckets.$inferSelect,
 	exposeSecrets: boolean,
@@ -154,6 +165,48 @@ const toReadableError = (error: unknown) => {
 		if (cause instanceof Error) return cause;
 	}
 	return new Error("Google Drive request failed");
+};
+
+const getS3ErrorMetadata = (error: unknown) => {
+	if (!error || typeof error !== "object" || !("$metadata" in error)) {
+		return undefined;
+	}
+
+	return error.$metadata as { httpStatusCode?: number } | undefined;
+};
+
+const getS3ConnectionErrorMessage = (error: unknown, bucketName: string) => {
+	if (!(error instanceof Error)) return "Failed to connect to S3";
+
+	if (error.name === "AbortError" || error.name === "TimeoutError") {
+		return "Connection timed out after 5 seconds. Please check the endpoint URL and your network connection.";
+	}
+
+	if (error.name === "NoSuchBucket") {
+		return `Bucket '${bucketName}' does not exist`;
+	}
+
+	if (error.name === "NetworkingError") {
+		return "Network error. Please check the endpoint URL and your network connection.";
+	}
+
+	if (error.name === "InvalidAccessKeyId") {
+		return "Invalid Access Key ID";
+	}
+
+	if (error.name === "SignatureDoesNotMatch") {
+		return "Invalid Secret Access Key";
+	}
+
+	if (error.name === "AccessDenied") {
+		return "Access denied. Please check your credentials and bucket permissions.";
+	}
+
+	if (getS3ErrorMetadata(error)?.httpStatusCode === 301) {
+		return "Received 301 redirect. This usually means the endpoint URL is incorrect or the bucket is in a different region.";
+	}
+
+	return "Failed to connect to S3";
 };
 
 const driveHasStoredData = async (
@@ -328,7 +381,7 @@ export async function getOrganizationStorageSettings(
 }
 
 export async function saveOrganizationS3Config(input: S3ConfigInput) {
-	const { user } = await requireOrganizationOwner(input.organizationId);
+	const { user } = await requireOrganizationOwnerPro(input.organizationId);
 	const credentials = await getS3InputCredentials(input);
 	const encryptedConfig = {
 		provider: input.provider,
@@ -360,7 +413,7 @@ export async function saveOrganizationS3Config(input: S3ConfigInput) {
 export async function removeOrganizationS3Config(
 	organizationId: Organisation.OrganisationId,
 ) {
-	await requireOrganizationOwner(organizationId);
+	await requireOrganizationOwnerPro(organizationId);
 	await db()
 		.update(s3Buckets)
 		.set({ active: false })
@@ -370,7 +423,7 @@ export async function removeOrganizationS3Config(
 }
 
 export async function testOrganizationS3Config(input: S3ConfigInput) {
-	await requireOrganizationOwner(input.organizationId);
+	await requireOrganizationOwnerPro(input.organizationId);
 	const credentials = await getS3InputCredentials(input);
 	const controller = new AbortController();
 	const timeoutId = setTimeout(() => controller.abort(), 5000);
@@ -388,6 +441,8 @@ export async function testOrganizationS3Config(input: S3ConfigInput) {
 			abortSignal: controller.signal,
 		});
 		return { success: true };
+	} catch (error) {
+		throw new Error(getS3ConnectionErrorMessage(error, input.bucketName));
 	} finally {
 		clearTimeout(timeoutId);
 	}
@@ -400,7 +455,7 @@ export async function setOrganizationStorageProvider({
 	organizationId: Organisation.OrganisationId;
 	provider: OrganizationStorageProvider;
 }) {
-	await requireOrganizationOwner(organizationId);
+	await requireOrganizationOwnerPro(organizationId);
 
 	if (provider === "s3") {
 		const bucket = await getOrganizationBucket(organizationId);
@@ -440,7 +495,7 @@ export async function setOrganizationStorageProvider({
 export async function connectOrganizationGoogleDrive(
 	organizationId: Organisation.OrganisationId,
 ) {
-	const { user } = await requireOrganizationOwner(organizationId);
+	const { user } = await requireOrganizationOwnerPro(organizationId);
 	const state = createGoogleDriveState(user.id, organizationId);
 	return { url: getGoogleDriveAuthUrl({ state }) };
 }
@@ -448,7 +503,7 @@ export async function connectOrganizationGoogleDrive(
 export async function disconnectOrganizationGoogleDrive(
 	organizationId: Organisation.OrganisationId,
 ) {
-	await requireOrganizationOwner(organizationId);
+	await requireOrganizationOwnerPro(organizationId);
 	await db()
 		.update(storageIntegrations)
 		.set({
@@ -474,7 +529,7 @@ export async function disconnectOrganizationGoogleDrive(
 export async function getOrganizationGoogleDrivePickerToken(
 	organizationId: Organisation.OrganisationId,
 ) {
-	await requireOrganizationOwner(organizationId);
+	await requireOrganizationOwnerPro(organizationId);
 	const drive = await getOrganizationDrive(organizationId);
 	if (!drive || drive.status !== "active") {
 		throw new Error("Google Drive is not connected");
@@ -501,7 +556,7 @@ export async function listOrganizationGoogleDriveFolders({
 	organizationId: Organisation.OrganisationId;
 	parentId?: string;
 }) {
-	await requireOrganizationOwner(organizationId);
+	await requireOrganizationOwnerPro(organizationId);
 	const drive = await getOrganizationDrive(organizationId);
 	if (!drive || drive.status !== "active") {
 		throw new Error("Google Drive is not connected");
@@ -563,7 +618,7 @@ export async function setOrganizationGoogleDriveLocation({
 	driveId?: string | null;
 	driveName?: string | null;
 }) {
-	const { user } = await requireOrganizationOwner(organizationId);
+	const { user } = await requireOrganizationOwnerPro(organizationId);
 	const drive = await getOrganizationDrive(organizationId);
 	if (!drive || drive.status !== "active") {
 		throw new Error("Google Drive is not connected");

--- a/apps/web/actions/video/create-for-processing.ts
+++ b/apps/web/actions/video/create-for-processing.ts
@@ -15,6 +15,7 @@ import {
 } from "@cap/web-domain";
 import { Option } from "effect";
 import { revalidatePath } from "next/cache";
+import { requireOrganizationAccess } from "@/actions/organization/authorization";
 import { runPromise } from "@/lib/server";
 
 export interface CreateForProcessingResult {
@@ -48,6 +49,8 @@ export async function createVideoForServerProcessing({
 		throw new Error("upgrade_required");
 	}
 
+	await requireOrganizationAccess(user.id, orgId);
+
 	const videoId = Video.VideoId.make(nanoId());
 
 	const date = new Date();
@@ -68,6 +71,7 @@ export async function createVideoForServerProcessing({
 				"x-amz-meta-resolution": resolution ?? "",
 			},
 		},
+		orgId,
 	).pipe(runPromise);
 
 	await db()

--- a/apps/web/actions/video/upload.ts
+++ b/apps/web/actions/video/upload.ts
@@ -16,6 +16,7 @@ import {
 import { eq } from "drizzle-orm";
 import { Effect, Option } from "effect";
 import { revalidatePath } from "next/cache";
+import { requireOrganizationAccess } from "@/actions/organization/authorization";
 import { runPromise } from "@/lib/server";
 
 const MAX_S3_DELETE_ATTEMPTS = 3;
@@ -29,6 +30,7 @@ async function getVideoUploadPresignedUrl({
 	audioCodec,
 	video,
 	userId,
+	organizationId,
 }: {
 	fileKey: string;
 	duration?: string;
@@ -37,6 +39,7 @@ async function getVideoUploadPresignedUrl({
 	audioCodec?: string;
 	video?: Video.Video;
 	userId: User.UserId;
+	organizationId?: Organisation.OrganisationId;
 }) {
 	try {
 		const contentType = fileKey.endsWith(".aac")
@@ -76,10 +79,15 @@ async function getVideoUploadPresignedUrl({
 				};
 			}
 
-			return yield* StorageService.createUploadTargetForUser(userId, fileKey, {
-				contentType,
-				fields: Fields,
-			});
+			return yield* StorageService.createUploadTargetForUser(
+				userId,
+				fileKey,
+				{
+					contentType,
+					fields: Fields,
+				},
+				organizationId,
+			);
 		}).pipe(runPromise);
 
 		return {
@@ -128,6 +136,8 @@ export async function createVideoAndGetUploadUrl({
 	try {
 		if (!userIsPro(user) && duration && duration > 300)
 			throw new Error("upgrade_required");
+
+		await requireOrganizationAccess(user.id, orgId);
 
 		const date = new Date();
 		const formattedDate = `${date.getDate()} ${date.toLocaleString("default", {
@@ -185,6 +195,7 @@ export async function createVideoAndGetUploadUrl({
 				videoCodec,
 				audioCodec,
 				userId: user.id,
+				organizationId: orgId,
 			});
 
 		const videoData = {

--- a/apps/web/app/(org)/dashboard/settings/organization/_components/SettingsNav.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/_components/SettingsNav.tsx
@@ -15,6 +15,10 @@ export function SettingsNav() {
 			href: "/dashboard/settings/organization/preferences",
 		},
 		{
+			label: "Integrations",
+			href: "/dashboard/settings/organization/integrations",
+		},
+		{
 			label: buildEnv.NEXT_PUBLIC_IS_CAP ? "Billing & Members" : "Members",
 			href: "/dashboard/settings/organization/billing",
 		},

--- a/apps/web/app/(org)/dashboard/settings/organization/integrations/page.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/integrations/page.tsx
@@ -21,7 +21,17 @@ export default async function OrganizationIntegrationsPage() {
 
 	const settings = await getOrganizationStorageSettings(
 		user.activeOrganizationId,
-	);
+	).catch((error: unknown) => {
+		if (
+			error instanceof Error &&
+			(error.message === "Only the owner can manage organization storage" ||
+				error.message === "Organization not found")
+		) {
+			redirect("/dashboard/caps");
+		}
+
+		throw error;
+	});
 
 	return <OrganizationStorageIntegrations initialSettings={settings} />;
 }

--- a/apps/web/app/(org)/dashboard/settings/organization/integrations/page.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/integrations/page.tsx
@@ -1,0 +1,27 @@
+import { getCurrentUser } from "@cap/database/auth/session";
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { getOrganizationStorageSettings } from "@/actions/organization/storage";
+import { OrganizationStorageIntegrations } from "./storage-integrations";
+
+export const metadata: Metadata = {
+	title: "Organization Integrations — Cap",
+};
+
+export default async function OrganizationIntegrationsPage() {
+	const user = await getCurrentUser();
+
+	if (!user) {
+		redirect("/auth/signin");
+	}
+
+	if (!user.activeOrganizationId) {
+		redirect("/dashboard/caps");
+	}
+
+	const settings = await getOrganizationStorageSettings(
+		user.activeOrganizationId,
+	);
+
+	return <OrganizationStorageIntegrations initialSettings={settings} />;
+}

--- a/apps/web/app/(org)/dashboard/settings/organization/integrations/storage-integrations.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/integrations/storage-integrations.tsx
@@ -1,0 +1,763 @@
+"use client";
+
+import { Button, Input, Label, Select } from "@cap/ui";
+import type { Organisation } from "@cap/web-domain";
+import {
+	ChevronRightIcon,
+	DatabaseIcon,
+	FolderOpenIcon,
+	HardDriveIcon,
+	InfoIcon,
+	UserIcon,
+	VideoIcon,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useId, useState, useTransition } from "react";
+import { toast } from "sonner";
+import {
+	connectOrganizationGoogleDrive,
+	disconnectOrganizationGoogleDrive,
+	getOrganizationGoogleDrivePickerToken,
+	listOrganizationGoogleDriveFolders,
+	type OrganizationGoogleDriveFolder,
+	type OrganizationStorageSettings,
+	removeOrganizationS3Config,
+	saveOrganizationS3Config,
+	setOrganizationGoogleDriveLocation,
+	setOrganizationStorageProvider,
+	testOrganizationS3Config,
+} from "@/actions/organization/storage";
+
+const defaultS3Config = {
+	provider: "aws",
+	accessKeyId: "",
+	secretAccessKey: "",
+	endpoint: "https://s3.amazonaws.com",
+	bucketName: "",
+	region: "us-east-1",
+};
+
+const s3ProviderOptions = [
+	{ value: "aws", label: "AWS S3" },
+	{ value: "cloudflare", label: "Cloudflare R2" },
+	{ value: "supabase", label: "Supabase" },
+	{ value: "minio", label: "MinIO" },
+	{ value: "other", label: "Other S3-Compatible" },
+];
+
+const getOrganizationId = (settings: OrganizationStorageSettings) =>
+	settings.organization.id as Organisation.OrganisationId;
+
+function StatusBadge({
+	configured,
+	active,
+}: {
+	configured: boolean;
+	active: boolean;
+}) {
+	if (active) {
+		return (
+			<span className="inline-flex items-center gap-1 px-2 py-0.5 text-[11px] font-medium rounded-md bg-green-500/10 text-green-600">
+				<span className="size-1.5 rounded-full bg-green-500" />
+				Active
+			</span>
+		);
+	}
+
+	if (configured) {
+		return (
+			<span className="inline-flex items-center gap-1 px-2 py-0.5 text-[11px] font-medium rounded-md bg-blue-500/10 text-blue-600">
+				<span className="size-1.5 rounded-full bg-blue-500" />
+				Connected
+			</span>
+		);
+	}
+
+	return (
+		<span className="inline-flex items-center px-2 py-0.5 text-[11px] font-medium rounded-md bg-gray-3 text-gray-9">
+			Not configured
+		</span>
+	);
+}
+
+export function OrganizationStorageIntegrations({
+	initialSettings,
+}: {
+	initialSettings: OrganizationStorageSettings;
+}) {
+	const router = useRouter();
+	const [settings, setSettings] = useState(initialSettings);
+	const [s3Config, setS3Config] = useState(
+		initialSettings.s3 ?? defaultS3Config,
+	);
+	const [isPending, startTransition] = useTransition();
+	const [expandedIntegration, setExpandedIntegration] = useState<
+		"s3" | "googleDrive" | null
+	>(null);
+	const [folderBrowserOpen, setFolderBrowserOpen] = useState(false);
+	const [folderBrowserParent, setFolderBrowserParent] = useState({
+		id: "root",
+		name: "My Drive",
+	});
+	const [folderBrowserHistory, setFolderBrowserHistory] = useState<
+		Array<{ id: string; name: string }>
+	>([]);
+	const [folderBrowserFolders, setFolderBrowserFolders] = useState<
+		OrganizationGoogleDriveFolder[]
+	>([]);
+	const [folderBrowserLoading, setFolderBrowserLoading] = useState(false);
+	const organizationId = getOrganizationId(settings);
+	const regionId = useId();
+	const bucketId = useId();
+	const endpointId = useId();
+	const accessKeyId = useId();
+	const secretKeyId = useId();
+
+	useEffect(() => {
+		setSettings(initialSettings);
+		setS3Config(initialSettings.s3 ?? defaultS3Config);
+	}, [initialSettings]);
+
+	const runMutation = (
+		action: () => Promise<unknown>,
+		successMessage: string,
+	) => {
+		startTransition(async () => {
+			try {
+				await action();
+				toast.success(successMessage);
+				router.refresh();
+			} catch (error) {
+				toast.error(error instanceof Error ? error.message : "Request failed");
+			}
+		});
+	};
+
+	const saveS3 = () =>
+		runMutation(
+			() =>
+				saveOrganizationS3Config({
+					organizationId,
+					provider: s3Config.provider,
+					accessKeyId: s3Config.accessKeyId,
+					secretAccessKey: s3Config.secretAccessKey,
+					endpoint: s3Config.endpoint,
+					bucketName: s3Config.bucketName,
+					region: s3Config.region,
+				}),
+			"S3 configuration saved",
+		);
+
+	const testS3 = () =>
+		runMutation(
+			() =>
+				testOrganizationS3Config({
+					organizationId,
+					provider: s3Config.provider,
+					accessKeyId: s3Config.accessKeyId,
+					secretAccessKey: s3Config.secretAccessKey,
+					endpoint: s3Config.endpoint,
+					bucketName: s3Config.bucketName,
+					region: s3Config.region,
+				}),
+			"S3 connection verified",
+		);
+
+	const connectDrive = () =>
+		runMutation(async () => {
+			const { url } = await connectOrganizationGoogleDrive(organizationId);
+			window.location.href = url;
+		}, "Opening Google Drive authorization");
+
+	const disconnectDrive = () =>
+		runMutation(
+			() => disconnectOrganizationGoogleDrive(organizationId),
+			"Google Drive disconnected",
+		);
+
+	const setActiveProvider = (provider: "s3" | "googleDrive") =>
+		runMutation(
+			() => setOrganizationStorageProvider({ organizationId, provider }),
+			provider === "s3" ? "S3 enabled" : "Google Drive enabled",
+		);
+
+	const setDriveRootLocation = () =>
+		runMutation(
+			() =>
+				setOrganizationGoogleDriveLocation({
+					organizationId,
+					folderId: "root",
+				}),
+			"Google Drive location updated",
+		);
+
+	const loadFolderBrowser = async (
+		parent: { id: string; name: string },
+		history: Array<{ id: string; name: string }>,
+	) => {
+		setFolderBrowserLoading(true);
+		try {
+			const { folders } = await listOrganizationGoogleDriveFolders({
+				organizationId,
+				parentId: parent.id,
+			});
+			setFolderBrowserParent(parent);
+			setFolderBrowserHistory(history);
+			setFolderBrowserFolders(folders);
+			setFolderBrowserOpen(true);
+		} catch (error) {
+			toast.error(
+				error instanceof Error ? error.message : "Failed to load Drive folders",
+			);
+		} finally {
+			setFolderBrowserLoading(false);
+		}
+	};
+
+	const openFolderBrowser = () => {
+		startTransition(async () => {
+			await loadFolderBrowser({ id: "root", name: "My Drive" }, []);
+		});
+	};
+
+	const openChildFolder = (folder: OrganizationGoogleDriveFolder) => {
+		startTransition(async () => {
+			await loadFolderBrowser({ id: folder.id, name: folder.name }, [
+				...folderBrowserHistory,
+				folderBrowserParent,
+			]);
+		});
+	};
+
+	const openParentFolder = () => {
+		const parent = folderBrowserHistory.at(-1);
+		if (!parent) return;
+		startTransition(async () => {
+			await loadFolderBrowser(parent, folderBrowserHistory.slice(0, -1));
+		});
+	};
+
+	const selectDriveFolder = (folder: OrganizationGoogleDriveFolder) =>
+		runMutation(async () => {
+			await setOrganizationGoogleDriveLocation({
+				organizationId,
+				folderId: folder.id,
+				folderName: folder.name,
+				driveId: folder.driveId,
+				driveName: folder.driveName,
+			});
+			setFolderBrowserOpen(false);
+		}, "Google Drive location updated");
+
+	const selectCurrentDriveFolder = () =>
+		selectDriveFolder({
+			id: folderBrowserParent.id,
+			name: folderBrowserParent.name,
+			driveId: null,
+			driveName: null,
+		});
+
+	const toggleExpand = (integration: "s3" | "googleDrive") => {
+		setExpandedIntegration((prev) =>
+			prev === integration ? null : integration,
+		);
+	};
+
+	const bothConfigured =
+		!!settings.s3?.configured && !!settings.googleDrive?.connected;
+	const hasDriveLocation = !!settings.googleDrive?.folderId;
+	const selectedDriveName = settings.googleDrive?.driveName ?? "My Drive";
+	const selectedFolderName = settings.googleDrive?.folderName ?? null;
+
+	return (
+		<div className="flex flex-col gap-4">
+			<div className="flex items-center gap-2 px-1">
+				<InfoIcon className="size-3.5 text-gray-9 shrink-0" />
+				<p className="text-[12px] text-gray-9">
+					Storage applies to all members of {settings.organization.name}. Only
+					owners and admins can manage integrations.
+				</p>
+			</div>
+
+			{bothConfigured && (
+				<div className="flex items-center justify-between px-3 py-2.5 rounded-lg border border-gray-3 bg-gray-2">
+					<p className="text-[12px] text-gray-11">Active provider</p>
+					<div className="flex items-center rounded-md bg-gray-3 p-0.5 gap-0.5">
+						<button
+							type="button"
+							className={`px-2.5 py-1 text-[11px] font-medium rounded transition-all cursor-pointer ${
+								settings.activeProvider === "s3"
+									? "bg-gray-12 text-gray-1 shadow-sm"
+									: "text-gray-10 hover:text-gray-12"
+							}`}
+							onClick={() => setActiveProvider("s3")}
+							disabled={isPending}
+						>
+							S3
+						</button>
+						<button
+							type="button"
+							className={`px-2.5 py-1 text-[11px] font-medium rounded transition-all cursor-pointer ${
+								settings.activeProvider === "googleDrive"
+									? "bg-gray-12 text-gray-1 shadow-sm"
+									: "text-gray-10 hover:text-gray-12"
+							}`}
+							onClick={() => setActiveProvider("googleDrive")}
+							disabled={!hasDriveLocation || isPending}
+						>
+							Google Drive
+						</button>
+					</div>
+				</div>
+			)}
+
+			<div className="rounded-xl border border-gray-3 overflow-hidden">
+				<button
+					type="button"
+					onClick={() => toggleExpand("s3")}
+					className="w-full flex items-center gap-3 px-3.5 py-3 text-left hover:bg-gray-2 transition-colors cursor-pointer"
+				>
+					<DatabaseIcon className="size-4 shrink-0 text-gray-10" />
+					<span className="flex-1 text-[13px] font-medium text-gray-12">
+						S3-Compatible Storage
+					</span>
+					<StatusBadge
+						configured={!!settings.s3?.configured}
+						active={bothConfigured && settings.activeProvider === "s3"}
+					/>
+					<ChevronRightIcon
+						className={`size-3.5 text-gray-8 transition-transform duration-150 shrink-0 ${
+							expandedIntegration === "s3" ? "rotate-90" : ""
+						}`}
+					/>
+				</button>
+
+				{expandedIntegration === "s3" && (
+					<div className="border-t border-gray-3 px-3.5 py-4">
+						<p className="text-[12px] text-gray-10 mb-4">
+							Connect your own bucket for full control.{" "}
+							<a
+								href="https://cap.so/docs/s3-config"
+								target="_blank"
+								rel="noopener noreferrer"
+								className="underline text-gray-12 hover:text-gray-11"
+							>
+								Setup guide
+							</a>
+						</p>
+						<div className="grid gap-3 md:grid-cols-2">
+							<div className="flex flex-col gap-1">
+								<Label className="text-[11px]">Provider</Label>
+								<Select
+									value={s3Config.provider}
+									onValueChange={(value) =>
+										setS3Config((current) => ({
+											...current,
+											provider: value,
+										}))
+									}
+									placeholder="Select provider"
+									options={s3ProviderOptions}
+								/>
+							</div>
+							<div className="flex flex-col gap-1">
+								<Label htmlFor={accessKeyId} className="text-[11px]">
+									Access Key ID
+								</Label>
+								<Input
+									id={accessKeyId}
+									type="password"
+									value={s3Config.accessKeyId}
+									placeholder="PL31OADSQNK"
+									autoComplete="off"
+									onChange={(event) =>
+										setS3Config((current) => ({
+											...current,
+											accessKeyId: event.target.value,
+										}))
+									}
+								/>
+							</div>
+							<div className="flex flex-col gap-1">
+								<Label htmlFor={secretKeyId} className="text-[11px]">
+									Secret Access Key
+								</Label>
+								<Input
+									id={secretKeyId}
+									type="password"
+									value={s3Config.secretAccessKey}
+									placeholder="PL31OADSQNK"
+									autoComplete="off"
+									onChange={(event) =>
+										setS3Config((current) => ({
+											...current,
+											secretAccessKey: event.target.value,
+										}))
+									}
+								/>
+							</div>
+							<div className="flex flex-col gap-1">
+								<Label htmlFor={endpointId} className="text-[11px]">
+									Endpoint
+								</Label>
+								<Input
+									id={endpointId}
+									value={s3Config.endpoint}
+									placeholder="https://s3.amazonaws.com"
+									onChange={(event) =>
+										setS3Config((current) => ({
+											...current,
+											endpoint: event.target.value,
+										}))
+									}
+								/>
+							</div>
+							<div className="flex flex-col gap-1">
+								<Label htmlFor={bucketId} className="text-[11px]">
+									Bucket Name
+								</Label>
+								<Input
+									id={bucketId}
+									value={s3Config.bucketName}
+									placeholder="my-bucket"
+									onChange={(event) =>
+										setS3Config((current) => ({
+											...current,
+											bucketName: event.target.value,
+										}))
+									}
+								/>
+							</div>
+							<div className="flex flex-col gap-1">
+								<Label htmlFor={regionId} className="text-[11px]">
+									Region
+								</Label>
+								<Input
+									id={regionId}
+									value={s3Config.region}
+									placeholder="us-east-1"
+									onChange={(event) =>
+										setS3Config((current) => ({
+											...current,
+											region: event.target.value,
+										}))
+									}
+								/>
+							</div>
+						</div>
+						<div className="flex items-center gap-2 mt-4 pt-3 border-t border-gray-3">
+							<Button
+								type="button"
+								size="xs"
+								onClick={saveS3}
+								disabled={isPending}
+							>
+								Save
+							</Button>
+							<Button
+								type="button"
+								size="xs"
+								variant="gray"
+								onClick={testS3}
+								disabled={isPending}
+							>
+								Test
+							</Button>
+							{settings.s3?.configured && (
+								<Button
+									type="button"
+									size="xs"
+									variant="destructive"
+									onClick={() =>
+										runMutation(
+											() => removeOrganizationS3Config(organizationId),
+											"S3 configuration removed",
+										)
+									}
+									disabled={isPending}
+								>
+									Remove
+								</Button>
+							)}
+						</div>
+					</div>
+				)}
+			</div>
+
+			<div className="rounded-xl border border-gray-3 overflow-hidden">
+				<button
+					type="button"
+					onClick={() => toggleExpand("googleDrive")}
+					className="w-full flex items-center gap-3 px-3.5 py-3 text-left hover:bg-gray-2 transition-colors cursor-pointer"
+				>
+					<svg
+						aria-hidden="true"
+						className="size-4 shrink-0"
+						viewBox="0 0 87.3 78"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<path
+							d="m6.6 66.85 3.85 6.65c.8 1.4 1.95 2.5 3.3 3.3l13.75-23.8h-27.5c0 1.55.4 3.1 1.2 4.5z"
+							fill="#0066da"
+						/>
+						<path
+							d="m43.65 25-13.75-23.8c-1.35.8-2.5 1.9-3.3 3.3l-25.4 44a9.06 9.06 0 0 0 -1.2 4.5h27.5z"
+							fill="#00ac47"
+						/>
+						<path
+							d="m73.55 76.8c1.35-.8 2.5-1.9 3.3-3.3l1.6-2.75 7.65-13.25c.8-1.4 1.2-2.95 1.2-4.5h-27.502l5.852 11.5z"
+							fill="#ea4335"
+						/>
+						<path
+							d="m43.65 25 13.75-23.8c-1.35-.8-2.9-1.2-4.5-1.2h-18.5c-1.6 0-3.15.45-4.5 1.2z"
+							fill="#00832d"
+						/>
+						<path
+							d="m59.8 53h-32.3l-13.75 23.8c1.35.8 2.9 1.2 4.5 1.2h50.8c1.6 0 3.15-.45 4.5-1.2z"
+							fill="#2684fc"
+						/>
+						<path
+							d="m73.4 26.5-12.7-22c-.8-1.4-1.95-2.5-3.3-3.3l-13.75 23.8 16.15 28h27.45c0-1.55-.4-3.1-1.2-4.5z"
+							fill="#ffba00"
+						/>
+					</svg>
+					<span className="flex-1 text-[13px] font-medium text-gray-12">
+						Google Drive
+					</span>
+					<StatusBadge
+						configured={!!settings.googleDrive?.connected}
+						active={bothConfigured && settings.activeProvider === "googleDrive"}
+					/>
+					<ChevronRightIcon
+						className={`size-3.5 text-gray-8 transition-transform duration-150 shrink-0 ${
+							expandedIntegration === "googleDrive" ? "rotate-90" : ""
+						}`}
+					/>
+				</button>
+
+				{expandedIntegration === "googleDrive" && (
+					<div className="border-t border-gray-3 px-3.5 py-4">
+						{settings.googleDrive?.connected ? (
+							<div className="flex flex-col gap-3">
+								{(settings.googleDrive.email ||
+									settings.googleDrive.folderName) && (
+									<div className="flex items-center gap-4 text-[12px]">
+										{settings.googleDrive.email && (
+											<span className="text-gray-10">
+												{settings.googleDrive.email}
+											</span>
+										)}
+										{settings.googleDrive.folderName && (
+											<span className="text-gray-12 font-medium">
+												{settings.googleDrive.folderName}
+											</span>
+										)}
+									</div>
+								)}
+
+								<div className="flex flex-col gap-2.5 rounded-lg border border-gray-3 bg-gray-2 p-3">
+									<div className="flex items-center justify-between">
+										<p className="text-[12px] font-medium text-gray-12">
+											Storage destination
+										</p>
+										{settings.activeProvider === "googleDrive" ? (
+											<span className="inline-flex items-center gap-1 px-2 py-0.5 text-[11px] font-medium rounded-md bg-green-500/10 text-green-600">
+												<span className="size-1.5 rounded-full bg-green-500" />
+												Enabled
+											</span>
+										) : (
+											<span className="text-[11px] text-gray-9">
+												Not enabled
+											</span>
+										)}
+									</div>
+									<div className="grid gap-1.5 sm:grid-cols-3">
+										<div className="flex items-center gap-2 rounded-md bg-gray-3 px-2.5 py-2 min-w-0">
+											<HardDriveIcon className="size-3.5 shrink-0 text-gray-9" />
+											<div className="min-w-0">
+												<p className="text-[10px] text-gray-9">Drive</p>
+												<p className="truncate text-[11px] font-medium text-gray-12">
+													{selectedDriveName}
+												</p>
+											</div>
+										</div>
+										<div className="flex items-center gap-2 rounded-md bg-gray-3 px-2.5 py-2 min-w-0">
+											<FolderOpenIcon className="size-3.5 shrink-0 text-gray-9" />
+											<div className="min-w-0">
+												<p className="text-[10px] text-gray-9">Folder</p>
+												<p className="truncate text-[11px] font-medium text-gray-12">
+													{selectedFolderName ?? "Select a folder"}
+												</p>
+											</div>
+										</div>
+										<div className="flex items-center gap-2 rounded-md bg-gray-3 px-2.5 py-2 min-w-0">
+											<UserIcon className="size-3.5 shrink-0 text-gray-9" />
+											<div className="min-w-0">
+												<p className="text-[10px] text-gray-9">Member</p>
+												<p className="truncate text-[11px] font-medium text-gray-12">
+													User ID
+												</p>
+											</div>
+										</div>
+									</div>
+									<div className="flex items-center gap-2 rounded-md bg-gray-3 px-2.5 py-1.5 text-[11px] text-gray-10">
+										<VideoIcon className="size-3.5 shrink-0 text-gray-9" />
+										<span className="min-w-0 truncate">
+											{hasDriveLocation
+												? `${selectedFolderName ?? selectedDriveName} / user-id / video-id`
+												: "Select a folder before enabling"}
+										</span>
+									</div>
+									<div className="flex items-center gap-2 pt-1">
+										<Button
+											type="button"
+											size="xs"
+											variant="gray"
+											onClick={openFolderBrowser}
+											disabled={isPending || folderBrowserLoading}
+										>
+											<FolderOpenIcon className="size-3" />
+											Select Folder
+										</Button>
+										<Button
+											type="button"
+											size="xs"
+											variant="gray"
+											onClick={setDriveRootLocation}
+											disabled={isPending}
+										>
+											Use Root
+										</Button>
+										<Button
+											type="button"
+											size="xs"
+											onClick={() => setActiveProvider("googleDrive")}
+											disabled={!hasDriveLocation || isPending}
+										>
+											Enable
+										</Button>
+									</div>
+								</div>
+
+								{folderBrowserOpen && (
+									<div className="flex flex-col gap-2 rounded-lg border border-gray-3 p-3">
+										<div className="flex items-center justify-between">
+											<div className="min-w-0">
+												<p className="text-[12px] font-medium text-gray-12">
+													{folderBrowserParent.name}
+												</p>
+											</div>
+											<div className="flex gap-1.5">
+												<Button
+													type="button"
+													size="xs"
+													variant="gray"
+													onClick={openParentFolder}
+													disabled={
+														folderBrowserHistory.length === 0 ||
+														folderBrowserLoading
+													}
+												>
+													Back
+												</Button>
+												<Button
+													type="button"
+													size="xs"
+													onClick={selectCurrentDriveFolder}
+													disabled={folderBrowserLoading || isPending}
+												>
+													Use This Folder
+												</Button>
+											</div>
+										</div>
+										<div className="flex flex-col gap-1">
+											{folderBrowserLoading ? (
+												<div className="rounded-md bg-gray-2 px-3 py-2 text-[12px] text-gray-10">
+													Loading...
+												</div>
+											) : folderBrowserFolders.length > 0 ? (
+												folderBrowserFolders.map((folder) => (
+													<div
+														key={folder.id}
+														className="flex items-center gap-2.5 rounded-md bg-gray-2 px-2.5 py-2"
+													>
+														<FolderOpenIcon className="size-3.5 shrink-0 text-gray-9" />
+														<p className="min-w-0 flex-1 truncate text-[12px] text-gray-12">
+															{folder.name}
+														</p>
+														<Button
+															type="button"
+															size="xs"
+															variant="gray"
+															onClick={() => openChildFolder(folder)}
+															disabled={folderBrowserLoading}
+														>
+															Open
+														</Button>
+														<Button
+															type="button"
+															size="xs"
+															onClick={() => selectDriveFolder(folder)}
+															disabled={isPending}
+														>
+															Select
+														</Button>
+													</div>
+												))
+											) : (
+												<div className="rounded-md bg-gray-2 px-3 py-2 text-[12px] text-gray-10">
+													No folders found
+												</div>
+											)}
+										</div>
+									</div>
+								)}
+
+								<div className="flex items-center gap-2 pt-2 border-t border-gray-3">
+									<Button
+										type="button"
+										size="xs"
+										variant="gray"
+										onClick={() =>
+											runMutation(
+												() =>
+													getOrganizationGoogleDrivePickerToken(organizationId),
+												"Google Drive connection verified",
+											)
+										}
+										disabled={isPending}
+									>
+										Test
+									</Button>
+									<Button
+										type="button"
+										size="xs"
+										variant="destructive"
+										onClick={disconnectDrive}
+										disabled={isPending}
+									>
+										Disconnect
+									</Button>
+								</div>
+							</div>
+						) : (
+							<div className="flex items-center justify-between">
+								<p className="text-[12px] text-gray-10">
+									Link your Google account to store uploads in Drive.
+								</p>
+								<Button
+									type="button"
+									size="xs"
+									onClick={connectDrive}
+									disabled={isPending}
+								>
+									Connect
+								</Button>
+							</div>
+						)}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/app/(org)/dashboard/settings/organization/integrations/storage-integrations.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/integrations/storage-integrations.tsx
@@ -275,7 +275,7 @@ export function OrganizationStorageIntegrations({
 				<InfoIcon className="size-3.5 text-gray-9 shrink-0" />
 				<p className="text-[12px] text-gray-9">
 					Storage applies to all members of {settings.organization.name}. Only
-					owners and admins can manage integrations.
+					owners can manage integrations.
 				</p>
 			</div>
 
@@ -368,7 +368,9 @@ export function OrganizationStorageIntegrations({
 									id={accessKeyId}
 									type="password"
 									value={s3Config.accessKeyId}
-									placeholder="PL31OADSQNK"
+									placeholder={
+										settings.s3?.configured ? "Stored securely" : "PL31OADSQNK"
+									}
 									autoComplete="off"
 									onChange={(event) =>
 										setS3Config((current) => ({
@@ -386,7 +388,9 @@ export function OrganizationStorageIntegrations({
 									id={secretKeyId}
 									type="password"
 									value={s3Config.secretAccessKey}
-									placeholder="PL31OADSQNK"
+									placeholder={
+										settings.s3?.configured ? "Stored securely" : "PL31OADSQNK"
+									}
 									autoComplete="off"
 									onChange={(event) =>
 										setS3Config((current) => ({

--- a/apps/web/app/(org)/dashboard/settings/organization/integrations/storage-integrations.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/integrations/storage-integrations.tsx
@@ -27,6 +27,7 @@ import {
 	setOrganizationStorageProvider,
 	testOrganizationS3Config,
 } from "@/actions/organization/storage";
+import { useDashboardContext } from "@/app/(org)/dashboard/Contexts";
 
 const defaultS3Config = {
 	provider: "aws",
@@ -44,6 +45,9 @@ const s3ProviderOptions = [
 	{ value: "minio", label: "MinIO" },
 	{ value: "other", label: "Other S3-Compatible" },
 ];
+
+const proRequiredMessage =
+	"Cap Pro is required to manage organization integrations";
 
 const getOrganizationId = (settings: OrganizationStorageSettings) =>
 	settings.organization.id as Organisation.OrganisationId;
@@ -86,6 +90,7 @@ export function OrganizationStorageIntegrations({
 	initialSettings: OrganizationStorageSettings;
 }) {
 	const router = useRouter();
+	const { user, setUpgradeModalOpen } = useDashboardContext();
 	const [settings, setSettings] = useState(initialSettings);
 	const [s3Config, setS3Config] = useState(
 		initialSettings.s3 ?? defaultS3Config,
@@ -118,16 +123,29 @@ export function OrganizationStorageIntegrations({
 		setS3Config(initialSettings.s3 ?? defaultS3Config);
 	}, [initialSettings]);
 
+	const requirePro = () => {
+		if (user.isPro) return true;
+		setUpgradeModalOpen(true);
+		return false;
+	};
+
 	const runMutation = (
 		action: () => Promise<unknown>,
 		successMessage: string,
 	) => {
+		if (!requirePro()) return;
+
 		startTransition(async () => {
 			try {
 				await action();
 				toast.success(successMessage);
 				router.refresh();
 			} catch (error) {
+				if (error instanceof Error && error.message === proRequiredMessage) {
+					setUpgradeModalOpen(true);
+					return;
+				}
+
 				toast.error(error instanceof Error ? error.message : "Request failed");
 			}
 		});
@@ -195,6 +213,8 @@ export function OrganizationStorageIntegrations({
 		parent: { id: string; name: string },
 		history: Array<{ id: string; name: string }>,
 	) => {
+		if (!requirePro()) return;
+
 		setFolderBrowserLoading(true);
 		try {
 			const { folders } = await listOrganizationGoogleDriveFolders({
@@ -206,6 +226,11 @@ export function OrganizationStorageIntegrations({
 			setFolderBrowserFolders(folders);
 			setFolderBrowserOpen(true);
 		} catch (error) {
+			if (error instanceof Error && error.message === proRequiredMessage) {
+				setUpgradeModalOpen(true);
+				return;
+			}
+
 			toast.error(
 				error instanceof Error ? error.message : "Failed to load Drive folders",
 			);
@@ -258,6 +283,8 @@ export function OrganizationStorageIntegrations({
 		});
 
 	const toggleExpand = (integration: "s3" | "googleDrive") => {
+		if (!requirePro()) return;
+
 		setExpandedIntegration((prev) =>
 			prev === integration ? null : integration,
 		);

--- a/apps/web/app/(org)/dashboard/settings/organization/layout.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/layout.tsx
@@ -1,7 +1,7 @@
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { organizationMembers, organizations } from "@cap/database/schema";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { redirect } from "next/navigation";
 import { SettingsNav } from "./_components/SettingsNav";
 
@@ -29,6 +29,7 @@ export default async function OrganizationSettingsLayout({
 			and(
 				eq(organizationMembers.userId, user.id),
 				eq(organizations.id, user.activeOrganizationId),
+				isNull(organizations.tombstoneAt),
 			),
 		)
 		.limit(1);

--- a/apps/web/app/api/desktop/[...route]/organizationStorage.ts
+++ b/apps/web/app/api/desktop/[...route]/organizationStorage.ts
@@ -1,0 +1,146 @@
+import { db } from "@cap/database";
+import {
+	organizationMembers,
+	organizations,
+	s3Buckets,
+	storageIntegrations,
+} from "@cap/database/schema";
+import type { Organisation, User } from "@cap/web-domain";
+import { and, desc, eq, isNull, or } from "drizzle-orm";
+
+const googleDriveProvider = "googleDrive";
+
+export type ManagedOrganizationStorage = {
+	id: string;
+	name: string;
+	activeProvider: "s3" | "googleDrive";
+};
+
+export const getAccessibleOrganization = async (
+	userId: User.UserId,
+	organizationId: Organisation.OrganisationId,
+) => {
+	const [organization] = await db()
+		.select({
+			id: organizations.id,
+			name: organizations.name,
+			ownerId: organizations.ownerId,
+			memberRole: organizationMembers.role,
+		})
+		.from(organizations)
+		.leftJoin(
+			organizationMembers,
+			and(
+				eq(organizationMembers.organizationId, organizations.id),
+				eq(organizationMembers.userId, userId),
+			),
+		)
+		.where(
+			and(
+				eq(organizations.id, organizationId),
+				isNull(organizations.tombstoneAt),
+				or(
+					eq(organizations.ownerId, userId),
+					eq(organizationMembers.userId, userId),
+				),
+			),
+		)
+		.limit(1);
+
+	return organization ?? null;
+};
+
+export const requireOrganizationOwner = async (
+	userId: User.UserId,
+	organizationId: Organisation.OrganisationId,
+) => {
+	const organization = await getAccessibleOrganization(userId, organizationId);
+	if (!organization || organization.ownerId !== userId) return null;
+	return organization;
+};
+
+export const getOrganizationGoogleDriveIntegration = async (
+	organizationId: Organisation.OrganisationId,
+) => {
+	const [integration] = await db()
+		.select()
+		.from(storageIntegrations)
+		.where(
+			and(
+				eq(storageIntegrations.organizationId, organizationId),
+				eq(storageIntegrations.provider, googleDriveProvider),
+			),
+		)
+		.orderBy(
+			desc(storageIntegrations.active),
+			desc(storageIntegrations.updatedAt),
+		)
+		.limit(1);
+
+	return integration ?? null;
+};
+
+export const getActiveOrganizationGoogleDriveIntegration = async (
+	organizationId: Organisation.OrganisationId,
+) => {
+	const [integration] = await db()
+		.select()
+		.from(storageIntegrations)
+		.where(
+			and(
+				eq(storageIntegrations.organizationId, organizationId),
+				eq(storageIntegrations.provider, googleDriveProvider),
+				eq(storageIntegrations.active, true),
+				eq(storageIntegrations.status, "active"),
+			),
+		)
+		.orderBy(desc(storageIntegrations.updatedAt))
+		.limit(1);
+
+	return integration ?? null;
+};
+
+export const getOrganizationS3Bucket = async (
+	organizationId: Organisation.OrganisationId,
+) => {
+	const [bucket] = await db()
+		.select()
+		.from(s3Buckets)
+		.where(
+			and(
+				eq(s3Buckets.organizationId, organizationId),
+				eq(s3Buckets.active, true),
+			),
+		)
+		.orderBy(desc(s3Buckets.updatedAt))
+		.limit(1);
+
+	return bucket ?? null;
+};
+
+export const getManagedOrganizationStorage = async (
+	userId: User.UserId,
+	organizationId: Organisation.OrganisationId,
+): Promise<ManagedOrganizationStorage | null> => {
+	const organization = await getAccessibleOrganization(userId, organizationId);
+	if (!organization) return null;
+
+	const activeDrive =
+		await getActiveOrganizationGoogleDriveIntegration(organizationId);
+	if (activeDrive) {
+		return {
+			id: organization.id,
+			name: organization.name,
+			activeProvider: "googleDrive",
+		};
+	}
+
+	const bucket = await getOrganizationS3Bucket(organizationId);
+	if (!bucket) return null;
+
+	return {
+		id: organization.id,
+		name: organization.name,
+		activeProvider: "s3",
+	};
+};

--- a/apps/web/app/api/desktop/[...route]/s3Config.ts
+++ b/apps/web/app/api/desktop/[...route]/s3Config.ts
@@ -3,14 +3,59 @@ import { db } from "@cap/database";
 import { decrypt, encrypt } from "@cap/database/crypto";
 import { nanoId } from "@cap/database/helpers";
 import { s3Buckets } from "@cap/database/schema";
-import { S3Bucket } from "@cap/web-domain";
+import { Organisation, S3Bucket } from "@cap/web-domain";
 import { zValidator } from "@hono/zod-validator";
-import { eq } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 import { withAuth } from "@/app/api/utils";
+import {
+	getAccessibleOrganization,
+	getManagedOrganizationStorage,
+	getOrganizationS3Bucket,
+} from "./organizationStorage";
 
 export const app = new Hono().use(withAuth);
+
+const defaultS3Config = {
+	provider: "aws",
+	accessKeyId: "",
+	secretAccessKey: "",
+	endpoint: "https://s3.amazonaws.com",
+	bucketName: "",
+	region: "us-east-1",
+};
+
+const orgIdQuery = z.object({
+	orgId: z
+		.string()
+		.optional()
+		.transform((value) =>
+			value ? Organisation.OrganisationId.make(value) : undefined,
+		),
+});
+
+const decryptBucketConfig = async (
+	bucket: typeof s3Buckets.$inferSelect,
+	exposeSecrets: boolean,
+) => ({
+	provider: bucket.provider,
+	accessKeyId: exposeSecrets ? await decrypt(bucket.accessKeyId) : "",
+	secretAccessKey: exposeSecrets ? await decrypt(bucket.secretAccessKey) : "",
+	endpoint: bucket.endpoint
+		? await decrypt(bucket.endpoint)
+		: "https://s3.amazonaws.com",
+	bucketName: await decrypt(bucket.bucketName),
+	region: await decrypt(bucket.region),
+});
+
+const getS3ErrorMetadata = (error: unknown) => {
+	if (!error || typeof error !== "object" || !("$metadata" in error)) {
+		return undefined;
+	}
+
+	return error.$metadata as { httpStatusCode?: number } | undefined;
+};
 
 app.post(
 	"/",
@@ -30,7 +75,6 @@ app.post(
 		const data = c.req.valid("json");
 
 		try {
-			// Encrypt the sensitive data
 			const encryptedConfig = {
 				id: S3Bucket.S3BucketId.make(nanoId()),
 				provider: data.provider,
@@ -40,24 +84,22 @@ app.post(
 				bucketName: await encrypt(data.bucketName),
 				region: await encrypt(data.region),
 				ownerId: user.id,
+				organizationId: null,
+				active: true,
 			};
 
-			// Check if user already has a bucket config
-			const [existingBucket] = await db()
-				.select()
-				.from(s3Buckets)
-				.where(eq(s3Buckets.ownerId, user.id));
-
-			if (existingBucket) {
-				// Update existing config
-				await db()
+			await db().transaction(async (tx) => {
+				await tx
 					.update(s3Buckets)
-					.set(encryptedConfig)
-					.where(eq(s3Buckets.id, existingBucket.id));
-			} else {
-				// Insert new config
-				await db().insert(s3Buckets).values(encryptedConfig);
-			}
+					.set({ active: false })
+					.where(
+						and(
+							eq(s3Buckets.ownerId, user.id),
+							isNull(s3Buckets.organizationId),
+						),
+					);
+				await tx.insert(s3Buckets).values(encryptedConfig);
+			});
 
 			return c.json({ success: true });
 		} catch (error) {
@@ -77,8 +119,12 @@ app.delete("/delete", async (c) => {
 	const user = c.get("user");
 
 	try {
-		// Delete the S3 configuration for the user
-		await db().delete(s3Buckets).where(eq(s3Buckets.ownerId, user.id));
+		await db()
+			.update(s3Buckets)
+			.set({ active: false })
+			.where(
+				and(eq(s3Buckets.ownerId, user.id), isNull(s3Buckets.organizationId)),
+			);
 
 		return c.json({ success: true });
 	} catch (error) {
@@ -93,40 +139,65 @@ app.delete("/delete", async (c) => {
 	}
 });
 
-app.get("/get", async (c) => {
+app.get("/get", zValidator("query", orgIdQuery), async (c) => {
 	const user = c.get("user");
+	const { orgId } = c.req.valid("query");
 
 	try {
+		if (orgId) {
+			const organization = await getAccessibleOrganization(user.id, orgId);
+			if (!organization)
+				return c.json({ error: "forbidden_org" }, { status: 403 });
+
+			const managedByOrganization = await getManagedOrganizationStorage(
+				user.id,
+				orgId,
+			);
+			if (managedByOrganization?.activeProvider === "s3") {
+				const bucket = await getOrganizationS3Bucket(orgId);
+				if (bucket) {
+					return c.json({
+						config: await decryptBucketConfig(bucket, false),
+						source: "organization" as const,
+						managedByOrganization,
+					});
+				}
+			}
+
+			if (managedByOrganization) {
+				return c.json({
+					config: defaultS3Config,
+					source: "organization" as const,
+					managedByOrganization,
+				});
+			}
+		}
+
 		const [bucket] = await db()
 			.select()
 			.from(s3Buckets)
-			.where(eq(s3Buckets.ownerId, user.id));
+			.where(
+				and(
+					eq(s3Buckets.ownerId, user.id),
+					isNull(s3Buckets.organizationId),
+					eq(s3Buckets.active, true),
+				),
+			)
+			.orderBy(desc(s3Buckets.updatedAt))
+			.limit(1);
 
 		if (!bucket)
 			return c.json({
-				config: {
-					provider: "aws",
-					accessKeyId: "",
-					secretAccessKey: "",
-					endpoint: "https://s3.amazonaws.com",
-					bucketName: "",
-					region: "us-east-1",
-				},
+				config: defaultS3Config,
+				source: "default" as const,
+				managedByOrganization: null,
 			});
 
-		// Decrypt the values before sending
-		const decryptedConfig = {
-			provider: bucket.provider,
-			accessKeyId: await decrypt(bucket.accessKeyId),
-			secretAccessKey: await decrypt(bucket.secretAccessKey),
-			endpoint: bucket.endpoint
-				? await decrypt(bucket.endpoint)
-				: "https://s3.amazonaws.com",
-			bucketName: await decrypt(bucket.bucketName),
-			region: await decrypt(bucket.region),
-		};
-
-		return c.json({ config: decryptedConfig });
+		return c.json({
+			config: await decryptBucketConfig(bucket, true),
+			source: "user" as const,
+			managedByOrganization: null,
+		});
 	} catch (error) {
 		console.error("Error in S3 config get route:", error);
 		return c.json(
@@ -197,7 +268,7 @@ app.post(
 					} else if (error.name === "AccessDenied") {
 						errorMessage =
 							"Access denied. Please check your credentials and bucket permissions.";
-					} else if ((error as any).$metadata?.httpStatusCode === 301) {
+					} else if (getS3ErrorMetadata(error)?.httpStatusCode === 301) {
 						errorMessage =
 							"Received 301 redirect. This usually means the endpoint URL is incorrect or the bucket is in a different region.";
 					}
@@ -207,7 +278,7 @@ app.post(
 					{
 						error: errorMessage,
 						details: error instanceof Error ? error.message : String(error),
-						metadata: (error as any)?.$metadata,
+						metadata: getS3ErrorMetadata(error),
 					},
 					{ status: 500 },
 				);
@@ -219,7 +290,7 @@ app.post(
 				{
 					error: "Failed to connect to S3",
 					details: error instanceof Error ? error.message : String(error),
-					metadata: (error as any)?.$metadata,
+					metadata: getS3ErrorMetadata(error),
 				},
 				{ status: 500 },
 			);

--- a/apps/web/app/api/desktop/[...route]/storage.ts
+++ b/apps/web/app/api/desktop/[...route]/storage.ts
@@ -16,18 +16,27 @@ import {
 	getGoogleDriveAuthUrl,
 	getGoogleDriveUserEmail,
 } from "@cap/web-backend";
-import { Storage, User } from "@cap/web-domain";
+import { Organisation, Storage, User } from "@cap/web-domain";
 import { zValidator } from "@hono/zod-validator";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 import { getCachedGoogleDriveStorageQuota } from "@/lib/google-drive-storage-quota";
 import { runPromise } from "@/lib/server";
 import { withAuth } from "../../utils";
+import {
+	getAccessibleOrganization,
+	getActiveOrganizationGoogleDriveIntegration,
+	getManagedOrganizationStorage,
+	getOrganizationGoogleDriveIntegration,
+	requireOrganizationOwner,
+} from "./organizationStorage";
 
 const GoogleDriveOAuthState = z.object({
 	userId: z.string(),
 	expiresAt: z.number(),
+	scope: z.enum(["user", "organization"]).default("user"),
+	organizationId: z.string().optional(),
 });
 
 const googleDriveProvider = "googleDrive";
@@ -37,6 +46,21 @@ const RefreshStorageQuotaQuery = z.object({
 		.union([z.literal("true"), z.literal("false"), z.boolean()])
 		.optional()
 		.transform((value) => value === true || value === "true"),
+	orgId: z
+		.string()
+		.optional()
+		.transform((value) =>
+			value ? Organisation.OrganisationId.make(value) : undefined,
+		),
+});
+
+const ConnectGoogleDriveStorageBody = z.object({
+	orgId: z
+		.string()
+		.optional()
+		.transform((value) =>
+			value ? Organisation.OrganisationId.make(value) : undefined,
+		),
 });
 
 const signStatePayload = (payload: string) =>
@@ -44,11 +68,16 @@ const signStatePayload = (payload: string) =>
 		.update(payload)
 		.digest("base64url");
 
-const createGoogleDriveState = (userId: string) => {
+const createGoogleDriveState = (
+	userId: string,
+	organizationId?: Organisation.OrganisationId,
+) => {
 	const payload = Buffer.from(
 		JSON.stringify({
 			userId,
 			expiresAt: Date.now() + 10 * 60 * 1000,
+			scope: organizationId ? "organization" : "user",
+			organizationId,
 		}),
 	).toString("base64url");
 	return `${payload}.${signStatePayload(payload)}`;
@@ -71,7 +100,13 @@ const verifyGoogleDriveState = (state: string) => {
 		JSON.parse(Buffer.from(payload, "base64url").toString("utf8")),
 	);
 	if (parsed.expiresAt < Date.now()) throw new Error("Expired OAuth state");
-	return User.UserId.make(parsed.userId);
+	return {
+		userId: User.UserId.make(parsed.userId),
+		organizationId:
+			parsed.scope === "organization" && parsed.organizationId
+				? Organisation.OrganisationId.make(parsed.organizationId)
+				: undefined,
+	};
 };
 
 const escapeHtml = (value: string) =>
@@ -110,6 +145,7 @@ const getGoogleDriveIntegration = (ownerId: User.UserId) =>
 		.where(
 			and(
 				eq(storageIntegrations.ownerId, ownerId),
+				isNull(storageIntegrations.organizationId),
 				eq(storageIntegrations.provider, googleDriveProvider),
 			),
 		)
@@ -128,7 +164,53 @@ protectedApp.get(
 	zValidator("query", RefreshStorageQuotaQuery),
 	async (c) => {
 		const user = c.get("user");
-		const { refreshStorageQuota } = c.req.valid("query");
+		const { refreshStorageQuota, orgId } = c.req.valid("query");
+		if (orgId) {
+			const organization = await getAccessibleOrganization(user.id, orgId);
+			if (!organization)
+				return c.json({ error: "forbidden_org" }, { status: 403 });
+
+			const managedByOrganization = await getManagedOrganizationStorage(
+				user.id,
+				orgId,
+			);
+			if (managedByOrganization) {
+				const drive =
+					managedByOrganization.activeProvider === "googleDrive"
+						? await getActiveOrganizationGoogleDriveIntegration(orgId)
+						: await getOrganizationGoogleDriveIntegration(orgId);
+				const storageQuota =
+					drive && drive.status === "active"
+						? await getCachedGoogleDriveStorageQuota(drive, {
+								forceRefresh: refreshStorageQuota,
+							})
+						: null;
+
+				return c.json({
+					activeProvider: managedByOrganization.activeProvider,
+					managedByOrganization,
+					googleDrive:
+						drive && managedByOrganization.activeProvider === "googleDrive"
+							? {
+									id: drive.id,
+									connected: drive.status === "active",
+									active: drive.active,
+									status: drive.status,
+									displayName: drive.displayName,
+									storageQuota,
+								}
+							: {
+									id: null,
+									connected: false,
+									active: false,
+									status: null,
+									displayName: null,
+									storageQuota: null,
+								},
+				});
+			}
+		}
+
 		const [drive] = await getGoogleDriveIntegration(user.id);
 		const storageQuota = drive
 			? await getCachedGoogleDriveStorageQuota(drive, {
@@ -139,6 +221,7 @@ protectedApp.get(
 		return c.json({
 			activeProvider:
 				drive?.active && drive.status === "active" ? "googleDrive" : "s3",
+			managedByOrganization: null,
 			googleDrive: drive
 				? {
 						id: drive.id,
@@ -160,17 +243,28 @@ protectedApp.get(
 	},
 );
 
-protectedApp.post("/google-drive/connect", async (c) => {
-	const user = c.get("user");
-	if (!userIsPro(user)) {
-		return c.json({ error: "upgrade_required" }, { status: 403 });
-	}
+protectedApp.post(
+	"/google-drive/connect",
+	zValidator("json", ConnectGoogleDriveStorageBody),
+	async (c) => {
+		const user = c.get("user");
+		const { orgId } = c.req.valid("json");
+		if (!userIsPro(user)) {
+			return c.json({ error: "upgrade_required" }, { status: 403 });
+		}
 
-	const state = createGoogleDriveState(user.id);
-	return c.json({
-		url: getGoogleDriveAuthUrl({ state }),
-	});
-});
+		if (orgId) {
+			const organization = await requireOrganizationOwner(user.id, orgId);
+			if (!organization)
+				return c.json({ error: "forbidden_org" }, { status: 403 });
+		}
+
+		const state = createGoogleDriveState(user.id, orgId);
+		return c.json({
+			url: getGoogleDriveAuthUrl({ state }),
+		});
+	},
+);
 
 protectedApp.post("/google-drive/test", async (c) => {
 	const user = c.get("user");
@@ -208,6 +302,7 @@ protectedApp.post(
 							.where(
 								and(
 									eq(storageIntegrations.ownerId, user.id),
+									isNull(storageIntegrations.organizationId),
 									eq(storageIntegrations.provider, googleDriveProvider),
 									eq(storageIntegrations.status, "active"),
 								),
@@ -226,7 +321,12 @@ protectedApp.post(
 			await tx
 				.update(storageIntegrations)
 				.set({ active: false })
-				.where(eq(storageIntegrations.ownerId, user.id));
+				.where(
+					and(
+						eq(storageIntegrations.ownerId, user.id),
+						isNull(storageIntegrations.organizationId),
+					),
+				);
 
 			if (provider === "googleDrive" && driveToActivate) {
 				await tx
@@ -262,6 +362,7 @@ protectedApp.delete("/google-drive/disconnect", async (c) => {
 		.where(
 			and(
 				eq(storageIntegrations.ownerId, user.id),
+				isNull(storageIntegrations.organizationId),
 				eq(storageIntegrations.provider, googleDriveProvider),
 			),
 		);
@@ -296,7 +397,15 @@ app.get("/google-drive/callback", async (c) => {
 			);
 		}
 
-		const userId = verifyGoogleDriveState(state);
+		const { userId, organizationId } = verifyGoogleDriveState(state);
+		if (organizationId) {
+			const organization = await requireOrganizationOwner(
+				userId,
+				organizationId,
+			);
+			if (!organization) throw new Error("Organization access denied");
+		}
+
 		const tokens = await exchangeGoogleDriveCode(code).pipe(runPromise);
 		if (!tokens.refresh_token) throw new Error("Missing refresh token");
 
@@ -304,30 +413,39 @@ app.get("/google-drive/callback", async (c) => {
 			refreshToken: tokens.refresh_token,
 			folderId: "",
 			scope: tokens.scope,
+			folderLayout: organizationId ? "userVideo" : "video",
 		};
-		const folderId = await ensureGoogleDriveFolder(initialConfig, "Cap").pipe(
-			runPromise,
-		);
-		const config: GoogleDriveIntegrationConfig = {
-			...initialConfig,
-			folderId,
-		};
+		const config: GoogleDriveIntegrationConfig = organizationId
+			? initialConfig
+			: {
+					...initialConfig,
+					folderId: await ensureGoogleDriveFolder(initialConfig, "Cap").pipe(
+						runPromise,
+					),
+					folderName: "Cap",
+				};
 		const email = await getGoogleDriveUserEmail(config).pipe(runPromise);
 		const encryptedConfig = await encrypt(
 			JSON.stringify({ ...config, email: email ?? undefined }),
 		);
 		const displayName = email ? `Google Drive (${email})` : "Google Drive";
+		const active = !organizationId;
 
 		await db().transaction(async (tx) => {
+			const integrationScope = organizationId
+				? and(
+						eq(storageIntegrations.organizationId, organizationId),
+						eq(storageIntegrations.provider, googleDriveProvider),
+					)
+				: and(
+						eq(storageIntegrations.ownerId, userId),
+						isNull(storageIntegrations.organizationId),
+						eq(storageIntegrations.provider, googleDriveProvider),
+					);
 			const existingIntegrations = await tx
 				.select()
 				.from(storageIntegrations)
-				.where(
-					and(
-						eq(storageIntegrations.ownerId, userId),
-						eq(storageIntegrations.provider, googleDriveProvider),
-					),
-				)
+				.where(integrationScope)
 				.orderBy(desc(storageIntegrations.updatedAt));
 
 			const dependencyChecks = await Promise.all(
@@ -356,20 +474,17 @@ app.get("/google-drive/callback", async (c) => {
 			await tx
 				.update(storageIntegrations)
 				.set({ active: false, status: "disconnected" })
-				.where(
-					and(
-						eq(storageIntegrations.ownerId, userId),
-						eq(storageIntegrations.provider, googleDriveProvider),
-					),
-				);
+				.where(integrationScope);
 
 			if (reusable) {
 				await tx
 					.update(storageIntegrations)
 					.set({
+						ownerId: userId,
+						organizationId: organizationId ?? null,
 						displayName,
 						status: "active",
-						active: true,
+						active,
 						encryptedConfig,
 						googleDriveAccessToken: null,
 						googleDriveAccessTokenExpiresAt: null,
@@ -384,10 +499,11 @@ app.get("/google-drive/callback", async (c) => {
 			await tx.insert(storageIntegrations).values({
 				id: Storage.StorageIntegrationId.make(nanoId()),
 				ownerId: userId,
+				organizationId: organizationId ?? null,
 				provider: googleDriveProvider,
 				displayName,
 				status: "active",
-				active: true,
+				active,
 				encryptedConfig,
 			});
 		});

--- a/apps/web/app/api/desktop/[...route]/video.ts
+++ b/apps/web/app/api/desktop/[...route]/video.ts
@@ -174,9 +174,24 @@ app.get(
 				c.req,
 				GOOGLE_DRIVE_UPLOAD_FEATURE,
 			);
+			const organizationWritable =
+				await Storage.getOrganizationWritableAccess(videoOrgId).pipe(
+					runPromise,
+				);
+			if (
+				!clientSupportsGoogleDriveUpload &&
+				Option.isSome(organizationWritable) &&
+				organizationWritable.value.access.provider === "googleDrive"
+			) {
+				return c.json(
+					{ error: "google_drive_upload_unsupported" },
+					{ status: 426 },
+				);
+			}
+
 			const writable = await (clientSupportsGoogleDriveUpload
-				? Storage.getWritableAccessForUser(user.id)
-				: Storage.getS3WritableAccessForUser(user.id)
+				? Storage.getWritableAccessForUser(user.id, videoOrgId)
+				: Storage.getS3WritableAccessForUser(user.id, videoOrgId)
 			).pipe(runPromise);
 
 			await db()

--- a/apps/web/public/.well-known/workflow/v1/manifest.json
+++ b/apps/web/public/.well-known/workflow/v1/manifest.json
@@ -1,6 +1,22 @@
 {
 	"version": "1.0.0",
 	"steps": {
+		"node_modules/.pnpm/workflow@4.2.0-beta.73_@nestjs+common@11.1.17_reflect-metadata@0.2.2_rxjs@7.8.2__@nestj_2a6f07c63175c34d8d104665b34a32ad/node_modules/workflow/dist/internal/builtins.js": {
+			"__builtin_response_array_buffer": {
+				"stepId": "__builtin_response_array_buffer"
+			},
+			"__builtin_response_json": {
+				"stepId": "__builtin_response_json"
+			},
+			"__builtin_response_text": {
+				"stepId": "__builtin_response_text"
+			}
+		},
+		"node_modules/.pnpm/workflow@4.2.0-beta.73_@nestjs+common@11.1.17_reflect-metadata@0.2.2_rxjs@7.8.2__@nestj_2a6f07c63175c34d8d104665b34a32ad/node_modules/workflow/dist/stdlib.js": {
+			"fetch": {
+				"stepId": "step//workflow@4.2.0-beta.73//fetch"
+			}
+		},
 		"workflows/process-video.ts": {
 			"cleanupRawUpload": {
 				"stepId": "step//./workflows/process-video//cleanupRawUpload"
@@ -16,25 +32,6 @@
 			},
 			"validateProcessingRequest": {
 				"stepId": "step//./workflows/process-video//validateProcessingRequest"
-			}
-		},
-		"workflows/import-loom-video.ts": {
-			"downloadLoomToS3": {
-				"stepId": "step//./workflows/import-loom-video//downloadLoomToS3"
-			},
-			"processVideoOnMediaServer": {
-				"stepId": "step//./workflows/import-loom-video//processVideoOnMediaServer"
-			},
-			"saveMetadataAndComplete": {
-				"stepId": "step//./workflows/import-loom-video//saveMetadataAndComplete"
-			},
-			"setProcessingError": {
-				"stepId": "step//./workflows/import-loom-video//setProcessingError"
-			}
-		},
-		"node_modules/.pnpm/workflow@4.2.0-beta.73_@nestjs+common@11.1.17_reflect-metadata@0.2.2_rxjs@7.8.2__@nestj_2a6f07c63175c34d8d104665b34a32ad/node_modules/workflow/dist/stdlib.js": {
-			"fetch": {
-				"stepId": "step//workflow@4.2.0-beta.73//fetch"
 			}
 		},
 		"workflows/transcribe.ts": {
@@ -69,15 +66,18 @@
 				"stepId": "step//./workflows/transcribe//validateVideo"
 			}
 		},
-		"node_modules/.pnpm/workflow@4.2.0-beta.73_@nestjs+common@11.1.17_reflect-metadata@0.2.2_rxjs@7.8.2__@nestj_2a6f07c63175c34d8d104665b34a32ad/node_modules/workflow/dist/internal/builtins.js": {
-			"__builtin_response_array_buffer": {
-				"stepId": "__builtin_response_array_buffer"
+		"workflows/import-loom-video.ts": {
+			"downloadLoomToS3": {
+				"stepId": "step//./workflows/import-loom-video//downloadLoomToS3"
 			},
-			"__builtin_response_json": {
-				"stepId": "__builtin_response_json"
+			"processVideoOnMediaServer": {
+				"stepId": "step//./workflows/import-loom-video//processVideoOnMediaServer"
 			},
-			"__builtin_response_text": {
-				"stepId": "__builtin_response_text"
+			"saveMetadataAndComplete": {
+				"stepId": "step//./workflows/import-loom-video//saveMetadataAndComplete"
+			},
+			"setProcessingError": {
+				"stepId": "step//./workflows/import-loom-video//setProcessingError"
 			}
 		},
 		"workflows/generate-ai.ts": {
@@ -132,16 +132,16 @@
 				}
 			}
 		},
-		"workflows/import-loom-video.ts": {
-			"importLoomVideoWorkflow": {
-				"workflowId": "workflow//./workflows/import-loom-video//importLoomVideoWorkflow",
+		"workflows/transcribe.ts": {
+			"transcribeVideoWorkflow": {
+				"workflowId": "workflow//./workflows/transcribe//transcribeVideoWorkflow",
 				"graph": {
 					"nodes": [
 						{
 							"id": "start",
 							"type": "workflowStart",
 							"data": {
-								"label": "Start: importLoomVideoWorkflow",
+								"label": "Start: transcribeVideoWorkflow",
 								"nodeKind": "workflow_start"
 							}
 						},
@@ -165,16 +165,16 @@
 				}
 			}
 		},
-		"workflows/transcribe.ts": {
-			"transcribeVideoWorkflow": {
-				"workflowId": "workflow//./workflows/transcribe//transcribeVideoWorkflow",
+		"workflows/import-loom-video.ts": {
+			"importLoomVideoWorkflow": {
+				"workflowId": "workflow//./workflows/import-loom-video//importLoomVideoWorkflow",
 				"graph": {
 					"nodes": [
 						{
 							"id": "start",
 							"type": "workflowStart",
 							"data": {
-								"label": "Start: transcribeVideoWorkflow",
+								"label": "Start: importLoomVideoWorkflow",
 								"nodeKind": "workflow_start"
 							}
 						},

--- a/packages/database/migrations/0021_glorious_khan.sql
+++ b/packages/database/migrations/0021_glorious_khan.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `s3_buckets` ADD `organizationId` varchar(15);--> statement-breakpoint
+ALTER TABLE `storage_integrations` ADD `organizationId` varchar(15);--> statement-breakpoint
+CREATE INDEX `owner_organization_idx` ON `s3_buckets` (`ownerId`,`organizationId`);--> statement-breakpoint
+CREATE INDEX `organization_id_idx` ON `s3_buckets` (`organizationId`);--> statement-breakpoint
+CREATE INDEX `organization_provider_idx` ON `storage_integrations` (`organizationId`,`provider`);--> statement-breakpoint
+CREATE INDEX `organization_active_idx` ON `storage_integrations` (`organizationId`,`active`,`status`);

--- a/packages/database/migrations/0022_dazzling_namor.sql
+++ b/packages/database/migrations/0022_dazzling_namor.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `s3_buckets` ADD `active` boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE `s3_buckets` ADD `createdAt` timestamp DEFAULT (now()) NOT NULL;--> statement-breakpoint
+ALTER TABLE `s3_buckets` ADD `updatedAt` timestamp DEFAULT (now()) NOT NULL ON UPDATE CURRENT_TIMESTAMP;--> statement-breakpoint
+CREATE INDEX `organization_active_idx` ON `s3_buckets` (`organizationId`,`active`,`updatedAt`);

--- a/packages/database/migrations/meta/0021_snapshot.json
+++ b/packages/database/migrations/meta/0021_snapshot.json
@@ -1,0 +1,3144 @@
+{
+	"version": "5",
+	"dialect": "mysql",
+	"id": "4045835b-67d0-487d-bcb6-b436c54ad136",
+	"prevId": "6ab81fa9-13db-405f-94b3-19becbd18ec9",
+	"tables": {
+		"accounts": {
+			"name": "accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerAccountId": {
+					"name": "providerAccountId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_in": {
+					"name": "expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_in": {
+					"name": "refresh_token_expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"tempColumn": {
+					"name": "tempColumn",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				},
+				"provider_account_id_idx": {
+					"name": "provider_account_id_idx",
+					"columns": ["providerAccountId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"accounts_id": {
+					"name": "accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"auth_api_keys": {
+			"name": "auth_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(36)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"auth_api_keys_id": {
+					"name": "auth_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"comments": {
+			"name": "comments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(6)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"authorId": {
+					"name": "authorId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"parentCommentId": {
+					"name": "parentCommentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"video_type_created_idx": {
+					"name": "video_type_created_idx",
+					"columns": ["videoId", "type", "createdAt", "id"],
+					"isUnique": false
+				},
+				"author_id_idx": {
+					"name": "author_id_idx",
+					"columns": ["authorId"],
+					"isUnique": false
+				},
+				"parent_comment_id_idx": {
+					"name": "parent_comment_id_idx",
+					"columns": ["parentCommentId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"comments_id": {
+					"name": "comments_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_api_keys": {
+			"name": "developer_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyType": {
+					"name": "keyType",
+					"type": "varchar(8)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyPrefix": {
+					"name": "keyPrefix",
+					"type": "varchar(12)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyHash": {
+					"name": "keyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"encryptedKey": {
+					"name": "encryptedKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"lastUsedAt": {
+					"name": "lastUsedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"revokedAt": {
+					"name": "revokedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"key_hash_idx": {
+					"name": "key_hash_idx",
+					"columns": ["keyHash"],
+					"isUnique": true
+				},
+				"app_key_type_idx": {
+					"name": "app_key_type_idx",
+					"columns": ["appId", "keyType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_api_keys_appId_developer_apps_id_fk": {
+					"name": "developer_api_keys_appId_developer_apps_id_fk",
+					"tableFrom": "developer_api_keys",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_api_keys_id": {
+					"name": "developer_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_app_domains": {
+			"name": "developer_app_domains",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"domain": {
+					"name": "domain",
+					"type": "varchar(253)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_app_domains_appId_developer_apps_id_fk": {
+					"name": "developer_app_domains_appId_developer_apps_id_fk",
+					"tableFrom": "developer_app_domains",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_app_domains_id": {
+					"name": "developer_app_domains_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_domain_unique": {
+					"name": "app_domain_unique",
+					"columns": ["appId", "domain"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_apps": {
+			"name": "developer_apps",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"environment": {
+					"name": "environment",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"logoUrl": {
+					"name": "logoUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_deleted_idx": {
+					"name": "owner_deleted_idx",
+					"columns": ["ownerId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"developer_apps_id": {
+					"name": "developer_apps_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_accounts": {
+			"name": "developer_credit_accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceMicroCredits": {
+					"name": "balanceMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripePaymentMethodId": {
+					"name": "stripePaymentMethodId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"autoTopUpEnabled": {
+					"name": "autoTopUpEnabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"autoTopUpThresholdMicroCredits": {
+					"name": "autoTopUpThresholdMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"autoTopUpAmountCents": {
+					"name": "autoTopUpAmountCents",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_id_unique": {
+					"name": "app_id_unique",
+					"columns": ["appId"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"developer_credit_accounts_appId_developer_apps_id_fk": {
+					"name": "developer_credit_accounts_appId_developer_apps_id_fk",
+					"tableFrom": "developer_credit_accounts",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_accounts_id": {
+					"name": "developer_credit_accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_transactions": {
+			"name": "developer_credit_transactions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amountMicroCredits": {
+					"name": "amountMicroCredits",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceAfterMicroCredits": {
+					"name": "balanceAfterMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"referenceId": {
+					"name": "referenceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"referenceType": {
+					"name": "referenceType",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"account_type_created_idx": {
+					"name": "account_type_created_idx",
+					"columns": ["accountId", "type", "createdAt"],
+					"isUnique": false
+				},
+				"account_ref_dedup_idx": {
+					"name": "account_ref_dedup_idx",
+					"columns": ["accountId", "referenceId", "referenceType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"dev_credit_txn_account_fk": {
+					"name": "dev_credit_txn_account_fk",
+					"tableFrom": "developer_credit_transactions",
+					"tableTo": "developer_credit_accounts",
+					"columnsFrom": ["accountId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_transactions_id": {
+					"name": "developer_credit_transactions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_daily_storage_snapshots": {
+			"name": "developer_daily_storage_snapshots",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"snapshotDate": {
+					"name": "snapshotDate",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"totalDurationMinutes": {
+					"name": "totalDurationMinutes",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"videoCount": {
+					"name": "videoCount",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"microCreditsCharged": {
+					"name": "microCreditsCharged",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processedAt": {
+					"name": "processedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_daily_storage_snapshots_appId_developer_apps_id_fk": {
+					"name": "developer_daily_storage_snapshots_appId_developer_apps_id_fk",
+					"tableFrom": "developer_daily_storage_snapshots",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_daily_storage_snapshots_id": {
+					"name": "developer_daily_storage_snapshots_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_date_unique": {
+					"name": "app_date_unique",
+					"columns": ["appId", "snapshotDate"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_videos": {
+			"name": "developer_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"externalUserId": {
+					"name": "externalUserId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Untitled'"
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"s3Key": {
+					"name": "s3Key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_created_idx": {
+					"name": "app_created_idx",
+					"columns": ["appId", "createdAt"],
+					"isUnique": false
+				},
+				"app_user_idx": {
+					"name": "app_user_idx",
+					"columns": ["appId", "externalUserId"],
+					"isUnique": false
+				},
+				"app_deleted_idx": {
+					"name": "app_deleted_idx",
+					"columns": ["appId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_videos_appId_developer_apps_id_fk": {
+					"name": "developer_videos_appId_developer_apps_id_fk",
+					"tableFrom": "developer_videos",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_videos_id": {
+					"name": "developer_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"folders": {
+			"name": "folders",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"color": {
+					"name": "color",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'normal'"
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parentId": {
+					"name": "parentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				},
+				"parent_id_idx": {
+					"name": "parent_id_idx",
+					"columns": ["parentId"],
+					"isUnique": false
+				},
+				"space_id_idx": {
+					"name": "space_id_idx",
+					"columns": ["spaceId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"folders_id": {
+					"name": "folders_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"imported_videos": {
+			"name": "imported_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"imported_videos_orgId_source_source_id_pk": {
+					"name": "imported_videos_orgId_source_source_id_pk",
+					"columns": ["orgId", "source", "source_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_conversations": {
+			"name": "messenger_conversations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent": {
+					"name": "agent",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'agent'"
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverByUserId": {
+					"name": "takeoverByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverAt": {
+					"name": "takeoverAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"lastMessageAt": {
+					"name": "lastMessageAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_last_message_idx": {
+					"name": "user_last_message_idx",
+					"columns": ["userId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"anonymous_last_message_idx": {
+					"name": "anonymous_last_message_idx",
+					"columns": ["anonymousId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"mode_last_message_idx": {
+					"name": "mode_last_message_idx",
+					"columns": ["mode", "lastMessageAt"],
+					"isUnique": false
+				},
+				"updated_at_idx": {
+					"name": "updated_at_idx",
+					"columns": ["updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"messenger_conversations_id": {
+					"name": "messenger_conversations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_messages": {
+			"name": "messenger_messages",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"conversationId": {
+					"name": "conversationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"conversation_created_at_idx": {
+					"name": "conversation_created_at_idx",
+					"columns": ["conversationId", "createdAt"],
+					"isUnique": false
+				},
+				"role_created_at_idx": {
+					"name": "role_created_at_idx",
+					"columns": ["role", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"messenger_messages_conversationId_messenger_conversations_id_fk": {
+					"name": "messenger_messages_conversationId_messenger_conversations_id_fk",
+					"tableFrom": "messenger_messages",
+					"tableTo": "messenger_conversations",
+					"columnsFrom": ["conversationId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"messenger_messages_id": {
+					"name": "messenger_messages_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"notifications": {
+			"name": "notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recipientId": {
+					"name": "recipientId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"data": {
+					"name": "data",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dedupKey": {
+					"name": "dedupKey",
+					"type": "varchar(128)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"readAt": {
+					"name": "readAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"org_id_idx": {
+					"name": "org_id_idx",
+					"columns": ["orgId"],
+					"isUnique": false
+				},
+				"type_idx": {
+					"name": "type_idx",
+					"columns": ["type"],
+					"isUnique": false
+				},
+				"read_at_idx": {
+					"name": "read_at_idx",
+					"columns": ["readAt"],
+					"isUnique": false
+				},
+				"created_at_idx": {
+					"name": "created_at_idx",
+					"columns": ["createdAt"],
+					"isUnique": false
+				},
+				"recipient_read_idx": {
+					"name": "recipient_read_idx",
+					"columns": ["recipientId", "readAt"],
+					"isUnique": false
+				},
+				"recipient_created_idx": {
+					"name": "recipient_created_idx",
+					"columns": ["recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"dedup_key_idx": {
+					"name": "dedup_key_idx",
+					"columns": ["dedupKey"],
+					"isUnique": true
+				},
+				"type_recipient_created_idx": {
+					"name": "type_recipient_created_idx",
+					"columns": ["type", "recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"type_recipient_video_created_idx": {
+					"name": "type_recipient_video_created_idx",
+					"columns": ["type", "recipientId", "videoId", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"notifications_id": {
+					"name": "notifications_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_invites": {
+			"name": "organization_invites",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedEmail": {
+					"name": "invitedEmail",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedByUserId": {
+					"name": "invitedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"invited_email_idx": {
+					"name": "invited_email_idx",
+					"columns": ["invitedEmail"],
+					"isUnique": false
+				},
+				"invited_by_user_id_idx": {
+					"name": "invited_by_user_id_idx",
+					"columns": ["invitedByUserId"],
+					"isUnique": false
+				},
+				"status_idx": {
+					"name": "status_idx",
+					"columns": ["status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_invites_id": {
+					"name": "organization_invites_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_members": {
+			"name": "organization_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"hasProSeat": {
+					"name": "hasProSeat",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"user_id_organization_id_idx": {
+					"name": "user_id_organization_id_idx",
+					"columns": ["userId", "organizationId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_members_id": {
+					"name": "organization_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organizations": {
+			"name": "organizations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tombstoneAt": {
+					"name": "tombstoneAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"allowedEmailDomain": {
+					"name": "allowedEmailDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customDomain": {
+					"name": "customDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"domainVerified": {
+					"name": "domainVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"workosOrganizationId": {
+					"name": "workosOrganizationId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"workosConnectionId": {
+					"name": "workosConnectionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"owner_id_tombstone_idx": {
+					"name": "owner_id_tombstone_idx",
+					"columns": ["ownerId", "tombstoneAt"],
+					"isUnique": false
+				},
+				"custom_domain_idx": {
+					"name": "custom_domain_idx",
+					"columns": ["customDomain"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organizations_id": {
+					"name": "organizations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"s3_buckets": {
+			"name": "s3_buckets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"region": {
+					"name": "region",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"endpoint": {
+					"name": "endpoint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"bucketName": {
+					"name": "bucketName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accessKeyId": {
+					"name": "accessKeyId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"secretAccessKey": {
+					"name": "secretAccessKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('aws')"
+				}
+			},
+			"indexes": {
+				"owner_organization_idx": {
+					"name": "owner_organization_idx",
+					"columns": ["ownerId", "organizationId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"s3_buckets_id": {
+					"name": "s3_buckets_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"sessions": {
+			"name": "sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sessionToken": {
+					"name": "sessionToken",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"session_token_idx": {
+					"name": "session_token_idx",
+					"columns": ["sessionToken"],
+					"isUnique": true
+				},
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"sessions_id": {
+					"name": "sessions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"shared_videos": {
+			"name": "shared_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedByUserId": {
+					"name": "sharedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedAt": {
+					"name": "sharedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"shared_by_user_id_idx": {
+					"name": "shared_by_user_id_idx",
+					"columns": ["sharedByUserId"],
+					"isUnique": false
+				},
+				"video_id_organization_id_idx": {
+					"name": "video_id_organization_id_idx",
+					"columns": ["videoId", "organizationId"],
+					"isUnique": false
+				},
+				"video_id_folder_id_idx": {
+					"name": "video_id_folder_id_idx",
+					"columns": ["videoId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"shared_videos_id": {
+					"name": "shared_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"space_members": {
+			"name": "space_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'member'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_members_id": {
+					"name": "space_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"space_id_user_id_unique": {
+					"name": "space_id_user_id_unique",
+					"columns": ["spaceId", "userId"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"space_videos": {
+			"name": "space_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedById": {
+					"name": "addedById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedAt": {
+					"name": "addedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"added_by_id_idx": {
+					"name": "added_by_id_idx",
+					"columns": ["addedById"],
+					"isUnique": false
+				},
+				"space_id_video_id_idx": {
+					"name": "space_id_video_id_idx",
+					"columns": ["spaceId", "videoId"],
+					"isUnique": false
+				},
+				"space_id_folder_id_idx": {
+					"name": "space_id_folder_id_idx",
+					"columns": ["spaceId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_videos_id": {
+					"name": "space_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"spaces": {
+			"name": "spaces",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"primary": {
+					"name": "primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "varchar(1000)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"privacy": {
+					"name": "privacy",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Private'"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"spaces_id": {
+					"name": "spaces_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_integrations": {
+			"name": "storage_integrations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"displayName": {
+					"name": "displayName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"encryptedConfig": {
+					"name": "encryptedConfig",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"googleDriveAccessToken": {
+					"name": "googleDriveAccessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveAccessTokenExpiresAt": {
+					"name": "googleDriveAccessTokenExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseId": {
+					"name": "googleDriveTokenRefreshLeaseId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseExpiresAt": {
+					"name": "googleDriveTokenRefreshLeaseExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveStorageQuotaCache": {
+					"name": "googleDriveStorageQuotaCache",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_provider_idx": {
+					"name": "owner_provider_idx",
+					"columns": ["ownerId", "provider"],
+					"isUnique": false
+				},
+				"owner_active_idx": {
+					"name": "owner_active_idx",
+					"columns": ["ownerId", "active"],
+					"isUnique": false
+				},
+				"organization_provider_idx": {
+					"name": "organization_provider_idx",
+					"columns": ["organizationId", "provider"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"storage_integrations_id": {
+					"name": "storage_integrations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_objects": {
+			"name": "storage_objects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"integrationId": {
+					"name": "integrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"objectKey": {
+					"name": "objectKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"objectKeyHash": {
+					"name": "objectKeyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerObjectId": {
+					"name": "providerObjectId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploadSessionUrl": {
+					"name": "uploadSessionUrl",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"uploadStatus": {
+					"name": "uploadStatus",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"contentType": {
+					"name": "contentType",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"contentLength": {
+					"name": "contentLength",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"integration_key_hash_idx": {
+					"name": "integration_key_hash_idx",
+					"columns": ["integrationId", "objectKeyHash"],
+					"isUnique": true
+				},
+				"integration_status_idx": {
+					"name": "integration_status_idx",
+					"columns": ["integrationId", "uploadStatus"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"storage_objects_integrationId_storage_integrations_id_fk": {
+					"name": "storage_objects_integrationId_storage_integrations_id_fk",
+					"tableFrom": "storage_objects",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["integrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"storage_objects_id": {
+					"name": "storage_objects_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"lastName": {
+					"name": "lastName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionId": {
+					"name": "stripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"thirdPartyStripeSubscriptionId": {
+					"name": "thirdPartyStripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionStatus": {
+					"name": "stripeSubscriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionPriceId": {
+					"name": "stripeSubscriptionPriceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preferences": {
+					"name": "preferences",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "('null')"
+				},
+				"activeOrganizationId": {
+					"name": "activeOrganizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"onboardingSteps": {
+					"name": "onboardingSteps",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"onboarding_completed_at": {
+					"name": "onboarding_completed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customBucket": {
+					"name": "customBucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"inviteQuota": {
+					"name": "inviteQuota",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"defaultOrgId": {
+					"name": "defaultOrgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"email_idx": {
+					"name": "email_idx",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"users_id": {
+					"name": "users_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"verification_tokens": {
+			"name": "verification_tokens",
+			"columns": {
+				"identifier": {
+					"name": "identifier",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"verification_tokens_identifier": {
+					"name": "verification_tokens_identifier",
+					"columns": ["identifier"]
+				}
+			},
+			"uniqueConstraints": {
+				"verification_tokens_token_unique": {
+					"name": "verification_tokens_token_unique",
+					"columns": ["token"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"video_uploads": {
+			"name": "video_uploads",
+			"columns": {
+				"video_id": {
+					"name": "video_id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploaded": {
+					"name": "uploaded",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"total": {
+					"name": "total",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phase": {
+					"name": "phase",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'uploading'"
+				},
+				"processing_progress": {
+					"name": "processing_progress",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processing_message": {
+					"name": "processing_message",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"processing_error": {
+					"name": "processing_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"raw_file_key": {
+					"name": "raw_file_key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"video_uploads_video_id": {
+					"name": "video_uploads_video_id",
+					"columns": ["video_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"videos": {
+			"name": "videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'My Video'"
+				},
+				"bucket": {
+					"name": "bucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"storageIntegrationId": {
+					"name": "storageIntegrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('{\"type\":\"MediaConvert\"}')"
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"effectiveCreatedAt": {
+					"name": "effectiveCreatedAt",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"generated": {
+						"as": "COALESCE(\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%s.%fZ'),\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%sZ'),\n          `createdAt`\n        )",
+						"type": "stored"
+					}
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"xStreamInfo": {
+					"name": "xStreamInfo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"firstViewEmailSentAt": {
+					"name": "firstViewEmailSentAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"isScreenshot": {
+					"name": "isScreenshot",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"awsRegion": {
+					"name": "awsRegion",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"awsBucket": {
+					"name": "awsBucket",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoStartTime": {
+					"name": "videoStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"audioStartTime": {
+					"name": "audioStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobId": {
+					"name": "jobId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobStatus": {
+					"name": "jobStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"skipProcessing": {
+					"name": "skipProcessing",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				},
+				"is_public_idx": {
+					"name": "is_public_idx",
+					"columns": ["public"],
+					"isUnique": false
+				},
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"storage_integration_id_idx": {
+					"name": "storage_integration_id_idx",
+					"columns": ["storageIntegrationId"],
+					"isUnique": false
+				},
+				"org_owner_folder_idx": {
+					"name": "org_owner_folder_idx",
+					"columns": ["orgId", "ownerId", "folderId"],
+					"isUnique": false
+				},
+				"org_effective_created_idx": {
+					"name": "org_effective_created_idx",
+					"columns": ["orgId", "effectiveCreatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"videos_storageIntegrationId_storage_integrations_id_fk": {
+					"name": "videos_storageIntegrationId_storage_integrations_id_fk",
+					"tableFrom": "videos",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["storageIntegrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"videos_id": {
+					"name": "videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		}
+	},
+	"views": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"tables": {},
+		"indexes": {}
+	}
+}

--- a/packages/database/migrations/meta/0022_snapshot.json
+++ b/packages/database/migrations/meta/0022_snapshot.json
@@ -1,0 +1,3174 @@
+{
+	"version": "5",
+	"dialect": "mysql",
+	"id": "7166a4df-5a5f-46ba-96ec-c12295186007",
+	"prevId": "4045835b-67d0-487d-bcb6-b436c54ad136",
+	"tables": {
+		"accounts": {
+			"name": "accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerAccountId": {
+					"name": "providerAccountId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_in": {
+					"name": "expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_in": {
+					"name": "refresh_token_expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"tempColumn": {
+					"name": "tempColumn",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				},
+				"provider_account_id_idx": {
+					"name": "provider_account_id_idx",
+					"columns": ["providerAccountId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"accounts_id": {
+					"name": "accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"auth_api_keys": {
+			"name": "auth_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(36)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"auth_api_keys_id": {
+					"name": "auth_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"comments": {
+			"name": "comments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(6)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"authorId": {
+					"name": "authorId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"parentCommentId": {
+					"name": "parentCommentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"video_type_created_idx": {
+					"name": "video_type_created_idx",
+					"columns": ["videoId", "type", "createdAt", "id"],
+					"isUnique": false
+				},
+				"author_id_idx": {
+					"name": "author_id_idx",
+					"columns": ["authorId"],
+					"isUnique": false
+				},
+				"parent_comment_id_idx": {
+					"name": "parent_comment_id_idx",
+					"columns": ["parentCommentId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"comments_id": {
+					"name": "comments_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_api_keys": {
+			"name": "developer_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyType": {
+					"name": "keyType",
+					"type": "varchar(8)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyPrefix": {
+					"name": "keyPrefix",
+					"type": "varchar(12)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyHash": {
+					"name": "keyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"encryptedKey": {
+					"name": "encryptedKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"lastUsedAt": {
+					"name": "lastUsedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"revokedAt": {
+					"name": "revokedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"key_hash_idx": {
+					"name": "key_hash_idx",
+					"columns": ["keyHash"],
+					"isUnique": true
+				},
+				"app_key_type_idx": {
+					"name": "app_key_type_idx",
+					"columns": ["appId", "keyType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_api_keys_appId_developer_apps_id_fk": {
+					"name": "developer_api_keys_appId_developer_apps_id_fk",
+					"tableFrom": "developer_api_keys",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_api_keys_id": {
+					"name": "developer_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_app_domains": {
+			"name": "developer_app_domains",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"domain": {
+					"name": "domain",
+					"type": "varchar(253)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_app_domains_appId_developer_apps_id_fk": {
+					"name": "developer_app_domains_appId_developer_apps_id_fk",
+					"tableFrom": "developer_app_domains",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_app_domains_id": {
+					"name": "developer_app_domains_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_domain_unique": {
+					"name": "app_domain_unique",
+					"columns": ["appId", "domain"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_apps": {
+			"name": "developer_apps",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"environment": {
+					"name": "environment",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"logoUrl": {
+					"name": "logoUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_deleted_idx": {
+					"name": "owner_deleted_idx",
+					"columns": ["ownerId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"developer_apps_id": {
+					"name": "developer_apps_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_accounts": {
+			"name": "developer_credit_accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceMicroCredits": {
+					"name": "balanceMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripePaymentMethodId": {
+					"name": "stripePaymentMethodId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"autoTopUpEnabled": {
+					"name": "autoTopUpEnabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"autoTopUpThresholdMicroCredits": {
+					"name": "autoTopUpThresholdMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"autoTopUpAmountCents": {
+					"name": "autoTopUpAmountCents",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_id_unique": {
+					"name": "app_id_unique",
+					"columns": ["appId"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"developer_credit_accounts_appId_developer_apps_id_fk": {
+					"name": "developer_credit_accounts_appId_developer_apps_id_fk",
+					"tableFrom": "developer_credit_accounts",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_accounts_id": {
+					"name": "developer_credit_accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_transactions": {
+			"name": "developer_credit_transactions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amountMicroCredits": {
+					"name": "amountMicroCredits",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceAfterMicroCredits": {
+					"name": "balanceAfterMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"referenceId": {
+					"name": "referenceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"referenceType": {
+					"name": "referenceType",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"account_type_created_idx": {
+					"name": "account_type_created_idx",
+					"columns": ["accountId", "type", "createdAt"],
+					"isUnique": false
+				},
+				"account_ref_dedup_idx": {
+					"name": "account_ref_dedup_idx",
+					"columns": ["accountId", "referenceId", "referenceType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"dev_credit_txn_account_fk": {
+					"name": "dev_credit_txn_account_fk",
+					"tableFrom": "developer_credit_transactions",
+					"tableTo": "developer_credit_accounts",
+					"columnsFrom": ["accountId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_transactions_id": {
+					"name": "developer_credit_transactions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_daily_storage_snapshots": {
+			"name": "developer_daily_storage_snapshots",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"snapshotDate": {
+					"name": "snapshotDate",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"totalDurationMinutes": {
+					"name": "totalDurationMinutes",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"videoCount": {
+					"name": "videoCount",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"microCreditsCharged": {
+					"name": "microCreditsCharged",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processedAt": {
+					"name": "processedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_daily_storage_snapshots_appId_developer_apps_id_fk": {
+					"name": "developer_daily_storage_snapshots_appId_developer_apps_id_fk",
+					"tableFrom": "developer_daily_storage_snapshots",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_daily_storage_snapshots_id": {
+					"name": "developer_daily_storage_snapshots_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_date_unique": {
+					"name": "app_date_unique",
+					"columns": ["appId", "snapshotDate"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_videos": {
+			"name": "developer_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"externalUserId": {
+					"name": "externalUserId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Untitled'"
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"s3Key": {
+					"name": "s3Key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_created_idx": {
+					"name": "app_created_idx",
+					"columns": ["appId", "createdAt"],
+					"isUnique": false
+				},
+				"app_user_idx": {
+					"name": "app_user_idx",
+					"columns": ["appId", "externalUserId"],
+					"isUnique": false
+				},
+				"app_deleted_idx": {
+					"name": "app_deleted_idx",
+					"columns": ["appId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_videos_appId_developer_apps_id_fk": {
+					"name": "developer_videos_appId_developer_apps_id_fk",
+					"tableFrom": "developer_videos",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_videos_id": {
+					"name": "developer_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"folders": {
+			"name": "folders",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"color": {
+					"name": "color",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'normal'"
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parentId": {
+					"name": "parentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				},
+				"parent_id_idx": {
+					"name": "parent_id_idx",
+					"columns": ["parentId"],
+					"isUnique": false
+				},
+				"space_id_idx": {
+					"name": "space_id_idx",
+					"columns": ["spaceId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"folders_id": {
+					"name": "folders_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"imported_videos": {
+			"name": "imported_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"imported_videos_orgId_source_source_id_pk": {
+					"name": "imported_videos_orgId_source_source_id_pk",
+					"columns": ["orgId", "source", "source_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_conversations": {
+			"name": "messenger_conversations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent": {
+					"name": "agent",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'agent'"
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverByUserId": {
+					"name": "takeoverByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverAt": {
+					"name": "takeoverAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"lastMessageAt": {
+					"name": "lastMessageAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_last_message_idx": {
+					"name": "user_last_message_idx",
+					"columns": ["userId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"anonymous_last_message_idx": {
+					"name": "anonymous_last_message_idx",
+					"columns": ["anonymousId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"mode_last_message_idx": {
+					"name": "mode_last_message_idx",
+					"columns": ["mode", "lastMessageAt"],
+					"isUnique": false
+				},
+				"updated_at_idx": {
+					"name": "updated_at_idx",
+					"columns": ["updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"messenger_conversations_id": {
+					"name": "messenger_conversations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_messages": {
+			"name": "messenger_messages",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"conversationId": {
+					"name": "conversationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"conversation_created_at_idx": {
+					"name": "conversation_created_at_idx",
+					"columns": ["conversationId", "createdAt"],
+					"isUnique": false
+				},
+				"role_created_at_idx": {
+					"name": "role_created_at_idx",
+					"columns": ["role", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"messenger_messages_conversationId_messenger_conversations_id_fk": {
+					"name": "messenger_messages_conversationId_messenger_conversations_id_fk",
+					"tableFrom": "messenger_messages",
+					"tableTo": "messenger_conversations",
+					"columnsFrom": ["conversationId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"messenger_messages_id": {
+					"name": "messenger_messages_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"notifications": {
+			"name": "notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recipientId": {
+					"name": "recipientId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"data": {
+					"name": "data",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dedupKey": {
+					"name": "dedupKey",
+					"type": "varchar(128)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"readAt": {
+					"name": "readAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"org_id_idx": {
+					"name": "org_id_idx",
+					"columns": ["orgId"],
+					"isUnique": false
+				},
+				"type_idx": {
+					"name": "type_idx",
+					"columns": ["type"],
+					"isUnique": false
+				},
+				"read_at_idx": {
+					"name": "read_at_idx",
+					"columns": ["readAt"],
+					"isUnique": false
+				},
+				"created_at_idx": {
+					"name": "created_at_idx",
+					"columns": ["createdAt"],
+					"isUnique": false
+				},
+				"recipient_read_idx": {
+					"name": "recipient_read_idx",
+					"columns": ["recipientId", "readAt"],
+					"isUnique": false
+				},
+				"recipient_created_idx": {
+					"name": "recipient_created_idx",
+					"columns": ["recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"dedup_key_idx": {
+					"name": "dedup_key_idx",
+					"columns": ["dedupKey"],
+					"isUnique": true
+				},
+				"type_recipient_created_idx": {
+					"name": "type_recipient_created_idx",
+					"columns": ["type", "recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"type_recipient_video_created_idx": {
+					"name": "type_recipient_video_created_idx",
+					"columns": ["type", "recipientId", "videoId", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"notifications_id": {
+					"name": "notifications_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_invites": {
+			"name": "organization_invites",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedEmail": {
+					"name": "invitedEmail",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedByUserId": {
+					"name": "invitedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"invited_email_idx": {
+					"name": "invited_email_idx",
+					"columns": ["invitedEmail"],
+					"isUnique": false
+				},
+				"invited_by_user_id_idx": {
+					"name": "invited_by_user_id_idx",
+					"columns": ["invitedByUserId"],
+					"isUnique": false
+				},
+				"status_idx": {
+					"name": "status_idx",
+					"columns": ["status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_invites_id": {
+					"name": "organization_invites_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_members": {
+			"name": "organization_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"hasProSeat": {
+					"name": "hasProSeat",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"user_id_organization_id_idx": {
+					"name": "user_id_organization_id_idx",
+					"columns": ["userId", "organizationId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_members_id": {
+					"name": "organization_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organizations": {
+			"name": "organizations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tombstoneAt": {
+					"name": "tombstoneAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"allowedEmailDomain": {
+					"name": "allowedEmailDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customDomain": {
+					"name": "customDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"domainVerified": {
+					"name": "domainVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"workosOrganizationId": {
+					"name": "workosOrganizationId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"workosConnectionId": {
+					"name": "workosConnectionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"owner_id_tombstone_idx": {
+					"name": "owner_id_tombstone_idx",
+					"columns": ["ownerId", "tombstoneAt"],
+					"isUnique": false
+				},
+				"custom_domain_idx": {
+					"name": "custom_domain_idx",
+					"columns": ["customDomain"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organizations_id": {
+					"name": "organizations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"s3_buckets": {
+			"name": "s3_buckets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"region": {
+					"name": "region",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"endpoint": {
+					"name": "endpoint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"bucketName": {
+					"name": "bucketName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accessKeyId": {
+					"name": "accessKeyId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"secretAccessKey": {
+					"name": "secretAccessKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('aws')"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_organization_idx": {
+					"name": "owner_organization_idx",
+					"columns": ["ownerId", "organizationId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"s3_buckets_id": {
+					"name": "s3_buckets_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"sessions": {
+			"name": "sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sessionToken": {
+					"name": "sessionToken",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"session_token_idx": {
+					"name": "session_token_idx",
+					"columns": ["sessionToken"],
+					"isUnique": true
+				},
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"sessions_id": {
+					"name": "sessions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"shared_videos": {
+			"name": "shared_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedByUserId": {
+					"name": "sharedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedAt": {
+					"name": "sharedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"shared_by_user_id_idx": {
+					"name": "shared_by_user_id_idx",
+					"columns": ["sharedByUserId"],
+					"isUnique": false
+				},
+				"video_id_organization_id_idx": {
+					"name": "video_id_organization_id_idx",
+					"columns": ["videoId", "organizationId"],
+					"isUnique": false
+				},
+				"video_id_folder_id_idx": {
+					"name": "video_id_folder_id_idx",
+					"columns": ["videoId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"shared_videos_id": {
+					"name": "shared_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"space_members": {
+			"name": "space_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'member'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_members_id": {
+					"name": "space_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"space_id_user_id_unique": {
+					"name": "space_id_user_id_unique",
+					"columns": ["spaceId", "userId"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"space_videos": {
+			"name": "space_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedById": {
+					"name": "addedById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedAt": {
+					"name": "addedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"added_by_id_idx": {
+					"name": "added_by_id_idx",
+					"columns": ["addedById"],
+					"isUnique": false
+				},
+				"space_id_video_id_idx": {
+					"name": "space_id_video_id_idx",
+					"columns": ["spaceId", "videoId"],
+					"isUnique": false
+				},
+				"space_id_folder_id_idx": {
+					"name": "space_id_folder_id_idx",
+					"columns": ["spaceId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_videos_id": {
+					"name": "space_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"spaces": {
+			"name": "spaces",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"primary": {
+					"name": "primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "varchar(1000)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"privacy": {
+					"name": "privacy",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Private'"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"spaces_id": {
+					"name": "spaces_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_integrations": {
+			"name": "storage_integrations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"displayName": {
+					"name": "displayName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"encryptedConfig": {
+					"name": "encryptedConfig",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"googleDriveAccessToken": {
+					"name": "googleDriveAccessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveAccessTokenExpiresAt": {
+					"name": "googleDriveAccessTokenExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseId": {
+					"name": "googleDriveTokenRefreshLeaseId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseExpiresAt": {
+					"name": "googleDriveTokenRefreshLeaseExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveStorageQuotaCache": {
+					"name": "googleDriveStorageQuotaCache",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_provider_idx": {
+					"name": "owner_provider_idx",
+					"columns": ["ownerId", "provider"],
+					"isUnique": false
+				},
+				"owner_active_idx": {
+					"name": "owner_active_idx",
+					"columns": ["ownerId", "active"],
+					"isUnique": false
+				},
+				"organization_provider_idx": {
+					"name": "organization_provider_idx",
+					"columns": ["organizationId", "provider"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"storage_integrations_id": {
+					"name": "storage_integrations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_objects": {
+			"name": "storage_objects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"integrationId": {
+					"name": "integrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"objectKey": {
+					"name": "objectKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"objectKeyHash": {
+					"name": "objectKeyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerObjectId": {
+					"name": "providerObjectId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploadSessionUrl": {
+					"name": "uploadSessionUrl",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"uploadStatus": {
+					"name": "uploadStatus",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"contentType": {
+					"name": "contentType",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"contentLength": {
+					"name": "contentLength",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"integration_key_hash_idx": {
+					"name": "integration_key_hash_idx",
+					"columns": ["integrationId", "objectKeyHash"],
+					"isUnique": true
+				},
+				"integration_status_idx": {
+					"name": "integration_status_idx",
+					"columns": ["integrationId", "uploadStatus"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"storage_objects_integrationId_storage_integrations_id_fk": {
+					"name": "storage_objects_integrationId_storage_integrations_id_fk",
+					"tableFrom": "storage_objects",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["integrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"storage_objects_id": {
+					"name": "storage_objects_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"lastName": {
+					"name": "lastName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionId": {
+					"name": "stripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"thirdPartyStripeSubscriptionId": {
+					"name": "thirdPartyStripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionStatus": {
+					"name": "stripeSubscriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionPriceId": {
+					"name": "stripeSubscriptionPriceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preferences": {
+					"name": "preferences",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "('null')"
+				},
+				"activeOrganizationId": {
+					"name": "activeOrganizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"onboardingSteps": {
+					"name": "onboardingSteps",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"onboarding_completed_at": {
+					"name": "onboarding_completed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customBucket": {
+					"name": "customBucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"inviteQuota": {
+					"name": "inviteQuota",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"defaultOrgId": {
+					"name": "defaultOrgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"email_idx": {
+					"name": "email_idx",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"users_id": {
+					"name": "users_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"verification_tokens": {
+			"name": "verification_tokens",
+			"columns": {
+				"identifier": {
+					"name": "identifier",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"verification_tokens_identifier": {
+					"name": "verification_tokens_identifier",
+					"columns": ["identifier"]
+				}
+			},
+			"uniqueConstraints": {
+				"verification_tokens_token_unique": {
+					"name": "verification_tokens_token_unique",
+					"columns": ["token"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"video_uploads": {
+			"name": "video_uploads",
+			"columns": {
+				"video_id": {
+					"name": "video_id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploaded": {
+					"name": "uploaded",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"total": {
+					"name": "total",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phase": {
+					"name": "phase",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'uploading'"
+				},
+				"processing_progress": {
+					"name": "processing_progress",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processing_message": {
+					"name": "processing_message",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"processing_error": {
+					"name": "processing_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"raw_file_key": {
+					"name": "raw_file_key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"video_uploads_video_id": {
+					"name": "video_uploads_video_id",
+					"columns": ["video_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"videos": {
+			"name": "videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'My Video'"
+				},
+				"bucket": {
+					"name": "bucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"storageIntegrationId": {
+					"name": "storageIntegrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('{\"type\":\"MediaConvert\"}')"
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"effectiveCreatedAt": {
+					"name": "effectiveCreatedAt",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"generated": {
+						"as": "COALESCE(\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%s.%fZ'),\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%sZ'),\n          `createdAt`\n        )",
+						"type": "stored"
+					}
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"xStreamInfo": {
+					"name": "xStreamInfo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"firstViewEmailSentAt": {
+					"name": "firstViewEmailSentAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"isScreenshot": {
+					"name": "isScreenshot",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"awsRegion": {
+					"name": "awsRegion",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"awsBucket": {
+					"name": "awsBucket",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoStartTime": {
+					"name": "videoStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"audioStartTime": {
+					"name": "audioStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobId": {
+					"name": "jobId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobStatus": {
+					"name": "jobStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"skipProcessing": {
+					"name": "skipProcessing",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				},
+				"is_public_idx": {
+					"name": "is_public_idx",
+					"columns": ["public"],
+					"isUnique": false
+				},
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"storage_integration_id_idx": {
+					"name": "storage_integration_id_idx",
+					"columns": ["storageIntegrationId"],
+					"isUnique": false
+				},
+				"org_owner_folder_idx": {
+					"name": "org_owner_folder_idx",
+					"columns": ["orgId", "ownerId", "folderId"],
+					"isUnique": false
+				},
+				"org_effective_created_idx": {
+					"name": "org_effective_created_idx",
+					"columns": ["orgId", "effectiveCreatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"videos_storageIntegrationId_storage_integrations_id_fk": {
+					"name": "videos_storageIntegrationId_storage_integrations_id_fk",
+					"tableFrom": "videos",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["storageIntegrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"videos_id": {
+					"name": "videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		}
+	},
+	"views": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"tables": {},
+		"indexes": {}
+	}
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -148,6 +148,20 @@
 			"when": 1778157016497,
 			"tag": "0020_orange_talkback",
 			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "5",
+			"when": 1778249922872,
+			"tag": "0021_glorious_khan",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "5",
+			"when": 1778252207674,
+			"tag": "0022_dazzling_namor",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -564,17 +564,36 @@ export const messengerMessages = mysqlTable(
 	}),
 );
 
-export const s3Buckets = mysqlTable("s3_buckets", {
-	id: nanoId("id").notNull().primaryKey().$type<S3Bucket.S3BucketId>(),
-	ownerId: nanoId("ownerId").notNull().$type<User.UserId>(),
-	// Use encryptedText for sensitive fields
-	region: encryptedText("region").notNull(),
-	endpoint: encryptedTextNullable("endpoint"),
-	bucketName: encryptedText("bucketName").notNull(),
-	accessKeyId: encryptedText("accessKeyId").notNull(),
-	secretAccessKey: encryptedText("secretAccessKey").notNull(),
-	provider: text("provider").notNull().default("aws"),
-});
+export const s3Buckets = mysqlTable(
+	"s3_buckets",
+	{
+		id: nanoId("id").notNull().primaryKey().$type<S3Bucket.S3BucketId>(),
+		ownerId: nanoId("ownerId").notNull().$type<User.UserId>(),
+		organizationId:
+			nanoIdNullable("organizationId").$type<Organisation.OrganisationId>(),
+		region: encryptedText("region").notNull(),
+		endpoint: encryptedTextNullable("endpoint"),
+		bucketName: encryptedText("bucketName").notNull(),
+		accessKeyId: encryptedText("accessKeyId").notNull(),
+		secretAccessKey: encryptedText("secretAccessKey").notNull(),
+		provider: text("provider").notNull().default("aws"),
+		active: boolean("active").notNull().default(true),
+		createdAt: timestamp("createdAt").notNull().defaultNow(),
+		updatedAt: timestamp("updatedAt").notNull().defaultNow().onUpdateNow(),
+	},
+	(table) => ({
+		ownerOrganizationIndex: index("owner_organization_idx").on(
+			table.ownerId,
+			table.organizationId,
+		),
+		organizationIdIndex: index("organization_id_idx").on(table.organizationId),
+		organizationActiveIndex: index("organization_active_idx").on(
+			table.organizationId,
+			table.active,
+			table.updatedAt,
+		),
+	}),
+);
 
 export const storageIntegrations = mysqlTable(
 	"storage_integrations",
@@ -584,6 +603,8 @@ export const storageIntegrations = mysqlTable(
 			.primaryKey()
 			.$type<Storage.StorageIntegrationId>(),
 		ownerId: nanoId("ownerId").notNull().$type<User.UserId>(),
+		organizationId:
+			nanoIdNullable("organizationId").$type<Organisation.OrganisationId>(),
 		provider: varchar("provider", { length: 64 })
 			.notNull()
 			.$type<Storage.StorageProvider>(),
@@ -616,6 +637,15 @@ export const storageIntegrations = mysqlTable(
 			table.provider,
 		),
 		ownerActiveIndex: index("owner_active_idx").on(table.ownerId, table.active),
+		organizationProviderIndex: index("organization_provider_idx").on(
+			table.organizationId,
+			table.provider,
+		),
+		organizationActiveIndex: index("organization_active_idx").on(
+			table.organizationId,
+			table.active,
+			table.status,
+		),
 	}),
 );
 
@@ -741,6 +771,10 @@ export const s3BucketsRelations = relations(s3Buckets, ({ one }) => ({
 		fields: [s3Buckets.ownerId],
 		references: [users.id],
 	}),
+	organization: one(organizations, {
+		fields: [s3Buckets.organizationId],
+		references: [organizations.id],
+	}),
 }));
 
 export const storageIntegrationsRelations = relations(
@@ -749,6 +783,10 @@ export const storageIntegrationsRelations = relations(
 		owner: one(users, {
 			fields: [storageIntegrations.ownerId],
 			references: [users.id],
+		}),
+		organization: one(organizations, {
+			fields: [storageIntegrations.organizationId],
+			references: [organizations.id],
 		}),
 		objects: many(storageObjects),
 	}),
@@ -776,6 +814,8 @@ export const organizationsRelations = relations(
 		sharedVideos: many(sharedVideos),
 		organizationInvites: many(organizationInvites),
 		spaces: many(spaces),
+		s3Buckets: many(s3Buckets),
+		storageIntegrations: many(storageIntegrations),
 	}),
 );
 

--- a/packages/web-api-contract-effect/src/index.ts
+++ b/packages/web-api-contract-effect/src/index.ts
@@ -35,8 +35,18 @@ const S3Config = Schema.Struct({
 	region: Schema.String,
 });
 
+const ManagedOrganizationStorage = Schema.NullOr(
+	Schema.Struct({
+		id: Schema.String,
+		name: Schema.String,
+		activeProvider: Schema.Literal("s3", "googleDrive"),
+	}),
+);
+
 const S3ConfigResponse = Schema.Struct({
 	config: S3Config,
+	source: Schema.Literal("default", "user", "organization"),
+	managedByOrganization: ManagedOrganizationStorage,
 });
 
 const ChangelogResponse = Schema.Struct({

--- a/packages/web-api-contract/src/desktop.ts
+++ b/packages/web-api-contract/src/desktop.ts
@@ -47,8 +47,17 @@ export type OrganizationBrandingPatchBody = z.infer<
 	typeof OrganizationBrandingPatchBody
 >;
 
+export const ManagedOrganizationStorage = z
+	.object({
+		id: z.string(),
+		name: z.string(),
+		activeProvider: z.enum(["s3", "googleDrive"]),
+	})
+	.nullable();
+
 export const DesktopStorageIntegrations = z.object({
 	activeProvider: z.enum(["s3", "googleDrive"]),
+	managedByOrganization: ManagedOrganizationStorage,
 	googleDrive: z.object({
 		id: z.string().nullable(),
 		connected: z.boolean(),
@@ -137,6 +146,11 @@ const protectedContract = c.router(
 		getS3Config: {
 			method: "GET",
 			path: "/desktop/s3/config/get",
+			query: z
+				.object({
+					orgId: z.string().optional(),
+				})
+				.optional(),
 			responses: {
 				200: z.object({
 					config: z.custom<{
@@ -147,6 +161,8 @@ const protectedContract = c.router(
 						bucketName: string;
 						region: string;
 					}>(),
+					source: z.enum(["default", "user", "organization"]),
+					managedByOrganization: ManagedOrganizationStorage,
 				}),
 			},
 		},
@@ -189,6 +205,7 @@ const protectedContract = c.router(
 			query: z
 				.object({
 					refreshStorageQuota: z.boolean().optional(),
+					orgId: z.string().optional(),
 				})
 				.optional(),
 			responses: {
@@ -198,7 +215,11 @@ const protectedContract = c.router(
 		connectGoogleDriveStorage: {
 			method: "POST",
 			path: "/desktop/storage/google-drive/connect",
-			body: z.object({}).optional(),
+			body: z
+				.object({
+					orgId: z.string().optional(),
+				})
+				.optional(),
 			responses: {
 				200: z.object({ url: z.string() }),
 				403: z.object({ error: z.literal("upgrade_required") }),

--- a/packages/web-backend/src/S3Buckets/S3BucketsRepo.ts
+++ b/packages/web-backend/src/S3Buckets/S3BucketsRepo.ts
@@ -1,5 +1,10 @@
 import * as Db from "@cap/database/schema";
-import { S3Bucket, type User, type Video } from "@cap/web-domain";
+import {
+	type Organisation,
+	S3Bucket,
+	type User,
+	type Video,
+} from "@cap/web-domain";
 import * as Dz from "drizzle-orm";
 import { Effect, Option } from "effect";
 
@@ -55,7 +60,14 @@ export class S3BucketsRepo extends Effect.Service<S3BucketsRepo>()(
 							db
 								.select({ bucket: Db.s3Buckets })
 								.from(Db.s3Buckets)
-								.where(Dz.eq(Db.s3Buckets.ownerId, userId)),
+								.where(
+									Dz.and(
+										Dz.eq(Db.s3Buckets.ownerId, userId),
+										Dz.isNull(Db.s3Buckets.organizationId),
+										Dz.eq(Db.s3Buckets.active, true),
+									),
+								)
+								.orderBy(Dz.desc(Db.s3Buckets.updatedAt)),
 						);
 
 						return Option.fromNullable(res).pipe(
@@ -66,7 +78,31 @@ export class S3BucketsRepo extends Effect.Service<S3BucketsRepo>()(
 					}),
 			);
 
-			return { getForVideo, getById, getForUser };
+			const getForOrganization = Effect.fn("S3BucketsRepo.getForOrganization")(
+				(organizationId: Organisation.OrganisationId) =>
+					Effect.gen(function* () {
+						const [res] = yield* db.use((db) =>
+							db
+								.select({ bucket: Db.s3Buckets })
+								.from(Db.s3Buckets)
+								.where(
+									Dz.and(
+										Dz.eq(Db.s3Buckets.organizationId, organizationId),
+										Dz.eq(Db.s3Buckets.active, true),
+									),
+								)
+								.orderBy(Dz.desc(Db.s3Buckets.updatedAt)),
+						);
+
+						return Option.fromNullable(res).pipe(
+							Option.map((v) =>
+								S3Bucket.decodeSync({ ...v.bucket, name: v.bucket.bucketName }),
+							),
+						);
+					}),
+			);
+
+			return { getForVideo, getById, getForUser, getForOrganization };
 		}),
 		dependencies: [Database.Default],
 	},

--- a/packages/web-backend/src/S3Buckets/index.ts
+++ b/packages/web-backend/src/S3Buckets/index.ts
@@ -1,7 +1,7 @@
 import * as S3 from "@aws-sdk/client-s3";
 import * as CloudFrontPresigner from "@aws-sdk/cloudfront-signer";
 import { decrypt } from "@cap/database/crypto";
-import type { S3Bucket, User } from "@cap/web-domain";
+import type { Organisation, S3Bucket, User } from "@cap/web-domain";
 import type { RequestPresigningArguments } from "@smithy/types";
 import { Config, Effect, Layer, Option } from "effect";
 
@@ -200,6 +200,17 @@ export class S3Buckets extends Effect.Service<S3Buckets>()("S3Buckets", {
 						);
 				},
 			),
+			getBucketAccessForOrganization: Effect.fn(
+				"S3Buckets.getBucketAccessForOrganization",
+			)(function* (organizationId: Organisation.OrganisationId) {
+				const customBucket = yield* repo.getForOrganization(organizationId);
+
+				return yield* Option.match(customBucket, {
+					onNone: () => Effect.succeed(Option.none()),
+					onSome: (bucket) =>
+						getBucketAccess(Option.some(bucket)).pipe(Effect.map(Option.some)),
+				});
+			}),
 		};
 	}),
 	dependencies: [
@@ -214,4 +225,10 @@ export class S3Buckets extends Effect.Service<S3Buckets>()("S3Buckets", {
 		);
 	static getBucketAccessForUser = (userId: User.UserId) =>
 		Effect.flatMap(S3Buckets, (b) => b.getBucketAccessForUser(userId));
+	static getBucketAccessForOrganization = (
+		organizationId: Organisation.OrganisationId,
+	) =>
+		Effect.flatMap(S3Buckets, (b) =>
+			b.getBucketAccessForOrganization(organizationId),
+		);
 }

--- a/packages/web-backend/src/Storage/GoogleDrive.ts
+++ b/packages/web-backend/src/Storage/GoogleDrive.ts
@@ -40,6 +40,13 @@ type GoogleDriveTokenResponse = {
 	refresh_token?: string;
 };
 
+export type GoogleDriveFolderLocation = {
+	id: string;
+	name: string;
+	driveId?: string | null;
+	driveName?: string | null;
+};
+
 export type GoogleDriveTokenStore = {
 	cacheKey: string;
 	getInitialAccessTokenCache: () => Effect.Effect<
@@ -74,6 +81,31 @@ export type CreateGoogleDriveUploadInput = {
 
 const normalizeContentType = (contentType?: string | null) =>
 	contentType?.trim() ? contentType : "application/octet-stream";
+
+const appendDriveQuery = (
+	url: string,
+	params: Record<string, string | undefined>,
+) => {
+	const nextUrl = new URL(url);
+	for (const [key, value] of Object.entries(params)) {
+		if (value !== undefined) nextUrl.searchParams.set(key, value);
+	}
+	return nextUrl.toString();
+};
+
+const appendSharedDriveCreateParams = (url: string) =>
+	appendDriveQuery(url, { supportsAllDrives: "true" });
+
+const appendSharedDriveListParams = (
+	url: string,
+	config: GoogleDriveIntegrationConfig,
+) =>
+	appendDriveQuery(url, {
+		supportsAllDrives: "true",
+		includeItemsFromAllDrives: "true",
+		corpora: config.driveId ? "drive" : undefined,
+		driveId: config.driveId ?? undefined,
+	});
 
 const parseDriveJson = async <T>(response: Response) => {
 	const text = await response.text();
@@ -362,6 +394,11 @@ const getCachedGoogleDriveAccessToken = (
 		Effect.map((token) => token.accessToken),
 	);
 
+export const getGoogleDriveAccessToken = (
+	config: GoogleDriveIntegrationConfig,
+	tokenStore?: GoogleDriveTokenStore,
+) => getCachedGoogleDriveAccessToken(config, tokenStore);
+
 const clearCachedGoogleDriveAccessToken = (
 	config: GoogleDriveIntegrationConfig,
 	tokenStore?: GoogleDriveTokenStore,
@@ -421,9 +458,18 @@ const getDriveFileName = (key: string) => {
 	return parts.at(-1) ?? "file";
 };
 
-const getDriveFolderParts = (key: string) => {
+const getDriveFolderParts = (
+	key: string,
+	config: GoogleDriveIntegrationConfig,
+) => {
 	const parts = key.split("/").filter(Boolean);
 	if (parts.length < 2) return [];
+	if (config.folderLayout === "userVideo") {
+		if (parts[2] === "segments")
+			return [parts[0] as string, parts[1] as string, "segments"];
+		return [parts[0] as string, parts[1] as string];
+	}
+
 	return parts[2] === "segments"
 		? [parts[1] as string, "segments"]
 		: [parts[1] as string];
@@ -494,7 +540,10 @@ export const ensureGoogleDriveFolder = (
 			"trashed=false",
 			...(parentId ? [`'${escapeDriveQueryValue(parentId)}' in parents`] : []),
 		].join(" and ");
-		const listUrl = `${DRIVE_API_BASE}/files?q=${encodeURIComponent(query)}&fields=files(id,name)&spaces=drive`;
+		const listUrl = appendSharedDriveListParams(
+			`${DRIVE_API_BASE}/files?q=${encodeURIComponent(query)}&fields=files(id,name)&spaces=drive`,
+			config,
+		);
 		const listResponse = yield* driveFetch(
 			config,
 			listUrl,
@@ -510,7 +559,7 @@ export const ensureGoogleDriveFolder = (
 
 		const createResponse = yield* driveFetch(
 			config,
-			`${DRIVE_API_BASE}/files`,
+			appendSharedDriveCreateParams(`${DRIVE_API_BASE}/files`),
 			{
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
@@ -537,6 +586,54 @@ export const ensureGoogleDriveFolder = (
 		return created.id;
 	});
 
+export const getGoogleDriveFolderLocation = (
+	config: GoogleDriveIntegrationConfig,
+	folderId: string,
+	tokenStore?: GoogleDriveTokenStore,
+) =>
+	driveFetch(
+		config,
+		appendSharedDriveCreateParams(
+			`${DRIVE_API_BASE}/files/${encodeURIComponent(folderId)}?fields=id,name,mimeType,driveId,capabilities(canAddChildren)`,
+		),
+		undefined,
+		tokenStore,
+	).pipe(
+		Effect.flatMap((response) =>
+			Effect.tryPromise({
+				try: () =>
+					parseDriveJson<{
+						id?: string;
+						name?: string;
+						mimeType?: string;
+						driveId?: string;
+						capabilities?: { canAddChildren?: boolean };
+					}>(response),
+				catch: (cause) => new Storage.StorageError({ cause }),
+			}),
+		),
+		Effect.flatMap((folder) => {
+			if (
+				folder.id &&
+				folder.name &&
+				folder.mimeType === GOOGLE_DRIVE_FOLDER_MIME_TYPE &&
+				folder.capabilities?.canAddChildren !== false
+			) {
+				return Effect.succeed<GoogleDriveFolderLocation>({
+					id: folder.id,
+					name: folder.name,
+					driveId: folder.driveId ?? null,
+				});
+			}
+
+			return Effect.fail(
+				new Storage.StorageError({
+					cause: new Error("Selected Google Drive location is not writable"),
+				}),
+			);
+		}),
+	);
+
 const createGoogleDriveFolderWithId = (
 	config: GoogleDriveIntegrationConfig,
 	id: string,
@@ -546,7 +643,7 @@ const createGoogleDriveFolderWithId = (
 ) =>
 	driveFetch(
 		config,
-		`${DRIVE_API_BASE}/files?fields=id,name`,
+		appendSharedDriveCreateParams(`${DRIVE_API_BASE}/files?fields=id,name`),
 		{
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
@@ -597,7 +694,9 @@ const createGoogleDriveTextFileWithId = ({
 
 	return driveFetch(
 		config,
-		`${DRIVE_UPLOAD_BASE}/files?uploadType=multipart&fields=id,name,mimeType,size`,
+		appendSharedDriveCreateParams(
+			`${DRIVE_UPLOAD_BASE}/files?uploadType=multipart&fields=id,name,mimeType,size`,
+		),
 		{
 			method: "POST",
 			headers: { "Content-Type": `multipart/related; boundary=${boundary}` },
@@ -793,7 +892,7 @@ const getGoogleDriveUploadParentId = (
 	tokenStore?: GoogleDriveTokenStore,
 ) =>
 	Effect.gen(function* () {
-		const folderParts = getDriveFolderParts(input.key);
+		const folderParts = getDriveFolderParts(input.key, config);
 		let parentId = config.folderId;
 		const pathParts: string[] = [];
 		let videoFolderId: string | null = null;
@@ -875,7 +974,9 @@ export const createGoogleDriveResumableUpload = (
 
 		const response = yield* driveFetch(
 			config,
-			`${DRIVE_UPLOAD_BASE}/files?uploadType=resumable&fields=id,name,mimeType,size`,
+			appendSharedDriveCreateParams(
+				`${DRIVE_UPLOAD_BASE}/files?uploadType=resumable&fields=id,name,mimeType,size`,
+			),
 			{
 				method: "POST",
 				headers,
@@ -927,7 +1028,9 @@ export const getGoogleDriveFileMetadata = (
 ) =>
 	driveFetch(
 		config,
-		`${DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}?fields=id,name,mimeType,size`,
+		appendSharedDriveCreateParams(
+			`${DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}?fields=id,name,mimeType,size`,
+		),
 		undefined,
 		tokenStore,
 	).pipe(
@@ -958,7 +1061,10 @@ export const findGoogleDriveFileByObjectKey = (
 
 	return driveFetch(
 		config,
-		`${DRIVE_API_BASE}/files?${params.toString()}`,
+		appendSharedDriveListParams(
+			`${DRIVE_API_BASE}/files?${params.toString()}`,
+			config,
+		),
 		undefined,
 		tokenStore,
 	).pipe(
@@ -984,7 +1090,9 @@ export const getGoogleDriveObjectText = (
 ) =>
 	driveFetch(
 		config,
-		`${DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}?alt=media`,
+		appendSharedDriveCreateParams(
+			`${DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}?alt=media`,
+		),
 		undefined,
 		tokenStore,
 	).pipe(
@@ -1007,7 +1115,9 @@ export const getGoogleDriveObjectResponse = (
 		if (range) headers.Range = range;
 		const response = yield* driveFetch(
 			config,
-			`${DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}?alt=media`,
+			appendSharedDriveCreateParams(
+				`${DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}?alt=media`,
+			),
 			{ headers },
 			tokenStore,
 		);
@@ -1021,7 +1131,9 @@ export const deleteGoogleDriveFile = (
 ) =>
 	driveFetch(
 		config,
-		`${DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}`,
+		appendSharedDriveCreateParams(
+			`${DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}`,
+		),
 		{
 			method: "DELETE",
 		},
@@ -1050,7 +1162,9 @@ export const copyGoogleDriveFile = ({
 		);
 		const response = yield* driveFetch(
 			config,
-			`${DRIVE_API_BASE}/files/${encodeURIComponent(sourceFileId)}/copy?fields=id,name,mimeType,size`,
+			appendSharedDriveCreateParams(
+				`${DRIVE_API_BASE}/files/${encodeURIComponent(sourceFileId)}/copy?fields=id,name,mimeType,size`,
+			),
 			{
 				method: "POST",
 				headers: { "Content-Type": "application/json" },

--- a/packages/web-backend/src/Storage/StorageRepo.ts
+++ b/packages/web-backend/src/Storage/StorageRepo.ts
@@ -2,7 +2,12 @@ import { createHash } from "node:crypto";
 import { decrypt, encrypt } from "@cap/database/crypto";
 import { nanoId } from "@cap/database/helpers";
 import * as Db from "@cap/database/schema";
-import { Storage, type User, type Video } from "@cap/web-domain";
+import {
+	type Organisation,
+	Storage,
+	type User,
+	type Video,
+} from "@cap/web-domain";
 import * as Dz from "drizzle-orm";
 import { Effect, Option } from "effect";
 
@@ -17,6 +22,10 @@ const escapeLikePattern = (value: string) =>
 export type GoogleDriveIntegrationConfig = {
 	refreshToken: string;
 	folderId: string;
+	folderName?: string;
+	driveId?: string | null;
+	driveName?: string | null;
+	folderLayout?: "video" | "userVideo";
 	email?: string;
 	scope?: string;
 };
@@ -102,6 +111,28 @@ export class StorageRepo extends Effect.Service<StorageRepo>()("StorageRepo", {
 						.where(
 							Dz.and(
 								Dz.eq(Db.storageIntegrations.ownerId, userId),
+								Dz.isNull(Db.storageIntegrations.organizationId),
+								Dz.eq(Db.storageIntegrations.active, true),
+								Dz.eq(Db.storageIntegrations.status, "active"),
+							),
+						),
+				);
+
+				return Option.fromNullable(integration);
+			}),
+		);
+
+		const getActiveIntegrationForOrganization = Effect.fn(
+			"StorageRepo.getActiveIntegrationForOrganization",
+		)((organizationId: Organisation.OrganisationId) =>
+			Effect.gen(function* () {
+				const [integration] = yield* db.use((db) =>
+					db
+						.select()
+						.from(Db.storageIntegrations)
+						.where(
+							Dz.and(
+								Dz.eq(Db.storageIntegrations.organizationId, organizationId),
 								Dz.eq(Db.storageIntegrations.active, true),
 								Dz.eq(Db.storageIntegrations.status, "active"),
 							),
@@ -449,6 +480,7 @@ export class StorageRepo extends Effect.Service<StorageRepo>()("StorageRepo", {
 
 		return {
 			getActiveIntegrationForUser,
+			getActiveIntegrationForOrganization,
 			getIntegrationById,
 			getGoogleDriveConfig,
 			getGoogleDriveAccessTokenCache,

--- a/packages/web-backend/src/Storage/index.ts
+++ b/packages/web-backend/src/Storage/index.ts
@@ -2,6 +2,8 @@ import type * as S3 from "@aws-sdk/client-s3";
 import type * as Db from "@cap/database/schema";
 import { serverEnv } from "@cap/env";
 import {
+	type Organisation,
+	type S3Bucket,
 	Storage as StorageDomain,
 	type User,
 	type Video,
@@ -692,6 +694,14 @@ const makeGoogleDriveAccess = ({
 	};
 };
 
+type WritableStorageAccess = {
+	access:
+		| ReturnType<typeof makeS3Access>
+		| ReturnType<typeof makeGoogleDriveAccess>;
+	bucketId: Option.Option<S3Bucket.S3BucketId>;
+	storageIntegrationId: Option.Option<StorageDomain.StorageIntegrationId>;
+};
+
 export class Storage extends Effect.Service<Storage>()("Storage", {
 	effect: Effect.gen(function* () {
 		const repo = yield* StorageRepo;
@@ -699,7 +709,25 @@ export class Storage extends Effect.Service<Storage>()("Storage", {
 
 		const getS3WritableAccessForUser = Effect.fn(
 			"Storage.getS3WritableAccessForUser",
-		)(function* (userId: User.UserId) {
+		)(function* (
+			userId: User.UserId,
+			organizationId?: Organisation.OrganisationId,
+		) {
+			if (organizationId) {
+				const organizationBucket = yield* mapStorageError(
+					s3Buckets.getBucketAccessForOrganization(organizationId),
+				);
+
+				if (Option.isSome(organizationBucket)) {
+					const [s3, customBucket] = organizationBucket.value;
+					return {
+						access: makeS3Access(s3),
+						bucketId: Option.map(customBucket, (bucket) => bucket.id),
+						storageIntegrationId: Option.none(),
+					};
+				}
+			}
+
 			const [s3, customBucket] = yield* mapStorageError(
 				s3Buckets.getBucketAccessForUser(userId),
 			);
@@ -734,9 +762,51 @@ export class Storage extends Effect.Service<Storage>()("Storage", {
 			return makeGoogleDriveAccess({ repo, integration, config });
 		});
 
+		const getOrganizationWritableAccess = Effect.fn(
+			"Storage.getOrganizationWritableAccess",
+		)(function* (organizationId: Organisation.OrganisationId) {
+			const activeIntegration = yield* mapStorageError(
+				repo.getActiveIntegrationForOrganization(organizationId),
+			);
+			if (Option.isSome(activeIntegration)) {
+				const access = yield* getDriveAccess(activeIntegration.value.id);
+				return Option.some<WritableStorageAccess>({
+					access,
+					bucketId: Option.none(),
+					storageIntegrationId: Option.some(activeIntegration.value.id),
+				});
+			}
+
+			const organizationBucket = yield* mapStorageError(
+				s3Buckets.getBucketAccessForOrganization(organizationId),
+			);
+			if (Option.isSome(organizationBucket)) {
+				const [s3, customBucket] = organizationBucket.value;
+				return Option.some<WritableStorageAccess>({
+					access: makeS3Access(s3),
+					bucketId: Option.map(customBucket, (bucket) => bucket.id),
+					storageIntegrationId: Option.none(),
+				});
+			}
+
+			return Option.none<WritableStorageAccess>();
+		});
+
 		const getWritableAccessForUser = Effect.fn(
 			"Storage.getWritableAccessForUser",
-		)(function* (userId: User.UserId) {
+		)(function* (
+			userId: User.UserId,
+			organizationId?: Organisation.OrganisationId,
+		) {
+			if (organizationId) {
+				const organizationAccess =
+					yield* getOrganizationWritableAccess(organizationId);
+
+				if (Option.isSome(organizationAccess)) {
+					return organizationAccess.value;
+				}
+			}
+
 			const activeIntegration = yield* mapStorageError(
 				repo.getActiveIntegrationForUser(userId),
 			);
@@ -768,8 +838,13 @@ export class Storage extends Effect.Service<Storage>()("Storage", {
 
 		const createUploadTargetForUser = Effect.fn(
 			"Storage.createUploadTargetForUser",
-		)(function* (userId: User.UserId, key: string, input: UploadTargetInput) {
-			const writable = yield* getWritableAccessForUser(userId);
+		)(function* (
+			userId: User.UserId,
+			key: string,
+			input: UploadTargetInput,
+			organizationId?: Organisation.OrganisationId,
+		) {
+			const writable = yield* getWritableAccessForUser(userId, organizationId);
 			const upload = yield* writable.access.createUploadTarget(key, input);
 			return { ...writable, upload };
 		});
@@ -783,6 +858,7 @@ export class Storage extends Effect.Service<Storage>()("Storage", {
 
 		return {
 			getS3WritableAccessForUser,
+			getOrganizationWritableAccess,
 			getWritableAccessForUser,
 			getAccessForVideo,
 			createUploadTargetForUser,
@@ -791,13 +867,25 @@ export class Storage extends Effect.Service<Storage>()("Storage", {
 	}),
 	dependencies: [StorageRepo.Default, S3Buckets.Default],
 }) {
-	static getWritableAccessForUser = (userId: User.UserId) =>
+	static getWritableAccessForUser = (
+		userId: User.UserId,
+		organizationId?: Organisation.OrganisationId,
+	) =>
 		Effect.flatMap(Storage, (storage) =>
-			storage.getWritableAccessForUser(userId),
+			storage.getWritableAccessForUser(userId, organizationId),
 		);
-	static getS3WritableAccessForUser = (userId: User.UserId) =>
+	static getS3WritableAccessForUser = (
+		userId: User.UserId,
+		organizationId?: Organisation.OrganisationId,
+	) =>
 		Effect.flatMap(Storage, (storage) =>
-			storage.getS3WritableAccessForUser(userId),
+			storage.getS3WritableAccessForUser(userId, organizationId),
+		);
+	static getOrganizationWritableAccess = (
+		organizationId: Organisation.OrganisationId,
+	) =>
+		Effect.flatMap(Storage, (storage) =>
+			storage.getOrganizationWritableAccess(organizationId),
 		);
 	static getAccessForVideo = (video: Video.Video) =>
 		Effect.flatMap(Storage, (storage) => storage.getAccessForVideo(video));
@@ -805,9 +893,10 @@ export class Storage extends Effect.Service<Storage>()("Storage", {
 		userId: User.UserId,
 		key: string,
 		input: UploadTargetInput,
+		organizationId?: Organisation.OrganisationId,
 	) =>
 		Effect.flatMap(Storage, (storage) =>
-			storage.createUploadTargetForUser(userId, key, input),
+			storage.createUploadTargetForUser(userId, key, input, organizationId),
 		);
 	static createUploadTargetForVideo = (
 		video: Video.Video,

--- a/packages/web-backend/src/Videos/index.ts
+++ b/packages/web-backend/src/Videos/index.ts
@@ -377,7 +377,10 @@ export class Videos extends Effect.Service<Videos>()("Videos", {
 					if (user.activeOrganizationId !== input.orgId)
 						return yield* Effect.fail(new Policy.PolicyDeniedError());
 
-					const writable = yield* storage.getWritableAccessForUser(user.id);
+					const writable = yield* storage.getWritableAccessForUser(
+						user.id,
+						input.orgId,
+					);
 					const bucketId: RepoCreateVideoInput["bucketId"] = writable.bucketId;
 					const storageIntegrationId: RepoCreateVideoInput["storageIntegrationId"] =
 						writable.storageIntegrationId;


### PR DESCRIPTION
Organizations can attach S3 or Google Drive as shared storage so recordings use org credentials instead of only the user’s. The dashboard gets an integrations area for owners to configure and switch providers; the desktop app discovers “managed” org storage and flows OAuth/S3 accordingly, with uploads and video creation passing orgId where needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds organization-managed storage, allowing org owners to configure a shared S3 bucket or Google Drive account that all members' recordings use instead of individual user storage. The schema, backend service layer, desktop API routes, dashboard UI, and desktop client are all updated in concert.

- Schema adds `organizationId`, `active`, and timestamp columns to `s3Buckets` and `storageIntegrations`, with appropriate indexes and relations; two sequential migrations handle the rollout.
- New `Storage.getOrganizationWritableAccess` resolves the org's active provider (Drive → S3 → user fallback) and is threaded through video creation on both the desktop API and dashboard upload paths.
- The dashboard gains an integrations settings page with S3 and Google Drive panels; the desktop client discovers managed org storage and adjusts its OAuth and upload flows accordingly.

<h3>Confidence Score: 4/5</h3>

Safe to merge after clarifying whether org-level Google Drive requires Pro and adding error handling to the S3 test server action.

Core storage routing, auth guards, secret masking, and OAuth state verification are all implemented correctly. Two items need resolution: `connectOrganizationGoogleDrive` skips the Pro check enforced by the desktop API for the same operation, and `testOrganizationS3Config` has no catch block so raw AWS errors reach the dashboard.

apps/web/actions/organization/storage.ts — Pro check for org Google Drive OAuth and S3 test error handling.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/actions/organization/storage.ts | New server actions for org storage management; Pro check missing for org Google Drive OAuth initiation, and S3 test lacks error handling. |
| apps/web/app/api/desktop/[...route]/organizationStorage.ts | Shared helpers for org storage queries on the desktop API; includes tombstone guard and correct org membership checks. |
| apps/web/app/api/desktop/[...route]/s3Config.ts | Adds org S3 config GET path; secrets correctly masked (exposeSecrets: false) and org access is gated on getAccessibleOrganization. |
| apps/web/app/api/desktop/[...route]/storage.ts | OAuth callback and storage integrations endpoint updated with org scope support; state HMAC verification and org ownership checks are correctly applied. |
| packages/database/schema.ts | Adds organizationId FK, active flag, and timestamps to s3Buckets and storageIntegrations; indexes look appropriate for query patterns. |
| packages/web-backend/src/Storage/index.ts | New getOrganizationWritableAccess resolves org Drive/S3 in priority order; fallback to user storage works correctly. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/web/app/(org)/dashboard/settings/organization/integrations/storage-integrations.tsx`, line 1207-1216 ([link](https://github.com/capsoftware/cap/blob/281ca9d24f0e7cc1829d21d3d4a9eb4d484ac4a3/apps/web/app/(org)/dashboard/settings/organization/integrations/storage-integrations.tsx#L1207-L1216)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **S3 secret access key exposed in RSC payload**

   `getOrganizationStorageSettings` decrypts the full S3 config — including `secretAccessKey` — and passes it as `initialSettings` to this client component. Because this is a Next.js RSC prop, the decrypted secret key is serialized into the HTML payload sent to the browser. Any browser extension, network proxy, or CSP-adjacent tooling that can read the RSC stream will see the organization's long-lived S3 credentials in cleartext. The API endpoint for desktop already handles this correctly (`exposeSecrets: false` for org buckets in `s3Config.ts`) — the dashboard should do the same and avoid returning `secretAccessKey` in `getOrganizationStorageSettings`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/app/(org)/dashboard/settings/organization/integrations/storage-integrations.tsx
   Line: 1207-1216

   Comment:
   **S3 secret access key exposed in RSC payload**

   `getOrganizationStorageSettings` decrypts the full S3 config — including `secretAccessKey` — and passes it as `initialSettings` to this client component. Because this is a Next.js RSC prop, the decrypted secret key is serialized into the HTML payload sent to the browser. Any browser extension, network proxy, or CSP-adjacent tooling that can read the RSC stream will see the organization's long-lived S3 credentials in cleartext. The API endpoint for desktop already handles this correctly (`exposeSecrets: false` for org buckets in `s3Config.ts`) — the dashboard should do the same and avoid returning `secretAccessKey` in `getOrganizationStorageSettings`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `apps/web/app/(org)/dashboard/settings/organization/integrations/page.tsx`, line 1113-1117 ([link](https://github.com/capsoftware/cap/blob/281ca9d24f0e7cc1829d21d3d4a9eb4d484ac4a3/apps/web/app/(org)/dashboard/settings/organization/integrations/page.tsx#L1113-L1117)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unhandled throw for non-owner org members**

   `getOrganizationStorageSettings` calls `requireOrganizationOwner` and throws `"Only the owner can manage organization storage"` for non-owners. This page has no error boundary, so any org member who clicks the "Integrations" nav item (which is visible to all members via `SettingsNav`) will get an unhandled server error / 500. Consider either adding a try/catch with a redirect, or gate the nav link to owners only.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/app/(org)/dashboard/settings/organization/integrations/page.tsx
   Line: 1113-1117

   Comment:
   **Unhandled throw for non-owner org members**

   `getOrganizationStorageSettings` calls `requireOrganizationOwner` and throws `"Only the owner can manage organization storage"` for non-owners. This page has no error boundary, so any org member who clicks the "Integrations" nav item (which is visible to all members via `SettingsNav`) will get an unhandled server error / 500. Consider either adding a try/catch with a redirect, or gate the nav link to owners only.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/actions/organization/storage.ts:440-446
**Pro check absent for org Google Drive connection**

`connectOrganizationGoogleDrive` starts the OAuth flow without verifying `userIsPro`, but the equivalent desktop API endpoint (`POST /google-drive/connect`) enforces `if (!userIsPro(user)) return 403` even when `orgId` is supplied. A non-Pro org owner can therefore connect org-level Google Drive through the dashboard, bypassing the subscription gate that is enforced on the desktop path. Either add a Pro check here (if org Drive requires Pro), or remove the check from the desktop API when `orgId` is present (if org Drive intentionally does not require Pro).

### Issue 2 of 2
apps/web/actions/organization/storage.ts:372-394
**S3 test errors propagate as raw exceptions from server action**

`testOrganizationS3Config` has no `catch` block, so any failure from `s3Client.send` (network error, invalid credentials, wrong region, etc.) is thrown as an unhandled exception from the server action. The desktop API route's `/s3Config/test` handler has thorough per-case error handling (e.g. `AbortError`, `NoSuchBucket`, `InvalidAccessKeyId`, `SignatureDoesNotMatch`) that surfaces friendly messages. Dashboard users will see a generic server error instead of an actionable message.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address organization storage review"](https://github.com/capsoftware/cap/commit/31f08a405c644a6d7900fcbc2cb1a24dc73b0a08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31440849)</sub>

<!-- /greptile_comment -->