### PR TITLE
test: add package-level Vitest examples

### DIFF
--- a/packages/sdk-embed/package.json
+++ b/packages/sdk-embed/package.json
@@ -24,6 +24,7 @@
 	],
 	"scripts": {
 		"build": "tsup",
+		"test": "vitest run",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {},
@@ -39,6 +40,7 @@
 		"@types/react": "^19.0.0",
 		"@types/react-dom": "^19.0.0",
 		"tsup": "^8.0.0",
-		"typescript": "^5.7.3"
+		"typescript": "^5.7.3",
+		"vitest": "^3.2.0"
 	}
 }

--- a/packages/sdk-embed/src/vanilla/cap-embed.test.ts
+++ b/packages/sdk-embed/src/vanilla/cap-embed.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { createEmbedUrl } from "./cap-embed";
+
+describe("createEmbedUrl", () => {
+	it("builds a default Cap embed URL", () => {
+		const url = new URL(
+			createEmbedUrl({
+				videoId: "video_123",
+				publicKey: "pk_test_123",
+			}),
+		);
+
+		expect(url.origin).toBe("https://cap.so");
+		expect(url.pathname).toBe("/embed/video_123");
+		expect(url.searchParams.get("sdk")).toBe("1");
+		expect(url.searchParams.get("pk")).toBe("pk_test_123");
+		expect(url.searchParams.has("autoplay")).toBe(false);
+	});
+
+	it("includes optional playback and branding parameters", () => {
+		const url = new URL(
+			createEmbedUrl({
+				apiBase: "https://app.example.com",
+				videoId: "video_456",
+				publicKey: "pk_live_456",
+				autoplay: true,
+				branding: {
+					logoUrl: "https://cdn.example.com/logo.svg",
+					accentColor: "#ff3366",
+				},
+			}),
+		);
+
+		expect(url.origin).toBe("https://app.example.com");
+		expect(url.pathname).toBe("/embed/video_456");
+		expect(url.searchParams.get("autoplay")).toBe("1");
+		expect(url.searchParams.get("logo")).toBe(
+			"https://cdn.example.com/logo.svg",
+		);
+		expect(url.searchParams.get("accent")).toBe("#ff3366");
+	});
+});

--- a/packages/sdk-embed/src/vanilla/cap-embed.test.ts
+++ b/packages/sdk-embed/src/vanilla/cap-embed.test.ts
@@ -33,6 +33,8 @@ describe("createEmbedUrl", () => {
 
 		expect(url.origin).toBe("https://app.example.com");
 		expect(url.pathname).toBe("/embed/video_456");
+		expect(url.searchParams.get("sdk")).toBe("1");
+		expect(url.searchParams.get("pk")).toBe("pk_live_456");
 		expect(url.searchParams.get("autoplay")).toBe("1");
 		expect(url.searchParams.get("logo")).toBe(
 			"https://cdn.example.com/logo.svg",

--- a/packages/sdk-recorder/package.json
+++ b/packages/sdk-recorder/package.json
@@ -20,6 +20,7 @@
 	],
 	"scripts": {
 		"build": "tsup",
+		"test": "vitest run",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {},
@@ -35,6 +36,7 @@
 		"@types/react": "^19.0.0",
 		"@types/react-dom": "^19.0.0",
 		"tsup": "^8.0.0",
-		"typescript": "^5.7.3"
+		"typescript": "^5.7.3",
+		"vitest": "^3.2.0"
 	}
 }

--- a/packages/sdk-recorder/src/core/mime-types.test.ts
+++ b/packages/sdk-recorder/src/core/mime-types.test.ts
@@ -25,6 +25,15 @@ describe("getSupportedMimeType", () => {
 		expect(getSupportedMimeType()).toBe("video/webm;codecs=vp8,opus");
 	});
 
+	it("prefers vp9,opus over vp8,opus when both are supported", () => {
+		setSupportedMimeTypes([
+			"video/webm;codecs=vp9,opus",
+			"video/webm;codecs=vp8,opus",
+		]);
+
+		expect(getSupportedMimeType()).toBe("video/webm;codecs=vp9,opus");
+	});
+
 	it("falls back to an empty string when no preferred types are supported", () => {
 		setSupportedMimeTypes([]);
 

--- a/packages/sdk-recorder/src/core/mime-types.test.ts
+++ b/packages/sdk-recorder/src/core/mime-types.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getSupportedMimeType } from "./mime-types";
+
+const originalMediaRecorder = globalThis.MediaRecorder;
+
+afterEach(() => {
+	if (originalMediaRecorder) {
+		globalThis.MediaRecorder = originalMediaRecorder;
+	} else {
+		delete (globalThis as { MediaRecorder?: typeof MediaRecorder })
+			.MediaRecorder;
+	}
+});
+
+const setSupportedMimeTypes = (mimeTypes: ReadonlyArray<string>) => {
+	globalThis.MediaRecorder = {
+		isTypeSupported: vi.fn((mimeType: string) => mimeTypes.includes(mimeType)),
+	} as unknown as typeof MediaRecorder;
+};
+
+describe("getSupportedMimeType", () => {
+	it("returns the first supported MIME type by preference order", () => {
+		setSupportedMimeTypes(["video/webm;codecs=vp8,opus", "video/webm"]);
+
+		expect(getSupportedMimeType()).toBe("video/webm;codecs=vp8,opus");
+	});
+
+	it("falls back to an empty string when no preferred types are supported", () => {
+		setSupportedMimeTypes([]);
+
+		expect(getSupportedMimeType()).toBe("");
+	});
+});

--- a/packages/web-domain/package.json
+++ b/packages/web-domain/package.json
@@ -9,6 +9,7 @@
 	},
 	"scripts": {
 		"build": "tsdown",
+		"test": "vitest run",
 		"generate-openapi": "node scripts/generate-openapi.ts"
 	},
 	"dependencies": {
@@ -18,6 +19,7 @@
 		"effect": "^3.18.4"
 	},
 	"devDependencies": {
-		"@effect/platform-node": "^0.98.3"
+		"@effect/platform-node": "^0.98.3",
+		"vitest": "^3.2.0"
 	}
 }

--- a/packages/web-domain/src/ImageUpload.test.ts
+++ b/packages/web-domain/src/ImageUpload.test.ts
@@ -1,0 +1,44 @@
+import { Option } from "effect";
+import { describe, expect, it } from "vitest";
+import { extractFileKey } from "./ImageUpload";
+
+const unwrap = <A>(option: Option.Option<A>) =>
+	Option.isSome(option) ? option.value : undefined;
+
+describe("extractFileKey", () => {
+	it("keeps existing image keys unchanged", () => {
+		expect(unwrap(extractFileKey("users/user-1/avatar.png", false))).toBe(
+			"users/user-1/avatar.png",
+		);
+	});
+
+	it("extracts keys from virtual-hosted S3 URLs", () => {
+		expect(
+			unwrap(
+				extractFileKey("https://assets.cap.so/users/user-1/avatar.png", false),
+			),
+		).toBe("users/user-1/avatar.png");
+	});
+
+	it("drops the bucket segment for path-style S3 URLs", () => {
+		expect(
+			unwrap(
+				extractFileKey(
+					"https://s3.us-east-1.amazonaws.com/cap-bucket/users/user-1/avatar.png",
+					true,
+				),
+			),
+		).toBe("users/user-1/avatar.png");
+	});
+
+	it("ignores Google profile image URLs", () => {
+		expect(
+			Option.isNone(
+				extractFileKey(
+					"https://lh3.googleusercontent.com/a/profile-image",
+					false,
+				),
+			),
+		).toBe(true);
+	});
+});

--- a/packages/web-domain/src/Video.test.ts
+++ b/packages/web-domain/src/Video.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+	M3U8Source,
+	Mp4Source,
+	normalizeSegmentEntry,
+	SegmentsSource,
+} from "./Video";
+
+describe("video source file keys", () => {
+	it("builds deterministic keys for MP4 sources", () => {
+		const source = new Mp4Source({ ownerId: "owner-1", videoId: "video-1" });
+
+		expect(source.getFileKey()).toBe("owner-1/video-1/result.mp4");
+	});
+
+	it("builds deterministic keys for HLS playlist sources", () => {
+		const source = new M3U8Source({
+			ownerId: "owner-1",
+			videoId: "video-1",
+			subpath: "combined-source/stream.m3u8",
+		});
+
+		expect(source.getPlaylistFileKey()).toBe(
+			"owner-1/video-1/combined-source/stream.m3u8",
+		);
+	});
+
+	it("builds deterministic keys for segmented desktop recordings", () => {
+		const source = new SegmentsSource({
+			ownerId: "owner-1",
+			videoId: "video-1",
+		});
+
+		expect(source.getManifestKey()).toBe(
+			"owner-1/video-1/segments/manifest.json",
+		);
+		expect(source.getVideoInitKey()).toBe(
+			"owner-1/video-1/segments/video/init.mp4",
+		);
+		expect(source.getAudioInitKey()).toBe(
+			"owner-1/video-1/segments/audio/init.mp4",
+		);
+		expect(source.getVideoSegmentKey(7)).toBe(
+			"owner-1/video-1/segments/video/segment_007.m4s",
+		);
+		expect(source.getAudioSegmentKey(12)).toBe(
+			"owner-1/video-1/segments/audio/segment_012.m4s",
+		);
+	});
+});
+
+describe("normalizeSegmentEntry", () => {
+	it("uses the legacy default duration for numeric manifest entries", () => {
+		expect(normalizeSegmentEntry(4)).toEqual({ index: 4, duration: 3.0 });
+	});
+
+	it("preserves explicit segment durations", () => {
+		expect(normalizeSegmentEntry({ index: 2, duration: 1.5 })).toEqual({
+			index: 2,
+			duration: 1.5,
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1089,6 +1089,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.8.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.17.43)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.44.0)(yaml@2.8.1)
 
   packages/sdk-recorder:
     dependencies:
@@ -1108,6 +1111,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.8.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.17.43)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.44.0)(yaml@2.8.1)
 
   packages/tsconfig: {}
 
@@ -1420,6 +1426,9 @@ importers:
       '@effect/platform-node':
         specifier: ^0.98.3
         version: 0.98.3(@effect/cluster@0.50.4(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/sql@0.44.2(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)(ioredis@5.6.1))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/workflow@0.11.3(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/sql@0.44.2(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)(ioredis@5.6.1))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.17.43)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.44.0)(yaml@2.8.1)
 
 packages:
 


### PR DESCRIPTION
## Summary
- Add `test` scripts for `@cap/web-domain`, `@cap/sdk-embed`, and `@cap/sdk-recorder` so these packages participate in the existing Turbo test pipeline.
- Add small Vitest examples for domain image/video helpers, embed URL construction, and recorder MIME type selection.
- Update the lockfile only for the new package-level Vitest importer entries.

## Verification
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm turbo run test --filter=@cap/web-domain --filter=@cap/sdk-embed --filter=@cap/sdk-recorder`
- `pnpm exec biome check packages/web-domain/package.json packages/web-domain/src/ImageUpload.test.ts packages/web-domain/src/Video.test.ts packages/sdk-embed/package.json packages/sdk-embed/src/vanilla/cap-embed.test.ts packages/sdk-recorder/package.json packages/sdk-recorder/src/core/mime-types.test.ts pnpm-lock.yaml`
- `pnpm --filter @cap/web-domain build`
- `pnpm --filter @cap/sdk-embed typecheck`

/claim #54

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wires three packages (`@cap/web-domain`, `@cap/sdk-embed`, `@cap/sdk-recorder`) into the existing Turbo `test` pipeline by adding `"test": "vitest run"` scripts and `vitest` devDependencies, then supplies a small set of Vitest unit tests for each.

- **`web-domain`** — `ImageUpload.test.ts` covers all four branches of `extractFileKey` (plain key, virtual-hosted URL, path-style S3 URL, Google URL); `Video.test.ts` covers file-key derivation for `Mp4Source`, `M3U8Source`, `SegmentsSource`, and `normalizeSegmentEntry` — all assertions match the implementation.
- **`sdk-embed`** — `cap-embed.test.ts` tests default and custom-base `createEmbedUrl` output; the second test omits assertions for the unconditionally-set `sdk` and `pk` params.
- **`sdk-recorder`** — `mime-types.test.ts` tests fallback to empty string and fallback from `vp9,opus` to `vp8,opus`, but never exercises the case where both are supported, so the priority ordering is not directly verified.

<h3>Confidence Score: 4/5</h3>

Safe to merge — only adds test infrastructure and unit tests with no changes to production code paths.

The production code is untouched; the only risk is that a couple of test cases have gaps (missing `pk`/`sdk` assertions in `cap-embed.test.ts` and missing vp9-priority case in `mime-types.test.ts`) that could let quiet regressions slip through future changes to those modules.

`mime-types.test.ts` and `cap-embed.test.ts` have the coverage gaps noted above; the `web-domain` tests are solid.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/sdk-embed/src/vanilla/cap-embed.test.ts | Tests `createEmbedUrl`; the second test omits assertions for the `sdk` and `pk` params that are also set unconditionally, leaving a silent regression path. |
| packages/sdk-recorder/src/core/mime-types.test.ts | Tests MIME-type selection; missing a case where both `vp9,opus` and `vp8,opus` are supported, so the stated preference ordering is never directly exercised. |
| packages/web-domain/src/ImageUpload.test.ts | Covers key/URL/path-style/Google-URL branches of `extractFileKey`; test inputs and expected outputs match the implementation. |
| packages/web-domain/src/Video.test.ts | Tests file-key derivation for all three source types and `normalizeSegmentEntry`; all expected values match the implementation's padding/path logic. |
| pnpm-lock.yaml | Adds three importer entries for `vitest@3.2.4`, reusing the already-resolved peer-dependency set; no new package versions introduced. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/sdk-recorder/src/core/mime-types.test.ts:22-26
The test title claims it verifies "first supported MIME type by preference order", but the mock only marks `vp8,opus` and `video/webm` as supported — so `vp9,opus` is simply absent. The test never exercises the case where a higher-priority type wins over a lower-priority one that is also available. If someone accidentally swapped the first two entries in `PREFERRED_MIME_TYPES`, this test would still pass. Adding a case where both `vp9,opus` and `vp8,opus` are supported confirms the priority ordering is actually enforced.

```suggestion
	it("returns the first supported MIME type by preference order", () => {
		setSupportedMimeTypes(["video/webm;codecs=vp8,opus", "video/webm"]);

		expect(getSupportedMimeType()).toBe("video/webm;codecs=vp8,opus");
	});

	it("prefers vp9,opus over vp8,opus when both are supported", () => {
		setSupportedMimeTypes([
			"video/webm;codecs=vp9,opus",
			"video/webm;codecs=vp8,opus",
		]);

		expect(getSupportedMimeType()).toBe("video/webm;codecs=vp9,opus");
	});
```

### Issue 2 of 2
packages/sdk-embed/src/vanilla/cap-embed.test.ts:34-36
The second test exercises `publicKey` and `sdk` params but never asserts their values. `pk` and `sdk` could silently regress (e.g., a rename or removal) while this test still passes. Adding the two assertions closes that blind spot without any extra setup.

```suggestion
		expect(url.origin).toBe("https://app.example.com");
		expect(url.pathname).toBe("/embed/video_456");
		expect(url.searchParams.get("sdk")).toBe("1");
		expect(url.searchParams.get("pk")).toBe("pk_live_456");
		expect(url.searchParams.get("autoplay")).toBe("1");
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add package-level vitest examples"](https://github.com/capsoftware/cap/commit/9563773c89f32a93f46b7a94d43f36497d056845) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32215131)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->