### PR TITLE
fix: allow /embed/ and /.well-known/ routes on self-hosted instances

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -49,7 +49,9 @@ export async function proxy(request: NextRequest) {
 				path.startsWith("/invite") ||
 				path.startsWith("/self-hosting") ||
 				path.startsWith("/terms") ||
-				path.startsWith("/verify-otp")
+				path.startsWith("/verify-otp") ||
+				path.startsWith("/embed/") ||
+				path.startsWith("/.well-known/")
 			) &&
 			process.env.NODE_ENV !== "development"
 		)


### PR DESCRIPTION
## Summary
Self-hosted instances currently redirect /embed/* and /.well-known/* requests to /login because the proxy whitelist does not include these paths.

## Changes
- Added path.startsWith("/embed/") and path.startsWith("/.well-known/") to the self-hosted whitelist in apps/web/proxy.ts

## Issues Fixed
- Fixes #1768 (embed routes blocked on self-hosted)
- Fixes #1774 (.well-known/workflow routes blocked on self-hosted)

## Notes
- This PR was created with AI assistance (Codex/Hermes) and manually reviewed before submission.
- The existing open PR #1415 attempted to fix the embed issue in the old middleware.ts location; this applies the fix to the current proxy.ts file.

## Test Plan
- [ ] Verify /embed/[videoId] loads without redirect on a self-hosted instance
- [ ] Verify /.well-known/workflow/v1/* loads without redirect on a self-hosted instance

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `/embed/` and `/.well-known/` to the self-hosted proxy whitelist in `apps/web/proxy.ts`, fixing two issues where those routes were incorrectly redirected to `/login` on self-hosted instances.

- **Embed routes**: `/embed/` is now whitelisted so embedded video pages load correctly without an auth redirect on self-hosted deployments.
- **Well-known routes**: `/.well-known/` is now whitelisted, enabling ACME challenges, OpenID Connect discovery, and similar standard discovery paths to function as expected.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is small and targeted, only affecting the self-hosted path whitelist with no impact on the main Cap cloud deployment.

The fix is correct and well-scoped. The only minor inconsistency is that `/embed/` is whitelisted with a trailing slash while all other entries in the same list use no trailing slash, which means a bare `/embed` request would still redirect to `/login`. This is unlikely to matter in practice but is worth aligning with the surrounding pattern.

Only `apps/web/proxy.ts` changed — a quick check on the trailing-slash consistency on line 53 is worthwhile.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/proxy.ts | Adds `/embed/` and `/.well-known/` to the self-hosted proxy whitelist so those routes are no longer redirected to `/login` on self-hosted instances. The logic change is minimal and correct, though `/embed` without the trailing slash remains blocked. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/proxy.ts:53
**Trailing-slash mismatch on `/embed/`**

The check uses `path.startsWith("/embed/")` (with a trailing slash), so a request to `/embed` (no trailing slash) would still be redirected to `/login`. All other "section" entries in this whitelist (e.g. `/dashboard`, `/onboarding`, `/terms`) omit the trailing slash and match both the root path and any sub-paths. To be consistent and safe, consider dropping the trailing slash so it reads `path.startsWith("/embed")`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: allow /embed/ and /.well-known/ rou..."](https://github.com/capsoftware/cap/commit/f62d069a1c18cd406d6283c4e1bd3616629b42fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31707657)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->