### PR TITLE
Add debug reports with context to feedback flow

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -799,6 +799,17 @@ async fn upload_logs(app_handle: AppHandle) -> Result<(), String> {
 
 #[tauri::command]
 #[specta::specta]
+async fn upload_debug_report(
+    app_handle: AppHandle,
+    report_id: String,
+    user_feedback: String,
+    client_context: String,
+) -> Result<(), String> {
+    logging::upload_debug_report(&app_handle, report_id, user_feedback, client_context).await
+}
+
+#[tauri::command]
+#[specta::specta]
 fn get_system_diagnostics() -> cap_recording::diagnostics::SystemDiagnostics {
     cap_recording::diagnostics::collect_diagnostics()
 }
@@ -3893,6 +3904,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             set_native_camera_preview_enabled,
             recording_settings::set_recording_mode,
             upload_logs,
+            upload_debug_report,
             get_system_diagnostics,
             recording::start_recording,
             recording::stop_recording,

--- a/apps/desktop/src-tauri/src/logging.rs
+++ b/apps/desktop/src-tauri/src/logging.rs
@@ -63,6 +63,12 @@ struct AppStateInfo {
     app_data_dir: String,
 }
 
+struct DebugReportUpload {
+    report_id: String,
+    user_feedback: String,
+    client_context: String,
+}
+
 fn collect_cameras(has_permission: bool) -> Vec<CameraDiagnostics> {
     if !has_permission {
         return vec![];
@@ -171,8 +177,12 @@ fn collect_diagnostics_for_upload(
     }
 }
 
-pub async fn upload_log_file(app: &AppHandle) -> Result<(), String> {
+async fn upload_log_file_with_context(
+    app: &AppHandle,
+    debug_report: Option<DebugReportUpload>,
+) -> Result<(), String> {
     let log_file = get_latest_log_file(app).await.ok_or("No log file found")?;
+    let requires_auth = debug_report.is_some();
 
     let metadata =
         fs::metadata(&log_file).map_err(|e| format!("Failed to read log file metadata: {e}"))?;
@@ -222,22 +232,57 @@ pub async fn upload_log_file(app: &AppHandle) -> Result<(), String> {
     let diagnostics = collect_diagnostics_for_upload(&recordings_dir, &app_data_dir, is_recording);
     let diagnostics_json = serde_json::to_string(&diagnostics).unwrap_or_else(|_| "{}".to_string());
 
-    let form = reqwest::multipart::Form::new()
+    let mut form = reqwest::multipart::Form::new()
         .text("log", log_content)
         .text("os", std::env::consts::OS)
         .text("version", env!("CARGO_PKG_VERSION"))
         .text("diagnostics", diagnostics_json);
 
-    let response = app
-        .api_request("/api/desktop/logs", |client, url| {
+    if let Some(debug_report) = debug_report {
+        form = form
+            .text("reportId", debug_report.report_id)
+            .text("feedback", debug_report.user_feedback)
+            .text("clientContext", debug_report.client_context);
+    }
+
+    let response = if requires_auth {
+        app.authed_api_request("/api/desktop/logs", |client, url| {
             client.post(url).multipart(form)
         })
         .await
-        .map_err(|e| format!("Failed to upload logs: {e}"))?;
+        .map_err(|e| format!("Failed to upload logs: {e}"))?
+    } else {
+        app.api_request("/api/desktop/logs", |client, url| {
+            client.post(url).multipart(form)
+        })
+        .await
+        .map_err(|e| format!("Failed to upload logs: {e}"))?
+    };
 
     if !response.status().is_success() {
         return Err(format!("Upload failed with status: {}", response.status()));
     }
 
     Ok(())
+}
+
+pub async fn upload_log_file(app: &AppHandle) -> Result<(), String> {
+    upload_log_file_with_context(app, None).await
+}
+
+pub async fn upload_debug_report(
+    app: &AppHandle,
+    report_id: String,
+    user_feedback: String,
+    client_context: String,
+) -> Result<(), String> {
+    upload_log_file_with_context(
+        app,
+        Some(DebugReportUpload {
+            report_id,
+            user_feedback,
+            client_context,
+        }),
+    )
+    .await
 }

--- a/apps/desktop/src/routes/(window-chrome)/settings/feedback.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/feedback.tsx
@@ -1,13 +1,35 @@
 import { Button } from "@cap/ui-solid";
 import { action, useAction, useSubmission } from "@solidjs/router";
 import { getVersion } from "@tauri-apps/api/app";
+import { invoke } from "@tauri-apps/api/core";
 import { type OsType, type as ostype } from "@tauri-apps/plugin-os";
 import * as shell from "@tauri-apps/plugin-shell";
 import { createResource, createSignal, For, Show } from "solid-js";
 import toast from "solid-toast";
 
+import {
+	authStore,
+	generalSettingsStore,
+	hotkeysStore,
+	presetsStore,
+	recordingSettingsStore,
+} from "~/store";
 import { commands, type SystemDiagnostics } from "~/utils/tauri";
 import { apiClient, protectedHeaders } from "~/utils/web-api";
+
+type CollectedValue<T> =
+	| {
+			ok: true;
+			value: T;
+	  }
+	| {
+			ok: false;
+			error: string;
+	  };
+
+type GeneralSettingsDebugState = Awaited<
+	ReturnType<typeof generalSettingsStore.get>
+>;
 
 const getFeedbackOs = (): Extract<OsType, "macos" | "windows"> => {
 	const os = ostype();
@@ -15,14 +37,257 @@ const getFeedbackOs = (): Extract<OsType, "macos" | "windows"> => {
 	throw new Error(`Unsupported OS for feedback submission: ${os}`);
 };
 
+const errorToString = (error: unknown) => {
+	if (error instanceof Error) return error.message;
+	if (typeof error === "string") return error;
+	try {
+		return JSON.stringify(error);
+	} catch {
+		return "Unknown error";
+	}
+};
+
+const collectValue = async <T,>(
+	fn: () => Promise<T>,
+): Promise<CollectedValue<T>> => {
+	try {
+		return { ok: true, value: await fn() };
+	} catch (error) {
+		return { ok: false, error: errorToString(error) };
+	}
+};
+
+const localStorageDebugKeys = [
+	"export_settings",
+	"selectedTranscriptionModel",
+	"selectedTranscriptionLanguage",
+	"modelDownloadState",
+	"cap-theme",
+	"cap.settings.scrollToSection",
+];
+
+const createReportId = () => {
+	if (typeof crypto !== "undefined" && crypto.randomUUID) {
+		return crypto.randomUUID();
+	}
+
+	return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+};
+
+function collectRuntimeContext() {
+	if (typeof window === "undefined") return null;
+
+	const colorScheme = window.matchMedia?.("(prefers-color-scheme: dark)")
+		.matches
+		? "dark"
+		: "light";
+
+	return {
+		userAgent: navigator.userAgent,
+		locale: navigator.language,
+		languages: navigator.languages,
+		timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+		platform: navigator.platform,
+		online: navigator.onLine,
+		devicePixelRatio: window.devicePixelRatio,
+		colorScheme,
+		route: window.location.href,
+		viewport: {
+			width: window.innerWidth,
+			height: window.innerHeight,
+		},
+		screen: {
+			width: window.screen.width,
+			height: window.screen.height,
+			availWidth: window.screen.availWidth,
+			availHeight: window.screen.availHeight,
+		},
+	};
+}
+
+function collectLocalStorageDebugState() {
+	const values: Record<string, string | null> = {};
+	if (typeof window === "undefined") return values;
+
+	for (const key of localStorageDebugKeys) {
+		try {
+			values[key] = window.localStorage.getItem(key);
+		} catch (error) {
+			values[key] = `Failed to read: ${errorToString(error)}`;
+		}
+	}
+
+	return values;
+}
+
+async function collectAuthDebugState() {
+	const auth = await authStore.get();
+	if (!auth) return null;
+
+	return {
+		userId: auth.user_id,
+		plan: auth.plan,
+		secretType: "api_key" in auth.secret ? "apiKey" : "sessionToken",
+		organizations: auth.organizations?.map((organization) => ({
+			id: organization.id,
+			name: organization.name,
+			ownerId: organization.ownerId,
+		})),
+	};
+}
+
+function sanitizeGeneralSettings(settings: GeneralSettingsDebugState) {
+	if (!settings?.commercialLicense) return settings;
+
+	return {
+		...settings,
+		commercialLicense: {
+			...settings.commercialLicense,
+			licenseKey: settings.commercialLicense.licenseKey ? "present" : "",
+		},
+	};
+}
+
+async function collectDesktopDebugContext({
+	reportId,
+	issue,
+	os,
+	version,
+}: {
+	reportId: string;
+	issue: string;
+	os: Extract<OsType, "macos" | "windows">;
+	version: string;
+}) {
+	const [
+		diagnostics,
+		devicesSnapshot,
+		permissions,
+		currentRecording,
+		captureDisplays,
+		captureWindows,
+		cameras,
+		microphones,
+		recordings,
+		screenshots,
+		generalSettings,
+		recordingSettings,
+		hotkeys,
+		presets,
+		auth,
+	] = await Promise.all([
+		collectValue(() => commands.getSystemDiagnostics()),
+		collectValue(() => commands.getDevicesSnapshot()),
+		collectValue(() => commands.doPermissionsCheck(false)),
+		collectValue(() =>
+			commands.getCurrentRecording().then((recording) => recording[0]),
+		),
+		collectValue(() => commands.listCaptureDisplays()),
+		collectValue(() => commands.listCaptureWindows()),
+		collectValue(() => commands.listCameras()),
+		collectValue(() => commands.listAudioDevices()),
+		collectValue(() =>
+			commands.listRecordings().then((entries) => entries.slice(0, 20)),
+		),
+		collectValue(() =>
+			commands.listScreenshots().then((entries) => entries.slice(0, 20)),
+		),
+		collectValue(async () =>
+			sanitizeGeneralSettings(await generalSettingsStore.get()),
+		),
+		collectValue(() => recordingSettingsStore.get()),
+		collectValue(() => hotkeysStore.get()),
+		collectValue(() => presetsStore.get()),
+		collectValue(collectAuthDebugState),
+	]);
+
+	return {
+		reportId,
+		submittedAt: new Date().toISOString(),
+		issue,
+		app: {
+			version,
+			os,
+			route: typeof window !== "undefined" ? window.location.href : null,
+		},
+		runtime: collectRuntimeContext(),
+		native: {
+			diagnostics,
+			devicesSnapshot,
+			permissions,
+			currentRecording,
+			captureDisplays,
+			captureWindows,
+			cameras,
+			microphones,
+			recordings,
+			screenshots,
+		},
+		stores: {
+			generalSettings,
+			recordingSettings,
+			hotkeys,
+			presets,
+			auth,
+		},
+		localStorage: collectLocalStorageDebugState(),
+	};
+}
+
 const sendFeedbackAction = action(async (feedback: string) => {
+	const trimmedFeedback = feedback.trim();
 	const response = await apiClient.desktop.submitFeedback({
-		body: { feedback, os: getFeedbackOs(), version: await getVersion() },
+		body: {
+			feedback: trimmedFeedback,
+			os: getFeedbackOs(),
+			version: await getVersion(),
+			kind: "feedback",
+		},
 		headers: await protectedHeaders(),
 	});
 
 	if (response.status !== 200) throw new Error("Failed to submit feedback");
 	return response.body;
+});
+
+const sendDebugReportAction = action(async (feedback: string) => {
+	const trimmedFeedback = feedback.trim();
+	if (trimmedFeedback.length < 10) {
+		throw new Error("Please describe the issue before sending a debug report");
+	}
+
+	const headers = await protectedHeaders();
+	const os = getFeedbackOs();
+	const version = await getVersion();
+	const reportId = createReportId();
+	const context = await collectDesktopDebugContext({
+		reportId,
+		issue: trimmedFeedback,
+		os,
+		version,
+	});
+	const clientContext = JSON.stringify(context, null, "\t");
+
+	await invoke<null>("upload_debug_report", {
+		reportId,
+		userFeedback: trimmedFeedback,
+		clientContext,
+	});
+
+	const response = await apiClient.desktop.submitFeedback({
+		body: {
+			feedback: trimmedFeedback,
+			os,
+			version,
+			reportId,
+			kind: "debugReport",
+			debugReport: clientContext,
+		},
+		headers,
+	});
+
+	if (response.status !== 200) throw new Error("Failed to submit debug report");
+	return { ...response.body, reportId };
 });
 
 async function fetchDiagnostics(): Promise<SystemDiagnostics | null> {
@@ -41,6 +306,8 @@ export default function FeedbackTab() {
 
 	const submission = useSubmission(sendFeedbackAction);
 	const sendFeedback = useAction(sendFeedbackAction);
+	const debugSubmission = useSubmission(sendDebugReportAction);
+	const sendDebugReport = useAction(sendDebugReportAction);
 
 	const handleUploadLogs = async () => {
 		setUploadingLogs(true);
@@ -73,12 +340,12 @@ export default function FeedbackTab() {
 							sendFeedback(feedback());
 						}}
 					>
-						<fieldset disabled={submission.pending}>
+						<fieldset disabled={submission.pending || debugSubmission.pending}>
 							<div>
 								<textarea
 									value={feedback()}
 									onInput={(e) => setFeedback(e.currentTarget.value)}
-									placeholder="Tell us what you think about Cap..."
+									placeholder="Tell us what happened, what you expected, and anything you already tried..."
 									required
 									minLength={10}
 									class="p-2 w-full h-32 text-[13px] rounded-md border transition-colors duration-200 resize-none bg-gray-2 placeholder:text-gray-10 border-gray-3 text-primary focus:outline-none focus:ring-1 focus:ring-gray-8 hover:border-gray-6"
@@ -125,21 +392,44 @@ export default function FeedbackTab() {
 					</div>
 
 					<div class="pt-6 border-t border-gray-2">
-						<h3 class="text-sm font-medium text-gray-12 mb-2">
-							Debug Information
-						</h3>
+						<h3 class="text-sm font-medium text-gray-12 mb-2">Debug Report</h3>
 						<p class="text-sm text-gray-10 mb-3">
-							Upload your logs to help us diagnose issues with Cap. No personal
-							information is included.
+							Send the issue description above with logs, device and display
+							diagnostics, permissions, settings, recent recording metadata,
+							current capture state, and editor/export state. This can include
+							device names, window titles, file paths, and logs, but no
+							recording media is attached.
 						</p>
-						<Button
-							onClick={handleUploadLogs}
-							size="md"
-							variant="gray"
-							disabled={uploadingLogs()}
-						>
-							{uploadingLogs() ? "Uploading..." : "Upload Logs"}
-						</Button>
+						<div class="flex gap-2 flex-wrap">
+							<Button
+								onClick={() => sendDebugReport(feedback())}
+								size="md"
+								variant="dark"
+								disabled={
+									feedback().trim().length < 10 || debugSubmission.pending
+								}
+							>
+								{debugSubmission.pending ? "Sending..." : "Send Debug Report"}
+							</Button>
+							<Button
+								onClick={handleUploadLogs}
+								size="md"
+								variant="gray"
+								disabled={uploadingLogs() || debugSubmission.pending}
+							>
+								{uploadingLogs() ? "Uploading..." : "Upload Logs Only"}
+							</Button>
+						</div>
+						{debugSubmission.error && (
+							<p class="mt-2 text-sm text-red-400">
+								{debugSubmission.error.toString()}
+							</p>
+						)}
+						{debugSubmission.result?.success && (
+							<p class="mt-2 text-sm text-primary">
+								Debug report sent. Report ID: {debugSubmission.result.reportId}
+							</p>
+						)}
 					</div>
 
 					<div class="pt-6 border-t border-gray-2">

--- a/apps/web/app/api/desktop/[...route]/root.ts
+++ b/apps/web/app/api/desktop/[...route]/root.ts
@@ -92,70 +92,224 @@ async function applyOrganizationLogoUpdate(
 	}).pipe(runPromise);
 }
 
-const diagnosticsSchema = z.object({
-	system: z
-		.object({
-			windowsVersion: z
-				.object({
-					displayName: z.string(),
-					meetsRequirements: z.boolean().optional(),
-					isWindows11: z.boolean().optional(),
-				})
-				.optional(),
-			macosVersion: z.object({ displayName: z.string() }).optional(),
-			gpuInfo: z
-				.object({
-					vendor: z.string(),
-					description: z.string(),
-					dedicatedVideoMemoryMb: z.number().optional(),
-					isSoftwareAdapter: z.boolean().optional(),
-					isBasicRenderDriver: z.boolean().optional(),
-					supportsHardwareEncoding: z.boolean().optional(),
-				})
-				.optional(),
-			allGpus: z
-				.object({
-					gpus: z.array(
-						z.object({
-							vendor: z.string(),
-							description: z.string(),
-							dedicatedVideoMemoryMb: z.number().optional(),
-						}),
-					),
-					isMultiGpuSystem: z.boolean().optional(),
-					hasDiscreteGpu: z.boolean().optional(),
-				})
-				.optional(),
-			renderingStatus: z
-				.object({
-					isUsingSoftwareRendering: z.boolean().optional(),
-					isUsingBasicRenderDriver: z.boolean().optional(),
-					hardwareEncodingAvailable: z.boolean().optional(),
-					warningMessage: z.string().optional(),
-				})
-				.optional(),
-			availableEncoders: z.array(z.string()).optional(),
-			graphicsCaptureSupported: z.boolean().optional(),
-			screenCaptureSupported: z.boolean().optional(),
-			d3D11VideoProcessorAvailable: z.boolean().optional(),
-		})
-		.optional(),
-	cameras: z.array(z.string()).optional(),
-	microphones: z.array(z.string()).optional(),
-	permissions: z
-		.object({
-			screenRecording: z.string().optional(),
-			camera: z.string().optional(),
-			microphone: z.string().optional(),
-		})
-		.optional(),
-});
+const hardwareSchema = z
+	.object({
+		cpuBrand: z.string().optional(),
+		cpuCores: z.number().optional(),
+		totalMemoryMb: z.number().optional(),
+		availableMemoryMb: z.number().optional(),
+		architecture: z.string().optional(),
+	})
+	.passthrough();
+
+const displayDiagnosticsSchema = z
+	.object({
+		id: z.string().optional(),
+		name: z.string().optional(),
+		width: z.number().optional(),
+		height: z.number().optional(),
+		refreshRate: z.number().optional(),
+		scaleFactor: z.number().optional(),
+		isPrimary: z.boolean().optional(),
+	})
+	.passthrough();
+
+const cameraDiagnosticsSchema = z
+	.object({
+		deviceId: z.string().optional(),
+		displayName: z.string().optional(),
+		modelId: z.string().nullable().optional(),
+		formats: z
+			.array(
+				z
+					.object({
+						width: z.number().optional(),
+						height: z.number().optional(),
+						frameRate: z.number().optional(),
+					})
+					.passthrough(),
+			)
+			.optional(),
+	})
+	.passthrough();
+
+const microphoneDiagnosticsSchema = z
+	.object({
+		name: z.string().optional(),
+		sampleRate: z.number().optional(),
+		channels: z.number().optional(),
+		sampleFormat: z.string().optional(),
+	})
+	.passthrough();
+
+const diagnosticsSchema = z
+	.object({
+		hardware: hardwareSchema.optional(),
+		system: z
+			.object({
+				windowsVersion: z
+					.object({
+						displayName: z.string(),
+						meetsRequirements: z.boolean().optional(),
+						isWindows11: z.boolean().optional(),
+					})
+					.passthrough()
+					.optional(),
+				macosVersion: z
+					.object({ displayName: z.string() })
+					.passthrough()
+					.optional(),
+				gpuInfo: z
+					.object({
+						vendor: z.string(),
+						description: z.string(),
+						dedicatedVideoMemoryMb: z.number().optional(),
+						isSoftwareAdapter: z.boolean().optional(),
+						isBasicRenderDriver: z.boolean().optional(),
+						supportsHardwareEncoding: z.boolean().optional(),
+					})
+					.passthrough()
+					.optional(),
+				allGpus: z
+					.object({
+						gpus: z.array(
+							z
+								.object({
+									vendor: z.string(),
+									description: z.string(),
+									dedicatedVideoMemoryMb: z.number().optional(),
+								})
+								.passthrough(),
+						),
+						isMultiGpuSystem: z.boolean().optional(),
+						hasDiscreteGpu: z.boolean().optional(),
+					})
+					.passthrough()
+					.optional(),
+				renderingStatus: z
+					.object({
+						isUsingSoftwareRendering: z.boolean().optional(),
+						isUsingBasicRenderDriver: z.boolean().optional(),
+						hardwareEncodingAvailable: z.boolean().optional(),
+						warningMessage: z.string().optional(),
+					})
+					.passthrough()
+					.optional(),
+				availableEncoders: z.array(z.string()).optional(),
+				graphicsCaptureSupported: z.boolean().optional(),
+				screenCaptureSupported: z.boolean().optional(),
+				d3D11VideoProcessorAvailable: z.boolean().optional(),
+				metalSupported: z.boolean().optional(),
+				gpuName: z.string().nullable().optional(),
+			})
+			.passthrough()
+			.optional(),
+		displays: z.array(displayDiagnosticsSchema).optional(),
+		cameras: z.array(z.union([z.string(), cameraDiagnosticsSchema])).optional(),
+		microphones: z
+			.array(z.union([z.string(), microphoneDiagnosticsSchema]))
+			.optional(),
+		storage: z
+			.object({
+				recordingsPath: z.string().optional(),
+				availableSpaceMb: z.number().optional(),
+				totalSpaceMb: z.number().optional(),
+			})
+			.passthrough()
+			.nullable()
+			.optional(),
+		permissions: z
+			.object({
+				screenRecording: z.string().optional(),
+				camera: z.string().optional(),
+				microphone: z.string().optional(),
+			})
+			.passthrough()
+			.optional(),
+		appState: z
+			.object({
+				isRecording: z.boolean().optional(),
+				recordingsDir: z.string().optional(),
+				appDataDir: z.string().optional(),
+			})
+			.passthrough()
+			.optional(),
+	})
+	.passthrough();
+
+const clientContextSchema = z
+	.object({
+		reportId: z.string().optional(),
+		submittedAt: z.string().optional(),
+		app: z
+			.object({
+				version: z.string().optional(),
+				os: z.string().optional(),
+				route: z.string().optional(),
+			})
+			.passthrough()
+			.optional(),
+		runtime: z
+			.object({
+				userAgent: z.string().optional(),
+				locale: z.string().optional(),
+				timezone: z.string().optional(),
+			})
+			.passthrough()
+			.optional(),
+	})
+	.passthrough();
+
+function truncateForDiscord(value: string, maxLength: number) {
+	const trimmed = value.trim();
+	if (trimmed.length <= maxLength) return trimmed;
+	return `${trimmed.slice(0, maxLength - 14)}...[truncated]`;
+}
+
+function formatCamera(
+	camera: string | z.infer<typeof cameraDiagnosticsSchema>,
+): string {
+	if (typeof camera === "string") return camera;
+
+	const name = camera.displayName ?? camera.deviceId ?? "Unknown camera";
+	const bestFormat = camera.formats?.[0];
+	if (!bestFormat?.width || !bestFormat.height) return name;
+
+	const fps = bestFormat.frameRate ? ` ${bestFormat.frameRate}fps` : "";
+	return `${name} (${bestFormat.width}x${bestFormat.height}${fps})`;
+}
+
+function formatMicrophone(
+	microphone: string | z.infer<typeof microphoneDiagnosticsSchema>,
+): string {
+	if (typeof microphone === "string") return microphone;
+
+	const name = microphone.name ?? "Unknown microphone";
+	const details = [
+		microphone.sampleRate ? `${microphone.sampleRate}Hz` : null,
+		microphone.channels ? `${microphone.channels}ch` : null,
+		microphone.sampleFormat ?? null,
+	].filter((value): value is string => value !== null);
+
+	return details.length > 0 ? `${name} (${details.join(", ")})` : name;
+}
 
 function formatDiagnosticsForDiscord(
 	diagnostics: z.infer<typeof diagnosticsSchema>,
 ): string {
 	const lines: string[] = [];
 	const sys = diagnostics.system;
+	const hardware = diagnostics.hardware;
+
+	if (hardware?.cpuBrand) {
+		const memory =
+			hardware.totalMemoryMb !== undefined
+				? `, ${Math.round(hardware.totalMemoryMb / 1024)}GB RAM`
+				: "";
+		const cores =
+			hardware.cpuCores !== undefined ? `, ${hardware.cpuCores} cores` : "";
+		lines.push(`**Hardware:** ${hardware.cpuBrand}${cores}${memory}`);
+	}
 
 	if (sys?.windowsVersion?.displayName) {
 		lines.push(`**OS:** ${sys.windowsVersion.displayName}`);
@@ -198,6 +352,14 @@ function formatDiagnosticsForDiscord(
 		);
 	}
 
+	if (sys?.gpuName) {
+		lines.push(`**GPU:** ${sys.gpuName}`);
+	}
+
+	if (sys?.metalSupported !== undefined) {
+		lines.push(`**Metal:** ${sys.metalSupported ? "✅" : "❌"}`);
+	}
+
 	if (sys?.d3D11VideoProcessorAvailable !== undefined) {
 		lines.push(
 			`**D3D11 Video Processor:** ${sys.d3D11VideoProcessorAvailable ? "✅" : "❌"}`,
@@ -220,9 +382,48 @@ function formatDiagnosticsForDiscord(
 		if (permList) lines.push(`**Permissions:** ${permList}`);
 	}
 
+	if (diagnostics.appState) {
+		const appState = diagnostics.appState;
+		lines.push(
+			`**Recording State:** ${appState.isRecording ? "Recording" : "Idle"}`,
+		);
+		if (appState.recordingsDir)
+			lines.push(`**Recordings Dir:** ${appState.recordingsDir}`);
+	}
+
+	if (diagnostics.storage) {
+		const storage = diagnostics.storage;
+		if (
+			storage.availableSpaceMb !== undefined &&
+			storage.totalSpaceMb !== undefined
+		) {
+			lines.push(
+				`**Storage:** ${Math.round(storage.availableSpaceMb / 1024)}GB free of ${Math.round(storage.totalSpaceMb / 1024)}GB`,
+			);
+		}
+	}
+
+	if (diagnostics.displays && diagnostics.displays.length > 0) {
+		const displays = diagnostics.displays
+			.map((display) => {
+				const size =
+					display.width && display.height
+						? `${display.width}x${display.height}`
+						: "unknown";
+				const refreshRate = display.refreshRate
+					? ` ${display.refreshRate}Hz`
+					: "";
+				const scale = display.scaleFactor ? ` @${display.scaleFactor}x` : "";
+				const primary = display.isPrimary ? " primary" : "";
+				return `${display.name ?? display.id ?? "Display"} ${size}${refreshRate}${scale}${primary}`;
+			})
+			.join("; ");
+		lines.push(`**Displays (${diagnostics.displays.length}):** ${displays}`);
+	}
+
 	if (diagnostics.cameras && diagnostics.cameras.length > 0) {
 		lines.push(
-			`**Cameras (${diagnostics.cameras.length}):** ${diagnostics.cameras.join(", ")}`,
+			`**Cameras (${diagnostics.cameras.length}):** ${diagnostics.cameras.map(formatCamera).join(", ")}`,
 		);
 	} else {
 		lines.push("**Cameras:** None detected");
@@ -230,10 +431,29 @@ function formatDiagnosticsForDiscord(
 
 	if (diagnostics.microphones && diagnostics.microphones.length > 0) {
 		lines.push(
-			`**Mics (${diagnostics.microphones.length}):** ${diagnostics.microphones.join(", ")}`,
+			`**Mics (${diagnostics.microphones.length}):** ${diagnostics.microphones.map(formatMicrophone).join(", ")}`,
 		);
 	} else {
 		lines.push("**Mics:** None detected");
+	}
+
+	return lines.join("\n");
+}
+
+function formatClientContextForDiscord(
+	context: z.infer<typeof clientContextSchema>,
+): string {
+	const lines: string[] = [];
+
+	if (context.submittedAt) lines.push(`**Submitted:** ${context.submittedAt}`);
+	if (context.app?.route) lines.push(`**Route:** ${context.app.route}`);
+	if (context.runtime?.locale || context.runtime?.timezone) {
+		lines.push(
+			`**Locale:** ${[context.runtime.locale, context.runtime.timezone].filter(Boolean).join(", ")}`,
+		);
+	}
+	if (context.runtime?.userAgent) {
+		lines.push(`**WebView:** ${context.runtime.userAgent}`);
 	}
 
 	return lines.join("\n");
@@ -248,6 +468,9 @@ app.post(
 			os: z.string().optional(),
 			version: z.string().optional(),
 			diagnostics: z.string().optional(),
+			reportId: z.string().optional(),
+			feedback: z.string().optional(),
+			clientContext: z.string().optional(),
 		}),
 	),
 	withOptionalAuth,
@@ -257,6 +480,9 @@ app.post(
 			os,
 			version,
 			diagnostics: diagnosticsJson,
+			reportId,
+			feedback,
+			clientContext,
 		} = c.req.valid("form");
 		const user = c.get("user");
 
@@ -267,7 +493,8 @@ app.post(
 
 			const formData = new FormData();
 			const logBlob = new Blob([log], { type: "text/plain" });
-			const fileName = `cap-desktop-${os || "unknown"}-${version || "unknown"}-${Date.now()}.log`;
+			const fileBase = `cap-desktop-${os || "unknown"}-${version || "unknown"}-${reportId || Date.now()}`;
+			const fileName = `${fileBase}.log`;
 			formData.append("file", logBlob, fileName);
 
 			let diagnosticsContent = "";
@@ -283,19 +510,58 @@ app.post(
 				}
 			}
 
+			let clientContextContent = "";
+			if (clientContext) {
+				try {
+					const parsed = JSON.parse(clientContext);
+					const validated = clientContextSchema.safeParse(parsed);
+					if (validated.success) {
+						clientContextContent = formatClientContextForDiscord(
+							validated.data,
+						);
+					}
+				} catch {
+					clientContextContent = "";
+				}
+
+				const contextBlob = new Blob([clientContext], {
+					type: "application/json",
+				});
+				formData.append("files[1]", contextBlob, `${fileBase}-context.json`);
+			}
+
+			if (diagnosticsJson && reportId) {
+				const diagnosticsBlob = new Blob([diagnosticsJson], {
+					type: "application/json",
+				});
+				formData.append(
+					"files[2]",
+					diagnosticsBlob,
+					`${fileBase}-native-diagnostics.json`,
+				);
+			}
+
 			const content = [
-				"📋 **New Log File Uploaded**",
+				reportId
+					? "🧪 **New Desktop Debug Report**"
+					: "📋 **New Log File Uploaded**",
 				"",
 				user ? `**User:** ${user.email} (${user.id})` : null,
+				reportId ? `**Report ID:** ${reportId}` : null,
 				os ? `**Platform:** ${os}` : null,
 				version ? `**App Version:** ${version}` : null,
+				feedback ? `**Issue:**\n${truncateForDiscord(feedback, 700)}` : null,
+				clientContextContent ? "" : null,
+				clientContextContent
+					? truncateForDiscord(clientContextContent, 500)
+					: null,
 				diagnosticsContent ? "" : null,
-				diagnosticsContent || null,
+				diagnosticsContent ? truncateForDiscord(diagnosticsContent, 900) : null,
 			]
 				.filter((line): line is string => line !== null)
 				.join("\n");
 
-			formData.append("content", content);
+			formData.append("content", truncateForDiscord(content, 1900));
 
 			const response = await fetch(discordWebhookUrl, {
 				method: "POST",
@@ -326,21 +592,31 @@ app.post(
 			feedback: z.string(),
 			os: z.union([z.literal("macos"), z.literal("windows")]).optional(),
 			version: z.string().optional(),
+			reportId: z.string().optional(),
+			kind: z.enum(["feedback", "debugReport"]).optional(),
+			debugReport: z.string().optional(),
 		}),
 	),
 	async (c) => {
-		const { feedback, os, version } = c.req.valid("form");
+		const { feedback, os, version, reportId, kind, debugReport } =
+			c.req.valid("form");
 		const userEmail = c.get("user").email;
 
 		try {
 			await sendEmail({
 				email: "hello@cap.so",
-				subject: `New Feedback from ${userEmail}`,
+				subject:
+					kind === "debugReport"
+						? `New Debug Report from ${userEmail}`
+						: `New Feedback from ${userEmail}`,
 				react: Feedback({
 					userEmail,
 					feedback,
 					os,
 					version,
+					reportId,
+					kind,
+					debugReport,
 				}),
 				cc: userEmail,
 				replyTo: userEmail,

--- a/packages/database/emails/feedback.tsx
+++ b/packages/database/emails/feedback.tsx
@@ -17,16 +17,26 @@ export function Feedback({
 	feedback = "",
 	os,
 	version,
+	reportId,
+	kind,
+	debugReport,
 }: {
 	userEmail: string;
 	feedback: string;
 	os?: string;
 	version?: string;
+	reportId?: string;
+	kind?: "feedback" | "debugReport";
+	debugReport?: string;
 }) {
+	const isDebugReport = kind === "debugReport";
+
 	return (
 		<Html>
 			<Head />
-			<Preview>New feedback from {userEmail}</Preview>
+			<Preview>
+				{isDebugReport ? "New debug report" : "New feedback"} from {userEmail}
+			</Preview>
 			<Tailwind>
 				<Body className="mx-auto my-auto bg-gray-1 font-sans">
 					<Container className="mx-auto my-10 max-w-[500px] rounded border border-solid border-gray-200 px-10 py-5">
@@ -40,11 +50,16 @@ export function Feedback({
 							/>
 						</Section>
 						<Heading className="mx-0 my-7 p-0 text-center text-xl font-semibold text-black">
-							New User Feedback
+							{isDebugReport ? "New Debug Report" : "New User Feedback"}
 						</Heading>
 						<Text className="text-sm leading-6 text-black">
 							<strong>From:</strong> {userEmail}
 						</Text>
+						{reportId && (
+							<Text className="text-sm leading-6 text-black">
+								<strong>Report ID:</strong> {reportId}
+							</Text>
+						)}
 						{(os || version) && (
 							<Text className="text-sm leading-6 text-black">
 								<strong>Platform:</strong> {os || "Unknown"}{" "}
@@ -56,6 +71,13 @@ export function Feedback({
 								{feedback}
 							</Text>
 						</Section>
+						{debugReport && (
+							<Section className="my-4 p-4 bg-gray-50 rounded-lg">
+								<Text className="text-xs leading-5 text-gray-700 whitespace-pre-wrap">
+									{debugReport}
+								</Text>
+							</Section>
+						)}
 						<Text className="text-sm leading-6 text-gray-500">
 							Reply to this email to respond directly to the user.
 						</Text>

--- a/packages/web-api-contract-effect/src/index.ts
+++ b/packages/web-api-contract-effect/src/index.ts
@@ -134,6 +134,9 @@ export class ApiContract extends HttpApi.make("cap-web-api")
 							feedback: Schema.String,
 							os: OSType,
 							version: Schema.String,
+							reportId: Schema.optional(Schema.String),
+							kind: Schema.optional(Schema.Literal("feedback", "debugReport")),
+							debugReport: Schema.optional(Schema.String),
 						}),
 					)
 					.addSuccess(Schema.Struct({ success: Schema.Boolean })),

--- a/packages/web-api-contract/src/desktop.ts
+++ b/packages/web-api-contract/src/desktop.ts
@@ -128,6 +128,9 @@ const protectedContract = c.router(
 				feedback: z.string(),
 				os: z.union([z.literal("macos"), z.literal("windows")]),
 				version: z.string(),
+				reportId: z.string().optional(),
+				kind: z.enum(["feedback", "debugReport"]).optional(),
+				debugReport: z.string().optional(),
 			}),
 			responses: {
 				200: z.object({ success: z.boolean() }),


### PR DESCRIPTION
adds an optional debug report path alongside normal feedback: the desktop app can generate a stable report ID, collect structured client context (runtime, route, stores, diagnostics, sanitized settings), upload logs via an authenticated multipart request when submitting a report, and notify the team through the existing Discord webhook and feedback email pipeline.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional debug report path to the existing feedback flow: the desktop app collects structured client context (runtime, stores, diagnostics, sanitized settings), uploads logs via an authenticated multipart request, and notifies the team via Discord and email.

- **Rust layer** (`lib.rs`, `logging.rs`): a new `upload_debug_report` Tauri command refactors the existing log-upload path into `upload_log_file_with_context`, switching to `authed_api_request` and appending report fields only when a debug report is present — logic is correct and clean.
- **Server layer** (`root.ts`): the `/logs` endpoint now accepts and uploads the context and diagnostics as separate Discord file attachments, with individual section truncation and a final 1900-char cap; the expanded Zod schemas use `.passthrough()` to stay forward-compatible.
- **Client layer** (`feedback.tsx`) and **email template**: the two-step submission flow creates a duplicate-Discord-notification risk on retry, and the full JSON context blob is passed to the email component without a size limit, which can silently fail email delivery for large payloads.

<h3>Confidence Score: 3/5</h3>

Two issues in the submission flow need attention before merging: oversized email payloads can silently fail, and retries generate duplicate Discord alerts.

The Rust and server changes are solid, but the client-side action sends the full tab-indented JSON context (potentially 50–100 KB) directly into the email template with no truncation, which can cause silent delivery failures at the email provider. Separately, the two-step submit design means a transient failure on step 2 leaves the Discord side-effect already fired — retries produce duplicate webhook notifications for the same issue.

`apps/desktop/src/routes/(window-chrome)/settings/feedback.tsx` (two-step retry logic) and `packages/database/emails/feedback.tsx` (unbounded `debugReport` field).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/(window-chrome)/settings/feedback.tsx | Adds debug report collection and a two-step submission flow (native log upload + web feedback API); the two-step design creates a duplicate-notification risk on retry, and sends the full JSON context to the email pipeline without truncation. |
| packages/database/emails/feedback.tsx | Extends the Feedback email component to render the full `debugReport` JSON blob inline; no size limit means oversized payloads could silently fail email delivery. |
| apps/desktop/src-tauri/src/logging.rs | Refactors `upload_log_file` into `upload_log_file_with_context`, adding optional debug report fields and switching to `authed_api_request` when a report is present; logic is correct and clean. |
| apps/desktop/src-tauri/src/lib.rs | Adds `upload_debug_report` Tauri command and registers it; straightforward delegation to `logging.rs`. |
| apps/web/app/api/desktop/[...route]/root.ts | Extends the `/logs` endpoint to accept and upload report context/diagnostics as Discord file attachments; expands the diagnostics schema with `.passthrough()` and adds Discord message formatting helpers with appropriate truncation. |
| packages/web-api-contract/src/desktop.ts | Adds optional `reportId`, `kind`, and `debugReport` fields to the `submitFeedback` contract; non-breaking change. |
| packages/web-api-contract-effect/src/index.ts | Mirrors the contract change for the Effect-based API client; clean and consistent. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/routes/(window-chrome)/settings/feedback.tsx`, line 382-420 ([link](https://github.com/capsoftware/cap/blob/69b1cb036afc35cc6ec65bd4e1b1e9f47b88191c/apps/desktop/src/routes/(window-chrome)/settings/feedback.tsx#L382-L420)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Retry causes duplicate Discord notifications**

   `sendDebugReportAction` calls `invoke("upload_debug_report")` first (which triggers the Discord webhook via `/api/desktop/logs`) and then calls `apiClient.desktop.submitFeedback`. If the second call fails (network hiccup, 500, etc.), the user sees the error toast and may click "Send Debug Report" again. Each retry re-fires the Discord webhook with a freshly-generated `reportId` and uploads a new log file to storage, so the support team receives duplicate Discord alerts that look like separate reports for the same issue.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/routes/(window-chrome)/settings/feedback.tsx
   Line: 382-420

   Comment:
   **Retry causes duplicate Discord notifications**

   `sendDebugReportAction` calls `invoke("upload_debug_report")` first (which triggers the Discord webhook via `/api/desktop/logs`) and then calls `apiClient.desktop.submitFeedback`. If the second call fails (network hiccup, 500, etc.), the user sees the error toast and may click "Send Debug Report" again. Each retry re-fires the Discord webhook with a freshly-generated `reportId` and uploads a new log file to storage, so the support team receives duplicate Discord alerts that look like separate reports for the same issue.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/database/emails/feedback.tsx:74-80
**Unbounded JSON blob in email body**

`debugReport` is the full tab-indented `clientContext` JSON, which includes up to 20 recordings, 20 screenshots, all device formats, all stores, and diagnostics. This can easily reach 50–100 KB. Many transactional email providers (e.g. Resend) impose payload size limits, and silently hitting that ceiling would cause the `sendEmail` call to throw, returning a 500 to the client with no useful error message. At minimum the field should be truncated before passing to this component.

### Issue 2 of 3
apps/desktop/src/routes/(window-chrome)/settings/feedback.tsx:382-420
**Retry causes duplicate Discord notifications**

`sendDebugReportAction` calls `invoke("upload_debug_report")` first (which triggers the Discord webhook via `/api/desktop/logs`) and then calls `apiClient.desktop.submitFeedback`. If the second call fails (network hiccup, 500, etc.), the user sees the error toast and may click "Send Debug Report" again. Each retry re-fires the Discord webhook with a freshly-generated `reportId` and uploads a new log file to storage, so the support team receives duplicate Discord alerts that look like separate reports for the same issue.

### Issue 3 of 3
apps/desktop/src/routes/(window-chrome)/settings/feedback.tsx:90-91
`navigator.platform` is deprecated in modern browsers and may return an empty string in some Chromium-based webviews. Consider using `navigator.userAgentData?.platform` as the preferred source with `navigator.platform` as a fallback.

```suggestion
		platform: (navigator as unknown as { userAgentData?: { platform?: string } }).userAgentData?.platform ?? navigator.platform,
		online: navigator.onLine,
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): submit debug reports from..."](https://github.com/capsoftware/cap/commit/69b1cb036afc35cc6ec65bd4e1b1e9f47b88191c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31632410)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->