### PR TITLE
docs: add Sealos one-click deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ docker compose logs cap-web
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template/PwpGcf)
 [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/cap)
 
-The Sealos template is maintained in the Sealos templates repository at `template/cap/index.yaml`. Before deploying, review the optional `RESEND_API_KEY` and `RESEND_FROM_DOMAIN` inputs, plus the provisioned MySQL and object storage persistence settings. After deployment, open the generated Sealos app URL and complete Cap's first-run or login flow.
 
 For production, configure public URLs and replace the default secrets before exposing the deployment to the internet:
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,13 @@ docker compose logs cap-web
 | --- | --- |
 | Docker Compose | VPS, home servers, and any Docker-capable host |
 | [Railway](https://railway.com/new/template/PwpGcf) | One-click managed hosting |
+| [Sealos](https://sealos.io/products/app-store/cap) | One-click managed hosting with template-managed resources |
 | Coolify | Self-hosted PaaS deployments with `docker-compose.coolify.yml` |
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template/PwpGcf)
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/cap)
+
+The Sealos template is maintained in the Sealos templates repository at `template/cap/index.yaml`. Before deploying, review the optional `RESEND_API_KEY` and `RESEND_FROM_DOMAIN` inputs, plus the provisioned MySQL and object storage persistence settings. After deployment, open the generated Sealos app URL and complete Cap's first-run or login flow.
 
 For production, configure public URLs and replace the default secrets before exposing the deployment to the internet:
 


### PR DESCRIPTION
## Summary

This PR adds an optional one-click deployment path for Sealos.

## Why this is useful

- Lowers friction for self-hosting and evaluation
- Keeps existing manual deployment instructions intact
- Does not change runtime behavior for existing users

## What changed

- Added Sealos to the README deployment options table
- Added a Deploy on Sealos button linked to `https://sealos.io/products/app-store/cap`

## Reviewability

- Docs-only change
- No referral, affiliate, or tracking links
- Deployment definition is maintained in the Sealos templates repository at [template/cap/index.yaml](https://github.com/labring-actions/templates/blob/kb-0.9/template/cap/index.yaml)
- Existing users are unaffected

## Validation

- Checked the Sealos App Store URL format
- Checked README and PR text for common secret and referral patterns
- Ran `git diff --check`