### PR TITLE
test: wire desktop and utils coverage into turbo

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,6 +9,7 @@
 		"localdev": "dotenv -e ../../.env -- vinxi dev --port 3002",
 		"build": "vinxi build",
 		"tauri": "tauri",
+		"test": "vitest run",
 		"test:memory": "node scripts/desktop-memory-soak.js",
 		"test:memory:unit": "vitest run scripts/desktop-memory-soak.test.js"
 	},

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -6,7 +6,8 @@
 	},
 	"scripts": {
 		"typecheck": "tsc -b",
-		"build": "tsdown"
+		"build": "tsdown",
+		"test": "vitest run"
 	},
 	"publishConfig": {
 		"main": "./dist/index.js"
@@ -16,7 +17,8 @@
 		"react-dom": "^19.1.1",
 		"react-router-dom": "^6.18.0",
 		"tsconfig": "workspace:*",
-		"typescript": "^5.8.3"
+		"typescript": "^5.8.3",
+		"vitest": "~2.1.9"
 	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.485.0",

--- a/packages/utils/src/helpers.test.ts
+++ b/packages/utils/src/helpers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	calculateStrokeDashoffset,
+	classNames,
+	getDisplayProgress,
+	getProgressCircleConfig,
+	isEmailAllowedByRestriction,
+	uuidFormat,
+	uuidParse,
+} from "./helpers";
+
+describe("helpers", () => {
+	it("merges class names and resolves conflicting Tailwind utilities", () => {
+		expect(classNames("px-2 text-sm", false, "px-4")).toBe("text-sm px-4");
+	});
+
+	it("round-trips uuid formatting helpers", () => {
+		const formatted = "123e4567-e89b-12d3-a456-426614174000";
+		const compact = "123e4567e89b12d3a456426614174000";
+
+		expect(uuidParse(formatted)).toBe(compact);
+		expect(uuidFormat(compact)).toBe(formatted);
+	});
+
+	it("calculates progress circle geometry", () => {
+		const { circumference } = getProgressCircleConfig();
+
+		expect(calculateStrokeDashoffset(25, circumference)).toBeCloseTo(
+			circumference * 0.75,
+		);
+		expect(calculateStrokeDashoffset(100, circumference)).toBe(0);
+	});
+
+	it("prefers upload progress over processing progress", () => {
+		expect(getDisplayProgress(42, 10)).toBe(42);
+		expect(getDisplayProgress(undefined, 64)).toBe(64);
+	});
+
+	it("allows emails by exact address or domain restrictions", () => {
+		expect(isEmailAllowedByRestriction("owner@cap.so", "")).toBe(true);
+		expect(isEmailAllowedByRestriction("owner@cap.so", "cap.so")).toBe(true);
+		expect(
+			isEmailAllowedByRestriction("owner@cap.so", "admin@example.com"),
+		).toBe(false);
+		expect(
+			isEmailAllowedByRestriction("admin@example.com", " admin@example.com "),
+		).toBe(true);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1323,6 +1323,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ~2.1.9
+        version: 2.1.9(@types/node@22.15.17)(jsdom@26.1.0)(terser@5.44.0)
 
   packages/web-api-contract:
     dependencies:


### PR DESCRIPTION
## Summary
- add a desktop `test` script so existing Vitest coverage participates in the root Turbo `pnpm test` pipeline
- add the first `@cap/utils` Vitest suite covering shared helper behavior for class merging, UUID formatting, progress math, and signup email restrictions
- add the matching utils Vitest dev dependency and lockfile importer entry

/claim #54

AI-assisted with Codex; I reviewed the diff and kept the change scoped to test infrastructure and example tests.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm turbo run test --filter=@cap/desktop --filter=@cap/utils`
- `pnpm exec biome check apps/desktop/package.json packages/utils/package.json packages/utils/src/helpers.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires existing Vitest coverage in `@cap/desktop` into the root Turbo `test` pipeline and adds the first `@cap/utils` test suite covering class merging, UUID round-trips, progress circle geometry, display-progress selection, and email restriction logic.

- `apps/desktop/package.json` gains a generic `\"test\": \"vitest run\"` script; the package already had `vitest` and a config, so the 4 existing `src/utils/*.test.ts` files and the memory-soak unit tests will all participate correctly.
- `packages/utils/package.json` adds `\"test\": \"vitest run\"` and `vitest ~2.1.9` as a devDependency; the new `helpers.test.ts` covers 7 exported functions with assertions that match the implementation, though the `uploadProgress = 0` edge case of `getDisplayProgress` is not exercised.

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are limited to test infrastructure and a new test file with no production code modifications.

All production code is untouched. The new tests are correct against the implementation. The only gaps are a missing edge-case assertion for `getDisplayProgress(0, n)` and the absence of an explicit `vitest.config.ts` in `@cap/utils`, both of which are non-blocking quality observations.

No files require special attention; `packages/utils/src/helpers.test.ts` has a minor coverage gap worth a quick look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/utils/src/helpers.test.ts | New test file covering 7 helpers; all assertions match the implementation, but the `getDisplayProgress(0, n)` edge case is untested and has non-obvious semantics. |
| packages/utils/package.json | Adds `test` script and `vitest ~2.1.9` devDependency; no `vitest.config.ts` is present, so the package runs with defaults. |
| apps/desktop/package.json | Adds generic `test` script wired to `vitest run`; vitest and config already existed, and existing unit tests will be picked up correctly. |
| pnpm-lock.yaml | Adds lockfile importer entry for `vitest ~2.1.9` in `packages/utils`, resolving to the same version already used by desktop — consistent. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/utils/src/helpers.test.ts:35-38
The `getDisplayProgress` test skips the `uploadProgress = 0` case. Because the implementation checks `uploadProgress !== undefined`, passing `0` returns `0` and never falls back to `processingProgress`. This is a non-obvious semantic boundary worth pinning so a future change to `=== undefined` vs. a falsy check doesn't silently regress.

```suggestion
	it("prefers upload progress over processing progress", () => {
		expect(getDisplayProgress(42, 10)).toBe(42);
		expect(getDisplayProgress(undefined, 64)).toBe(64);
		// uploadProgress=0 is defined, so processing progress is NOT used
		expect(getDisplayProgress(0, 64)).toBe(0);
	});
```

### Issue 2 of 2
packages/utils/package.json:10
`@cap/utils` has no `vitest.config.ts`. Vitest will default to Node environment and the standard `**/*.test.*` glob, which works for the current pure-function tests. As the package grows (or if path aliases from `tsconfig` are needed), the absence of an explicit config may cause friction. Consider adding a minimal config now to make the test environment intentional.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: wire desktop and utils coverage in..."](https://github.com/capsoftware/cap/commit/c5546bb6747d62080198c005c4343a0ee19a23fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31830352)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->