### PR TITLE
test: add web-backend vitest coverage

### DIFF
--- a/packages/web-backend/package.json
+++ b/packages/web-backend/package.json
@@ -8,7 +8,8 @@
 		"main": "./dist/index.js"
 	},
 	"scripts": {
-		"build": "tsdown"
+		"build": "tsdown",
+		"test": "vitest run"
 	},
 	"dependencies": {
 		"@cap/env": "workspace:*",
@@ -30,5 +31,8 @@
 		"effect": "^3.18.4",
 		"next": "15.5.9",
 		"server-only": "^0.0.1"
+	},
+	"devDependencies": {
+		"vitest": "~2.1.9"
 	}
 }

--- a/packages/web-backend/src/Storage/GoogleDrive.test.ts
+++ b/packages/web-backend/src/Storage/GoogleDrive.test.ts
@@ -1,0 +1,17 @@
+import { Option } from "effect";
+import { describe, expect, it } from "vitest";
+import { parseVideoIdFromObjectKey } from "./GoogleDrive.ts";
+
+describe("parseVideoIdFromObjectKey", () => {
+	it("extracts the video id from user/video object keys", () => {
+		const result = parseVideoIdFromObjectKey("owner-1/video-1/source.mp4");
+
+		expect(Option.isSome(result)).toBe(true);
+		expect(result.pipe(Option.getOrElse(() => ""))).toBe("video-1");
+	});
+
+	it("returns none when the object key does not include a video segment", () => {
+		expect(Option.isNone(parseVideoIdFromObjectKey("owner-1"))).toBe(true);
+		expect(Option.isNone(parseVideoIdFromObjectKey("owner-1/"))).toBe(true);
+	});
+});

--- a/packages/web-backend/src/Storage/SignedObject.test.ts
+++ b/packages/web-backend/src/Storage/SignedObject.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const REQUIRED_ENV = {
+	DATABASE_URL: "mysql://user:password@localhost:3306/cap",
+	WEB_URL: "http://localhost:3000",
+	NEXTAUTH_SECRET: "test-nextauth-secret",
+	NEXTAUTH_URL: "http://localhost:3000",
+	CAP_AWS_BUCKET: "test-bucket",
+	CAP_AWS_REGION: "us-east-1",
+	NODE_ENV: "test",
+};
+
+function setRequiredEnv() {
+	for (const [key, value] of Object.entries(REQUIRED_ENV)) {
+		process.env[key] = value;
+	}
+}
+
+function clearRequiredEnv() {
+	for (const key of Object.keys(REQUIRED_ENV)) {
+		delete process.env[key];
+	}
+}
+
+async function importSignedObject() {
+	vi.resetModules();
+	setRequiredEnv();
+	return import("./SignedObject.ts");
+}
+
+describe("storage object tokens", () => {
+	beforeEach(() => {
+		setRequiredEnv();
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-05-15T00:00:00.000Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		clearRequiredEnv();
+	});
+
+	it("creates tokens that verify back to their storage payload", async () => {
+		const { createStorageObjectToken, verifyStorageObjectToken } =
+			await importSignedObject();
+
+		const token = createStorageObjectToken(
+			{ videoId: "video-1", key: "owner-1/video-1/source.mp4" },
+			60,
+		);
+
+		expect(verifyStorageObjectToken(token)).toEqual({
+			videoId: "video-1",
+			key: "owner-1/video-1/source.mp4",
+			expiresAt: Date.parse("2026-05-15T00:01:00.000Z"),
+		});
+	});
+
+	it("rejects tokens when the signature is changed", async () => {
+		const { createStorageObjectToken, verifyStorageObjectToken } =
+			await importSignedObject();
+
+		const token = createStorageObjectToken({
+			videoId: "video-1",
+			key: "owner-1/video-1/source.mp4",
+		});
+		const [payload, signature] = token.split(".");
+		const changedSignature = `${signature?.slice(0, -1)}${
+			signature?.endsWith("A") ? "B" : "A"
+		}`;
+
+		expect(
+			verifyStorageObjectToken(`${payload}.${changedSignature}`),
+		).toBeNull();
+	});
+
+	it("rejects tokens after their expiry time", async () => {
+		const { createStorageObjectToken, verifyStorageObjectToken } =
+			await importSignedObject();
+
+		const token = createStorageObjectToken(
+			{ videoId: "video-1", key: "owner-1/video-1/source.mp4" },
+			60,
+		);
+
+		vi.advanceTimersByTime(60_001);
+
+		expect(verifyStorageObjectToken(token)).toBeNull();
+	});
+});

--- a/packages/web-backend/src/Videos/EffectiveVideoRules.test.ts
+++ b/packages/web-backend/src/Videos/EffectiveVideoRules.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+	collectPasswordHashes,
+	resolveEffectiveVideoRules,
+} from "./EffectiveVideoRules.ts";
+
+describe("resolveEffectiveVideoRules", () => {
+	it("defaults every viewer setting to enabled when no restrictions exist", () => {
+		const rules = resolveEffectiveVideoRules({
+			videoSettings: null,
+			organizationSettings: null,
+			spaces: [],
+		});
+
+		expect(rules.settings).toEqual({
+			disableSummary: false,
+			disableCaptions: false,
+			disableChapters: false,
+			disableReactions: false,
+			disableTranscript: false,
+			disableComments: false,
+		});
+		expect(rules.inheritedSettings).toEqual({});
+		expect(rules.hasInheritedPassword).toBe(false);
+	});
+
+	it("records every space that forces the same inherited setting", () => {
+		const rules = resolveEffectiveVideoRules({
+			videoSettings: { disableComments: false },
+			organizationSettings: { disableComments: false },
+			spaces: [
+				{
+					id: "space-1",
+					name: "Legal",
+					settings: { disableComments: true },
+				},
+				{
+					id: "space-2",
+					name: "Customer Success",
+					settings: { disableComments: true },
+				},
+			],
+		});
+
+		expect(rules.settings.disableComments).toBe(true);
+		expect(rules.inheritedSettings.disableComments).toEqual([
+			{ id: "space-1", name: "Legal" },
+			{ id: "space-2", name: "Customer Success" },
+		]);
+	});
+
+	it("treats either explicit password metadata or stored password hashes as inherited passwords", () => {
+		const rules = resolveEffectiveVideoRules({
+			videoSettings: {},
+			organizationSettings: {},
+			spaces: [
+				{ id: "space-1", name: "Recorded Training", hasPassword: true },
+				{ id: "space-2", name: "Sales", password: "space-password-hash" },
+				{ id: "space-3", name: "Open", hasPassword: false, password: "" },
+			],
+		});
+
+		expect(rules.hasInheritedPassword).toBe(true);
+		expect(rules.inheritedPasswordSources).toEqual([
+			{ id: "space-1", name: "Recorded Training" },
+			{ id: "space-2", name: "Sales" },
+		]);
+	});
+});
+
+describe("collectPasswordHashes", () => {
+	it("preserves the video password first and skips empty inherited passwords", () => {
+		expect(
+			collectPasswordHashes({
+				videoPassword: "video-password-hash",
+				spacePasswords: [
+					{ password: "space-password-hash" },
+					{ password: "" },
+					{ password: null },
+					{},
+				],
+			}),
+		).toEqual(["video-password-hash", "space-password-hash"]);
+	});
+});

--- a/packages/web-backend/vitest.config.ts
+++ b/packages/web-backend/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+		include: ["src/**/*.test.ts"],
+		exclude: ["**/node_modules/**", "**/dist/**"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1401,6 +1401,10 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+    devDependencies:
+      vitest:
+        specifier: ~2.1.9
+        version: 2.1.9(@types/node@22.15.17)(jsdom@26.1.0)(terser@5.44.0)
 
   packages/web-domain:
     dependencies:


### PR DESCRIPTION
## Summary
- add a Vitest test script and config for `@cap/web-backend`
- add package-level example tests for effective video rules, Google Drive object-key parsing, and signed storage object tokens
- keep the lockfile change limited to the `packages/web-backend` importer

## Verification
- `corepack pnpm install --filter @cap/web-backend... --frozen-lockfile --ignore-scripts`
- `corepack pnpm --filter @cap/web-backend test`
- `corepack pnpm exec biome check packages/web-backend/package.json packages/web-backend/vitest.config.ts packages/web-backend/src/Videos/EffectiveVideoRules.test.ts packages/web-backend/src/Storage/GoogleDrive.test.ts packages/web-backend/src/Storage/SignedObject.test.ts`
- `corepack pnpm exec tsc -p packages/web-backend/tsconfig.json --noEmit`

This is a focused follow-up for the current architecture and avoids the desktop/utils/sdk scopes already covered by other open testing attempts.

/claim #54

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces Vitest coverage for `@cap/web-backend`, adding a config, a `test` script, and three test files targeting `EffectiveVideoRules`, `parseVideoIdFromObjectKey`, and the `SignedObject` token helpers.

- `EffectiveVideoRules.test.ts` tests pure functions against no external state and is clean end-to-end.
- `GoogleDrive.test.ts` correctly uses a static import because `parseVideoIdFromObjectKey` is env-independent; the assertion logic matches the `Option.filter` implementation precisely.
- `SignedObject.test.ts` applies the `vi.resetModules()` + dynamic-import pattern to isolate `@cap/env`'s cached state across tests, and the fake-timer expiry boundary check is correct (`60_001 ms` past a `60 s` TTL).

<h3>Confidence Score: 4/5</h3>

Safe to merge — the changes are additive test files only, with no modifications to production code paths.

All three test files exercise the correct production logic and would catch real regressions. The only observations are minor style points in SignedObject.test.ts: a redundant setRequiredEnv() in beforeEach and unnecessary optional chaining on a value that is always defined.

packages/web-backend/src/Storage/SignedObject.test.ts has the minor style issues noted; the other test files and config are clean.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/web-backend/vitest.config.ts | New vitest config using node environment, standard include/exclude patterns — looks correct |
| packages/web-backend/package.json | Adds `test` script and `vitest ~2.1.9` devDependency; straightforward and correctly scoped |
| packages/web-backend/src/Videos/EffectiveVideoRules.test.ts | Tests pure functions with no side-effects or env dependencies; coverage of defaults, inherited settings, and password hashing looks thorough |
| packages/web-backend/src/Storage/GoogleDrive.test.ts | Correctly tests the pure `parseVideoIdFromObjectKey` with a static import; assertions are accurate against the implementation |
| packages/web-backend/src/Storage/SignedObject.test.ts | Uses vi.resetModules() + dynamic import pattern to isolate env-sensitive module; setRequiredEnv() in importSignedObject() is redundant with beforeEach but harmless; expiry boundary and tamper tests are correct |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/web-backend/src/Storage/SignedObject.test.ts:32-36
The `setRequiredEnv()` call in `beforeEach` is redundant: `importSignedObject()` always calls `vi.resetModules()` first (which clears `@cap/env`'s cached state) and then calls `setRequiredEnv()` itself before the dynamic import. The `beforeEach` call fires before the module reset happens, so it's the import-time call inside `importSignedObject()` that's meaningful. Having the call in both places obscures which one is load-order critical.

```suggestion
	beforeEach(() => {
		vi.useFakeTimers();
		vi.setSystemTime(new Date("2026-05-15T00:00:00.000Z"));
	});
```

### Issue 2 of 2
packages/web-backend/src/Storage/SignedObject.test.ts:67-70
`signature` is always defined here because `createStorageObjectToken` always returns a string in the form `encodedPayload.signature`, and neither segment contains a `.`. The optional chaining (`?.`) is misleading — if `signature` were ever `undefined`, `signature?.slice(0, -1)` would evaluate to `undefined`, and the template literal would produce `"undefinedA"` or `"undefinedB"`, which coincidentally would still differ from the real signature. Using a non-optional access makes the intent explicit.

```suggestion
		const [payload, signature] = token.split(".");
		if (!payload || !signature) throw new Error("unexpected token format");
		const changedSignature = `${signature.slice(0, -1)}${
			signature.endsWith("A") ? "B" : "A"
		}`;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add web-backend vitest coverage"](https://github.com/capsoftware/cap/commit/e439a98a90944f3eacdb458785b4bb5457645143) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32242032)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->