### PR TITLE
feat(desktop): add deeplink control actions

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -60,6 +60,12 @@ struct RaycastDeviceCache {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+struct RaycastScreenshotResult {
+    path: PathBuf,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct RaycastCamera {
     name: String,
     camera: DeviceOrModelID,
@@ -185,9 +191,8 @@ impl DeepLinkAction {
             }
             DeepLinkAction::TakeScreenshot { capture_mode } => {
                 let capture_target = capture_target_from_mode(capture_mode)?;
-                crate::recording::take_screenshot(app.clone(), capture_target)
-                    .await
-                    .map(|_| ())
+                let path = crate::recording::take_screenshot(app.clone(), capture_target).await?;
+                write_raycast_screenshot_result(app, path).await
             }
             DeepLinkAction::SetMicrophone { mic_label } => {
                 crate::set_mic_input(app.state(), mic_label).await
@@ -222,39 +227,62 @@ fn capture_target_from_mode(capture_mode: CaptureMode) -> Result<ScreenCaptureTa
 }
 
 async fn refresh_raycast_device_cache(app: &AppHandle) -> Result<(), String> {
-    let displays = cap_recording::screen_capture::list_displays()
-        .into_iter()
-        .map(|(display, _)| display.name)
-        .collect();
-    let windows = cap_recording::screen_capture::list_windows()
-        .into_iter()
-        .map(|(window, _)| window.name)
-        .collect();
-    let microphones = MicrophoneFeed::list().keys().cloned().collect();
-    let cameras = cap_camera::list_cameras()
-        .map(|camera| RaycastCamera {
-            name: camera.display_name().to_string(),
-            camera: DeviceOrModelID::from_info(&camera),
-        })
-        .collect();
-    let cache = RaycastDeviceCache {
-        displays,
-        windows,
-        microphones,
-        cameras,
-    };
-    let cache_path = app
+    let cache = tokio::task::spawn_blocking(|| {
+        let displays = cap_recording::screen_capture::list_displays()
+            .into_iter()
+            .map(|(display, _)| display.name)
+            .collect();
+        let windows = cap_recording::screen_capture::list_windows()
+            .into_iter()
+            .map(|(window, _)| window.name)
+            .collect();
+        let microphones = MicrophoneFeed::list().keys().cloned().collect();
+        let cameras = cap_camera::list_cameras()
+            .map(|camera| RaycastCamera {
+                name: camera.display_name().to_string(),
+                camera: DeviceOrModelID::from_info(&camera),
+            })
+            .collect();
+
+        RaycastDeviceCache {
+            displays,
+            windows,
+            microphones,
+            cameras,
+        }
+    })
+    .await
+    .map_err(|err| err.to_string())?;
+
+    write_raycast_json(app, "raycast-device-cache.json", &cache).await
+}
+
+async fn write_raycast_screenshot_result(app: &AppHandle, path: PathBuf) -> Result<(), String> {
+    write_raycast_json(
+        app,
+        "raycast-last-screenshot.json",
+        &RaycastScreenshotResult { path },
+    )
+    .await
+}
+
+async fn write_raycast_json<T: Serialize>(
+    app: &AppHandle,
+    file_name: &str,
+    value: &T,
+) -> Result<(), String> {
+    let path = app
         .path()
         .app_data_dir()
         .map_err(|err| err.to_string())?
-        .join("raycast-device-cache.json");
-    let json = serde_json::to_vec_pretty(&cache).map_err(|err| err.to_string())?;
-    if let Some(parent) = cache_path.parent() {
+        .join(file_name);
+    let json = serde_json::to_vec_pretty(value).map_err(|err| err.to_string())?;
+    if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent)
             .await
             .map_err(|err| err.to_string())?;
     }
-    tokio::fs::write(cache_path, json)
+    tokio::fs::write(path, json)
         .await
         .map_err(|err| err.to_string())
 }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -1,5 +1,6 @@
 use cap_recording::{
-    RecordingMode, feeds::camera::DeviceOrModelID, sources::screen_capture::ScreenCaptureTarget,
+    MicrophoneFeed, RecordingMode, feeds::camera::DeviceOrModelID,
+    sources::screen_capture::ScreenCaptureTarget,
 };
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -8,14 +9,14 @@ use tracing::trace;
 
 use crate::{App, ArcLock, recording::StartRecordingInputs, windows::ShowCapWindow};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum CaptureMode {
     Screen(String),
     Window(String),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum DeepLinkAction {
     StartRecording {
@@ -32,6 +33,36 @@ pub enum DeepLinkAction {
     OpenSettings {
         page: Option<String>,
     },
+    PauseRecording,
+    ResumeRecording,
+    TogglePauseRecording,
+    RestartRecording,
+    TakeScreenshot {
+        capture_mode: CaptureMode,
+    },
+    SetMicrophone {
+        mic_label: Option<String>,
+    },
+    SetCamera {
+        camera: Option<DeviceOrModelID>,
+    },
+    RefreshRaycastDeviceCache,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RaycastDeviceCache {
+    displays: Vec<String>,
+    windows: Vec<String>,
+    microphones: Vec<String>,
+    cameras: Vec<RaycastCamera>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RaycastCamera {
+    name: String,
+    camera: DeviceOrModelID,
 }
 
 pub fn handle(app_handle: &AppHandle, urls: Vec<Url>) {
@@ -70,6 +101,7 @@ pub fn handle(app_handle: &AppHandle, urls: Vec<Url>) {
     });
 }
 
+#[derive(Debug)]
 pub enum ActionParseFromUrlError {
     ParseFailed(String),
     Invalid,
@@ -88,9 +120,10 @@ impl TryFrom<&Url> for DeepLinkAction {
                 .map_err(|_| ActionParseFromUrlError::Invalid);
         }
 
-        match url.domain() {
+        match url.host_str() {
             Some(v) if v != "action" => Err(ActionParseFromUrlError::NotAction),
-            _ => Err(ActionParseFromUrlError::Invalid),
+            Some(_) => Ok(()),
+            None => Err(ActionParseFromUrlError::Invalid),
         }?;
 
         let params = url
@@ -120,18 +153,7 @@ impl DeepLinkAction {
                 crate::set_camera_input(app.clone(), state.clone(), camera, None).await?;
                 crate::set_mic_input(state.clone(), mic_label).await?;
 
-                let capture_target: ScreenCaptureTarget = match capture_mode {
-                    CaptureMode::Screen(name) => cap_recording::screen_capture::list_displays()
-                        .into_iter()
-                        .find(|(s, _)| s.name == name)
-                        .map(|(s, _)| ScreenCaptureTarget::Display { id: s.id })
-                        .ok_or(format!("No screen with name \"{}\"", &name))?,
-                    CaptureMode::Window(name) => cap_recording::screen_capture::list_windows()
-                        .into_iter()
-                        .find(|(w, _)| w.name == name)
-                        .map(|(w, _)| ScreenCaptureTarget::Window { id: w.id })
-                        .ok_or(format!("No window with name \"{}\"", &name))?,
-                };
+                let capture_target = capture_target_from_mode(capture_mode)?;
 
                 let inputs = StartRecordingInputs {
                     mode,
@@ -147,6 +169,33 @@ impl DeepLinkAction {
             DeepLinkAction::StopRecording => {
                 crate::recording::stop_recording(app.clone(), app.state()).await
             }
+            DeepLinkAction::PauseRecording => {
+                crate::recording::pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::ResumeRecording => {
+                crate::recording::resume_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::TogglePauseRecording => {
+                crate::recording::toggle_pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::RestartRecording => {
+                crate::recording::restart_recording(app.clone(), app.state())
+                    .await
+                    .map(|_| ())
+            }
+            DeepLinkAction::TakeScreenshot { capture_mode } => {
+                let capture_target = capture_target_from_mode(capture_mode)?;
+                crate::recording::take_screenshot(app.clone(), capture_target)
+                    .await
+                    .map(|_| ())
+            }
+            DeepLinkAction::SetMicrophone { mic_label } => {
+                crate::set_mic_input(app.state(), mic_label).await
+            }
+            DeepLinkAction::SetCamera { camera } => {
+                crate::set_camera_input(app.clone(), app.state(), camera, None).await
+            }
+            DeepLinkAction::RefreshRaycastDeviceCache => refresh_raycast_device_cache(app).await,
             DeepLinkAction::OpenEditor { project_path } => {
                 crate::open_project_from_path(Path::new(&project_path), app.clone())
             }
@@ -154,5 +203,183 @@ impl DeepLinkAction {
                 crate::show_window(app.clone(), ShowCapWindow::Settings { page }).await
             }
         }
+    }
+}
+
+fn capture_target_from_mode(capture_mode: CaptureMode) -> Result<ScreenCaptureTarget, String> {
+    match capture_mode {
+        CaptureMode::Screen(name) => cap_recording::screen_capture::list_displays()
+            .into_iter()
+            .find(|(screen, _)| screen.name == name)
+            .map(|(screen, _)| ScreenCaptureTarget::Display { id: screen.id })
+            .ok_or(format!("No screen with name \"{}\"", &name)),
+        CaptureMode::Window(name) => cap_recording::screen_capture::list_windows()
+            .into_iter()
+            .find(|(window, _)| window.name == name)
+            .map(|(window, _)| ScreenCaptureTarget::Window { id: window.id })
+            .ok_or(format!("No window with name \"{}\"", &name)),
+    }
+}
+
+async fn refresh_raycast_device_cache(app: &AppHandle) -> Result<(), String> {
+    let displays = cap_recording::screen_capture::list_displays()
+        .into_iter()
+        .map(|(display, _)| display.name)
+        .collect();
+    let windows = cap_recording::screen_capture::list_windows()
+        .into_iter()
+        .map(|(window, _)| window.name)
+        .collect();
+    let microphones = MicrophoneFeed::list().keys().cloned().collect();
+    let cameras = cap_camera::list_cameras()
+        .map(|camera| RaycastCamera {
+            name: camera.display_name().to_string(),
+            camera: DeviceOrModelID::from_info(&camera),
+        })
+        .collect();
+    let cache = RaycastDeviceCache {
+        displays,
+        windows,
+        microphones,
+        cameras,
+    };
+    let cache_path = app
+        .path()
+        .app_data_dir()
+        .map_err(|err| err.to_string())?
+        .join("raycast-device-cache.json");
+    let json = serde_json::to_vec_pretty(&cache).map_err(|err| err.to_string())?;
+    if let Some(parent) = cache_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|err| err.to_string())?;
+    }
+    tokio::fs::write(cache_path, json)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_action(value: serde_json::Value) -> DeepLinkAction {
+        let mut url = Url::parse("cap-desktop://action").unwrap();
+        url.query_pairs_mut()
+            .append_pair("value", &value.to_string());
+
+        DeepLinkAction::try_from(&url).unwrap()
+    }
+
+    #[test]
+    fn parses_action_host_deeplinks() {
+        assert_eq!(
+            parse_action(serde_json::json!("pause_recording")),
+            DeepLinkAction::PauseRecording
+        );
+        assert_eq!(
+            parse_action(serde_json::json!("resume_recording")),
+            DeepLinkAction::ResumeRecording
+        );
+        assert_eq!(
+            parse_action(serde_json::json!("toggle_pause_recording")),
+            DeepLinkAction::TogglePauseRecording
+        );
+        assert_eq!(
+            parse_action(serde_json::json!("restart_recording")),
+            DeepLinkAction::RestartRecording
+        );
+        assert_eq!(
+            parse_action(serde_json::json!("refresh_raycast_device_cache")),
+            DeepLinkAction::RefreshRaycastDeviceCache
+        );
+    }
+
+    #[test]
+    fn parses_nullable_input_selection_payloads() {
+        assert_eq!(
+            parse_action(serde_json::json!({
+                "set_microphone": {
+                    "mic_label": "MacBook Pro Microphone"
+                }
+            })),
+            DeepLinkAction::SetMicrophone {
+                mic_label: Some("MacBook Pro Microphone".to_string())
+            }
+        );
+        assert_eq!(
+            parse_action(serde_json::json!({
+                "set_microphone": {
+                    "mic_label": null
+                }
+            })),
+            DeepLinkAction::SetMicrophone { mic_label: None }
+        );
+        assert_eq!(
+            parse_action(serde_json::json!({
+                "set_camera": {
+                    "camera": {
+                        "DeviceID": "camera-device-id"
+                    }
+                }
+            })),
+            DeepLinkAction::SetCamera {
+                camera: Some(DeviceOrModelID::DeviceID("camera-device-id".to_string()))
+            }
+        );
+        assert_eq!(
+            parse_action(serde_json::json!({
+                "set_camera": {
+                    "camera": null
+                }
+            })),
+            DeepLinkAction::SetCamera { camera: None }
+        );
+    }
+
+    #[test]
+    fn parses_capture_payloads() {
+        assert_eq!(
+            parse_action(serde_json::json!({
+                "take_screenshot": {
+                    "capture_mode": {
+                        "screen": "Built-in Display"
+                    }
+                }
+            })),
+            DeepLinkAction::TakeScreenshot {
+                capture_mode: CaptureMode::Screen("Built-in Display".to_string())
+            }
+        );
+        assert_eq!(
+            parse_action(serde_json::json!({
+                "start_recording": {
+                    "capture_mode": {
+                        "window": "Cap"
+                    },
+                    "camera": null,
+                    "mic_label": null,
+                    "capture_system_audio": false,
+                    "mode": "studio"
+                }
+            })),
+            DeepLinkAction::StartRecording {
+                capture_mode: CaptureMode::Window("Cap".to_string()),
+                camera: None,
+                mic_label: None,
+                capture_system_audio: false,
+                mode: RecordingMode::Studio
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_non_action_hosts_without_blocking_auth_links() {
+        let url = Url::parse("cap-desktop://signin?token=abc").unwrap();
+
+        assert!(matches!(
+            DeepLinkAction::try_from(&url),
+            Err(ActionParseFromUrlError::NotAction)
+        ));
     }
 }


### PR DESCRIPTION
/claim #1540

This is a focused desktop-side quality pass for the Cap deeplink/Raycast surface.

What changed:
- fixes `cap-desktop://action?...` routing so action deeplinks reach the JSON payload parser instead of being rejected as invalid
- adds recording control actions for pause, resume, toggle pause, restart, screenshot, microphone selection, camera selection, and Raycast device-cache refresh
- reuses the existing desktop recording/input functions rather than duplicating state changes
- writes the Raycast device cache asynchronously to the app data directory so an extension can read displays, windows, microphones, and cameras without blocking the handler
- adds parser coverage for action-host links, nullable microphone/camera payloads, screenshot/start-recording payloads, and non-action hosts such as `cap-desktop://signin`

Why this is useful:
- the existing parser path made the documented action host unusable
- nullable mic/camera payloads are important for clearing selected devices from Raycast, not only setting them
- the device-cache action gives Raycast a stable desktop-owned source for selectable targets

Validation:
- `cargo fmt --all -- --check` passes
- `git diff --check` passes
- attempted `cargo test -p cap-desktop deeplink_actions --lib --no-run`, but this Windows environment resolves `link.exe` to `uutils.coreutils` instead of the MSVC linker, so Rust dependency build scripts fail before compiling project code

Demo note:
- I cannot record a real Raycast/macOS desktop demo from this Windows runner. The included parser tests cover the concrete payload surface this PR changes, and the actions delegate into existing Cap desktop commands.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a long-standing routing bug where `cap-desktop://action?...` deeplinks were silently rejected because `url.domain()` returns `None` for custom URL schemes — only `url.host_str()` correctly returns `\"action\"`. It also adds eight new recording-control actions (pause, resume, toggle-pause, restart, screenshot, microphone selection, camera selection, and Raycast device-cache refresh) that delegate directly into existing Cap desktop commands.

- **Routing fix**: `TryFrom<&Url>` now uses `host_str()` instead of `domain()`, making the `action` host correctly routable for all non-special URL schemes.
- **New actions**: Pause/resume/toggle/restart reuse the existing `recording.rs` commands verbatim; `SetMicrophone`/`SetCamera` correctly pass `Option` to support deselection; `TakeScreenshot` extracts the shared `capture_target_from_mode` helper from `StartRecording`.
- **Raycast device cache**: `refresh_raycast_device_cache` enumerates displays, windows, microphones, and cameras and writes a JSON file asynchronously to the app data directory for Raycast to read.

<h3>Confidence Score: 4/5</h3>

The routing fix is correct and well-tested; the new actions delegate cleanly into existing, proven commands with no data-loss or correctness risk.

The url.domain() → url.host_str() fix is verified by the new parser tests. New actions reuse existing code paths without introducing new state. The device-cache refresh runs several synchronous OS APIs directly on a Tokio task thread; on a machine with slow camera or audio subsystems this could momentarily stall the runtime, but it is not a data-loss or correctness issue.

The refresh_raycast_device_cache function in deeplink_actions.rs deserves a second look for the blocking enumeration calls.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/deeplink_actions.rs | Fixes the core url.domain() → url.host_str() routing bug, adds 8 new control actions, extracts capture_target_from_mode helper, and writes the Raycast device cache asynchronously. Blocking OS enumeration calls inside the async refresh function are a minor concern. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src-tauri/src/deeplink_actions.rs:224-240
**Blocking OS APIs on async task thread**

`list_displays()`, `list_windows()`, `MicrophoneFeed::list()`, and `cap_camera::list_cameras()` are all synchronous, potentially slow OS API calls executed directly on a Tokio async task thread. Camera and audio enumeration in particular can stall the entire Tauri runtime while they run. Since this action is designed to be called frequently from Raycast, the risk of stalls is higher than it is for `StartRecording`. Consider wrapping the enumeration block in `tokio::task::spawn_blocking(|| { ... }).await` to keep the runtime free.

### Issue 2 of 2
apps/desktop/src-tauri/src/deeplink_actions.rs:186-191
**`TakeScreenshot` silently drops the output path**

`take_screenshot` returns `Result<PathBuf, String>` and this arm discards the `PathBuf` with `.map(|_| ())`. That's fine for the deeplink contract, but there's no signal back to the Raycast caller whether the capture succeeded or where the file landed. Worth confirming whether Raycast needs the resulting path or whether fire-and-forget is intentional here.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add desktop deeplink control actions"](https://github.com/capsoftware/cap/commit/126e574b14e18e1550cf48533a20ba9f4e5a711f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31759620)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->