### PR TITLE
feat: add recording control deeplinks and Raycast extension

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -26,6 +26,15 @@ pub enum DeepLinkAction {
         mode: RecordingMode,
     },
     StopRecording,
+    PauseRecording,
+    ResumeRecording,
+    TogglePauseRecording,
+    SwitchCamera {
+        camera: DeviceOrModelID,
+    },
+    SwitchMic {
+        mic_label: String,
+    },
     OpenEditor {
         project_path: PathBuf,
     },
@@ -146,6 +155,21 @@ impl DeepLinkAction {
             }
             DeepLinkAction::StopRecording => {
                 crate::recording::stop_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::PauseRecording => {
+                crate::recording::pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::ResumeRecording => {
+                crate::recording::resume_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::TogglePauseRecording => {
+                crate::recording::toggle_pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::SwitchCamera { camera } => {
+                crate::set_camera_input(app.clone(), app.state(), Some(camera), None).await
+            }
+            DeepLinkAction::SwitchMic { mic_label } => {
+                crate::set_mic_input(app.state(), Some(mic_label)).await
             }
             DeepLinkAction::OpenEditor { project_path } => {
                 crate::open_project_from_path(Path::new(&project_path), app.clone())

--- a/packages/raycast/package.json
+++ b/packages/raycast/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "cap-raycast",
+  "title": "Cap",
+  "description": "Control Cap recording from Raycast",
+  "icon": "icon.png",
+  "author": "CapSoftware",
+  "categories": [
+    "Productivity",
+    "Media"
+  ],
+  "license": "MIT",
+  "commands": [
+    {
+      "name": "start-recording",
+      "title": "Start Recording",
+      "description": "Start a new recording in Cap",
+      "mode": "no-view"
+    },
+    {
+      "name": "stop-recording",
+      "title": "Stop Recording",
+      "description": "Stop current recording in Cap",
+      "mode": "no-view"
+    },
+    {
+      "name": "pause-recording",
+      "title": "Pause Recording",
+      "description": "Pause current recording in Cap",
+      "mode": "no-view"
+    },
+    {
+      "name": "resume-recording",
+      "title": "Resume Recording",
+      "description": "Resume current recording in Cap",
+      "mode": "no-view"
+    },
+    {
+      "name": "toggle-pause",
+      "title": "Toggle Pause",
+      "description": "Toggle pause/resume for current recording",
+      "mode": "no-view"
+    },
+    {
+      "name": "switch-camera",
+      "title": "Switch Camera",
+      "description": "Switch to a specific camera",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "camera",
+          "placeholder": "Camera Name/ID",
+          "type": "text",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "switch-mic",
+      "title": "Switch Microphone",
+      "description": "Switch to a specific microphone",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "mic",
+          "placeholder": "Microphone Label",
+          "type": "text",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "dependencies": {
+    "@raycast/api": "^1.88.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.8.10",
+    "@types/react": "18.2.27",
+    "typescript": "^5.2.2"
+  },
+  "scripts": {
+    "dev": "ray dev",
+    "fix-lint": "ray lint --fix",
+    "lint": "ray lint",
+    "publish": "npx @raycast/api@latest publish"
+  }
+}

--- a/packages/raycast/src/pause-recording.ts
+++ b/packages/raycast/src/pause-recording.ts
@@ -1,0 +1,7 @@
+import { triggerAction } from "./utils";
+import { showHUD } from "@raycast/api";
+
+export default async function Command() {
+  await triggerAction("pause_recording");
+  await showHUD("Pausing Cap Recording");
+}

--- a/packages/raycast/src/resume-recording.ts
+++ b/packages/raycast/src/resume-recording.ts
@@ -1,0 +1,7 @@
+import { triggerAction } from "./utils";
+import { showHUD } from "@raycast/api";
+
+export default async function Command() {
+  await triggerAction("resume_recording");
+  await showHUD("Resuming Cap Recording");
+}

--- a/packages/raycast/src/start-recording.ts
+++ b/packages/raycast/src/start-recording.ts
@@ -1,0 +1,16 @@
+import { triggerAction } from "./utils";
+import { showHUD } from "@raycast/api";
+
+export default async function Command() {
+  // Trigger a standard recording. User can configure devices in the app.
+  await triggerAction({
+    start_recording: {
+      capture_mode: { screen: "Main" },
+      camera: null,
+      mic_label: null,
+      capture_system_audio: true,
+      mode: "instant"
+    }
+  });
+  await showHUD("Starting Cap Recording");
+}

--- a/packages/raycast/src/stop-recording.ts
+++ b/packages/raycast/src/stop-recording.ts
@@ -1,0 +1,7 @@
+import { triggerAction } from "./utils";
+import { showHUD } from "@raycast/api";
+
+export default async function Command() {
+  await triggerAction("stop_recording");
+  await showHUD("Stopping Cap Recording");
+}

--- a/packages/raycast/src/switch-camera.ts
+++ b/packages/raycast/src/switch-camera.ts
@@ -1,0 +1,13 @@
+import { triggerAction } from "./utils";
+import { showHUD } from "@raycast/api";
+
+interface Arguments {
+  camera: string;
+}
+
+export default async function Command(props: { arguments: Arguments }) {
+  const { camera } = props.arguments;
+  // We assume it's a DeviceID for simplicity in this Raycast command
+  await triggerAction({ switch_camera: { camera: { device_id: camera } } });
+  await showHUD(`Switching Camera to ${camera}`);
+}

--- a/packages/raycast/src/switch-mic.ts
+++ b/packages/raycast/src/switch-mic.ts
@@ -1,0 +1,12 @@
+import { triggerAction } from "./utils";
+import { showHUD } from "@raycast/api";
+
+interface Arguments {
+  mic: string;
+}
+
+export default async function Command(props: { arguments: Arguments }) {
+  const { mic } = props.arguments;
+  await triggerAction({ switch_mic: { mic_label: mic } });
+  await showHUD(`Switching Microphone to ${mic}`);
+}

--- a/packages/raycast/src/toggle-pause.ts
+++ b/packages/raycast/src/toggle-pause.ts
@@ -1,0 +1,7 @@
+import { triggerAction } from "./utils";
+import { showHUD } from "@raycast/api";
+
+export default async function Command() {
+  await triggerAction("toggle_pause_recording");
+  await showHUD("Toggling Cap Pause");
+}

--- a/packages/raycast/src/utils.ts
+++ b/packages/raycast/src/utils.ts
@@ -1,0 +1,12 @@
+import { open, showHUD } from "@raycast/api";
+
+export async function triggerAction(action: any) {
+  try {
+    const json = JSON.stringify(action);
+    const url = `cap-desktop://action?value=${encodeURIComponent(json)}`;
+    await open(url);
+  } catch (error) {
+    await showHUD("Failed to trigger Cap action");
+    console.error(error);
+  }
+}


### PR DESCRIPTION
This PR implements the requested deeplink actions (pause, resume, toggle, switch device) and adds a corresponding Raycast extension. Fixes #1540.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up five new deeplink actions (`PauseRecording`, `ResumeRecording`, `TogglePauseRecording`, `SwitchCamera`, `SwitchMic`) in the Rust backend and ships a new Raycast extension that invokes them over the `cap-desktop://action` URL scheme.

- **Backend (`deeplink_actions.rs`)**: New enum variants and `execute()` arms delegate cleanly to the existing recording functions — no issues here.
- **Raycast `utils.ts`**: `triggerAction` catches errors internally without re-throwing, so every caller unconditionally shows a success HUD even when the deeplink failed to open. The failure HUD is immediately overwritten by the success message.
- **`start-recording.ts`**: `capture_mode` is hardcoded to `{ screen: "Main" }`, which silently fails on any machine where the primary display is not named exactly `"Main"` (backend returns an error that is only logged to stderr).

<h3>Confidence Score: 3/5</h3>

The Rust backend additions are solid, but two defects in the Raycast layer mean that failures show a success message to the user and the start-recording command will silently do nothing on most machines.

The error-swallowing in triggerAction causes the success HUD to overwrite the failure HUD on every command — users get no actionable feedback when a deeplink fails. The hardcoded "Main" display name in start-recording.ts will silently break recording on any system whose primary display has a different name, with no user-visible error. Both are present defects on the current code path.

packages/raycast/src/utils.ts and packages/raycast/src/start-recording.ts need the most attention before this is published to the Raycast store.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/deeplink_actions.rs | Adds PauseRecording, ResumeRecording, TogglePauseRecording, SwitchCamera, and SwitchMic enum variants with matching execute() branches that delegate to existing recording functions — clean and consistent with the existing pattern. |
| packages/raycast/src/utils.ts | triggerAction swallows errors internally without re-throwing, so all callers unconditionally display a success HUD even when the open() call failed — the failure HUD is immediately overwritten by the success HUD. |
| packages/raycast/src/start-recording.ts | Hardcodes capture_mode to { screen: "Main" }, which fails silently on any system where the primary display isn't named exactly "Main". |
| packages/raycast/src/switch-camera.ts | Always sends camera as device_id, ignoring model_id — the placeholder text says "Camera Name/ID" but model_id is silently unsupported; this is documented in a code comment. |
| packages/raycast/package.json | New Raycast extension manifest; commands, arguments, and dependencies look correct. |
| packages/raycast/src/pause-recording.ts | Correct deeplink key; affected by the utils.ts error-swallowing issue shared by all command files. |
| packages/raycast/src/resume-recording.ts | Correct deeplink key; affected by the utils.ts error-swallowing issue shared by all command files. |
| packages/raycast/src/stop-recording.ts | Correct deeplink key; affected by the utils.ts error-swallowing issue shared by all command files. |
| packages/raycast/src/toggle-pause.ts | Correct deeplink key; affected by the utils.ts error-swallowing issue shared by all command files. |
| packages/raycast/src/switch-mic.ts | Correctly passes mic_label through the deeplink URL. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
packages/raycast/src/utils.ts:3-12
Error is caught and swallowed here without re-throwing, so every caller unconditionally runs its success `showHUD` immediately after. When `open(url)` fails the user sees the failure HUD replaced by the success HUD — the failure is completely masked.

```suggestion
export async function triggerAction(action: any): Promise<boolean> {
  try {
    const json = JSON.stringify(action);
    const url = `cap-desktop://action?value=${encodeURIComponent(json)}`;
    await open(url);
    return true;
  } catch (error) {
    await showHUD("Failed to trigger Cap action");
    console.error(error);
    return false;
  }
}
```

### Issue 2 of 5
packages/raycast/src/pause-recording.ts:4-7
Because `triggerAction` silently swallows errors, `showHUD` here always runs — even when the deeplink failed to open. The same pattern appears in `resume-recording.ts`, `stop-recording.ts`, `toggle-pause.ts`, `switch-camera.ts`, and `switch-mic.ts`. Guard the success HUD on the return value of `triggerAction`.

```suggestion
export default async function Command() {
  const ok = await triggerAction("pause_recording");
  if (ok) await showHUD("Pausing Cap Recording");
}
```

### Issue 3 of 5
packages/raycast/src/start-recording.ts:6-14
The screen name `"Main"` is hardcoded, but the backend matches it with an exact string comparison against `list_displays()`. On systems where the primary display is named anything other than `"Main"` the action silently fails with no user-visible feedback — the deeplink error is only logged to stderr in the desktop app.

### Issue 4 of 5
packages/raycast/src/switch-camera.ts:10-11
**Placeholder misleads users about model ID support.** The `package.json` argument placeholder says `"Camera Name/ID"`, implying a human-readable name or model ID is accepted, but this command always wraps the value as `{ device_id: camera }`. Passing a model ID or display name will send it to the backend as a device ID and silently fail to match any camera. Either restrict the placeholder to `"Device ID"` or branch on the input to support both `device_id` and `model_id`.

### Issue 5 of 5
packages/raycast/src/utils.ts:3
**Loose `any` type removes compile-time safety.** Using `any` for `action` means malformed payloads (e.g., `switch_mic` with a typo in the key) pass TypeScript checking and only fail silently at runtime. A typed union matching the backend's `DeepLinkAction` variants would catch these mistakes before shipping.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add recording control deeplinks an..."](https://github.com/capsoftware/cap/commit/0c0ac57a81d9684615069914249d0dedbce9696c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32098245)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->