### PR TITLE
Organization admin roles, space managers, and shareable link branding

### DIFF
--- a/apps/media-server/package.json
+++ b/apps/media-server/package.json
@@ -10,10 +10,16 @@
 		"test:watch": "bun test --watch"
 	},
 	"dependencies": {
+		"@mediabunny/server": "^1.45.2",
 		"hono": "^4.12.12",
+		"mediabunny": "^1.45.2",
+		"node-av": "^5.2.4",
 		"zod": "^3.24.2"
 	},
 	"devDependencies": {
 		"@types/bun": "latest"
-	}
+	},
+	"trustedDependencies": [
+		"node-av"
+	]
 }

--- a/apps/web/__tests__/unit/desktop-organization-branding.test.ts
+++ b/apps/web/__tests__/unit/desktop-organization-branding.test.ts
@@ -85,6 +85,7 @@ describe("desktop organization branding", () => {
 	it("filters tombstoned and inaccessible organization rows", () => {
 		const rows = [
 			row({ id: "owned" }),
+			row({ id: "admin", ownerId: "user-2", role: "admin" }),
 			row({ id: "member", ownerId: "user-2", role: "member" }),
 			row({ id: "owner-member", ownerId: "user-2", role: "owner" }),
 			row({ id: "tombstone", tombstoneAt: new Date() }),
@@ -93,7 +94,7 @@ describe("desktop organization branding", () => {
 
 		expect(
 			filterAccessibleOrganizationRows(rows, "user-1").map((r) => r.id),
-		).toEqual(["owned", "member", "owner-member"]);
+		).toEqual(["owned", "admin", "member", "owner-member"]);
 	});
 
 	it("derives owner role and edit access from ownership", () => {
@@ -135,6 +136,12 @@ describe("desktop organization branding", () => {
 			),
 		).toBe(false);
 		expect(
+			canEditOrganizationBranding(
+				row({ ownerId: "user-2", role: "admin" }),
+				"user-1",
+			),
+		).toBe(true);
+		expect(
 			canEditOrganizationBranding(row({ tombstoneAt: new Date() }), "user-1"),
 		).toBe(false);
 		expect(
@@ -142,7 +149,7 @@ describe("desktop organization branding", () => {
 				row({ ownerId: "user-2", role: "owner" }),
 				"user-1",
 			),
-		).toBe(true);
+		).toBe(false);
 	});
 
 	it("validates and normalizes branding patch payloads", () => {

--- a/apps/web/__tests__/unit/loom-import.test.ts
+++ b/apps/web/__tests__/unit/loom-import.test.ts
@@ -629,7 +629,7 @@ describe("importFromLoom", () => {
 			expect.objectContaining({
 				spaceId: "video-123",
 				userId: "user-123",
-				role: "Admin",
+				role: "admin",
 			}),
 		);
 		expect(valuesMock).toHaveBeenCalledWith(

--- a/apps/web/__tests__/unit/roles-permissions.test.ts
+++ b/apps/web/__tests__/unit/roles-permissions.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import {
+	canChangeOrganizationMemberRole,
+	canChangeSpaceMemberRole,
+	canManageOrganizationBilling,
+	canManageOrganizationMembers,
+	canManageSpace,
+	canRemoveOrganizationMember,
+	canRemoveSpaceMember,
+	canViewOrganizationSettings,
+	getEffectiveOrganizationRole,
+	getEffectiveSpaceRole,
+	normalizeAssignableOrganizationRole,
+	normalizeOrganizationRole,
+	normalizeSpaceRole,
+} from "@/lib/permissions/roles";
+
+describe("organization role permissions", () => {
+	it("normalizes organization roles and rejects non-assignable owner changes", () => {
+		expect(normalizeOrganizationRole("OWNER")).toBe("owner");
+		expect(normalizeOrganizationRole("admin")).toBe("admin");
+		expect(normalizeOrganizationRole("member")).toBe("member");
+		expect(normalizeOrganizationRole("unknown")).toBeNull();
+		expect(normalizeAssignableOrganizationRole("admin")).toBe("admin");
+		expect(normalizeAssignableOrganizationRole("member")).toBe("member");
+		expect(normalizeAssignableOrganizationRole("owner")).toBeNull();
+	});
+
+	it("derives owner from organization ownership even when membership role differs", () => {
+		expect(
+			getEffectiveOrganizationRole({
+				userId: "user-1",
+				ownerId: "user-1",
+				memberRole: "member",
+			}),
+		).toBe("owner");
+		expect(
+			getEffectiveOrganizationRole({
+				userId: "user-2",
+				ownerId: "user-1",
+				memberRole: "admin",
+			}),
+		).toBe("admin");
+		expect(
+			getEffectiveOrganizationRole({
+				userId: "stale-owner-row",
+				ownerId: "real-owner",
+				memberRole: "owner",
+			}),
+		).toBe("member");
+	});
+
+	it("allows only owners and admins to view and manage organization members", () => {
+		expect(canViewOrganizationSettings("owner")).toBe(true);
+		expect(canViewOrganizationSettings("admin")).toBe(true);
+		expect(canViewOrganizationSettings("member")).toBe(false);
+		expect(canManageOrganizationMembers("owner")).toBe(true);
+		expect(canManageOrganizationMembers("admin")).toBe(true);
+		expect(canManageOrganizationMembers("member")).toBe(false);
+		expect(canManageOrganizationBilling("owner")).toBe(true);
+		expect(canManageOrganizationBilling("admin")).toBe(false);
+	});
+
+	it("lets owners and admins assign admin/member roles to non-owner members", () => {
+		for (const actorRole of ["owner", "admin"] as const) {
+			for (const nextRole of ["admin", "member"] as const) {
+				expect(
+					canChangeOrganizationMemberRole({
+						actorRole,
+						actorUserId: "actor",
+						targetUserId: "target",
+						ownerId: "owner",
+						targetRole: "member",
+						nextRole,
+					}),
+				).toBe(true);
+			}
+		}
+	});
+
+	it("protects organization owners and actor self role from role changes", () => {
+		expect(
+			canChangeOrganizationMemberRole({
+				actorRole: "admin",
+				actorUserId: "admin",
+				targetUserId: "owner",
+				ownerId: "owner",
+				targetRole: "owner",
+				nextRole: "member",
+			}),
+		).toBe(false);
+		expect(
+			canChangeOrganizationMemberRole({
+				actorRole: "admin",
+				actorUserId: "admin",
+				targetUserId: "admin",
+				ownerId: "owner",
+				targetRole: "admin",
+				nextRole: "member",
+			}),
+		).toBe(false);
+		expect(
+			canChangeOrganizationMemberRole({
+				actorRole: "member",
+				actorUserId: "member",
+				targetUserId: "target",
+				ownerId: "owner",
+				targetRole: "member",
+				nextRole: "admin",
+			}),
+		).toBe(false);
+	});
+
+	it("lets admins remove non-owner members but never owners or themselves", () => {
+		expect(
+			canRemoveOrganizationMember({
+				actorRole: "admin",
+				actorUserId: "admin",
+				targetUserId: "member",
+				ownerId: "owner",
+				targetRole: "member",
+			}),
+		).toBe(true);
+		expect(
+			canRemoveOrganizationMember({
+				actorRole: "admin",
+				actorUserId: "admin",
+				targetUserId: "owner",
+				ownerId: "owner",
+				targetRole: "owner",
+			}),
+		).toBe(false);
+		expect(
+			canRemoveOrganizationMember({
+				actorRole: "admin",
+				actorUserId: "admin",
+				targetUserId: "admin",
+				ownerId: "owner",
+				targetRole: "admin",
+			}),
+		).toBe(false);
+	});
+});
+
+describe("space role permissions", () => {
+	it("normalizes current and legacy space admin roles", () => {
+		expect(normalizeSpaceRole("admin")).toBe("admin");
+		expect(normalizeSpaceRole("Admin")).toBe("admin");
+		expect(normalizeSpaceRole("member")).toBe("member");
+		expect(normalizeSpaceRole("owner")).toBeNull();
+	});
+
+	it("treats the creator as a space admin", () => {
+		expect(
+			getEffectiveSpaceRole({
+				userId: "creator",
+				createdById: "creator",
+				memberRole: "member",
+			}),
+		).toBe("admin");
+		expect(
+			getEffectiveSpaceRole({
+				userId: "member",
+				createdById: "creator",
+				memberRole: "Admin",
+			}),
+		).toBe("admin");
+	});
+
+	it("allows organization owners, organization admins, and space admins to manage a space", () => {
+		expect(canManageSpace({ organizationRole: "owner", spaceRole: null })).toBe(
+			true,
+		);
+		expect(canManageSpace({ organizationRole: "admin", spaceRole: null })).toBe(
+			true,
+		);
+		expect(
+			canManageSpace({ organizationRole: "member", spaceRole: "admin" }),
+		).toBe(true);
+		expect(
+			canManageSpace({ organizationRole: "member", spaceRole: "member" }),
+		).toBe(false);
+		expect(canManageSpace({ organizationRole: null, spaceRole: null })).toBe(
+			false,
+		);
+	});
+
+	it("protects the space creator from role changes and removal", () => {
+		expect(
+			canChangeSpaceMemberRole({
+				canManage: true,
+				targetUserId: "creator",
+				createdById: "creator",
+				nextRole: "member",
+			}),
+		).toBe(false);
+		expect(
+			canRemoveSpaceMember({
+				canManage: true,
+				targetUserId: "creator",
+				createdById: "creator",
+			}),
+		).toBe(false);
+		expect(
+			canChangeSpaceMemberRole({
+				canManage: true,
+				targetUserId: "member",
+				createdById: "creator",
+				nextRole: "admin",
+			}),
+		).toBe(true);
+		expect(
+			canRemoveSpaceMember({
+				canManage: true,
+				targetUserId: "member",
+				createdById: "creator",
+			}),
+		).toBe(true);
+	});
+});

--- a/apps/web/__tests__/unit/roles-permissions.test.ts
+++ b/apps/web/__tests__/unit/roles-permissions.test.ts
@@ -78,7 +78,7 @@ describe("organization role permissions", () => {
 		}
 	});
 
-	it("protects organization owners and actor self role from role changes", () => {
+	it("protects organization owners, peer admins, and actor self role from role changes", () => {
 		expect(
 			canChangeOrganizationMemberRole({
 				actorRole: "admin",
@@ -89,6 +89,26 @@ describe("organization role permissions", () => {
 				nextRole: "member",
 			}),
 		).toBe(false);
+		expect(
+			canChangeOrganizationMemberRole({
+				actorRole: "admin",
+				actorUserId: "admin-1",
+				targetUserId: "admin-2",
+				ownerId: "owner",
+				targetRole: "admin",
+				nextRole: "member",
+			}),
+		).toBe(false);
+		expect(
+			canChangeOrganizationMemberRole({
+				actorRole: "owner",
+				actorUserId: "owner",
+				targetUserId: "admin",
+				ownerId: "owner",
+				targetRole: "admin",
+				nextRole: "member",
+			}),
+		).toBe(true);
 		expect(
 			canChangeOrganizationMemberRole({
 				actorRole: "admin",
@@ -111,7 +131,7 @@ describe("organization role permissions", () => {
 		).toBe(false);
 	});
 
-	it("lets admins remove non-owner members but never owners or themselves", () => {
+	it("lets admins remove members but never owners, peer admins, or themselves", () => {
 		expect(
 			canRemoveOrganizationMember({
 				actorRole: "admin",
@@ -130,6 +150,24 @@ describe("organization role permissions", () => {
 				targetRole: "owner",
 			}),
 		).toBe(false);
+		expect(
+			canRemoveOrganizationMember({
+				actorRole: "admin",
+				actorUserId: "admin-1",
+				targetUserId: "admin-2",
+				ownerId: "owner",
+				targetRole: "admin",
+			}),
+		).toBe(false);
+		expect(
+			canRemoveOrganizationMember({
+				actorRole: "owner",
+				actorUserId: "owner",
+				targetUserId: "admin",
+				ownerId: "owner",
+				targetRole: "admin",
+			}),
+		).toBe(true);
 		expect(
 			canRemoveOrganizationMember({
 				actorRole: "admin",

--- a/apps/web/actions/loom.ts
+++ b/apps/web/actions/loom.ts
@@ -568,7 +568,7 @@ async function getOrCreateImportSpace({
 			id: SpaceMemberId.make(nanoId()),
 			spaceId,
 			userId: createdById,
-			role: "Admin",
+			role: "admin",
 		});
 	});
 

--- a/apps/web/actions/organization/authorization.ts
+++ b/apps/web/actions/organization/authorization.ts
@@ -2,13 +2,32 @@ import { db } from "@cap/database";
 import { organizationMembers, organizations } from "@cap/database/schema";
 import type { Organisation, User } from "@cap/web-domain";
 import { and, eq, isNull, or } from "drizzle-orm";
+import {
+	canManageOrganizationBilling,
+	canManageOrganizationSettings,
+	canViewOrganizationSettings,
+	getEffectiveOrganizationRole,
+	type OrganizationRole,
+} from "@/lib/permissions/roles";
 
-export async function requireOrganizationAccess(
+export type OrganizationAccess = {
+	id: Organisation.OrganisationId;
+	ownerId: User.UserId;
+	memberId: string | null;
+	role: OrganizationRole;
+};
+
+export async function getOrganizationAccess(
 	userId: User.UserId,
 	organizationId: Organisation.OrganisationId,
-) {
+): Promise<OrganizationAccess | null> {
 	const [organization] = await db()
-		.select({ id: organizations.id })
+		.select({
+			id: organizations.id,
+			ownerId: organizations.ownerId,
+			memberId: organizationMembers.id,
+			memberRole: organizationMembers.role,
+		})
 		.from(organizations)
 		.leftJoin(
 			organizationMembers,
@@ -29,5 +48,67 @@ export async function requireOrganizationAccess(
 		)
 		.limit(1);
 
-	if (!organization) throw new Error("Forbidden");
+	if (!organization) return null;
+
+	const role = getEffectiveOrganizationRole({
+		userId,
+		ownerId: organization.ownerId,
+		memberRole: organization.memberRole,
+	});
+
+	if (!role) return null;
+
+	return {
+		id: organization.id,
+		ownerId: organization.ownerId,
+		memberId: organization.memberId,
+		role,
+	};
+}
+
+export async function requireOrganizationAccess(
+	userId: User.UserId,
+	organizationId: Organisation.OrganisationId,
+) {
+	const access = await getOrganizationAccess(userId, organizationId);
+	if (!access) throw new Error("Forbidden");
+	return access;
+}
+
+export async function requireOrganizationSettingsAccess(
+	userId: User.UserId,
+	organizationId: Organisation.OrganisationId,
+) {
+	const access = await requireOrganizationAccess(userId, organizationId);
+	if (!canViewOrganizationSettings(access.role)) {
+		throw new Error(
+			"Organization settings are only available to admins and owners",
+		);
+	}
+	return access;
+}
+
+export async function requireOrganizationSettingsManager(
+	userId: User.UserId,
+	organizationId: Organisation.OrganisationId,
+) {
+	const access = await requireOrganizationSettingsAccess(
+		userId,
+		organizationId,
+	);
+	if (!canManageOrganizationSettings(access.role)) {
+		throw new Error("Only admins and owners can manage organization settings");
+	}
+	return access;
+}
+
+export async function requireOrganizationOwner(
+	userId: User.UserId,
+	organizationId: Organisation.OrganisationId,
+) {
+	const access = await requireOrganizationAccess(userId, organizationId);
+	if (!canManageOrganizationBilling(access.role)) {
+		throw new Error("Only the owner can manage this organization setting");
+	}
+	return access;
 }

--- a/apps/web/actions/organization/check-domain.ts
+++ b/apps/web/actions/organization/check-domain.ts
@@ -5,6 +5,7 @@ import { getCurrentUser } from "@cap/database/auth/session";
 import { organizations } from "@cap/database/schema";
 import type { Organisation } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
+import { requireOrganizationSettingsManager } from "./authorization";
 import { checkDomainStatus } from "./domain-utils";
 
 export async function checkOrganizationDomain(
@@ -21,9 +22,9 @@ export async function checkOrganizationDomain(
 		.from(organizations)
 		.where(eq(organizations.id, organizationId));
 
-	if (!organization || organization.ownerId !== user.id) {
-		throw new Error("Only the owner can check domain status");
-	}
+	if (!organization) throw new Error("Organization not found");
+
+	await requireOrganizationSettingsManager(user.id, organizationId);
 
 	if (!organization.customDomain) {
 		throw new Error("No custom domain set");

--- a/apps/web/actions/organization/create-space.ts
+++ b/apps/web/actions/organization/create-space.ts
@@ -76,7 +76,6 @@ export async function createSpace(
 			};
 		}
 
-		// Check for duplicate space name in the same organization
 		const existingSpace = await db()
 			.select({ id: spaces.id })
 			.from(spaces)
@@ -95,7 +94,6 @@ export async function createSpace(
 			};
 		}
 
-		// Generate the space ID early so we can use it in the file path
 		const spaceId = Space.SpaceId.make(nanoId());
 		let iconUrl: ImageUpload.ImageUrlOrKey | null = null;
 		const hashedPassword =
@@ -104,7 +102,6 @@ export async function createSpace(
 				: null;
 
 		await db().transaction(async (tx) => {
-			// Create the space first
 			await tx.insert(spaces).values({
 				id: spaceId,
 				name,
@@ -115,8 +112,6 @@ export async function createSpace(
 				password: hashedPassword,
 			});
 
-			// --- Member Management Logic ---
-			// Collect member user IDs from formData
 			const memberUserIds: string[] = [];
 			for (const entry of formData.getAll("members[]")) {
 				if (typeof entry === "string" && entry.length > 0) {
@@ -124,16 +119,13 @@ export async function createSpace(
 				}
 			}
 
-			// Always add the creator as Admin (if not already in the list)
 			if (!memberUserIds.includes(user.id)) {
 				memberUserIds.push(user.id);
 			}
 
-			// Create space members
 			if (memberUserIds.length > 0) {
 				const spaceMembersToInsert = memberUserIds.map((userId) => {
-					// Creator is always Admin, others are member
-					const role: SpaceMemberRole = userId === user.id ? "Admin" : "member";
+					const role: SpaceMemberRole = userId === user.id ? "admin" : "member";
 					return {
 						id: SpaceMemberId.make(nanoId()),
 						spaceId,

--- a/apps/web/actions/organization/delete-space.ts
+++ b/apps/web/actions/organization/delete-space.ts
@@ -14,6 +14,7 @@ import { eq } from "drizzle-orm";
 import { Effect, Option } from "effect";
 import { revalidatePath } from "next/cache";
 import { runPromise } from "@/lib/server";
+import { requireSpaceManager } from "./space-authorization";
 
 interface DeleteSpaceResponse {
 	success: boolean;
@@ -33,7 +34,6 @@ export async function deleteSpace(
 			};
 		}
 
-		// Check if the space exists and belongs to the user's organization
 		const space = await db()
 			.select()
 			.from(spaces)
@@ -47,28 +47,23 @@ export async function deleteSpace(
 			};
 		}
 
-		// Check if user has permission to delete the space
-		// Only the space creator or organization owner should be able to delete spaces
 		const spaceData = space[0];
-		if (!spaceData || spaceData.createdById !== user.id) {
+		const access = await requireSpaceManager(user.id, spaceId).catch(
+			() => null,
+		);
+		if (!spaceData || !access) {
 			return {
 				success: false,
 				error: "You don't have permission to delete this space",
 			};
 		}
 
-		// Delete in order to maintain referential integrity:
-
-		// 1. First delete all space videos
 		await db().delete(spaceVideos).where(eq(spaceVideos.spaceId, spaceId));
 
-		// 2. Delete all space members
 		await db().delete(spaceMembers).where(eq(spaceMembers.spaceId, spaceId));
 
-		// 3. Delete all space folders
 		await db().delete(folders).where(eq(folders.spaceId, spaceId));
 
-		// 4. Delete space icons from S3
 		try {
 			await Effect.gen(function* () {
 				const [bucket] = yield* S3Buckets.getBucketAccess(Option.none());
@@ -89,11 +84,8 @@ export async function deleteSpace(
 					);
 				}
 			}).pipe(runPromise);
-
-			// List all objects with the space prefix
 		} catch (error) {
 			console.error("Error deleting space icons from S3:", error);
-			// Continue with space deletion even if S3 deletion fails
 		}
 
 		await db().delete(spaces).where(eq(spaces.id, spaceId));

--- a/apps/web/actions/organization/remove-domain.ts
+++ b/apps/web/actions/organization/remove-domain.ts
@@ -6,6 +6,7 @@ import { organizations } from "@cap/database/schema";
 import type { Organisation } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import { requireOrganizationSettingsManager } from "./authorization";
 
 export async function removeOrganizationDomain(
 	organizationId: Organisation.OrganisationId,
@@ -21,9 +22,9 @@ export async function removeOrganizationDomain(
 		.from(organizations)
 		.where(eq(organizations.id, organizationId));
 
-	if (!organization || organization.ownerId !== user.id) {
-		throw new Error("Only the owner can remove the custom domain");
-	}
+	if (!organization) throw new Error("Organization not found");
+
+	await requireOrganizationSettingsManager(user.id, organizationId);
 
 	try {
 		if (organization.customDomain) {

--- a/apps/web/actions/organization/remove-invite.ts
+++ b/apps/web/actions/organization/remove-invite.ts
@@ -6,6 +6,7 @@ import { organizationInvites, organizations } from "@cap/database/schema";
 import type { Organisation } from "@cap/web-domain";
 import { and, eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import { requireOrganizationSettingsManager } from "./authorization";
 
 export async function removeOrganizationInvite(
 	inviteId: string,
@@ -27,9 +28,7 @@ export async function removeOrganizationInvite(
 		throw new Error("Organization not found");
 	}
 
-	if (organization[0]?.ownerId !== user.id) {
-		throw new Error("Only the owner can remove organization invites");
-	}
+	await requireOrganizationSettingsManager(user.id, organizationId);
 
 	const [result] = await db()
 		.delete(organizationInvites)

--- a/apps/web/actions/organization/remove-member.ts
+++ b/apps/web/actions/organization/remove-member.ts
@@ -2,16 +2,20 @@
 
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
-import { organizationMembers, organizations } from "@cap/database/schema";
+import {
+	organizationMembers,
+	spaceMembers,
+	spaces,
+} from "@cap/database/schema";
 import type { Organisation } from "@cap/web-domain";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import {
+	canRemoveOrganizationMember,
+	getEffectiveOrganizationRole,
+} from "@/lib/permissions/roles";
+import { requireOrganizationSettingsManager } from "./authorization";
 
-/**
- * Remove a member from an organization. Only the owner can perform this action.
- * @param memberId The organizationMembers.id to remove
- * @param organizationId The organization to remove from
- */
 export async function removeOrganizationMember(
 	memberId: string,
 	organizationId: Organisation.OrganisationId,
@@ -19,22 +23,17 @@ export async function removeOrganizationMember(
 	const user = await getCurrentUser();
 	if (!user) throw new Error("Unauthorized");
 
-	const organization = await db()
-		.select()
-		.from(organizations)
-		.where(eq(organizations.id, organizationId))
-		.limit(1);
+	const actor = await requireOrganizationSettingsManager(
+		user.id,
+		organizationId,
+	);
 
-	if (!organization || organization.length === 0) {
-		throw new Error("Organization not found");
-	}
-	if (organization[0]?.ownerId !== user.id) {
-		throw new Error("Only the owner can remove organization members");
-	}
-
-	// Prevent owner from removing themselves
-	const member = await db()
-		.select()
+	const [member] = await db()
+		.select({
+			id: organizationMembers.id,
+			userId: organizationMembers.userId,
+			role: organizationMembers.role,
+		})
 		.from(organizationMembers)
 		.where(
 			and(
@@ -43,25 +42,60 @@ export async function removeOrganizationMember(
 			),
 		)
 		.limit(1);
-	if (!member || member.length === 0) {
+
+	if (!member) {
 		throw new Error("Member not found");
 	}
-	if (member[0]?.userId === user.id) {
-		// Defensive: this should never happen due to the above check, but TS wants safety
-		throw new Error("Owner cannot remove themselves");
+
+	const targetRole = getEffectiveOrganizationRole({
+		userId: member.userId,
+		ownerId: actor.ownerId,
+		memberRole: member.role,
+	});
+
+	if (
+		!canRemoveOrganizationMember({
+			actorRole: actor.role,
+			actorUserId: user.id,
+			targetUserId: member.userId,
+			ownerId: actor.ownerId,
+			targetRole,
+		})
+	) {
+		throw new Error("You do not have permission to remove this member");
 	}
 
-	const [result] = await db()
-		.delete(organizationMembers)
-		.where(
-			and(
-				eq(organizationMembers.id, memberId),
-				eq(organizationMembers.organizationId, organizationId),
-			),
-		);
+	await db().transaction(async (tx) => {
+		const organizationSpaces = await tx
+			.select({ id: spaces.id })
+			.from(spaces)
+			.where(eq(spaces.organizationId, organizationId));
+		const spaceIds = organizationSpaces.map((space) => space.id);
 
-	if (result.affectedRows === 0) throw new Error("Member not found");
+		if (spaceIds.length > 0) {
+			await tx
+				.delete(spaceMembers)
+				.where(
+					and(
+						eq(spaceMembers.userId, member.userId),
+						inArray(spaceMembers.spaceId, spaceIds),
+					),
+				);
+		}
+
+		const [result] = await tx
+			.delete(organizationMembers)
+			.where(
+				and(
+					eq(organizationMembers.id, memberId),
+					eq(organizationMembers.organizationId, organizationId),
+				),
+			);
+
+		if (result.affectedRows === 0) throw new Error("Member not found");
+	});
 
 	revalidatePath("/dashboard/settings/organization");
+	revalidatePath("/dashboard");
 	return { success: true };
 }

--- a/apps/web/actions/organization/send-invites.ts
+++ b/apps/web/actions/organization/send-invites.ts
@@ -15,15 +15,31 @@ import { serverEnv } from "@cap/env";
 import type { Organisation } from "@cap/web-domain";
 import { and, eq, inArray } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import {
+	type AssignableOrganizationRole,
+	normalizeAssignableOrganizationRole,
+} from "@/lib/permissions/roles";
+import { requireOrganizationSettingsManager } from "./authorization";
+
+type OrganizationInviteInput = {
+	email: string;
+	role?: string | null;
+};
 
 export async function sendOrganizationInvites(
-	invitedEmails: string[],
+	inviteInputs: string[] | OrganizationInviteInput[],
 	organizationId: Organisation.OrganisationId,
+	roleInput = "member",
 ) {
 	const user = await getCurrentUser();
 
 	if (!user) {
 		throw new Error("Unauthorized");
+	}
+
+	const role = normalizeAssignableOrganizationRole(roleInput);
+	if (!role) {
+		throw new Error("Invalid organization role");
 	}
 
 	const [organization] = await db()
@@ -35,23 +51,39 @@ export async function sendOrganizationInvites(
 		throw new Error("Organization not found");
 	}
 
-	if (organization.ownerId !== user.id) {
-		throw new Error("Only the organization owner can send invites");
-	}
+	await requireOrganizationSettingsManager(user.id, organizationId);
 
 	const MAX_INVITES = 50;
-	if (invitedEmails.length > MAX_INVITES) {
+	if (inviteInputs.length > MAX_INVITES) {
 		throw new Error(`Cannot send more than ${MAX_INVITES} invites at once`);
 	}
 
 	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-	const validEmails = Array.from(
-		new Set(
-			invitedEmails
-				.map((email) => email.trim().toLowerCase())
-				.filter((email) => emailRegex.test(email)),
-		),
-	);
+	const inviteMap = new Map<string, AssignableOrganizationRole>();
+
+	for (const inviteInput of inviteInputs) {
+		const email =
+			typeof inviteInput === "string" ? inviteInput : inviteInput.email;
+		const normalizedEmail = email.trim().toLowerCase();
+		if (!emailRegex.test(normalizedEmail)) continue;
+
+		const inviteRole =
+			typeof inviteInput === "string" || !inviteInput.role
+				? role
+				: normalizeAssignableOrganizationRole(inviteInput.role);
+
+		if (!inviteRole) {
+			throw new Error("Invalid organization role");
+		}
+
+		inviteMap.set(normalizedEmail, inviteRole);
+	}
+
+	const validInvites = Array.from(inviteMap, ([email, inviteRole]) => ({
+		email,
+		role: inviteRole,
+	}));
+	const validEmails = validInvites.map((invite) => invite.email);
 
 	if (validEmails.length === 0) {
 		return { success: true, failedEmails: [] as string[] };
@@ -88,14 +120,16 @@ export async function sendOrganizationInvites(
 			existingMembers.map((m) => m.email.toLowerCase()),
 		);
 
-		const emailsToInvite = validEmails.filter(
-			(email) =>
-				!existingInviteEmails.has(email) && !existingMemberEmails.has(email),
+		const invitesToSend = validInvites.filter(
+			(invite) =>
+				!existingInviteEmails.has(invite.email) &&
+				!existingMemberEmails.has(invite.email),
 		);
 
-		const records = emailsToInvite.map((email) => ({
+		const records = invitesToSend.map((invite) => ({
 			id: nanoId(),
-			email,
+			email: invite.email,
+			role: invite.role,
 		}));
 
 		if (records.length > 0) {
@@ -105,7 +139,7 @@ export async function sendOrganizationInvites(
 					organizationId: organizationId,
 					invitedEmail: r.email,
 					invitedByUserId: user.id,
-					role: "member" as const,
+					role: r.role,
 				})),
 			);
 		}

--- a/apps/web/actions/organization/settings.ts
+++ b/apps/web/actions/organization/settings.ts
@@ -3,17 +3,46 @@
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { organizations } from "@cap/database/schema";
+import { userIsPro } from "@cap/utils";
 import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import { requireOrganizationSettingsManager } from "./authorization";
 
-export async function updateOrganizationSettings(settings: {
+type OrganizationSettingsInput = {
 	disableSummary?: boolean;
 	disableCaptions?: boolean;
 	disableChapters?: boolean;
 	disableReactions?: boolean;
 	disableTranscript?: boolean;
 	disableComments?: boolean;
-}) {
+	hideShareableLinkCapLogo?: boolean;
+	shareableLinkUseOrganizationIcon?: boolean;
+};
+
+const proOrganizationSettingKeys = [
+	"disableSummary",
+	"disableChapters",
+	"disableTranscript",
+	"hideShareableLinkCapLogo",
+	"shareableLinkUseOrganizationIcon",
+] as const satisfies readonly (keyof OrganizationSettingsInput)[];
+
+const preserveProSettings = (
+	submittedSettings: OrganizationSettingsInput,
+	existingSettings: OrganizationSettingsInput | null | undefined,
+) => ({
+	...submittedSettings,
+	...Object.fromEntries(
+		proOrganizationSettingKeys.map((key) => [
+			key,
+			existingSettings?.[key] ?? false,
+		]),
+	),
+});
+
+export async function updateOrganizationSettings(
+	settings: OrganizationSettingsInput,
+) {
 	const user = await getCurrentUser();
 
 	if (!user) {
@@ -22,6 +51,10 @@ export async function updateOrganizationSettings(settings: {
 
 	if (!settings) {
 		throw new Error("Settings are required");
+	}
+
+	if (!user.activeOrganizationId) {
+		throw new Error("Organization not found");
 	}
 
 	const [organization] = await db()
@@ -33,12 +66,20 @@ export async function updateOrganizationSettings(settings: {
 		throw new Error("Organization not found");
 	}
 
+	await requireOrganizationSettingsManager(user.id, user.activeOrganizationId);
+
+	const nextSettings = userIsPro(user)
+		? settings
+		: preserveProSettings(settings, organization.settings);
+
 	await db()
 		.update(organizations)
-		.set({ settings })
+		.set({ settings: nextSettings })
 		.where(eq(organizations.id, user.activeOrganizationId));
 
 	revalidatePath("/dashboard/caps");
+	revalidatePath("/dashboard/settings/organization");
+	revalidatePath("/dashboard/settings/organization/preferences");
 
 	return { success: true };
 }

--- a/apps/web/actions/organization/shareable-link-icon.ts
+++ b/apps/web/actions/organization/shareable-link-icon.ts
@@ -1,0 +1,162 @@
+"use server";
+
+import { db } from "@cap/database";
+import { getCurrentUser } from "@cap/database/auth/session";
+import { organizations } from "@cap/database/schema";
+import { userIsPro } from "@cap/utils";
+import { ImageUploads } from "@cap/web-backend";
+import { Organisation } from "@cap/web-domain";
+import { eq } from "drizzle-orm";
+import { Effect, Option } from "effect";
+import { revalidatePath } from "next/cache";
+import { runPromise } from "@/lib/server";
+import { requireOrganizationSettingsManager } from "./authorization";
+
+const allowedImageTypes = new Set(["image/jpeg", "image/png"]);
+const maxIconSizeBytes = 1024 * 1024;
+
+async function getManageableProOrganization(
+	organizationId: Organisation.OrganisationId,
+) {
+	const user = await getCurrentUser();
+
+	if (!user) {
+		throw new Error("Unauthorized");
+	}
+
+	await requireOrganizationSettingsManager(user.id, organizationId);
+
+	if (!userIsPro(user)) {
+		throw new Error("Upgrade required to customize shareable link branding");
+	}
+
+	const [organization] = await db()
+		.select({
+			id: organizations.id,
+			iconUrl: organizations.iconUrl,
+			settings: organizations.settings,
+			shareableLinkIconUrl: organizations.shareableLinkIconUrl,
+		})
+		.from(organizations)
+		.where(eq(organizations.id, organizationId))
+		.limit(1);
+
+	if (!organization) {
+		throw new Error("Organization not found");
+	}
+
+	return organization;
+}
+
+function validateIcon(file: File) {
+	if (!file || file.size === 0) {
+		throw new Error("No file provided");
+	}
+
+	if (!allowedImageTypes.has(file.type.toLowerCase())) {
+		throw new Error("Please select a PNG or JPEG image");
+	}
+
+	if (file.size > maxIconSizeBytes) {
+		throw new Error("File size must be 1MB or less");
+	}
+}
+
+function revalidateOrganizationBrandingPaths() {
+	revalidatePath("/dashboard/caps");
+	revalidatePath("/dashboard/settings/organization");
+	revalidatePath("/dashboard/settings/organization/preferences");
+}
+
+export async function uploadShareableLinkIcon(formData: FormData) {
+	const organizationId = Organisation.OrganisationId.make(
+		String(formData.get("organizationId")),
+	);
+	const file = formData.get("icon");
+
+	if (!(file instanceof File)) {
+		throw new Error("No file provided");
+	}
+
+	validateIcon(file);
+	const organization = await getManageableProOrganization(organizationId);
+	const arrayBuffer = await file.arrayBuffer();
+
+	await Effect.gen(function* () {
+		const imageUploads = yield* ImageUploads;
+
+		yield* imageUploads.applyUpdate({
+			payload: Option.some({
+				contentType: file.type,
+				fileName: file.name,
+				data: new Uint8Array(arrayBuffer),
+			}),
+			existing: Option.fromNullable(organization.shareableLinkIconUrl),
+			keyPrefix: `organizations/${organization.id}/shareable-links`,
+			update: (db, urlOrKey) =>
+				db
+					.update(organizations)
+					.set({ shareableLinkIconUrl: urlOrKey })
+					.where(eq(organizations.id, organization.id)),
+		});
+	}).pipe(runPromise);
+
+	revalidateOrganizationBrandingPaths();
+
+	return { success: true };
+}
+
+export async function removeShareableLinkIcon(
+	organizationId: Organisation.OrganisationId,
+) {
+	const organization = await getManageableProOrganization(organizationId);
+
+	await Effect.gen(function* () {
+		const imageUploads = yield* ImageUploads;
+
+		yield* imageUploads.applyUpdate({
+			payload: Option.none(),
+			existing: Option.fromNullable(organization.shareableLinkIconUrl),
+			keyPrefix: `organizations/${organization.id}/shareable-links`,
+			update: (db, urlOrKey) =>
+				db
+					.update(organizations)
+					.set({ shareableLinkIconUrl: urlOrKey })
+					.where(eq(organizations.id, organization.id)),
+		});
+	}).pipe(runPromise);
+
+	revalidateOrganizationBrandingPaths();
+
+	return { success: true };
+}
+
+export async function updateShareableLinkIconPreference({
+	organizationId,
+	useOrganizationIcon,
+}: {
+	organizationId: Organisation.OrganisationId;
+	useOrganizationIcon: boolean;
+}) {
+	const organization = await getManageableProOrganization(organizationId);
+
+	if (useOrganizationIcon && !organization.iconUrl) {
+		throw new Error(
+			"Add an organization icon before using it for shareable links",
+		);
+	}
+
+	await db()
+		.update(organizations)
+		.set({
+			settings: {
+				...(organization.settings ?? {}),
+				shareableLinkUseOrganizationIcon: useOrganizationIcon,
+			},
+		})
+		.where(eq(organizations.id, organization.id));
+
+	revalidateOrganizationBrandingPaths();
+
+	return { success: true };
+}

--- a/apps/web/actions/organization/space-authorization.ts
+++ b/apps/web/actions/organization/space-authorization.ts
@@ -1,0 +1,95 @@
+"use server";
+
+import { db } from "@cap/database";
+import {
+	organizationMembers,
+	organizations,
+	spaceMembers,
+	spaces,
+} from "@cap/database/schema";
+import type { Organisation, Space, User } from "@cap/web-domain";
+import { and, eq, isNull } from "drizzle-orm";
+import {
+	canManageSpace,
+	getEffectiveOrganizationRole,
+	getEffectiveSpaceRole,
+	type OrganizationRole,
+	type SpaceRole,
+} from "@/lib/permissions/roles";
+
+export type SpaceAccess = {
+	spaceId: Space.SpaceIdOrOrganisationId;
+	organizationId: Organisation.OrganisationId;
+	organizationOwnerId: User.UserId;
+	createdById: User.UserId;
+	organizationRole: OrganizationRole | null;
+	spaceRole: SpaceRole | null;
+	canManage: boolean;
+};
+
+export async function getSpaceAccess(
+	userId: User.UserId,
+	spaceId: Space.SpaceIdOrOrganisationId,
+): Promise<SpaceAccess | null> {
+	const [space] = await db()
+		.select({
+			id: spaces.id,
+			organizationId: spaces.organizationId,
+			createdById: spaces.createdById,
+			ownerId: organizations.ownerId,
+			organizationMemberRole: organizationMembers.role,
+			spaceMemberRole: spaceMembers.role,
+		})
+		.from(spaces)
+		.innerJoin(organizations, eq(spaces.organizationId, organizations.id))
+		.leftJoin(
+			organizationMembers,
+			and(
+				eq(organizationMembers.organizationId, spaces.organizationId),
+				eq(organizationMembers.userId, userId),
+			),
+		)
+		.leftJoin(
+			spaceMembers,
+			and(eq(spaceMembers.spaceId, spaces.id), eq(spaceMembers.userId, userId)),
+		)
+		.where(and(eq(spaces.id, spaceId), isNull(organizations.tombstoneAt)))
+		.limit(1);
+
+	if (!space) return null;
+
+	const organizationRole = getEffectiveOrganizationRole({
+		userId,
+		ownerId: space.ownerId,
+		memberRole: space.organizationMemberRole,
+	});
+	const spaceRole = getEffectiveSpaceRole({
+		userId,
+		createdById: space.createdById,
+		memberRole: space.spaceMemberRole,
+	});
+
+	return {
+		spaceId: space.id,
+		organizationId: space.organizationId,
+		organizationOwnerId: space.ownerId,
+		createdById: space.createdById,
+		organizationRole,
+		spaceRole,
+		canManage: canManageSpace({ organizationRole, spaceRole }),
+	};
+}
+
+export async function requireSpaceManager(
+	userId: User.UserId,
+	spaceId: Space.SpaceIdOrOrganisationId,
+) {
+	const access = await getSpaceAccess(userId, spaceId);
+	if (!access) throw new Error("Space not found");
+	if (!access.canManage) {
+		throw new Error(
+			"Only space admins, organization admins, and owners can manage this space",
+		);
+	}
+	return access;
+}

--- a/apps/web/actions/organization/storage.ts
+++ b/apps/web/actions/organization/storage.ts
@@ -26,6 +26,7 @@ import { type Organisation, S3Bucket, Storage } from "@cap/web-domain";
 import { and, desc, eq, isNull } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { runPromise } from "@/lib/server";
+import { requireOrganizationSettingsManager } from "./authorization";
 
 const googleDriveProvider = "googleDrive";
 const settingsPath = "/dashboard/settings/organization/integrations";
@@ -85,7 +86,7 @@ export type OrganizationGoogleDriveFolder = {
 const googleDriveFolderMimeType = "application/vnd.google-apps.folder";
 const driveApiBase = "https://www.googleapis.com/drive/v3";
 
-const requireOrganizationOwner = async (
+const requireOrganizationStorageManager = async (
 	organizationId: Organisation.OrganisationId,
 ) => {
 	const user = await getCurrentUser();
@@ -107,17 +108,15 @@ const requireOrganizationOwner = async (
 		.limit(1);
 
 	if (!organization) throw new Error("Organization not found");
-	if (organization.ownerId !== user.id) {
-		throw new Error("Only the owner can manage organization storage");
-	}
+	await requireOrganizationSettingsManager(user.id, organizationId);
 
 	return { user, organization };
 };
 
-const requireOrganizationOwnerPro = async (
+const requireOrganizationStorageManagerPro = async (
 	organizationId: Organisation.OrganisationId,
 ) => {
-	const result = await requireOrganizationOwner(organizationId);
+	const result = await requireOrganizationStorageManager(organizationId);
 	if (!userIsPro(result.user)) throw new Error(proRequiredMessage);
 	return result;
 };
@@ -344,7 +343,8 @@ const createGoogleDriveState = (
 export async function getOrganizationStorageSettings(
 	organizationId: Organisation.OrganisationId,
 ): Promise<OrganizationStorageSettings> {
-	const { organization } = await requireOrganizationOwner(organizationId);
+	const { organization } =
+		await requireOrganizationStorageManager(organizationId);
 	const [bucket, drive, activeDrive] = await Promise.all([
 		getOrganizationBucket(organizationId),
 		getOrganizationDrive(organizationId),
@@ -381,7 +381,9 @@ export async function getOrganizationStorageSettings(
 }
 
 export async function saveOrganizationS3Config(input: S3ConfigInput) {
-	const { user } = await requireOrganizationOwnerPro(input.organizationId);
+	const { user } = await requireOrganizationStorageManagerPro(
+		input.organizationId,
+	);
 	const credentials = await getS3InputCredentials(input);
 	const encryptedConfig = {
 		provider: input.provider,
@@ -413,7 +415,7 @@ export async function saveOrganizationS3Config(input: S3ConfigInput) {
 export async function removeOrganizationS3Config(
 	organizationId: Organisation.OrganisationId,
 ) {
-	await requireOrganizationOwnerPro(organizationId);
+	await requireOrganizationStorageManagerPro(organizationId);
 	await db()
 		.update(s3Buckets)
 		.set({ active: false })
@@ -423,7 +425,7 @@ export async function removeOrganizationS3Config(
 }
 
 export async function testOrganizationS3Config(input: S3ConfigInput) {
-	await requireOrganizationOwnerPro(input.organizationId);
+	await requireOrganizationStorageManagerPro(input.organizationId);
 	const credentials = await getS3InputCredentials(input);
 	const controller = new AbortController();
 	const timeoutId = setTimeout(() => controller.abort(), 5000);
@@ -455,7 +457,7 @@ export async function setOrganizationStorageProvider({
 	organizationId: Organisation.OrganisationId;
 	provider: OrganizationStorageProvider;
 }) {
-	await requireOrganizationOwnerPro(organizationId);
+	await requireOrganizationStorageManagerPro(organizationId);
 
 	if (provider === "s3") {
 		const bucket = await getOrganizationBucket(organizationId);
@@ -495,7 +497,7 @@ export async function setOrganizationStorageProvider({
 export async function connectOrganizationGoogleDrive(
 	organizationId: Organisation.OrganisationId,
 ) {
-	const { user } = await requireOrganizationOwnerPro(organizationId);
+	const { user } = await requireOrganizationStorageManagerPro(organizationId);
 	const state = createGoogleDriveState(user.id, organizationId);
 	return { url: getGoogleDriveAuthUrl({ state }) };
 }
@@ -503,7 +505,7 @@ export async function connectOrganizationGoogleDrive(
 export async function disconnectOrganizationGoogleDrive(
 	organizationId: Organisation.OrganisationId,
 ) {
-	await requireOrganizationOwnerPro(organizationId);
+	await requireOrganizationStorageManagerPro(organizationId);
 	await db()
 		.update(storageIntegrations)
 		.set({
@@ -529,7 +531,7 @@ export async function disconnectOrganizationGoogleDrive(
 export async function getOrganizationGoogleDrivePickerToken(
 	organizationId: Organisation.OrganisationId,
 ) {
-	await requireOrganizationOwnerPro(organizationId);
+	await requireOrganizationStorageManagerPro(organizationId);
 	const drive = await getOrganizationDrive(organizationId);
 	if (!drive || drive.status !== "active") {
 		throw new Error("Google Drive is not connected");
@@ -556,7 +558,7 @@ export async function listOrganizationGoogleDriveFolders({
 	organizationId: Organisation.OrganisationId;
 	parentId?: string;
 }) {
-	await requireOrganizationOwnerPro(organizationId);
+	await requireOrganizationStorageManagerPro(organizationId);
 	const drive = await getOrganizationDrive(organizationId);
 	if (!drive || drive.status !== "active") {
 		throw new Error("Google Drive is not connected");
@@ -618,7 +620,7 @@ export async function setOrganizationGoogleDriveLocation({
 	driveId?: string | null;
 	driveName?: string | null;
 }) {
-	const { user } = await requireOrganizationOwnerPro(organizationId);
+	const { user } = await requireOrganizationStorageManagerPro(organizationId);
 	const drive = await getOrganizationDrive(organizationId);
 	if (!drive || drive.status !== "active") {
 		throw new Error("Google Drive is not connected");

--- a/apps/web/actions/organization/update-details.ts
+++ b/apps/web/actions/organization/update-details.ts
@@ -6,6 +6,7 @@ import { organizations } from "@cap/database/schema";
 import type { Organisation } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import { requireOrganizationSettingsManager } from "./authorization";
 
 export async function updateOrganizationDetails({
 	organizationName,
@@ -31,9 +32,7 @@ export async function updateOrganizationDetails({
 		throw new Error("Organization not found");
 	}
 
-	if (organization[0]?.ownerId !== user.id) {
-		throw new Error("Only the owner can update organization details");
-	}
+	await requireOrganizationSettingsManager(user.id, organizationId);
 
 	if (organizationName) {
 		await db()

--- a/apps/web/actions/organization/update-domain.ts
+++ b/apps/web/actions/organization/update-domain.ts
@@ -7,6 +7,7 @@ import { userIsPro } from "@cap/utils";
 import type { Organisation } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import { requireOrganizationSettingsManager } from "./authorization";
 import { addDomain, checkDomainStatus } from "./domain-utils";
 
 export async function updateDomain(
@@ -28,9 +29,9 @@ export async function updateDomain(
 		.from(organizations)
 		.where(eq(organizations.id, organizationId));
 
-	if (!organization || organization.ownerId !== user.id) {
-		throw new Error("Only the owner can update the custom domain");
-	}
+	if (!organization) throw new Error("Organization not found");
+
+	await requireOrganizationSettingsManager(user.id, organizationId);
 
 	// Check if domain is already being used by another organization
 	const existingDomain = await db()

--- a/apps/web/actions/organization/update-member-role.ts
+++ b/apps/web/actions/organization/update-member-role.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { db } from "@cap/database";
+import { getCurrentUser } from "@cap/database/auth/session";
+import { organizationMembers } from "@cap/database/schema";
+import type { Organisation } from "@cap/web-domain";
+import { and, eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import {
+	canChangeOrganizationMemberRole,
+	getEffectiveOrganizationRole,
+	normalizeAssignableOrganizationRole,
+} from "@/lib/permissions/roles";
+import { requireOrganizationSettingsManager } from "./authorization";
+
+export async function updateOrganizationMemberRole(
+	memberId: string,
+	organizationId: Organisation.OrganisationId,
+	roleInput: string,
+) {
+	const user = await getCurrentUser();
+	if (!user) throw new Error("Unauthorized");
+
+	const nextRole = normalizeAssignableOrganizationRole(roleInput);
+	if (!nextRole) throw new Error("Invalid organization role");
+
+	const actor = await requireOrganizationSettingsManager(
+		user.id,
+		organizationId,
+	);
+
+	const [member] = await db()
+		.select({
+			id: organizationMembers.id,
+			userId: organizationMembers.userId,
+			role: organizationMembers.role,
+		})
+		.from(organizationMembers)
+		.where(
+			and(
+				eq(organizationMembers.id, memberId),
+				eq(organizationMembers.organizationId, organizationId),
+			),
+		)
+		.limit(1);
+
+	if (!member) throw new Error("Member not found");
+
+	const targetRole = getEffectiveOrganizationRole({
+		userId: member.userId,
+		ownerId: actor.ownerId,
+		memberRole: member.role,
+	});
+
+	if (
+		!canChangeOrganizationMemberRole({
+			actorRole: actor.role,
+			actorUserId: user.id,
+			targetUserId: member.userId,
+			ownerId: actor.ownerId,
+			targetRole,
+			nextRole,
+		})
+	) {
+		throw new Error("You do not have permission to update this member role");
+	}
+
+	await db()
+		.update(organizationMembers)
+		.set({ role: nextRole })
+		.where(eq(organizationMembers.id, memberId));
+
+	revalidatePath("/dashboard/settings/organization");
+	revalidatePath("/dashboard");
+
+	return { success: true };
+}

--- a/apps/web/actions/organization/update-space.ts
+++ b/apps/web/actions/organization/update-space.ts
@@ -13,10 +13,12 @@ import {
 	type SpaceMemberRole,
 	type User,
 } from "@cap/web-domain";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { Effect, Option } from "effect";
 import { revalidatePath } from "next/cache";
+import { normalizeSpaceRole } from "@/lib/permissions/roles";
 import { runPromise } from "@/lib/server";
+import { requireSpaceManager } from "./space-authorization";
 import {
 	getSpaceSettingsFromFormData,
 	preserveProSpaceSettings,
@@ -52,14 +54,8 @@ export async function updateSpace(formData: FormData) {
 		return { success: false, error: "Space not found" };
 	}
 
-	const isCreator = space.createdById === user.id;
-	const [membership] = await db()
-		.select({ role: spaceMembers.role })
-		.from(spaceMembers)
-		.where(and(eq(spaceMembers.spaceId, id), eq(spaceMembers.userId, user.id)))
-		.limit(1);
-
-	if (!isCreator && membership?.role !== "Admin") {
+	const access = await requireSpaceManager(user.id, id).catch(() => null);
+	if (!access) {
 		return { success: false, error: "Unauthorized" };
 	}
 
@@ -92,6 +88,16 @@ export async function updateSpace(formData: FormData) {
 	await db().update(spaces).set(spaceUpdate).where(eq(spaces.id, id));
 
 	const memberIds = Array.from(new Set([...members, space.createdById]));
+	const existingMembers = await db()
+		.select({ userId: spaceMembers.userId, role: spaceMembers.role })
+		.from(spaceMembers)
+		.where(eq(spaceMembers.spaceId, id));
+	const existingRoleByUserId = new Map(
+		existingMembers.map((member) => [
+			member.userId,
+			normalizeSpaceRole(member.role) ?? "member",
+		]),
+	);
 
 	await db().delete(spaceMembers).where(eq(spaceMembers.spaceId, id));
 	await db()
@@ -99,7 +105,9 @@ export async function updateSpace(formData: FormData) {
 		.values(
 			memberIds.map((userId) => {
 				const role: SpaceMemberRole =
-					userId === space.createdById ? "Admin" : "member";
+					userId === space.createdById
+						? "admin"
+						: (existingRoleByUserId.get(userId) ?? "member");
 				return {
 					id: SpaceMemberId.make(nanoId()),
 					spaceId: id,

--- a/apps/web/actions/organization/upload-space-icon.ts
+++ b/apps/web/actions/organization/upload-space-icon.ts
@@ -10,6 +10,7 @@ import { Option } from "effect";
 import { revalidatePath } from "next/cache";
 import { sanitizeFile } from "@/lib/sanitizeFile";
 import { runPromise } from "@/lib/server";
+import { requireSpaceManager } from "./space-authorization";
 
 export async function uploadSpaceIcon(
 	formData: FormData,
@@ -21,7 +22,6 @@ export async function uploadSpaceIcon(
 		throw new Error("Unauthorized");
 	}
 
-	// Fetch the space and check permissions
 	const spaceArr = await db()
 		.select()
 		.from(spaces)
@@ -36,9 +36,7 @@ export async function uploadSpaceIcon(
 		throw new Error("Space not found");
 	}
 
-	if (space.organizationId !== user.activeOrganizationId) {
-		throw new Error("You do not have permission to update this space");
-	}
+	await requireSpaceManager(user.id, spaceId);
 
 	const file = formData.get("icon") as File;
 	if (!file) {
@@ -51,7 +49,6 @@ export async function uploadSpaceIcon(
 		throw new Error("File size must be less than 1MB");
 	}
 
-	// Prepare new file key
 	const fileExtension = file.name.split(".").pop();
 	const fileKey = ImageUpload.ImageKey.make(
 		`organizations/${
@@ -64,9 +61,7 @@ export async function uploadSpaceIcon(
 	);
 
 	try {
-		// Remove previous icon if exists
 		if (space.iconUrl) {
-			// Extract the S3 key (it might already be a key or could be a legacy URL)
 			const key = space.iconUrl.startsWith("organizations/")
 				? space.iconUrl
 				: space.iconUrl.match(/organizations\/.+/)?.[0];
@@ -74,7 +69,6 @@ export async function uploadSpaceIcon(
 				try {
 					await bucket.deleteObject(key).pipe(runPromise);
 				} catch (e) {
-					// Log and continue
 					console.warn("Failed to delete old space icon from S3", e);
 				}
 			}

--- a/apps/web/actions/spaces/add-videos.ts
+++ b/apps/web/actions/spaces/add-videos.ts
@@ -7,6 +7,8 @@ import { sharedVideos, spaceVideos, videos } from "@cap/database/schema";
 import type { Space, Video } from "@cap/web-domain";
 import { and, eq, inArray } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import { requireOrganizationSettingsManager } from "@/actions/organization/authorization";
+import { getSpaceAccess } from "@/actions/organization/space-authorization";
 
 export async function addVideosToSpace(
 	spaceId: Space.SpaceIdOrOrganisationId,
@@ -24,6 +26,17 @@ export async function addVideosToSpace(
 		}
 
 		const isAllSpacesEntry = user.activeOrganizationId === spaceId;
+
+		if (isAllSpacesEntry) {
+			await requireOrganizationSettingsManager(user.id, spaceId);
+		} else {
+			const access = await getSpaceAccess(user.id, spaceId);
+			if (!access?.canManage) {
+				throw new Error(
+					"You don't have permission to add videos to this space",
+				);
+			}
+		}
 
 		const userVideos = await db()
 			.select({ id: videos.id })
@@ -64,7 +77,6 @@ export async function addVideosToSpace(
 					);
 			}
 
-			// Insert new videos
 			if (newVideoIds.length > 0) {
 				const sharedVideoEntries = newVideoIds.map((videoId) => ({
 					id: nanoId(),
@@ -75,7 +87,6 @@ export async function addVideosToSpace(
 				await db().insert(sharedVideos).values(sharedVideoEntries);
 			}
 		} else {
-			// Check which videos already exist in spaceVideos
 			const existingSpaceVideos = await db()
 				.select({ videoId: spaceVideos.videoId })
 				.from(spaceVideos)

--- a/apps/web/actions/spaces/remove-videos.ts
+++ b/apps/web/actions/spaces/remove-videos.ts
@@ -6,6 +6,8 @@ import { sharedVideos, spaceVideos, videos } from "@cap/database/schema";
 import type { Space, Video } from "@cap/web-domain";
 import { and, eq, inArray } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import { requireOrganizationSettingsManager } from "@/actions/organization/authorization";
+import { getSpaceAccess } from "@/actions/organization/space-authorization";
 
 export async function removeVideosFromSpace(
 	spaceId: Space.SpaceIdOrOrganisationId,
@@ -22,7 +24,19 @@ export async function removeVideosFromSpace(
 			throw new Error("Missing required data");
 		}
 
-		// Only allow removing videos the user owns
+		const isAllSpacesEntry = user.activeOrganizationId === spaceId;
+
+		if (isAllSpacesEntry) {
+			await requireOrganizationSettingsManager(user.id, spaceId);
+		} else {
+			const access = await getSpaceAccess(user.id, spaceId);
+			if (!access?.canManage) {
+				throw new Error(
+					"You don't have permission to remove videos from this space",
+				);
+			}
+		}
+
 		const userVideos = await db()
 			.select({ id: videos.id })
 			.from(videos)
@@ -33,8 +47,6 @@ export async function removeVideosFromSpace(
 		if (validVideoIds.length === 0) {
 			throw new Error("No valid videos found");
 		}
-
-		const isAllSpacesEntry = user.activeOrganizationId === spaceId;
 
 		if (isAllSpacesEntry) {
 			await db()

--- a/apps/web/app/(org)/dashboard/_components/MobileTab.tsx
+++ b/apps/web/app/(org)/dashboard/_components/MobileTab.tsx
@@ -15,6 +15,10 @@ import {
 	useState,
 } from "react";
 import { SignedImageUrl } from "@/components/SignedImageUrl";
+import {
+	canViewOrganizationSettings,
+	getEffectiveOrganizationRole,
+} from "@/lib/permissions/roles";
 import { useDashboardContext } from "../Contexts";
 import { CapIcon, CogIcon, LayersIcon } from "./AnimatedIcons";
 import { updateActiveOrganization } from "./Navbar/server";
@@ -25,15 +29,23 @@ const Tabs = [
 	{
 		icon: <CogIcon size={22} />,
 		href: "/dashboard/settings/organization",
-		ownerOnly: true,
+		adminOnly: true,
 	},
 ];
 
 const MobileTab = () => {
 	const [open, setOpen] = useState(false);
-	const containerRef = useRef<HTMLDivElement>(null);
+	const containerRef = useRef<HTMLButtonElement>(null);
 	const { activeOrganization: activeOrg, user } = useDashboardContext();
-	const isOwner = activeOrg?.organization.ownerId === user.id;
+	const currentMember = activeOrg?.members.find(
+		(member) => member.userId === user.id,
+	);
+	const currentRole = getEffectiveOrganizationRole({
+		userId: user.id,
+		ownerId: activeOrg?.organization.ownerId,
+		memberRole: currentMember?.role,
+	});
+	const canViewSettings = canViewOrganizationSettings(currentRole);
 	const menuRef = useClickAway((e) => {
 		if (
 			containerRef.current &&
@@ -51,7 +63,7 @@ const MobileTab = () => {
 				<Orgs open={open} setOpen={setOpen} containerRef={containerRef} />
 			</div>
 			<div className="flex gap-6 justify-between items-center h-full text-gray-11">
-				{Tabs.filter((i) => !i.ownerOnly || isOwner).map((tab) => (
+				{Tabs.filter((i) => !i.adminOnly || canViewSettings).map((tab) => (
 					<Link href={tab.href} key={tab.href}>
 						{tab.icon}
 					</Link>
@@ -68,11 +80,12 @@ const Orgs = ({
 }: {
 	setOpen: Dispatch<SetStateAction<boolean>>;
 	open: boolean;
-	containerRef: MutableRefObject<HTMLDivElement | null>;
+	containerRef: MutableRefObject<HTMLButtonElement | null>;
 }) => {
 	const { activeOrganization: activeOrg } = useDashboardContext();
 	return (
-		<div
+		<button
+			type="button"
 			onClick={() => setOpen((p) => !p)}
 			ref={containerRef}
 			className="flex gap-1.5 items-center flex-auto max-w-[224px] p-2 rounded-full border bg-gray-3 border-gray-5"
@@ -92,7 +105,7 @@ const Orgs = ({
 					open && "rotate-180",
 				)}
 			/>
-		</div>
+		</button>
 	);
 };
 
@@ -121,9 +134,10 @@ const OrgsMenu = ({
 				const isSelected =
 					activeOrg?.organization.id === organization.organization.id;
 				return (
-					<div
+					<button
+						type="button"
 						className={clsx(
-							"p-2 rounded-lg transition-colors duration-300 group",
+							"p-2 rounded-lg transition-colors duration-300 group w-full text-left",
 							isSelected
 								? "pointer-events-none"
 								: "text-gray-10 hover:text-gray-12 hover:bg-gray-6",
@@ -154,7 +168,7 @@ const OrgsMenu = ({
 								<Check size={18} className={"ml-auto text-gray-12"} />
 							)}
 						</div>
-					</div>
+					</button>
 				);
 			})}
 		</motion.div>

--- a/apps/web/app/(org)/dashboard/_components/Navbar/Items.tsx
+++ b/apps/web/app/(org)/dashboard/_components/Navbar/Items.tsx
@@ -34,6 +34,10 @@ import { NewOrganization } from "@/components/forms/NewOrganization";
 import { SignedImageUrl } from "@/components/SignedImageUrl";
 import { Tooltip } from "@/components/Tooltip";
 import { UsageButton } from "@/components/UsageButton";
+import {
+	canViewOrganizationSettings,
+	getEffectiveOrganizationRole,
+} from "@/lib/permissions/roles";
 import { useDashboardContext } from "../../Contexts";
 import {
 	CapIcon,
@@ -94,7 +98,7 @@ const AdminNavItems = ({ toggleMobileNav }: Props) => {
 		{
 			name: "Organization Settings",
 			href: `/dashboard/settings/organization`,
-			ownerOnly: true,
+			adminOnly: true,
 			matchChildren: true,
 			icon: <CogIcon />,
 			subNav: [],
@@ -120,6 +124,15 @@ const AdminNavItems = ({ toggleMobileNav }: Props) => {
 	const [createLoading, setCreateLoading] = useState(false);
 	const [organizationName, setOrganizationName] = useState("");
 	const isOwner = activeOrg?.organization.ownerId === user.id;
+	const currentMember = activeOrg?.members.find(
+		(member) => member.userId === user.id,
+	);
+	const currentRole = getEffectiveOrganizationRole({
+		userId: user.id,
+		ownerId: activeOrg?.organization.ownerId,
+		memberRole: currentMember?.role,
+	});
+	const canViewSettings = canViewOrganizationSettings(currentRole);
 	const [_openAIDialog, _setOpenAIDialog] = useState(false);
 	const router = useRouter();
 
@@ -161,6 +174,7 @@ const AdminNavItems = ({ toggleMobileNav }: Props) => {
 								)}
 								role="combobox"
 								aria-expanded={open}
+								tabIndex={0}
 							>
 								<div
 									className={clsx(
@@ -315,6 +329,7 @@ const AdminNavItems = ({ toggleMobileNav }: Props) => {
 				>
 					{manageNavigation
 						.filter((item) => !item.ownerOnly || isOwner)
+						.filter((item) => !item.adminOnly || canViewSettings)
 						.map((item) => (
 							<div
 								key={item.name}
@@ -336,7 +351,6 @@ const AdminNavItems = ({ toggleMobileNav }: Props) => {
 											},
 										}}
 										layoutId="navlinks"
-										id="navlinks"
 										className="absolute h-[36px] w-full rounded-xl pointer-events-none bg-gray-3"
 									/>
 								)}

--- a/apps/web/app/(org)/dashboard/_components/Navbar/MemberAvatars.tsx
+++ b/apps/web/app/(org)/dashboard/_components/Navbar/MemberAvatars.tsx
@@ -3,6 +3,10 @@
 import { Plus } from "lucide-react";
 import { SignedImageUrl } from "@/components/SignedImageUrl";
 import { Tooltip } from "@/components/Tooltip";
+import {
+	canManageOrganizationMembers,
+	getEffectiveOrganizationRole,
+} from "@/lib/permissions/roles";
 import { useDashboardContext } from "../../Contexts";
 
 const MAX_VISIBLE = 4;
@@ -11,7 +15,15 @@ export function MemberAvatars() {
 	const { activeOrganization, sidebarCollapsed, setInviteDialogOpen, user } =
 		useDashboardContext();
 
-	const isOwner = user?.id === activeOrganization?.organization.ownerId;
+	const currentMember = activeOrganization?.members.find(
+		(member) => member.userId === user?.id,
+	);
+	const currentRole = getEffectiveOrganizationRole({
+		userId: user?.id,
+		ownerId: activeOrganization?.organization.ownerId,
+		memberRole: currentMember?.role,
+	});
+	const canInviteMembers = canManageOrganizationMembers(currentRole);
 
 	if (sidebarCollapsed) return null;
 
@@ -19,6 +31,12 @@ export function MemberAvatars() {
 	const visibleMembers = members.slice(0, MAX_VISIBLE);
 	const extraCount = members.length - MAX_VISIBLE;
 	const emptySlots = Math.max(0, MAX_VISIBLE - members.length);
+	const emptySlotKeys = [
+		"empty-slot-1",
+		"empty-slot-2",
+		"empty-slot-3",
+		"empty-slot-4",
+	].slice(0, emptySlots);
 
 	return (
 		<div className="flex items-center mt-2.5 px-2.5">
@@ -48,10 +66,10 @@ export function MemberAvatars() {
 				</div>
 			)}
 
-			{isOwner &&
-				Array.from({ length: emptySlots }).map((_, i) => (
+			{canInviteMembers &&
+				emptySlotKeys.map((slotKey) => (
 					<Tooltip
-						key={`empty-${i}`}
+						key={slotKey}
 						content="Invite to your organization"
 						position="bottom"
 						delayDuration={0}

--- a/apps/web/app/(org)/dashboard/_components/Navbar/SpacesList.tsx
+++ b/apps/web/app/(org)/dashboard/_components/Navbar/SpacesList.tsx
@@ -28,7 +28,7 @@ import { ConfirmationDialog } from "../ConfirmationDialog";
 import SpaceDialog from "./SpaceDialog";
 
 const SpacesList = ({ toggleMobileNav }: { toggleMobileNav?: () => void }) => {
-	const { spacesData, sidebarCollapsed, user } = useDashboardContext();
+	const { spacesData, sidebarCollapsed } = useDashboardContext();
 	const [showSpaceDialog, setShowSpaceDialog] = useState(false);
 	const [showAllSpaces, setShowAllSpaces] = useState(false);
 	const [activeDropTarget, setActiveDropTarget] = useState<string | null>(null);
@@ -107,7 +107,6 @@ const SpacesList = ({ toggleMobileNav }: { toggleMobileNav?: () => void }) => {
 
 			const cap = JSON.parse(capData);
 
-			// Call the share action with just this space ID
 			const result = await shareCap({
 				capId: cap.id,
 				spaceIds: [spaceId],
@@ -206,7 +205,6 @@ const SpacesList = ({ toggleMobileNav }: { toggleMobileNav?: () => void }) => {
 				</Link>
 			</Tooltip>
 
-			{/* Wrapper div with overflow hidden to prevent scrollbar flash */}
 			<div className="overflow-hidden">
 				<div
 					className={clsx(
@@ -222,7 +220,6 @@ const SpacesList = ({ toggleMobileNav }: { toggleMobileNav?: () => void }) => {
 					}}
 				>
 					{displayedSpaces.map((space: Spaces) => {
-						const isOwner = space.createdById === user?.id;
 						return (
 							<Tooltip
 								position="right"
@@ -303,8 +300,7 @@ const SpacesList = ({ toggleMobileNav }: { toggleMobileNav?: () => void }) => {
 														className="ml-1.5 size-2.5 text-amber-600"
 													/>
 												)}
-												{/* Hide delete button for 'All spaces' synthetic entry */}
-												{!space.primary && isOwner && (
+												{!space.primary && space.currentUserCanManage && (
 													<button
 														type="button"
 														onClick={(e) => handleDeleteSpace(e, space)}

--- a/apps/web/app/(org)/dashboard/caps/components/SettingsDialog.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/SettingsDialog.tsx
@@ -28,7 +28,7 @@ interface SettingsDialogProps {
 
 const options: {
 	label: string;
-	value: keyof NonNullable<OrganizationSettings>;
+	value: ViewerSettingKey;
 	description: string;
 	pro?: boolean;
 }[] = [
@@ -77,7 +77,9 @@ export const SettingsDialog = ({
 	const { user, organizationSettings } = useDashboardContext();
 	const [saveLoading, setSaveLoading] = useState(false);
 	const buildSettings = useCallback(
-		(data?: OrganizationSettings): OrganizationSettings => ({
+		(
+			data?: OrganizationSettings,
+		): Partial<Record<ViewerSettingKey, boolean>> => ({
 			disableComments: data?.disableComments,
 			disableSummary: data?.disableSummary,
 			disableCaptions: data?.disableCaptions,
@@ -117,9 +119,9 @@ export const SettingsDialog = ({
 	};
 
 	const toggleSettingHandler = useCallback(
-		(value: string) => {
+		(value: ViewerSettingKey) => {
 			setSettings((prev) => {
-				const key = value as keyof OrganizationSettings;
+				const key = value;
 				const currentValue = prev?.[key];
 				const orgValue = organizationSettings?.[key] ?? false;
 
@@ -143,7 +145,7 @@ export const SettingsDialog = ({
 		[organizationSettings],
 	);
 
-	const getEffectiveValue = (key: keyof OrganizationSettings) => {
+	const getEffectiveValue = (key: ViewerSettingKey) => {
 		const inheritedSources = inheritedSpaceSettings?.[key];
 		if (inheritedSources && inheritedSources.length > 0) return true;
 		const videoValue = settings?.[key];
@@ -153,7 +155,7 @@ export const SettingsDialog = ({
 			: orgValue;
 	};
 
-	const getInheritedLabel = (key: keyof OrganizationSettings) => {
+	const getInheritedLabel = (key: ViewerSettingKey) => {
 		const sources = inheritedSpaceSettings?.[key];
 		if (!sources || sources.length === 0) return null;
 		if (sources.length === 1) return `Required by ${sources[0]?.name}`;
@@ -171,7 +173,7 @@ export const SettingsDialog = ({
 				</DialogHeader>
 				<div className="grid grid-cols-2 gap-3 p-5">
 					{options.map((option) => {
-						const key = option.value as keyof OrganizationSettings;
+						const key = option.value;
 						const effectiveValue = getEffectiveValue(key);
 						const orgValue = organizationSettings?.[key] ?? false;
 						const inheritedLabel = getInheritedLabel(key);
@@ -207,9 +209,7 @@ export const SettingsDialog = ({
 										Boolean(inheritedLabel) ||
 										(option.pro && !user.isPro) ||
 										((key === "disableSummary" || key === "disableChapters") &&
-											getEffectiveValue(
-												"disableTranscript" as keyof OrganizationSettings,
-											))
+											getEffectiveValue("disableTranscript"))
 									}
 									onCheckedChange={() => toggleSettingHandler(option.value)}
 									checked={!effectiveValue}

--- a/apps/web/app/(org)/dashboard/dashboard-data.ts
+++ b/apps/web/app/(org)/dashboard/dashboard-data.ts
@@ -14,11 +14,23 @@ import { Database, ImageUploads } from "@cap/web-backend";
 import type { ImageUpload } from "@cap/web-domain";
 import { and, count, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import { Effect } from "effect";
+import {
+	canManageOrganizationMembers,
+	canManageSpace,
+	getEffectiveOrganizationRole,
+	getEffectiveSpaceRole,
+	type OrganizationRole,
+	type SpaceRole,
+} from "@/lib/permissions/roles";
 import { runPromise } from "@/lib/server";
 
 export type Organization = {
-	organization: Omit<typeof organizations.$inferSelect, "iconUrl"> & {
+	organization: Omit<
+		typeof organizations.$inferSelect,
+		"iconUrl" | "shareableLinkIconUrl"
+	> & {
 		iconUrl: ImageUpload.ImageUrl | null;
+		shareableLinkIconUrl: ImageUpload.ImageUrl | null;
 	};
 	members: (typeof organizationMembers.$inferSelect & {
 		user: Pick<
@@ -43,6 +55,8 @@ export type Spaces = Omit<
 	videoCount: number;
 	iconUrl: ImageUpload.ImageUrl | null;
 	hasPassword: boolean;
+	currentUserRole: OrganizationRole | SpaceRole | null;
+	currentUserCanManage: boolean;
 };
 
 export type UserPreferences = (typeof users.$inferSelect)["preferences"];
@@ -82,7 +96,7 @@ export async function getDashboardData(user: typeof userSelectProps) {
 		let spacesData: Spaces[] = [];
 		let organizationSettings: OrganizationSettings | null = null;
 		let userCapsCount = 0;
-		// Find active organization ID
+		let currentOrganizationRole: OrganizationRole | null = null;
 
 		let activeOrganizationId = organizationIds.find(
 			(orgId) => orgId === user.activeOrganizationId,
@@ -92,9 +106,26 @@ export async function getDashboardData(user: typeof userSelectProps) {
 			activeOrganizationId = organizationIds[0];
 		}
 
-		// Only fetch spaces for the active organization
-
 		if (activeOrganizationId) {
+			const activeOrgInfo = userOrganizations.find(
+				(org) => org.id === activeOrganizationId,
+			);
+			const [activeOrgMembership] = await db()
+				.select({ role: organizationMembers.role })
+				.from(organizationMembers)
+				.where(
+					and(
+						eq(organizationMembers.organizationId, activeOrganizationId),
+						eq(organizationMembers.userId, user.id),
+					),
+				)
+				.limit(1);
+			currentOrganizationRole = getEffectiveOrganizationRole({
+				userId: user.id,
+				ownerId: activeOrgInfo?.ownerId,
+				memberRole: activeOrgMembership?.role,
+			});
+
 			const [notification] = await db()
 				.select({ id: notifications.id })
 				.from(notifications)
@@ -132,6 +163,12 @@ export async function getDashboardData(user: typeof userSelectProps) {
 								createdById: spaces.createdById,
 								iconUrl: spaces.iconUrl,
 								settings: spaces.settings,
+								currentUserSpaceRole: sql<string | null>`(
+          SELECT space_members.role FROM space_members
+          WHERE space_members.spaceId = spaces.id
+          AND space_members.userId = ${user.id}
+          LIMIT 1
+        )`,
 								hasPassword: sql`${spaces.password} IS NOT NULL`.mapWith(
 									Boolean,
 								),
@@ -147,11 +184,8 @@ export async function getDashboardData(user: typeof userSelectProps) {
 								and(
 									eq(spaces.organizationId, activeOrganizationId),
 									or(
-										// User is the space creator
 										eq(spaces.createdById, user.id),
-										// Space is public within the organization
 										eq(spaces.privacy, "Public"),
-										// User is a member of the space
 										sql`EXISTS (
           SELECT 1 FROM space_members 
           WHERE space_members.spaceId = spaces.id 
@@ -165,11 +199,22 @@ export async function getDashboardData(user: typeof userSelectProps) {
 						Effect.map((rows) =>
 							rows.map(
 								Effect.fn(function* (row) {
+									const { currentUserSpaceRole, ...spaceRow } = row;
+									const currentUserRole = getEffectiveSpaceRole({
+										userId: user.id,
+										createdById: row.createdById,
+										memberRole: currentUserSpaceRole,
+									});
 									return {
-										...row,
+										...spaceRow,
 										iconUrl: row.iconUrl
 											? yield* imageUploads.resolveImageUrl(row.iconUrl)
 											: null,
+										currentUserRole,
+										currentUserCanManage: canManageSpace({
+											organizationRole: currentOrganizationRole,
+											spaceRole: currentUserRole,
+										}),
 									};
 								}),
 							),
@@ -178,10 +223,6 @@ export async function getDashboardData(user: typeof userSelectProps) {
 					);
 			}).pipe(runPromise);
 
-			// Add a single 'All spaces' entry for the active organization
-			const activeOrgInfo = userOrganizations.find(
-				(org) => org.id === activeOrganizationId,
-			);
 			if (activeOrgInfo) {
 				const orgMemberCountResult = await db()
 					.select({ value: sql<number>`COUNT(*)` })
@@ -231,6 +272,10 @@ export async function getDashboardData(user: typeof userSelectProps) {
 						videoCount: orgVideoCount,
 						settings: null,
 						hasPassword: false,
+						currentUserRole: currentOrganizationRole,
+						currentUserCanManage: canManageOrganizationMembers(
+							currentOrganizationRole,
+						),
 					} as const;
 				}).pipe(runPromise);
 
@@ -321,6 +366,11 @@ export async function getDashboardData(user: typeof userSelectProps) {
 							...organization,
 							iconUrl: organization.iconUrl
 								? yield* iconImages.resolveImageUrl(organization.iconUrl)
+								: null,
+							shareableLinkIconUrl: organization.shareableLinkIconUrl
+								? yield* iconImages.resolveImageUrl(
+										organization.shareableLinkIconUrl,
+									)
 								: null,
 						},
 						members: yield* Effect.all(

--- a/apps/web/app/(org)/dashboard/settings/organization/billing/page.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/billing/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { buildEnv } from "@cap/env";
-import { useCallback, useRef } from "react";
-import { toast } from "sonner";
+import { Card, CardDescription, CardHeader, CardTitle } from "@cap/ui";
 import { useDashboardContext } from "@/app/(org)/dashboard/Contexts";
+import {
+	canManageOrganizationBilling,
+	getEffectiveOrganizationRole,
+} from "@/lib/permissions/roles";
 import { BillingSummaryCard } from "../components/BillingSummaryCard";
 import { MembersCard } from "../components/MembersCard";
 import { SeatManagementCard } from "../components/SeatManagementCard";
@@ -11,28 +14,35 @@ import { SeatManagementCard } from "../components/SeatManagementCard";
 export default function BillingAndMembersPage() {
 	const { activeOrganization, user, setInviteDialogOpen } =
 		useDashboardContext();
-	const isOwner = user?.id === activeOrganization?.organization.ownerId;
-	const ownerToastShown = useRef(false);
-
-	const showOwnerToast = useCallback(() => {
-		if (!ownerToastShown.current) {
-			toast.error("Only the owner can make changes");
-			ownerToastShown.current = true;
-			setTimeout(() => {
-				ownerToastShown.current = false;
-			}, 3000);
-		}
-	}, []);
+	const currentMember = activeOrganization?.members.find(
+		(member) => member.userId === user.id,
+	);
+	const currentRole = getEffectiveOrganizationRole({
+		userId: user.id,
+		ownerId: activeOrganization?.organization.ownerId,
+		memberRole: currentMember?.role,
+	});
+	const canManageBilling = canManageOrganizationBilling(currentRole);
 
 	return (
 		<div className="flex flex-col gap-6">
-			{buildEnv.NEXT_PUBLIC_IS_CAP && <BillingSummaryCard />}
-			{buildEnv.NEXT_PUBLIC_IS_CAP && <SeatManagementCard />}
-			<MembersCard
-				isOwner={isOwner}
-				showOwnerToast={showOwnerToast}
-				setIsInviteDialogOpen={setInviteDialogOpen}
-			/>
+			{buildEnv.NEXT_PUBLIC_IS_CAP &&
+				(canManageBilling ? (
+					<>
+						<BillingSummaryCard />
+						<SeatManagementCard />
+					</>
+				) : (
+					<Card>
+						<CardHeader>
+							<CardTitle>Billing</CardTitle>
+							<CardDescription>
+								Billing is managed by the organization owner.
+							</CardDescription>
+						</CardHeader>
+					</Card>
+				))}
+			<MembersCard setIsInviteDialogOpen={setInviteDialogOpen} />
 		</div>
 	);
 }

--- a/apps/web/app/(org)/dashboard/settings/organization/components/CapSettingsCard.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/CapSettingsCard.tsx
@@ -9,7 +9,23 @@ import { updateOrganizationSettings } from "@/actions/organization/settings";
 import { useDashboardContext } from "../../../Contexts";
 import type { OrganizationSettings } from "../../../dashboard-data";
 
-const options = [
+const defaultSettings: OrganizationSettings = {
+	disableComments: false,
+	disableSummary: false,
+	disableCaptions: false,
+	disableChapters: false,
+	disableReactions: false,
+	disableTranscript: false,
+	hideShareableLinkCapLogo: false,
+	shareableLinkUseOrganizationIcon: false,
+};
+
+const options: Array<{
+	label: string;
+	value: keyof OrganizationSettings;
+	description: string;
+	pro?: boolean;
+}> = [
 	{
 		label: "Enable comments",
 		value: "disableComments",
@@ -43,36 +59,31 @@ const options = [
 		description: "Enabling this also allows chapters and summary",
 		pro: true,
 	},
+	{
+		label: "Show Cap logo",
+		value: "hideShareableLinkCapLogo",
+		description: "Show Cap branding at the top of shareable links",
+		pro: true,
+	},
 ];
+
+const mergeSettings = (settings?: OrganizationSettings | null) => ({
+	...defaultSettings,
+	...(settings ?? {}),
+});
 
 const CapSettingsCard = () => {
 	const { user, organizationSettings } = useDashboardContext();
-	const [settings, setSettings] = useState<OrganizationSettings>(
-		organizationSettings || {
-			disableComments: false,
-			disableSummary: false,
-			disableCaptions: false,
-			disableChapters: false,
-			disableReactions: false,
-			disableTranscript: false,
-		},
-	);
+	const initialSettings = mergeSettings(organizationSettings);
+	const [settings, setSettings] =
+		useState<OrganizationSettings>(initialSettings);
 
-	const lastSavedSettings = useRef<OrganizationSettings>(
-		organizationSettings || settings,
-	);
+	const lastSavedSettings = useRef<OrganizationSettings>(initialSettings);
 
 	const debouncedUpdateSettings = useDebounce(settings, 1000);
 
 	useEffect(() => {
-		const next = organizationSettings ?? {
-			disableComments: false,
-			disableSummary: false,
-			disableCaptions: false,
-			disableChapters: false,
-			disableReactions: false,
-			disableTranscript: false,
-		};
+		const next = mergeSettings(organizationSettings);
 		setSettings(next);
 		lastSavedSettings.current = next;
 	}, [organizationSettings]);
@@ -103,21 +114,27 @@ const CapSettingsCard = () => {
 
 					changedKeys.forEach((changedKey) => {
 						const option = options.find((opt) => opt.value === changedKey);
-						const isDisabled = debouncedUpdateSettings[changedKey];
-						const action = isDisabled ? "disabled" : "enabled";
-						const label = option?.label.split(" ")[1] || changedKey;
-						toast.success(
-							`${label.charAt(0).toUpperCase()}${label.slice(1)} ${action}`,
-						);
+						if (changedKey === "hideShareableLinkCapLogo") {
+							toast.success(
+								debouncedUpdateSettings[changedKey]
+									? "Cap logo hidden"
+									: "Cap logo shown",
+							);
+						} else {
+							const isDisabled = debouncedUpdateSettings[changedKey];
+							const action = isDisabled ? "disabled" : "enabled";
+							const label = option?.label.split(" ")[1] || changedKey;
+							toast.success(
+								`${label.charAt(0).toUpperCase()}${label.slice(1)} ${action}`,
+							);
+						}
 					});
 
 					lastSavedSettings.current = debouncedUpdateSettings;
 				} catch (error) {
 					console.error("Error updating organization settings:", error);
 					toast.error("Failed to update settings");
-					if (organizationSettings) {
-						setSettings(organizationSettings);
-					}
+					setSettings(mergeSettings(organizationSettings));
 				}
 			};
 
@@ -182,9 +199,9 @@ const CapSettingsCard = () => {
 									settings?.disableTranscript)
 							}
 							onCheckedChange={() => {
-								handleToggle(option.value as keyof OrganizationSettings);
+								handleToggle(option.value);
 							}}
-							checked={!settings?.[option.value as keyof typeof settings]}
+							checked={!settings?.[option.value]}
 						/>
 					</div>
 				))}

--- a/apps/web/app/(org)/dashboard/settings/organization/components/DeleteOrg.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/DeleteOrg.tsx
@@ -1,11 +1,24 @@
 import { Button, Card, CardDescription, CardHeader, CardTitle } from "@cap/ui";
 import { useState } from "react";
+import {
+	canManageOrganizationBilling,
+	getEffectiveOrganizationRole,
+} from "@/lib/permissions/roles";
 import { useDashboardContext } from "../../../Contexts";
 import DeleteOrgDialog from "./DeleteOrgDialog";
 
 const DeleteOrg = () => {
 	const [toggleDeleteDialog, setToggleDeleteDialog] = useState(false);
-	const { organizationData, user } = useDashboardContext();
+	const { activeOrganization, organizationData, user } = useDashboardContext();
+	const currentMember = activeOrganization?.members.find(
+		(member) => member.userId === user.id,
+	);
+	const currentRole = getEffectiveOrganizationRole({
+		userId: user.id,
+		ownerId: activeOrganization?.organization.ownerId,
+		memberRole: currentMember?.role,
+	});
+	const canDeleteOrganization = canManageOrganizationBilling(currentRole);
 
 	return (
 		<>
@@ -22,7 +35,7 @@ const DeleteOrg = () => {
 				</CardHeader>
 				<Button
 					variant="destructive"
-					disabled={organizationData?.length === 1}
+					disabled={organizationData?.length === 1 || !canDeleteOrganization}
 					size="sm"
 					onClick={(e) => {
 						e.stopPropagation();

--- a/apps/web/app/(org)/dashboard/settings/organization/components/InviteDialog.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/InviteDialog.tsx
@@ -8,6 +8,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 	Input,
+	Select,
 } from "@cap/ui";
 import { faUserGroup } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -23,10 +24,21 @@ interface InviteDialogProps {
 	setIsOpen: (open: boolean) => void;
 }
 
+type InviteRole = "admin" | "member";
+type InviteEmail = {
+	email: string;
+	role: InviteRole;
+};
+
+const roleOptions = [
+	{ value: "member", label: "Member" },
+	{ value: "admin", label: "Admin" },
+];
+
 export const InviteDialog = ({ isOpen, setIsOpen }: InviteDialogProps) => {
 	const router = useRouter();
 	const { activeOrganization } = useDashboardContext();
-	const [inviteEmails, setInviteEmails] = useState<string[]>([]);
+	const [inviteEmails, setInviteEmails] = useState<InviteEmail[]>([]);
 	const [emailInput, setEmailInput] = useState("");
 	const emailInputId = useId();
 	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -38,7 +50,7 @@ export const InviteDialog = ({ isOpen, setIsOpen }: InviteDialogProps) => {
 		}
 	}, [isOpen]);
 
-	const handleAddEmails = () => {
+	const buildInviteEmailsWithPendingInput = () => {
 		const newEmails = emailInput
 			.split(",")
 			.map((email) => email.trim().toLowerCase())
@@ -49,24 +61,50 @@ export const InviteDialog = ({ isOpen, setIsOpen }: InviteDialogProps) => {
 			toast.error(
 				`Invalid email${invalidEmails.length > 1 ? "s" : ""}: ${invalidEmails.join(", ")}`,
 			);
+			return null;
 		}
 
 		const validEmails = newEmails.filter((email) => emailRegex.test(email));
-		setInviteEmails([...new Set([...inviteEmails, ...validEmails])]);
+		const inviteMap = new Map(
+			inviteEmails.map((invite) => [invite.email, invite]),
+		);
+
+		for (const email of validEmails) {
+			if (!inviteMap.has(email)) {
+				inviteMap.set(email, { email, role: "member" });
+			}
+		}
+
+		return Array.from(inviteMap.values());
+	};
+
+	const handleAddEmails = () => {
+		const nextInviteEmails = buildInviteEmailsWithPendingInput();
+		if (!nextInviteEmails) return;
+
+		setInviteEmails(nextInviteEmails);
 		setEmailInput("");
 	};
 
 	const handleRemoveEmail = (email: string) => {
-		setInviteEmails(inviteEmails.filter((e) => e !== email));
+		setInviteEmails(inviteEmails.filter((invite) => invite.email !== email));
+	};
+
+	const handleUpdateEmailRole = (email: string, role: InviteRole) => {
+		setInviteEmails(
+			inviteEmails.map((invite) =>
+				invite.email === email ? { ...invite, role } : invite,
+			),
+		);
 	};
 
 	const sendInvites = useMutation({
-		mutationFn: async () => {
+		mutationFn: async (emails: InviteEmail[]) => {
 			if (!activeOrganization?.organization.id) {
 				throw new Error("No active organization");
 			}
 			return await sendOrganizationInvites(
-				inviteEmails,
+				emails,
 				activeOrganization.organization.id,
 			);
 		},
@@ -91,6 +129,17 @@ export const InviteDialog = ({ isOpen, setIsOpen }: InviteDialogProps) => {
 		},
 	});
 
+	const handleSendInvites = () => {
+		const nextInviteEmails = buildInviteEmailsWithPendingInput();
+		if (!nextInviteEmails || nextInviteEmails.length === 0) return;
+
+		setInviteEmails(nextInviteEmails);
+		setEmailInput("");
+		sendInvites.mutate(nextInviteEmails);
+	};
+
+	const hasPendingEmailInput = emailInput.trim() !== "";
+
 	return (
 		<Dialog open={isOpen} onOpenChange={setIsOpen}>
 			<DialogContent className="p-0 w-full max-w-md rounded-xl border bg-gray-2 border-gray-4">
@@ -111,7 +160,16 @@ export const InviteDialog = ({ isOpen, setIsOpen }: InviteDialogProps) => {
 						value={emailInput}
 						onChange={(e) => setEmailInput(e.target.value)}
 						placeholder="name@company.com"
-						onBlur={handleAddEmails}
+						onBlur={(e) => {
+							const relatedTarget = e.relatedTarget;
+							if (
+								relatedTarget instanceof HTMLElement &&
+								relatedTarget.dataset.inviteSubmit === "true"
+							) {
+								return;
+							}
+							handleAddEmails();
+						}}
 						onKeyDown={(e) => {
 							if (e.key === "Enter" || e.key === ",") {
 								e.preventDefault();
@@ -120,12 +178,27 @@ export const InviteDialog = ({ isOpen, setIsOpen }: InviteDialogProps) => {
 						}}
 					/>
 					<div className="flex overflow-y-auto flex-col gap-2.5 mt-4 max-h-60">
-						{inviteEmails.map((email) => (
+						{inviteEmails.map((invite) => (
 							<div
-								key={email}
-								className="flex justify-between items-center p-3 rounded-xl border transition-colors duration-200 cursor-pointer border-gray-4 hover:bg-gray-3"
+								key={invite.email}
+								className="flex gap-3 justify-between items-center p-3 rounded-xl border transition-colors duration-200 border-gray-4 hover:bg-gray-3"
 							>
-								<span className="text-sm text-gray-12">{email}</span>
+								<span className="min-w-0 text-sm truncate text-gray-12">
+									{invite.email}
+								</span>
+								<Select
+									value={invite.role}
+									placeholder="Role"
+									options={roleOptions}
+									size="sm"
+									variant="gray"
+									onValueChange={(value) =>
+										handleUpdateEmailRole(
+											invite.email,
+											value === "admin" ? "admin" : "member",
+										)
+									}
+								/>
 								<Button
 									style={
 										{
@@ -135,7 +208,7 @@ export const InviteDialog = ({ isOpen, setIsOpen }: InviteDialogProps) => {
 									type="button"
 									variant="destructive"
 									size="xs"
-									onClick={() => handleRemoveEmail(email)}
+									onClick={() => handleRemoveEmail(invite.email)}
 								>
 									Remove
 								</Button>
@@ -157,8 +230,12 @@ export const InviteDialog = ({ isOpen, setIsOpen }: InviteDialogProps) => {
 						size="sm"
 						variant="dark"
 						spinner={sendInvites.isPending}
-						disabled={sendInvites.isPending || inviteEmails.length === 0}
-						onClick={() => sendInvites.mutate()}
+						disabled={
+							sendInvites.isPending ||
+							(inviteEmails.length === 0 && !hasPendingEmailInput)
+						}
+						data-invite-submit="true"
+						onClick={handleSendInvites}
 					>
 						Send Invites
 					</Button>

--- a/apps/web/app/(org)/dashboard/settings/organization/components/MembersCard.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/MembersCard.tsx
@@ -7,6 +7,7 @@ import {
 	CardDescription,
 	CardHeader,
 	CardTitle,
+	Select,
 	Switch,
 	Table,
 	TableBody,
@@ -25,24 +26,39 @@ import { toast } from "sonner";
 import { removeOrganizationInvite } from "@/actions/organization/remove-invite";
 import { removeOrganizationMember } from "@/actions/organization/remove-member";
 import { toggleProSeat } from "@/actions/organization/toggle-pro-seat";
+import { updateOrganizationMemberRole } from "@/actions/organization/update-member-role";
 import { ConfirmationDialog } from "@/app/(org)/dashboard/_components/ConfirmationDialog";
 import { useDashboardContext } from "@/app/(org)/dashboard/Contexts";
+import {
+	type AssignableOrganizationRole,
+	canChangeOrganizationMemberRole,
+	canManageOrganizationBilling,
+	canManageOrganizationMembers,
+	canRemoveOrganizationMember,
+	getEffectiveOrganizationRole,
+	normalizeAssignableOrganizationRole,
+	organizationRoleLabel,
+} from "@/lib/permissions/roles";
 import { calculateSeats } from "@/utils/organization";
 
 interface MembersCardProps {
-	isOwner: boolean;
-	showOwnerToast: () => void;
 	setIsInviteDialogOpen: (isOpen: boolean) => void;
 }
 
-export const MembersCard = ({
-	isOwner,
-	showOwnerToast,
-	setIsInviteDialogOpen,
-}: MembersCardProps) => {
+export const MembersCard = ({ setIsInviteDialogOpen }: MembersCardProps) => {
 	const router = useRouter();
-	const { activeOrganization } = useDashboardContext();
+	const { activeOrganization, user } = useDashboardContext();
 	const { proSeatsRemaining } = calculateSeats(activeOrganization || {});
+	const currentMember = activeOrganization?.members.find(
+		(member) => member.userId === user.id,
+	);
+	const currentRole = getEffectiveOrganizationRole({
+		userId: user.id,
+		ownerId: activeOrganization?.organization.ownerId,
+		memberRole: currentMember?.role,
+	});
+	const canManageMembers = canManageOrganizationMembers(currentRole);
+	const canManageBilling = canManageOrganizationBilling(currentRole);
 
 	const [confirmOpen, setConfirmOpen] = useState(false);
 	const [pendingMember, setPendingMember] = useState<{
@@ -51,6 +67,13 @@ export const MembersCard = ({
 		email: string;
 	} | null>(null);
 	const [deletingInviteId, setDeletingInviteId] = useState<string | null>(null);
+	const roleOptions = [
+		{ value: "admin", label: "Admin" },
+		{ value: "member", label: "Member" },
+	];
+	const showMemberManagerToast = () => {
+		toast.error("Only admins and owners can manage organization members");
+	};
 
 	const deleteInviteMutation = useMutation({
 		mutationFn: (inviteId: string) => {
@@ -95,6 +118,34 @@ export const MembersCard = ({
 				error instanceof Error
 					? error.message
 					: "An error occurred while removing member",
+			);
+		},
+	});
+
+	const updateRoleMutation = useMutation({
+		mutationFn: ({
+			memberId,
+			role,
+		}: {
+			memberId: string;
+			role: AssignableOrganizationRole;
+		}) => {
+			if (!activeOrganization?.organization.id) {
+				throw new Error("Organization not found");
+			}
+			return updateOrganizationMemberRole(
+				memberId,
+				activeOrganization.organization.id,
+				role,
+			);
+		},
+		onSuccess: () => {
+			toast.success("Role updated");
+			router.refresh();
+		},
+		onError: (error) => {
+			toast.error(
+				error instanceof Error ? error.message : "Failed to update role",
 			);
 		},
 	});
@@ -179,13 +230,13 @@ export const MembersCard = ({
 						variant="dark"
 						className="px-6 min-w-auto"
 						onClick={() => {
-							if (!isOwner) {
-								showOwnerToast();
+							if (!canManageMembers) {
+								showMemberManagerToast();
 								return;
 							}
 							setIsInviteDialogOpen(true);
 						}}
-						disabled={!isOwner}
+						disabled={!canManageMembers}
 					>
 						+ Invite users
 					</Button>
@@ -205,11 +256,58 @@ export const MembersCard = ({
 					<TableBody>
 						{activeOrganization?.members?.map((member) => {
 							const memberIsOwner = isMemberOwner(member.user.id);
+							const memberRole = getEffectiveOrganizationRole({
+								userId: member.user.id,
+								ownerId: activeOrganization.organization.ownerId,
+								memberRole: member.role,
+							});
+							const assignableRole =
+								normalizeAssignableOrganizationRole(memberRole);
+							const canUpdateRole = canChangeOrganizationMemberRole({
+								actorRole: currentRole,
+								actorUserId: user.id,
+								targetUserId: member.user.id,
+								ownerId: activeOrganization.organization.ownerId,
+								targetRole: memberRole,
+								nextRole: assignableRole,
+							});
+							const canRemoveMember = canRemoveOrganizationMember({
+								actorRole: currentRole,
+								actorUserId: user.id,
+								targetUserId: member.user.id,
+								ownerId: activeOrganization.organization.ownerId,
+								targetRole: memberRole,
+							});
+							const roleUpdating =
+								updateRoleMutation.isPending &&
+								updateRoleMutation.variables?.memberId === member.id;
 							return (
 								<TableRow key={member.id}>
 									<TableCell>{member.user.name}</TableCell>
 									<TableCell>{member.user.email}</TableCell>
-									<TableCell>{memberIsOwner ? "Owner" : "Member"}</TableCell>
+									<TableCell>
+										{memberIsOwner || memberRole === "owner" ? (
+											"Owner"
+										) : (
+											<Select
+												value={assignableRole ?? "member"}
+												placeholder="Role"
+												options={roleOptions}
+												size="sm"
+												variant="gray"
+												onValueChange={(value) => {
+													const nextRole =
+														normalizeAssignableOrganizationRole(value);
+													if (!nextRole) return;
+													updateRoleMutation.mutate({
+														memberId: member.id,
+														role: nextRole,
+													});
+												}}
+												disabled={!canUpdateRole || roleUpdating}
+											/>
+										)}
+									</TableCell>
 									{buildEnv.NEXT_PUBLIC_IS_CAP && (
 										<TableCell>
 											{memberIsOwner ? (
@@ -224,7 +322,7 @@ export const MembersCard = ({
 														})
 													}
 													disabled={
-														!isOwner ||
+														!canManageBilling ||
 														(toggleProSeatMutation.isPending &&
 															toggleProSeatMutation.variables?.memberId ===
 																member.id) ||
@@ -246,7 +344,7 @@ export const MembersCard = ({
 												variant="destructive"
 												className="min-w-[unset] h-[28px]"
 												onClick={() => {
-													if (isOwner) {
+													if (canRemoveMember) {
 														handleRemoveMember({
 															id: member.id,
 															user: {
@@ -255,10 +353,10 @@ export const MembersCard = ({
 															},
 														});
 													} else {
-														showOwnerToast();
+														showMemberManagerToast();
 													}
 												}}
-												disabled={!isOwner}
+												disabled={!canRemoveMember}
 											>
 												Remove
 											</Button>
@@ -273,7 +371,12 @@ export const MembersCard = ({
 							<TableRow key={invite.id}>
 								<TableCell className="text-gray-10">Pending</TableCell>
 								<TableCell>{invite.invitedEmail}</TableCell>
-								<TableCell>Member</TableCell>
+								<TableCell>
+									{organizationRoleLabel(
+										normalizeAssignableOrganizationRole(invite.role) ??
+											"member",
+									)}
+								</TableCell>
 								{buildEnv.NEXT_PUBLIC_IS_CAP && <TableCell>-</TableCell>}
 								<TableCell>-</TableCell>
 								<TableCell>Invited</TableCell>
@@ -283,13 +386,15 @@ export const MembersCard = ({
 										size="xs"
 										variant="destructive"
 										onClick={() => {
-											if (isOwner) {
+											if (canManageMembers) {
 												deleteInviteMutation.mutate(invite.id);
 											} else {
-												showOwnerToast();
+												showMemberManagerToast();
 											}
 										}}
-										disabled={!isOwner || deletingInviteId === invite.id}
+										disabled={
+											!canManageMembers || deletingInviteId === invite.id
+										}
 									>
 										{deletingInviteId === invite.id
 											? "Deleting..."

--- a/apps/web/app/(org)/dashboard/settings/organization/components/OrganizationDetailsCard.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/OrganizationDetailsCard.tsx
@@ -5,6 +5,7 @@ import AccessEmailDomain from "./AccessEmailDomain";
 import { CustomDomain } from "./CustomDomain";
 import { OrganizationIcon } from "./OrganizationIcon";
 import OrgName from "./OrgName";
+import { ShareableLinkIcon } from "./ShareableLinkIcon";
 
 export const OrganizationDetailsCard = () => {
 	return (
@@ -13,14 +14,15 @@ export const OrganizationDetailsCard = () => {
 				<CardTitle>Settings</CardTitle>
 				<CardDescription>
 					Set the organization name, access email domain, custom domain, and
-					organization icon.
+					organization icons.
 				</CardDescription>
 			</CardHeader>
 			<div className="grid grid-cols-1 gap-8 md:grid-cols-2">
 				<OrgName />
 				<CustomDomain />
-				<AccessEmailDomain />
 				<OrganizationIcon />
+				<ShareableLinkIcon />
+				<AccessEmailDomain />
 			</div>
 		</Card>
 	);

--- a/apps/web/app/(org)/dashboard/settings/organization/components/ShareableLinkIcon.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/ShareableLinkIcon.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { CardDescription, Label, Switch } from "@cap/ui";
+import type { Organisation } from "@cap/web-domain";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { useEffect, useId, useState } from "react";
+import { toast } from "sonner";
+import {
+	removeShareableLinkIcon,
+	updateShareableLinkIconPreference,
+	uploadShareableLinkIcon,
+} from "@/actions/organization/shareable-link-icon";
+import { FileInput } from "@/components/FileInput";
+import { UpgradeModal } from "@/components/UpgradeModal";
+import { useDashboardContext } from "../../../Contexts";
+
+export const ShareableLinkIcon = () => {
+	const router = useRouter();
+	const iconInputId = useId();
+	const { activeOrganization, user } = useDashboardContext();
+	const [showUpgradeModal, setShowUpgradeModal] = useState(false);
+	const organization = activeOrganization?.organization;
+	const organizationId = organization?.id;
+	const hasOrganizationIcon = Boolean(organization?.iconUrl);
+	const existingIconUrl = organization?.shareableLinkIconUrl ?? null;
+	const [useOrganizationIcon, setUseOrganizationIcon] = useState(
+		Boolean(organization?.settings?.shareableLinkUseOrganizationIcon),
+	);
+
+	useEffect(() => {
+		setUseOrganizationIcon(
+			Boolean(organization?.settings?.shareableLinkUseOrganizationIcon),
+		);
+	}, [organization?.settings?.shareableLinkUseOrganizationIcon]);
+
+	const uploadIcon = useMutation({
+		mutationFn: async ({
+			file,
+			organizationId,
+		}: {
+			organizationId: Organisation.OrganisationId;
+			file: File;
+		}) => {
+			const formData = new FormData();
+			formData.append("organizationId", organizationId);
+			formData.append("icon", file);
+			return uploadShareableLinkIcon(formData);
+		},
+		onSuccess: () => {
+			toast.success("Shareable link icon updated successfully");
+			router.refresh();
+		},
+		onError: (error) => {
+			toast.error(
+				error instanceof Error
+					? error.message
+					: "Failed to upload shareable link icon",
+			);
+		},
+	});
+
+	const removeIcon = useMutation({
+		mutationFn: (organizationId: Organisation.OrganisationId) =>
+			removeShareableLinkIcon(organizationId),
+		onSuccess: () => {
+			toast.success("Shareable link icon removed successfully");
+			router.refresh();
+		},
+		onError: (error) => {
+			toast.error(
+				error instanceof Error
+					? error.message
+					: "Failed to remove shareable link icon",
+			);
+		},
+	});
+
+	const updateIconPreference = useMutation({
+		mutationFn: ({
+			organizationId,
+			useOrganizationIcon,
+		}: {
+			organizationId: Organisation.OrganisationId;
+			useOrganizationIcon: boolean;
+		}) =>
+			updateShareableLinkIconPreference({
+				organizationId,
+				useOrganizationIcon,
+			}),
+		onSuccess: () => {
+			toast.success("Shareable link icon preference updated");
+			router.refresh();
+		},
+		onError: (error) => {
+			setUseOrganizationIcon(
+				Boolean(organization?.settings?.shareableLinkUseOrganizationIcon),
+			);
+			toast.error(
+				error instanceof Error
+					? error.message
+					: "Failed to update shareable link icon preference",
+			);
+		},
+	});
+
+	const isMutating =
+		uploadIcon.isPending ||
+		removeIcon.isPending ||
+		updateIconPreference.isPending;
+	const useOrganizationIconChecked = useOrganizationIcon && hasOrganizationIcon;
+
+	return (
+		<>
+			<div className="flex-1 space-y-4">
+				<div className="space-y-1">
+					<div className="flex gap-1.5 items-center">
+						<Label htmlFor={iconInputId}>Shareable link icon</Label>
+						<p className="py-1 px-1.5 text-[10px] leading-none font-medium rounded-full text-white bg-blue-11">
+							Pro
+						</p>
+					</div>
+					<CardDescription className="w-full">
+						Use a custom logo or icon on your shareable link pages.
+					</CardDescription>
+				</div>
+				<div className="flex items-center justify-between gap-4 rounded-xl border border-gray-3 bg-gray-2 p-4">
+					<div className="space-y-1">
+						<p className="text-sm text-gray-12">Use organization icon</p>
+						<p className="text-xs text-gray-10">
+							Use the organization icon when one is available.
+						</p>
+					</div>
+					<Switch
+						disabled={!user.isPro || !hasOrganizationIcon || isMutating}
+						checked={useOrganizationIconChecked}
+						onCheckedChange={(checked) => {
+							if (!organizationId) return;
+							if (!user.isPro) {
+								setShowUpgradeModal(true);
+								return;
+							}
+
+							setUseOrganizationIcon(checked);
+							updateIconPreference.mutate({
+								organizationId,
+								useOrganizationIcon: checked,
+							});
+						}}
+					/>
+				</div>
+				<FileInput
+					height={44}
+					previewIconSize={20}
+					id={iconInputId}
+					name="shareable-link-icon"
+					onChange={(file) => {
+						if (!file || !organizationId) return;
+						if (!user.isPro) {
+							setShowUpgradeModal(true);
+							return;
+						}
+						uploadIcon.mutate({ organizationId, file });
+					}}
+					disabled={!user.isPro || useOrganizationIconChecked || isMutating}
+					isLoading={uploadIcon.isPending}
+					initialPreviewUrl={
+						useOrganizationIconChecked
+							? (organization?.iconUrl ?? null)
+							: existingIconUrl
+					}
+					onRemove={() => {
+						if (!organizationId) return;
+						if (!user.isPro) {
+							setShowUpgradeModal(true);
+							return;
+						}
+						removeIcon.mutate(organizationId);
+					}}
+					maxFileSizeBytes={1024 * 1024}
+				/>
+			</div>
+			<UpgradeModal
+				open={showUpgradeModal}
+				onOpenChange={setShowUpgradeModal}
+			/>
+		</>
+	);
+};

--- a/apps/web/app/(org)/dashboard/settings/organization/integrations/page.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/integrations/page.tsx
@@ -24,7 +24,8 @@ export default async function OrganizationIntegrationsPage() {
 	).catch((error: unknown) => {
 		if (
 			error instanceof Error &&
-			(error.message === "Only the owner can manage organization storage" ||
+			(error.message ===
+				"Organization settings are only available to admins and owners" ||
 				error.message === "Organization not found")
 		) {
 			redirect("/dashboard/caps");

--- a/apps/web/app/(org)/dashboard/settings/organization/integrations/storage-integrations.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/integrations/storage-integrations.tsx
@@ -295,8 +295,8 @@ export function OrganizationStorageIntegrations({
 			<div className="flex items-center gap-2 px-1">
 				<InfoIcon className="size-3.5 text-gray-9 shrink-0" />
 				<p className="text-[12px] text-gray-9">
-					Storage applies to all members of {settings.organization.name}. Only
-					owners can manage integrations.
+					Storage applies to all members of {settings.organization.name}. Admins
+					and owners can manage integrations.
 				</p>
 			</div>
 

--- a/apps/web/app/(org)/dashboard/settings/organization/layout.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/layout.tsx
@@ -1,8 +1,8 @@
-import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
-import { organizationMembers, organizations } from "@cap/database/schema";
-import { and, eq, isNull } from "drizzle-orm";
+import { Card, CardDescription, CardHeader, CardTitle } from "@cap/ui";
 import { redirect } from "next/navigation";
+import { getOrganizationAccess } from "@/actions/organization/authorization";
+import { canViewOrganizationSettings } from "@/lib/permissions/roles";
 import { SettingsNav } from "./_components/SettingsNav";
 
 export default async function OrganizationSettingsLayout({
@@ -16,26 +16,28 @@ export default async function OrganizationSettingsLayout({
 		redirect("/auth/signin");
 	}
 
-	const [member] = await db()
-		.select({
-			role: organizationMembers.role,
-		})
-		.from(organizationMembers)
-		.leftJoin(
-			organizations,
-			eq(organizationMembers.organizationId, organizations.id),
-		)
-		.where(
-			and(
-				eq(organizationMembers.userId, user.id),
-				eq(organizations.id, user.activeOrganizationId),
-				isNull(organizations.tombstoneAt),
-			),
-		)
-		.limit(1);
-
-	if (!member || member.role !== "owner") {
+	if (!user.activeOrganizationId) {
 		redirect("/dashboard/caps");
+	}
+
+	const access = await getOrganizationAccess(
+		user.id,
+		user.activeOrganizationId,
+	);
+
+	if (!access || !canViewOrganizationSettings(access.role)) {
+		return (
+			<div className="flex flex-col gap-6">
+				<Card>
+					<CardHeader>
+						<CardTitle>Organization settings are restricted</CardTitle>
+						<CardDescription>
+							Ask an admin or owner to make the change.
+						</CardDescription>
+					</CardHeader>
+				</Card>
+			</div>
+		);
 	}
 
 	return (

--- a/apps/web/app/(org)/dashboard/spaces/[spaceId]/SharedCaps.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/[spaceId]/SharedCaps.tsx
@@ -18,6 +18,12 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
+import {
+	canManageOrganizationMembers,
+	canManageSpace,
+	getEffectiveOrganizationRole,
+	getEffectiveSpaceRole,
+} from "@/lib/permissions/roles";
 import { useVideosAnalyticsQuery } from "@/lib/Queries/Analytics";
 import SpaceDialog from "../../_components/Navbar/SpaceDialog";
 import { useDashboardContext } from "../../Contexts";
@@ -118,8 +124,33 @@ export const SharedCaps = ({
 		setIsAddOrganizationVideosDialogOpen,
 	] = useState(false);
 
-	const isSpaceOwner = spaceData?.createdById === currentUserId;
-	const isOrgOwner = organizationData?.ownerId === currentUserId;
+	const currentOrgMember = organizationMembers?.find(
+		(member) => member.userId === currentUserId,
+	);
+	const currentOrganizationRole = getEffectiveOrganizationRole({
+		userId: currentUserId,
+		ownerId:
+			organizationData?.ownerId ?? activeOrganization?.organization.ownerId,
+		memberRole: currentOrgMember?.role,
+	});
+	const currentSpaceMember = spaceMembers?.find(
+		(member) => member.userId === currentUserId,
+	);
+	const currentSpaceRole = getEffectiveSpaceRole({
+		userId: currentUserId,
+		createdById: spaceData?.createdById,
+		memberRole: currentSpaceMember?.role,
+	});
+	const canManageCurrentSpace = canManageSpace({
+		organizationRole: currentOrganizationRole,
+		spaceRole: currentSpaceRole,
+	});
+	const canManageCurrentOrganization = canManageOrganizationMembers(
+		currentOrganizationRole,
+	);
+	const canManageCurrentSharedCollection = spaceData
+		? canManageCurrentSpace
+		: canManageCurrentOrganization;
 
 	const spaceMemberCount = spaceMembers?.length || 0;
 
@@ -160,11 +191,13 @@ export const SharedCaps = ({
 		return (
 			<div className="flex relative flex-col w-full h-full">
 				{spaceSettingsDialog}
-				<NewFolderDialog
-					open={openNewFolderDialog}
-					spaceId={spaceId}
-					onOpenChange={setOpenNewFolderDialog}
-				/>
+				{canManageCurrentSharedCollection && (
+					<NewFolderDialog
+						open={openNewFolderDialog}
+						spaceId={spaceId}
+						onOpenChange={setOpenNewFolderDialog}
+					/>
+				)}
 				<div className="flex flex-wrap gap-3">
 					{spaceData && spaceMembers && (
 						<>
@@ -173,10 +206,14 @@ export const SharedCaps = ({
 								members={spaceMembers}
 								organizationMembers={organizationMembers || []}
 								spaceId={spaceData.id}
-								canManageMembers={isSpaceOwner}
-								onAddVideos={() => setIsAddVideosDialogOpen(true)}
+								canManageMembers={canManageCurrentSpace}
+								onAddVideos={
+									canManageCurrentSpace
+										? () => setIsAddVideosDialogOpen(true)
+										: undefined
+								}
 							/>
-							{isSpaceOwner && (
+							{canManageCurrentSpace && (
 								<Button
 									variant="gray"
 									size="sm"
@@ -193,25 +230,32 @@ export const SharedCaps = ({
 							memberCount={organizationMemberCount}
 							members={organizationMembers}
 							organizationName={organizationData.name}
-							canManageMembers={isOrgOwner}
-							onAddVideos={() => setIsAddOrganizationVideosDialogOpen(true)}
+							canManageMembers={canManageCurrentOrganization}
+							onAddVideos={
+								canManageCurrentOrganization
+									? () => setIsAddOrganizationVideosDialogOpen(true)
+									: undefined
+							}
 						/>
 					)}
-					<Button
-						onClick={() => setOpenNewFolderDialog(true)}
-						size="sm"
-						variant="dark"
-						className="flex gap-2 items-center w-fit"
-					>
-						<FontAwesomeIcon className="size-3.5" icon={faFolderPlus} />
-						New Folder
-					</Button>
+					{canManageCurrentSharedCollection && (
+						<Button
+							onClick={() => setOpenNewFolderDialog(true)}
+							size="sm"
+							variant="dark"
+							className="flex gap-2 items-center w-fit"
+						>
+							<FontAwesomeIcon className="size-3.5" icon={faFolderPlus} />
+							New Folder
+						</Button>
+					)}
 				</div>
 				<EmptySharedCapState
 					organizationName={activeOrganization?.organization.name || ""}
 					type={spaceData ? "space" : "organization"}
 					spaceData={spaceData}
 					currentUserId={currentUserId}
+					canAddVideos={canManageCurrentSpace}
 					onAddVideos={
 						spaceData
 							? () => setIsAddVideosDialogOpen(true)
@@ -261,11 +305,13 @@ export const SharedCaps = ({
 					</div>
 				</div>
 			)}
-			<NewFolderDialog
-				open={openNewFolderDialog}
-				spaceId={spaceId}
-				onOpenChange={setOpenNewFolderDialog}
-			/>
+			{canManageCurrentSharedCollection && (
+				<NewFolderDialog
+					open={openNewFolderDialog}
+					spaceId={spaceId}
+					onOpenChange={setOpenNewFolderDialog}
+				/>
+			)}
 			<div className="flex flex-wrap gap-3 mb-10">
 				{spaceData && spaceMembers && (
 					<>
@@ -274,10 +320,14 @@ export const SharedCaps = ({
 							members={spaceMembers}
 							organizationMembers={organizationMembers || []}
 							spaceId={spaceData.id}
-							canManageMembers={isSpaceOwner}
-							onAddVideos={() => setIsAddVideosDialogOpen(true)}
+							canManageMembers={canManageCurrentSpace}
+							onAddVideos={
+								canManageCurrentSpace
+									? () => setIsAddVideosDialogOpen(true)
+									: undefined
+							}
 						/>
-						{isSpaceOwner && (
+						{canManageCurrentSpace && (
 							<Button
 								variant="gray"
 								size="sm"
@@ -294,8 +344,12 @@ export const SharedCaps = ({
 						memberCount={organizationMemberCount}
 						members={organizationMembers}
 						organizationName={organizationData.name}
-						canManageMembers={isOrgOwner}
-						onAddVideos={() => setIsAddOrganizationVideosDialogOpen(true)}
+						canManageMembers={canManageCurrentOrganization}
+						onAddVideos={
+							canManageCurrentOrganization
+								? () => setIsAddOrganizationVideosDialogOpen(true)
+								: undefined
+						}
 					/>
 				)}
 				{spaceData && (
@@ -317,15 +371,17 @@ export const SharedCaps = ({
 						spaceId={spaceId}
 					/>
 				)}
-				<Button
-					onClick={() => setOpenNewFolderDialog(true)}
-					size="sm"
-					variant="dark"
-					className="flex gap-2 items-center w-fit"
-				>
-					<FontAwesomeIcon className="size-3.5" icon={faFolderPlus} />
-					New Folder
-				</Button>
+				{canManageCurrentSharedCollection && (
+					<Button
+						onClick={() => setOpenNewFolderDialog(true)}
+						size="sm"
+						variant="dark"
+						className="flex gap-2 items-center w-fit"
+					>
+						<FontAwesomeIcon className="size-3.5" icon={faFolderPlus} />
+						New Folder
+					</Button>
+				)}
 			</div>
 			{folders && folders.length > 0 && (
 				<>

--- a/apps/web/app/(org)/dashboard/spaces/[spaceId]/actions.ts
+++ b/apps/web/app/(org)/dashboard/spaces/[spaceId]/actions.ts
@@ -3,14 +3,28 @@
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { nanoIdLength } from "@cap/database/helpers";
-import { spaceMembers, spaces } from "@cap/database/schema";
-import { Space, User } from "@cap/web-domain";
-import { eq, inArray } from "drizzle-orm";
+import { organizationMembers, spaceMembers } from "@cap/database/schema";
+import { type Organisation, Space, User } from "@cap/web-domain";
+import { and, eq, inArray } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
+import { requireSpaceManager } from "@/actions/organization/space-authorization";
+import {
+	canRemoveSpaceMember,
+	normalizeSpaceRole,
+	type SpaceRole,
+} from "@/lib/permissions/roles";
 
-const spaceRole = z.union([z.literal("Admin"), z.literal("member")]);
+const spaceRole = z.preprocess(
+	(value) => (value === "Admin" ? "admin" : value),
+	z.union([z.literal("admin"), z.literal("member")]),
+);
+
+const spaceMemberRoleSchema = z.object({
+	userId: z.string().transform((v) => User.UserId.make(v)),
+	role: spaceRole,
+});
 
 const addSpaceMemberSchema = z.object({
 	spaceId: z.string().transform((v) => Space.SpaceId.make(v)),
@@ -23,6 +37,37 @@ const addSpaceMembersSchema = z.object({
 	userIds: z.array(z.string().transform((v) => User.UserId.make(v))),
 	role: spaceRole,
 });
+
+async function assertUsersBelongToOrganization(
+	organizationId: Organisation.OrganisationId,
+	organizationOwnerId: User.UserId,
+	userIds: User.UserId[],
+) {
+	const uniqueUserIds = Array.from(new Set(userIds));
+	if (uniqueUserIds.length === 0) return;
+
+	const rows = await db()
+		.select({ userId: organizationMembers.userId })
+		.from(organizationMembers)
+		.where(
+			and(
+				eq(organizationMembers.organizationId, organizationId),
+				inArray(
+					organizationMembers.userId,
+					uniqueUserIds.map((id) => User.UserId.make(id)),
+				),
+			),
+		);
+	const allowedUserIds = new Set([
+		organizationOwnerId,
+		...rows.map((row) => row.userId),
+	]);
+	const invalidUserIds = uniqueUserIds.filter((id) => !allowedUserIds.has(id));
+
+	if (invalidUserIds.length > 0) {
+		throw new Error("All space members must belong to the organization");
+	}
+}
 
 export async function addSpaceMember(
 	data: z.infer<typeof addSpaceMemberSchema>,
@@ -40,6 +85,12 @@ export async function addSpaceMember(
 	}
 
 	const { spaceId, userId, role } = validation.data;
+	const access = await requireSpaceManager(currentUser.id, spaceId);
+	await assertUsersBelongToOrganization(
+		access.organizationId,
+		access.organizationOwnerId,
+		[userId],
+	);
 
 	await db()
 		.insert(spaceMembers)
@@ -71,8 +122,13 @@ export async function addSpaceMembers(
 	}
 
 	const { spaceId, userIds, role } = validation.data;
+	const access = await requireSpaceManager(currentUser.id, spaceId);
+	await assertUsersBelongToOrganization(
+		access.organizationId,
+		access.organizationOwnerId,
+		userIds,
+	);
 
-	// Fetch existing members to avoid duplicates
 	const existing = await db()
 		.select({ userId: spaceMembers.userId })
 		.from(spaceMembers)
@@ -126,7 +182,7 @@ export async function removeSpaceMember(
 	const { memberId } = validation.data;
 
 	const member = await db()
-		.select({ spaceId: spaceMembers.spaceId })
+		.select({ spaceId: spaceMembers.spaceId, userId: spaceMembers.userId })
 		.from(spaceMembers)
 		.where(eq(spaceMembers.id, memberId))
 		.limit(1);
@@ -141,6 +197,17 @@ export async function removeSpaceMember(
 		throw new Error("Space ID not found");
 	}
 
+	const access = await requireSpaceManager(currentUser.id, spaceId);
+	if (
+		!canRemoveSpaceMember({
+			canManage: access.canManage,
+			targetUserId: member[0]?.userId,
+			createdById: access.createdById,
+		})
+	) {
+		throw new Error("You do not have permission to remove this space member");
+	}
+
 	await db().delete(spaceMembers).where(eq(spaceMembers.id, memberId));
 
 	revalidatePath(`/dashboard/spaces/${spaceId}`);
@@ -148,13 +215,13 @@ export async function removeSpaceMember(
 	return { success: true };
 }
 
-// Replace all members for a space
 const setSpaceMembersSchema = z.object({
 	spaceId: z
 		.string()
 		.transform((v) => Space.SpaceId.make(v) as Space.SpaceIdOrOrganisationId),
 	userIds: z.array(z.string().transform((v) => User.UserId.make(v))),
 	role: spaceRole.default("member"),
+	members: z.array(spaceMemberRoleSchema).optional(),
 });
 
 export async function setSpaceMembers(
@@ -168,39 +235,51 @@ export async function setSpaceMembers(
 	if (!currentUser) {
 		throw new Error("Unauthorized");
 	}
-	const { spaceId, userIds, role } = validation.data;
+	const { spaceId, userIds, role, members } = validation.data;
 
-	// Get the space creator to ensure they're always included
-	const [space] = await db()
-		.select({ createdById: spaces.createdById })
-		.from(spaces)
-		.where(eq(spaces.id, spaceId))
-		.limit(1);
+	const access = await requireSpaceManager(currentUser.id, spaceId);
 
-	if (!space) {
-		throw new Error("Space not found");
-	}
+	const submittedMembers =
+		members?.map((member) => ({
+			userId: member.userId,
+			role: normalizeSpaceRole(member.role) ?? "member",
+		})) ??
+		userIds.map((userId) => ({
+			userId,
+			role: normalizeSpaceRole(role) ?? "member",
+		}));
 
-	// Ensure creator is always included in the member list
-	const allMemberIds = Array.from(new Set([...userIds, space.createdById]));
+	await assertUsersBelongToOrganization(
+		access.organizationId,
+		access.organizationOwnerId,
+		submittedMembers.map((member) => member.userId),
+	);
 
-	// Remove all current members
-	await db().delete(spaceMembers).where(eq(spaceMembers.spaceId, spaceId));
-
-	// Insert new members (always at least the creator)
+	const roleByUserId = new Map(
+		submittedMembers.map((member) => [member.userId, member.role]),
+	);
+	const allMemberIds = Array.from(
+		new Set([
+			...submittedMembers.map((member) => member.userId),
+			access.createdById,
+		]),
+	);
 	const now = new Date();
 	const values = allMemberIds.map((userId) => {
-		// Creator is always Admin, others get the specified role
-		const memberRole = userId === space.createdById ? "Admin" : role;
 		return {
-			id: User.UserId.make(uuidv4().substring(0, nanoIdLength)),
+			id: uuidv4().substring(0, nanoIdLength),
 			spaceId,
 			userId,
-			role: memberRole,
+			role:
+				userId === access.createdById
+					? ("admin" as const)
+					: ((roleByUserId.get(userId) as SpaceRole | undefined) ?? "member"),
 			createdAt: now,
 			updatedAt: now,
 		};
 	});
+
+	await db().delete(spaceMembers).where(eq(spaceMembers.spaceId, spaceId));
 	await db().insert(spaceMembers).values(values);
 
 	revalidatePath(`/dashboard/spaces/${spaceId}`);
@@ -229,16 +308,39 @@ export async function batchRemoveSpaceMembers(
 		return { success: true, removed: [] };
 	}
 
-	// Get spaceId for revalidation (assume all memberIds are from the same space)
 	const members = await db()
-		.select({ spaceId: spaceMembers.spaceId })
+		.select({
+			id: spaceMembers.id,
+			spaceId: spaceMembers.spaceId,
+			userId: spaceMembers.userId,
+		})
 		.from(spaceMembers)
 		.where(inArray(spaceMembers.id, memberIds));
 	const spaceId = members[0]?.spaceId;
 
-	await db().delete(spaceMembers).where(inArray(spaceMembers.id, memberIds));
-	if (spaceId) {
-		revalidatePath(`/dashboard/spaces/${spaceId}`);
+	if (!spaceId) {
+		return { success: true, removed: [] };
 	}
+
+	if (members.some((member) => member.spaceId !== spaceId)) {
+		throw new Error("Cannot remove members from multiple spaces at once");
+	}
+
+	const access = await requireSpaceManager(currentUser.id, spaceId);
+	const protectedMember = members.find(
+		(member) =>
+			!canRemoveSpaceMember({
+				canManage: access.canManage,
+				targetUserId: member.userId,
+				createdById: access.createdById,
+			}),
+	);
+
+	if (protectedMember) {
+		throw new Error("You do not have permission to remove one or more members");
+	}
+
+	await db().delete(spaceMembers).where(inArray(spaceMembers.id, memberIds));
+	revalidatePath(`/dashboard/spaces/${spaceId}`);
 	return { success: true, removed: memberIds };
 }

--- a/apps/web/app/(org)/dashboard/spaces/[spaceId]/components/EmptySharedCapState.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/[spaceId]/components/EmptySharedCapState.tsx
@@ -14,6 +14,7 @@ interface EmptySharedCapStateProps {
 		createdById: string;
 	};
 	currentUserId?: string;
+	canAddVideos?: boolean;
 	onAddVideos?: () => void;
 }
 
@@ -22,6 +23,7 @@ export const EmptySharedCapState: React.FC<EmptySharedCapStateProps> = ({
 	type = "organization",
 	spaceData,
 	currentUserId,
+	canAddVideos,
 	onAddVideos,
 }) => {
 	const { theme } = useTheme();
@@ -33,7 +35,7 @@ export const EmptySharedCapState: React.FC<EmptySharedCapStateProps> = ({
 
 	const isSpaceOwner = spaceData?.createdById === currentUserId;
 	const showAddButton =
-		(type === "space" && isSpaceOwner && onAddVideos) ||
+		(type === "space" && (isSpaceOwner || canAddVideos) && onAddVideos) ||
 		(type === "organization" && onAddVideos);
 
 	return (

--- a/apps/web/app/(org)/dashboard/spaces/[spaceId]/components/MembersIndicator.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/[spaceId]/components/MembersIndicator.tsx
@@ -11,17 +11,23 @@ import {
 	Form,
 	FormControl,
 	FormField,
+	Select,
 } from "@cap/ui";
 import { type Space, User } from "@cap/web-domain";
 import { faPlus, faUserGroup } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import * as z from "zod";
 import { SignedImageUrl } from "@/components/SignedImageUrl";
+import {
+	normalizeSpaceRole,
+	type SpaceRole,
+	spaceRoleLabel,
+} from "@/lib/permissions/roles";
 import { useDashboardContext } from "../../../Contexts";
 import { setSpaceMembers } from "../actions";
 import type { SpaceMemberData } from "../page";
@@ -48,9 +54,14 @@ export const MembersIndicator = ({
 	const router = useRouter();
 	const [open, setOpen] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
+	const [memberRoles, setMemberRoles] = useState<Record<string, SpaceRole>>({});
+	const roleOptions = [
+		{ value: "member", label: "Member" },
+		{ value: "admin", label: "Admin" },
+	];
 
 	const formSchema = z.object({
-		members: z.array(z.string().email("Invalid email address")).optional(),
+		members: z.array(z.string()).optional(),
 	});
 
 	const form = useForm<z.infer<typeof formSchema>>({
@@ -60,15 +71,33 @@ export const MembersIndicator = ({
 		},
 	});
 
+	useEffect(() => {
+		setMemberRoles(
+			Object.fromEntries(
+				members.map((member) => [
+					member.userId,
+					normalizeSpaceRole(member.role) ?? "member",
+				]),
+			),
+		);
+		form.reset({
+			members: members.map((member) => member.userId),
+		});
+	}, [members, form]);
+
 	const handleSaveMembers = async (selectedUserIds: User.UserId[]) => {
 		if (!canManageMembers) return;
 
-		// Compare selectedUserIds to current members' userIds (order-insensitive)
 		const currentIds = members.map((m) => m.userId).sort();
 		const selectedIds = (selectedUserIds ?? []).slice().sort();
 		const noChange =
 			currentIds.length === selectedIds.length &&
-			currentIds.every((id, i) => id === selectedIds[i]);
+			currentIds.every((id, i) => id === selectedIds[i]) &&
+			currentIds.every(
+				(id) =>
+					(normalizeSpaceRole(members.find((m) => m.userId === id)?.role) ??
+						"member") === (memberRoles[id] ?? "member"),
+			);
 
 		if (noChange) {
 			toast.info("No changes were applied");
@@ -80,6 +109,10 @@ export const MembersIndicator = ({
 			await setSpaceMembers({
 				spaceId,
 				userIds: selectedUserIds ?? [],
+				members: (selectedUserIds ?? []).map((userId) => ({
+					userId,
+					role: memberRoles[userId] ?? "member",
+				})),
 				role: "member",
 			});
 			toast.success("Members updated!");
@@ -96,16 +129,14 @@ export const MembersIndicator = ({
 	const OrgMembers = useCallback(
 		(field: { value?: string[] }) => {
 			return organizationMembers
-				.filter(
-					(m) => (field.value ?? []).includes(m.userId) && m.userId !== user.id,
-				)
+				.filter((m) => (field.value ?? []).includes(m.userId))
 				.map((m) => ({
 					value: m.userId,
 					label: m.name || m.email,
 					image: m.image || undefined,
 				}));
 		},
-		[organizationMembers, user],
+		[organizationMembers],
 	);
 
 	return (
@@ -140,20 +171,71 @@ export const MembersIndicator = ({
 											control={form.control}
 											name="members"
 											render={({ field }) => {
+												const selectedMembers = OrgMembers(field);
 												return (
 													<FormControl>
-														<MemberSelect
-															placeholder="Add member..."
-															disabled={false}
-															canManageMembers={true}
-															showEmptyIfNoMembers={false}
-															selected={OrgMembers(field)}
-															onSelect={(selected) => {
-																field.onChange(
-																	selected.map((opt) => opt.value),
-																);
-															}}
-														/>
+														<div className="space-y-3">
+															<MemberSelect
+																placeholder="Add member..."
+																disabled={false}
+																canManageMembers={true}
+																showEmptyIfNoMembers={false}
+																selected={selectedMembers}
+																onSelect={(selected) => {
+																	const selectedIds = selected.map(
+																		(opt) => opt.value,
+																	);
+																	field.onChange(selectedIds);
+																	setMemberRoles((prev) => {
+																		const next: Record<string, SpaceRole> = {};
+																		for (const userId of selectedIds) {
+																			next[userId] = prev[userId] ?? "member";
+																		}
+																		return next;
+																	});
+																}}
+															/>
+															{selectedMembers.length > 0 && (
+																<div className="space-y-2">
+																	{selectedMembers.map((member) => (
+																		<div
+																			key={member.value}
+																			className="flex items-center justify-between gap-3 rounded-lg border border-gray-4 bg-gray-3 p-2"
+																		>
+																			<div className="flex min-w-0 items-center gap-2">
+																				<SignedImageUrl
+																					name={member.label}
+																					image={member.image}
+																					className="size-7"
+																					letterClass="text-xs"
+																				/>
+																				<span className="truncate text-sm text-gray-12">
+																					{member.label}
+																				</span>
+																			</div>
+																			<Select
+																				value={
+																					memberRoles[member.value] ?? "member"
+																				}
+																				placeholder="Role"
+																				options={roleOptions}
+																				size="sm"
+																				variant="gray"
+																				disabled={member.value === user.id}
+																				onValueChange={(value) => {
+																					setMemberRoles((prev) => ({
+																						...prev,
+																						[member.value]:
+																							normalizeSpaceRole(value) ??
+																							"member",
+																					}));
+																				}}
+																			/>
+																		</div>
+																	))}
+																</div>
+															)}
+														</div>
 													</FormControl>
 												);
 											}}
@@ -162,7 +244,6 @@ export const MembersIndicator = ({
 								</Form>
 							) : (
 								<div className="space-y-2 max-h-[320px] custom-scroll overflow-y-auto">
-									{/* Just display the list of members for non-managers */}
 									{members.map((member) => (
 										<div
 											key={member.userId}
@@ -176,6 +257,11 @@ export const MembersIndicator = ({
 											/>
 											<span className="text-sm text-gray-12">
 												{member.name || member.email}
+											</span>
+											<span className="ml-auto rounded-full bg-gray-5 px-2 py-1 text-xs text-gray-11">
+												{spaceRoleLabel(
+													normalizeSpaceRole(member.role) ?? "member",
+												)}
 											</span>
 										</div>
 									))}

--- a/apps/web/app/(org)/dashboard/spaces/[spaceId]/components/OrganizationIndicator.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/[spaceId]/components/OrganizationIndicator.tsx
@@ -15,7 +15,11 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import clsx from "clsx";
 import { useState } from "react";
 import { SignedImageUrl } from "@/components/SignedImageUrl";
-import { useDashboardContext } from "../../../Contexts";
+import {
+	compareOrganizationRoles,
+	normalizeOrganizationRole,
+	organizationRoleLabel,
+} from "@/lib/permissions/roles";
 
 export type OrganizationMemberData = {
 	id: string;
@@ -41,7 +45,6 @@ export const OrganizationIndicator = ({
 	canManageMembers,
 	onAddVideos,
 }: OrganizationIndicatorProps) => {
-	const { user } = useDashboardContext();
 	const [open, setOpen] = useState(false);
 
 	return (
@@ -67,7 +70,7 @@ export const OrganizationIndicator = ({
 						<div className="flex flex-col">
 							<div className="space-y-3 max-h-[320px] custom-scroll overflow-y-auto">
 								{members
-									.sort((a, b) => b.role.localeCompare(a.role))
+									.sort((a, b) => compareOrganizationRoles(a.role, b.role))
 									.map((member) => (
 										<div
 											key={member.id}
@@ -92,12 +95,16 @@ export const OrganizationIndicator = ({
 											<p
 												className={clsx(
 													"px-2.5 py-1.5 text-xs font-medium capitalize text-white rounded-full",
-													member.role === "owner"
+													normalizeOrganizationRole(member.role) === "owner"
 														? "bg-blue-500"
-														: "bg-gray-10",
+														: normalizeOrganizationRole(member.role) === "admin"
+															? "bg-gray-12"
+															: "bg-gray-10",
 												)}
 											>
-												{member.role}
+												{organizationRoleLabel(
+													normalizeOrganizationRole(member.role) ?? "member",
+												)}
 											</p>
 										</div>
 									))}

--- a/apps/web/app/(org)/dashboard/spaces/[spaceId]/page.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/[spaceId]/page.tsx
@@ -80,7 +80,7 @@ const fetchSpaceMembers = Effect.fn(function* (
 				.select({
 					id: spaceMembers.id,
 					userId: spaceMembers.userId,
-					role: sql<string>`'member'`,
+					role: spaceMembers.role,
 					name: users.name,
 					email: users.email,
 					image: users.image,

--- a/apps/web/app/(org)/dashboard/spaces/browse/page.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/browse/page.tsx
@@ -15,15 +15,23 @@ import { toast } from "sonner";
 
 import { deleteSpace } from "@/actions/organization/delete-space";
 import { SignedImageUrl } from "@/components/SignedImageUrl";
+import {
+	normalizeOrganizationRole,
+	normalizeSpaceRole,
+	organizationRoleLabel,
+	spaceRoleLabel,
+} from "@/lib/permissions/roles";
 import { ConfirmationDialog } from "../../_components/ConfirmationDialog";
-import SpaceDialog from "../../_components/Navbar/SpaceDialog";
+import SpaceDialog, {
+	type NewSpaceFormProps,
+} from "../../_components/Navbar/SpaceDialog";
 import { useDashboardContext } from "../../Contexts";
 import type { Spaces } from "../../dashboard-data";
 
 export default function BrowseSpacesPage() {
 	const { spacesData, user, activeOrganization } = useDashboardContext();
 	const [showSpaceDialog, setShowSpaceDialog] = useState(false);
-	const [editSpace, setEditSpace] = useState<any | null>(null);
+	const [editSpace, setEditSpace] = useState<NewSpaceFormProps["space"]>(null);
 	const [searchQuery, setSearchQuery] = useState("");
 
 	const trueActiveOrgMembers = activeOrganization?.members.filter(
@@ -47,6 +55,13 @@ export default function BrowseSpacesPage() {
 		e.stopPropagation();
 		setPendingDeleteSpace(space);
 		setConfirmOpen(true);
+	};
+
+	const getRoleLabel = (role: Spaces["currentUserRole"]) => {
+		const organizationRole = normalizeOrganizationRole(role);
+		if (organizationRole) return organizationRoleLabel(organizationRole);
+		const spaceRole = normalizeSpaceRole(role);
+		return spaceRole ? spaceRoleLabel(spaceRole) : "Member";
 	};
 
 	const confirmRemoveSpace = async () => {
@@ -150,10 +165,10 @@ export default function BrowseSpacesPage() {
 										{space.videoCount === 1 ? "" : "s"}
 									</td>
 									<td className="px-6 py-4 text-sm text-gray-12">
-										{space.createdById === user?.id ? "Admin" : "Member"}
+										{getRoleLabel(space.currentUserRole)}
 									</td>
 									<td className="px-6">
-										{space.createdById === user?.id && !space.primary ? (
+										{space.currentUserCanManage && !space.primary ? (
 											<div className="flex gap-2">
 												<Button
 													variant="gray"
@@ -167,7 +182,7 @@ export default function BrowseSpacesPage() {
 															members: (trueActiveOrgMembers || []).map(
 																(m: { user: { id: string } }) => m.user.id,
 															),
-															iconUrl: space.iconUrl,
+															iconUrl: space.iconUrl ?? undefined,
 														});
 														setShowSpaceDialog(true);
 													}}

--- a/apps/web/app/api/desktop/[...route]/organization-branding.ts
+++ b/apps/web/app/api/desktop/[...route]/organization-branding.ts
@@ -7,6 +7,10 @@ import {
 	OrganizationHexColor,
 	type OrganizationLogoUpdate,
 } from "@cap/web-api-contract";
+import {
+	getEffectiveOrganizationRole,
+	normalizeOrganizationRole,
+} from "@/lib/permissions/roles";
 
 export const EMPTY_ORGANIZATION_BRAND_COLORS = {
 	primary: null,
@@ -39,7 +43,7 @@ export type DesktopOrganizationRow = {
 	tombstoneAt: Date | null;
 	iconUrl: string | null;
 	metadata: unknown;
-	role: "owner" | "member" | null;
+	role: "owner" | "admin" | "member" | null;
 };
 
 export type DecodedOrganizationLogoUpdate =
@@ -160,7 +164,7 @@ export function filterAccessibleOrganizationRows(
 	return rows.filter(
 		(row) =>
 			row.tombstoneAt === null &&
-			(row.ownerId === userId || row.role === "owner" || row.role === "member"),
+			(row.ownerId === userId || normalizeOrganizationRole(row.role) !== null),
 	);
 }
 
@@ -170,14 +174,18 @@ export function toDesktopOrganization(
 	iconUrl: string | null,
 ): DesktopOrganization {
 	const role =
-		row.ownerId === userId || row.role === "owner" ? "owner" : "member";
+		getEffectiveOrganizationRole({
+			userId,
+			ownerId: row.ownerId,
+			memberRole: row.role,
+		}) ?? "member";
 
 	return DesktopOrganizationSchema.parse({
 		id: row.id,
 		name: row.name,
 		ownerId: row.ownerId,
 		role,
-		canEditBrand: role === "owner",
+		canEditBrand: role === "owner" || role === "admin",
 		iconUrl,
 		brandColors: organizationBrandColorsFromMetadata(row.metadata),
 	});
@@ -187,9 +195,12 @@ export function canEditOrganizationBranding(
 	row: DesktopOrganizationRow,
 	userId: string,
 ) {
-	return (
-		row.tombstoneAt === null && (row.ownerId === userId || row.role === "owner")
-	);
+	const role = getEffectiveOrganizationRole({
+		userId,
+		ownerId: row.ownerId,
+		memberRole: row.role,
+	});
+	return row.tombstoneAt === null && (role === "owner" || role === "admin");
 }
 
 export function normalizeOrganizationBrandingPatchBody(

--- a/apps/web/app/api/desktop/[...route]/root.ts
+++ b/apps/web/app/api/desktop/[...route]/root.ts
@@ -505,7 +505,7 @@ app.patch(
 
 		if (!canEditOrganizationBranding(row, user.id)) {
 			return c.json(
-				{ error: "Only organization owners can edit branding" },
+				{ error: "Only organization admins and owners can edit branding" },
 				{ status: 403 },
 			);
 		}

--- a/apps/web/app/api/invite/accept/route.ts
+++ b/apps/web/app/api/invite/accept/route.ts
@@ -9,6 +9,7 @@ import {
 } from "@cap/database/schema";
 import { and, eq } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
+import { normalizeAssignableOrganizationRole } from "@/lib/permissions/roles";
 import { calculateProSeats } from "@/utils/organization";
 
 export async function POST(request: NextRequest) {
@@ -62,11 +63,13 @@ export async function POST(request: NextRequest) {
 
 			if (!existingMembership) {
 				const newId = nanoId();
+				const role =
+					normalizeAssignableOrganizationRole(invite.role) ?? "member";
 				await tx.insert(organizationMembers).values({
 					id: newId,
 					organizationId: invite.organizationId,
 					userId: user.id,
-					role: invite.role,
+					role,
 				});
 				memberId = newId;
 			}

--- a/apps/web/app/s/[videoId]/_components/caption-cues.ts
+++ b/apps/web/app/s/[videoId]/_components/caption-cues.ts
@@ -6,9 +6,15 @@ export function getActiveCaptionText(
 	}
 
 	let selectedCue: VTTCue | null = null;
+	const cueList = activeCues as TextTrackCueList & {
+		item?: (index: number) => TextTrackCue | null;
+	};
 
 	for (let index = 0; index < activeCues.length; index++) {
-		const cue = activeCues.item(index) as VTTCue | null;
+		const cue = (cueList[index] ?? cueList.item?.(index)) as
+			| VTTCue
+			| null
+			| undefined;
 		if (cue && (!selectedCue || cue.startTime >= selectedCue.startTime)) {
 			selectedCue = cue;
 		}

--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -25,6 +25,7 @@ import {
 import { VideosPolicy } from "@cap/web-backend/src/Videos/VideosPolicy";
 import {
 	Comment,
+	type ImageUpload,
 	type Organisation,
 	Policy,
 	type Video,
@@ -33,6 +34,7 @@ import { and, eq, type InferSelectModel, isNull, sql } from "drizzle-orm";
 import { Effect, Option } from "effect";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
+import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getVideoAnalytics } from "@/actions/videos/get-analytics";
@@ -160,6 +162,82 @@ const renderPolicyDenied = (videoId: Video.VideoId, reason?: string) =>
 	Effect.succeed(<PolicyDeniedView key={videoId} reason={reason} />);
 
 const renderNoSuchElement = () => Effect.sync(() => notFound());
+
+type SharePageBranding =
+	| {
+			type: "custom";
+			imageUrl: ImageUpload.ImageUrl;
+			name: string;
+	  }
+	| {
+			type: "cap";
+	  };
+
+function getSharePageBranding(data: {
+	owner: { isPro: boolean };
+	orgSettings?: OrganizationSettings | null;
+	organizationName?: string | null;
+	organizationIconUrl?: ImageUpload.ImageUrl | null;
+	shareableLinkIconUrl?: ImageUpload.ImageUrl | null;
+}): SharePageBranding | null {
+	if (!data.owner.isPro) {
+		return { type: "cap" };
+	}
+
+	const brandedIcon = data.orgSettings?.shareableLinkUseOrganizationIcon
+		? data.organizationIconUrl
+		: data.shareableLinkIconUrl;
+
+	if (brandedIcon) {
+		return {
+			type: "custom",
+			imageUrl: brandedIcon,
+			name: data.organizationName ?? "Organization",
+		};
+	}
+
+	if (data.orgSettings?.hideShareableLinkCapLogo) {
+		return null;
+	}
+
+	return { type: "cap" };
+}
+
+function SharePageBranding({
+	branding,
+	videoId,
+}: {
+	branding: SharePageBranding | null;
+	videoId: Video.VideoId;
+}) {
+	if (!branding) return null;
+
+	return (
+		<div className="flex justify-center pt-8">
+			{branding.type === "custom" ? (
+				<div className="inline-flex h-12 max-w-64 items-center justify-center rounded-xl border border-gray-5 bg-white px-4">
+					<Image
+						src={branding.imageUrl}
+						alt={`${branding.name} logo`}
+						width={208}
+						height={32}
+						unoptimized
+						className="max-h-8 w-auto max-w-52 object-contain"
+					/>
+				</div>
+			) : (
+				<a
+					target="_blank"
+					rel="noreferrer"
+					href={`/?ref=video_${videoId}`}
+					className="inline-flex items-center rounded-full border border-gray-5 bg-white px-4 py-2"
+				>
+					<Logo className="h-7 w-auto" />
+				</a>
+			)}
+		</div>
+	);
+}
 
 const getShareVideoPageCatchers = (videoId: Video.VideoId) => ({
 	PolicyDenied: (e: Policy.PolicyDeniedError) =>
@@ -371,6 +449,9 @@ export default async function ShareVideoPage(props: PageProps<"/s/[videoId]">) {
 						organizationId: sharedVideos.organizationId,
 					},
 					orgSettings: organizations.settings,
+					organizationName: organizations.name,
+					organizationIconUrl: organizations.iconUrl,
+					shareableLinkIconUrl: organizations.shareableLinkIconUrl,
 					hasActiveUpload: sql`${videoUploads.videoId} IS NOT NULL`.mapWith(
 						Boolean,
 					),
@@ -421,6 +502,9 @@ async function AuthorizedContent({
 		activeUploadRawFileKey: string | null;
 		orgSettings?: OrganizationSettings | null;
 		videoSettings?: OrganizationSettings | null;
+		organizationName?: string | null;
+		organizationIconUrl?: ImageUpload.ImageUrlOrKey | null;
+		shareableLinkIconUrl?: ImageUpload.ImageUrlOrKey | null;
 	};
 	searchParams: { [key: string]: string | string[] | undefined };
 }) {
@@ -692,6 +776,13 @@ async function AuthorizedContent({
 			password: null,
 			folderId: null,
 			orgSettings: video.orgSettings || null,
+			organizationName: video.organizationName,
+			organizationIconUrl: video.organizationIconUrl
+				? yield* imageUploads.resolveImageUrl(video.organizationIconUrl)
+				: null,
+			shareableLinkIconUrl: video.shareableLinkIconUrl
+				? yield* imageUploads.resolveImageUrl(video.shareableLinkIconUrl)
+				: null,
 			settings: rules.settings,
 			hasInheritedPassword: rules.hasInheritedPassword,
 			inheritedPasswordSources: rules.inheritedPasswordSources,
@@ -705,49 +796,41 @@ async function AuthorizedContent({
 	});
 
 	return (
-		<>
-			<div className="container flex-1 px-4 mx-auto">
-				<ShareHeader
-					data={{
-						...videoWithOrganizationInfo,
-						createdAt: video.metadata?.customCreatedAt
-							? new Date(video.metadata.customCreatedAt)
-							: video.createdAt,
-					}}
-					customDomain={customDomain}
-					domainVerified={domainVerified}
-					sharedOrganizations={
-						videoWithOrganizationInfo.sharedOrganizations || []
-					}
-					sharedSpaces={sharedSpaces}
-					userOrganizations={userOrganizations}
-					spacesData={spacesData}
-				/>
+		<div className="container flex-1 px-4 mx-auto">
+			<SharePageBranding
+				branding={getSharePageBranding(videoWithOrganizationInfo)}
+				videoId={video.id}
+			/>
+			<ShareHeader
+				data={{
+					...videoWithOrganizationInfo,
+					createdAt: video.metadata?.customCreatedAt
+						? new Date(video.metadata.customCreatedAt)
+						: video.createdAt,
+				}}
+				customDomain={customDomain}
+				domainVerified={domainVerified}
+				sharedOrganizations={
+					videoWithOrganizationInfo.sharedOrganizations || []
+				}
+				sharedSpaces={sharedSpaces}
+				userOrganizations={userOrganizations}
+				spacesData={spacesData}
+			/>
 
-				<Share
-					data={videoWithOrganizationInfo}
-					videoSettings={videoWithOrganizationInfo.settings}
-					comments={commentsPromise}
-					views={viewsPromise}
-					customDomain={customDomain}
-					domainVerified={domainVerified}
-					userOrganizations={userOrganizations}
-					viewerId={user?.id ?? null}
-					isEditProcessing={isEditProcessing}
-					initialAiData={initialAiData}
-					aiGenerationEnabled={aiGenerationEnabled}
-				/>
-			</div>
-			<div className="py-4 mt-auto">
-				<a
-					target="_blank"
-					href={`/?ref=video_${video.id}`}
-					className="flex justify-center items-center px-4 py-2 mx-auto mb-2 space-x-2 bg-white rounded-full border border-gray-5 w-fit"
-				>
-					<span className="text-sm">Recorded with</span>
-					<Logo className="w-14 h-auto" />
-				</a>
-			</div>
-		</>
+			<Share
+				data={videoWithOrganizationInfo}
+				videoSettings={videoWithOrganizationInfo.settings}
+				comments={commentsPromise}
+				views={viewsPromise}
+				customDomain={customDomain}
+				domainVerified={domainVerified}
+				userOrganizations={userOrganizations}
+				viewerId={user?.id ?? null}
+				isEditProcessing={isEditProcessing}
+				initialAiData={initialAiData}
+				aiGenerationEnabled={aiGenerationEnabled}
+			/>
+		</div>
 	);
 }

--- a/apps/web/app/s/[videoId]/types.ts
+++ b/apps/web/app/s/[videoId]/types.ts
@@ -13,6 +13,9 @@ export type VideoData = Omit<typeof videos.$inferSelect, "ownerId"> & {
 	inheritedPasswordSources?: SpaceRuleSource[];
 	inheritedSpaceSettings?: Partial<Record<ViewerSettingKey, SpaceRuleSource[]>>;
 	orgSettings?: OrganizationSettings | null;
+	organizationName?: string | null;
+	organizationIconUrl?: ImageUpload.ImageUrl | null;
+	shareableLinkIconUrl?: ImageUpload.ImageUrl | null;
 	hasActiveUpload?: boolean;
 	activeUploadRawFileKey?: string | null;
 };

--- a/apps/web/lib/permissions/roles.ts
+++ b/apps/web/lib/permissions/roles.ts
@@ -1,0 +1,240 @@
+export const organizationRoles = ["owner", "admin", "member"] as const;
+export type OrganizationRole = (typeof organizationRoles)[number];
+
+export const assignableOrganizationRoles = ["admin", "member"] as const;
+export type AssignableOrganizationRole =
+	(typeof assignableOrganizationRoles)[number];
+
+export const spaceRoles = ["admin", "member"] as const;
+export type SpaceRole = (typeof spaceRoles)[number];
+export type PersistedSpaceRole = SpaceRole | "Admin";
+
+const organizationRoleRank: Record<OrganizationRole, number> = {
+	owner: 3,
+	admin: 2,
+	member: 1,
+};
+
+const spaceRoleRank: Record<SpaceRole, number> = {
+	admin: 2,
+	member: 1,
+};
+
+function includesValue<T extends readonly string[]>(
+	values: T,
+	value: string,
+): value is T[number] {
+	return values.includes(value);
+}
+
+export function normalizeOrganizationRole(
+	role: string | null | undefined,
+): OrganizationRole | null {
+	if (!role) return null;
+	const normalized = role.toLowerCase();
+	return includesValue(organizationRoles, normalized) ? normalized : null;
+}
+
+export function normalizeAssignableOrganizationRole(
+	role: string | null | undefined,
+): AssignableOrganizationRole | null {
+	if (!role) return null;
+	const normalized = role.toLowerCase();
+	return includesValue(assignableOrganizationRoles, normalized)
+		? normalized
+		: null;
+}
+
+export function getEffectiveOrganizationRole({
+	userId,
+	ownerId,
+	memberRole,
+}: {
+	userId: string | null | undefined;
+	ownerId: string | null | undefined;
+	memberRole: string | null | undefined;
+}): OrganizationRole | null {
+	if (userId && ownerId && userId === ownerId) return "owner";
+	const role = normalizeOrganizationRole(memberRole);
+	return role === "owner" ? "member" : role;
+}
+
+export function normalizeSpaceRole(
+	role: string | null | undefined,
+): SpaceRole | null {
+	if (!role) return null;
+	if (role === "Admin") return "admin";
+	const normalized = role.toLowerCase();
+	return includesValue(spaceRoles, normalized) ? normalized : null;
+}
+
+export function getEffectiveSpaceRole({
+	userId,
+	createdById,
+	memberRole,
+}: {
+	userId: string | null | undefined;
+	createdById: string | null | undefined;
+	memberRole: string | null | undefined;
+}): SpaceRole | null {
+	if (userId && createdById && userId === createdById) return "admin";
+	return normalizeSpaceRole(memberRole);
+}
+
+export function canViewOrganizationSettings(
+	role: OrganizationRole | null | undefined,
+) {
+	return role === "owner" || role === "admin";
+}
+
+export function canManageOrganizationMembers(
+	role: OrganizationRole | null | undefined,
+) {
+	return role === "owner" || role === "admin";
+}
+
+export function canManageOrganizationBilling(
+	role: OrganizationRole | null | undefined,
+) {
+	return role === "owner";
+}
+
+export function canManageOrganizationSettings(
+	role: OrganizationRole | null | undefined,
+) {
+	return role === "owner" || role === "admin";
+}
+
+export function isOrganizationOwnerTarget({
+	targetUserId,
+	ownerId,
+	targetRole,
+}: {
+	targetUserId: string | null | undefined;
+	ownerId: string | null | undefined;
+	targetRole: OrganizationRole | null | undefined;
+}) {
+	return targetRole === "owner" || (!!targetUserId && targetUserId === ownerId);
+}
+
+export function canChangeOrganizationMemberRole({
+	actorRole,
+	actorUserId,
+	targetUserId,
+	ownerId,
+	targetRole,
+	nextRole,
+}: {
+	actorRole: OrganizationRole | null | undefined;
+	actorUserId: string | null | undefined;
+	targetUserId: string | null | undefined;
+	ownerId: string | null | undefined;
+	targetRole: OrganizationRole | null | undefined;
+	nextRole: AssignableOrganizationRole | null | undefined;
+}) {
+	if (!canManageOrganizationMembers(actorRole)) return false;
+	if (!nextRole) return false;
+	if (isOrganizationOwnerTarget({ targetUserId, ownerId, targetRole })) {
+		return false;
+	}
+	if (actorUserId && targetUserId && actorUserId === targetUserId) return false;
+	return true;
+}
+
+export function canRemoveOrganizationMember({
+	actorRole,
+	actorUserId,
+	targetUserId,
+	ownerId,
+	targetRole,
+}: {
+	actorRole: OrganizationRole | null | undefined;
+	actorUserId: string | null | undefined;
+	targetUserId: string | null | undefined;
+	ownerId: string | null | undefined;
+	targetRole: OrganizationRole | null | undefined;
+}) {
+	if (!canManageOrganizationMembers(actorRole)) return false;
+	if (isOrganizationOwnerTarget({ targetUserId, ownerId, targetRole })) {
+		return false;
+	}
+	if (actorUserId && targetUserId && actorUserId === targetUserId) return false;
+	return true;
+}
+
+export function canManageSpace({
+	organizationRole,
+	spaceRole,
+}: {
+	organizationRole: OrganizationRole | null | undefined;
+	spaceRole: SpaceRole | null | undefined;
+}) {
+	return (
+		organizationRole === "owner" ||
+		organizationRole === "admin" ||
+		spaceRole === "admin"
+	);
+}
+
+export function canChangeSpaceMemberRole({
+	canManage,
+	targetUserId,
+	createdById,
+	nextRole,
+}: {
+	canManage: boolean;
+	targetUserId: string | null | undefined;
+	createdById: string | null | undefined;
+	nextRole: SpaceRole | null | undefined;
+}) {
+	if (!canManage) return false;
+	if (!nextRole) return false;
+	if (targetUserId && createdById && targetUserId === createdById) return false;
+	return true;
+}
+
+export function canRemoveSpaceMember({
+	canManage,
+	targetUserId,
+	createdById,
+}: {
+	canManage: boolean;
+	targetUserId: string | null | undefined;
+	createdById: string | null | undefined;
+}) {
+	if (!canManage) return false;
+	if (targetUserId && createdById && targetUserId === createdById) return false;
+	return true;
+}
+
+export function organizationRoleLabel(role: OrganizationRole) {
+	return role[0]?.toUpperCase() + role.slice(1);
+}
+
+export function spaceRoleLabel(role: SpaceRole) {
+	return role[0]?.toUpperCase() + role.slice(1);
+}
+
+export function compareOrganizationRoles(
+	a: string | null | undefined,
+	b: string | null | undefined,
+) {
+	const roleA = normalizeOrganizationRole(a);
+	const roleB = normalizeOrganizationRole(b);
+	return (
+		(organizationRoleRank[roleB ?? "member"] ?? 0) -
+		(organizationRoleRank[roleA ?? "member"] ?? 0)
+	);
+}
+
+export function compareSpaceRoles(
+	a: string | null | undefined,
+	b: string | null | undefined,
+) {
+	const roleA = normalizeSpaceRole(a);
+	const roleB = normalizeSpaceRole(b);
+	return (
+		(spaceRoleRank[roleB ?? "member"] ?? 0) -
+		(spaceRoleRank[roleA ?? "member"] ?? 0)
+	);
+}

--- a/apps/web/lib/permissions/roles.ts
+++ b/apps/web/lib/permissions/roles.ts
@@ -7,7 +7,6 @@ export type AssignableOrganizationRole =
 
 export const spaceRoles = ["admin", "member"] as const;
 export type SpaceRole = (typeof spaceRoles)[number];
-export type PersistedSpaceRole = SpaceRole | "Admin";
 
 const organizationRoleRank: Record<OrganizationRole, number> = {
 	owner: 3,
@@ -25,6 +24,19 @@ function includesValue<T extends readonly string[]>(
 	value: string,
 ): value is T[number] {
 	return values.includes(value);
+}
+
+function getOrganizationRoleRank(role: OrganizationRole | null | undefined) {
+	return role ? organizationRoleRank[role] : 0;
+}
+
+function organizationRoleOutranks(
+	actorRole: OrganizationRole | null | undefined,
+	targetRole: OrganizationRole | null | undefined,
+) {
+	return (
+		getOrganizationRoleRank(actorRole) > getOrganizationRoleRank(targetRole)
+	);
 }
 
 export function normalizeOrganizationRole(
@@ -63,7 +75,6 @@ export function normalizeSpaceRole(
 	role: string | null | undefined,
 ): SpaceRole | null {
 	if (!role) return null;
-	if (role === "Admin") return "admin";
 	const normalized = role.toLowerCase();
 	return includesValue(spaceRoles, normalized) ? normalized : null;
 }
@@ -138,6 +149,7 @@ export function canChangeOrganizationMemberRole({
 		return false;
 	}
 	if (actorUserId && targetUserId && actorUserId === targetUserId) return false;
+	if (!organizationRoleOutranks(actorRole, targetRole)) return false;
 	return true;
 }
 
@@ -159,6 +171,7 @@ export function canRemoveOrganizationMember({
 		return false;
 	}
 	if (actorUserId && targetUserId && actorUserId === targetUserId) return false;
+	if (!organizationRoleOutranks(actorRole, targetRole)) return false;
 	return true;
 }
 

--- a/apps/web/public/.well-known/workflow/v1/manifest.json
+++ b/apps/web/public/.well-known/workflow/v1/manifest.json
@@ -1,283 +1,289 @@
 {
-	"version": "1.0.0",
-	"steps": {
-		"node_modules/.pnpm/workflow@4.2.0-beta.73_@nestjs+common@11.1.17_reflect-metadata@0.2.2_rxjs@7.8.2__@nestj_2a6f07c63175c34d8d104665b34a32ad/node_modules/workflow/dist/stdlib.js": {
-			"fetch": {
-				"stepId": "step//workflow@4.2.0-beta.73//fetch"
-			}
-		},
-		"workflows/process-video.ts": {
-			"cleanupRawUpload": {
-				"stepId": "step//./workflows/process-video//cleanupRawUpload"
-			},
-			"processVideoOnMediaServer": {
-				"stepId": "step//./workflows/process-video//processVideoOnMediaServer"
-			},
-			"saveMetadataAndComplete": {
-				"stepId": "step//./workflows/process-video//saveMetadataAndComplete"
-			},
-			"setProcessingError": {
-				"stepId": "step//./workflows/process-video//setProcessingError"
-			},
-			"validateProcessingRequest": {
-				"stepId": "step//./workflows/process-video//validateProcessingRequest"
-			}
-		},
-		"workflows/import-loom-video.ts": {
-			"downloadLoomToS3": {
-				"stepId": "step//./workflows/import-loom-video//downloadLoomToS3"
-			},
-			"processVideoOnMediaServer": {
-				"stepId": "step//./workflows/import-loom-video//processVideoOnMediaServer"
-			},
-			"saveMetadataAndComplete": {
-				"stepId": "step//./workflows/import-loom-video//saveMetadataAndComplete"
-			},
-			"setProcessingError": {
-				"stepId": "step//./workflows/import-loom-video//setProcessingError"
-			}
-		},
-		"workflows/generate-ai.ts": {
-			"fetchTranscript": {
-				"stepId": "step//./workflows/generate-ai//fetchTranscript"
-			},
-			"generateWithAi": {
-				"stepId": "step//./workflows/generate-ai//generateWithAi"
-			},
-			"markSkipped": {
-				"stepId": "step//./workflows/generate-ai//markSkipped"
-			},
-			"saveResults": {
-				"stepId": "step//./workflows/generate-ai//saveResults"
-			},
-			"validateAndSetProcessing": {
-				"stepId": "step//./workflows/generate-ai//validateAndSetProcessing"
-			}
-		},
-		"node_modules/.pnpm/workflow@4.2.0-beta.73_@nestjs+common@11.1.17_reflect-metadata@0.2.2_rxjs@7.8.2__@nestj_2a6f07c63175c34d8d104665b34a32ad/node_modules/workflow/dist/internal/builtins.js": {
-			"__builtin_response_array_buffer": {
-				"stepId": "__builtin_response_array_buffer"
-			},
-			"__builtin_response_json": {
-				"stepId": "__builtin_response_json"
-			},
-			"__builtin_response_text": {
-				"stepId": "__builtin_response_text"
-			}
-		},
-		"workflows/transcribe.ts": {
-			"_enhanceAndSaveAudio": {
-				"stepId": "step//./workflows/transcribe//_enhanceAndSaveAudio"
-			},
-			"_markEnhancedAudioProcessing": {
-				"stepId": "step//./workflows/transcribe//_markEnhancedAudioProcessing"
-			},
-			"cleanupTempAudio": {
-				"stepId": "step//./workflows/transcribe//cleanupTempAudio"
-			},
-			"extractAudio": {
-				"stepId": "step//./workflows/transcribe//extractAudio"
-			},
-			"markNoAudio": {
-				"stepId": "step//./workflows/transcribe//markNoAudio"
-			},
-			"markSkipped": {
-				"stepId": "step//./workflows/transcribe//markSkipped"
-			},
-			"queueAiGeneration": {
-				"stepId": "step//./workflows/transcribe//queueAiGeneration"
-			},
-			"saveTranscription": {
-				"stepId": "step//./workflows/transcribe//saveTranscription"
-			},
-			"transcribeWithDeepgram": {
-				"stepId": "step//./workflows/transcribe//transcribeWithDeepgram"
-			},
-			"validateVideo": {
-				"stepId": "step//./workflows/transcribe//validateVideo"
-			}
-		},
-		"workflows/edit-video.ts": {
-			"renderVideoEditOnMediaServer": {
-				"stepId": "step//./workflows/edit-video//renderVideoEditOnMediaServer"
-			},
-			"saveMetadataAndComplete": {
-				"stepId": "step//./workflows/edit-video//saveMetadataAndComplete"
-			},
-			"setProcessingError": {
-				"stepId": "step//./workflows/edit-video//setProcessingError"
-			},
-			"validateEditRequest": {
-				"stepId": "step//./workflows/edit-video//validateEditRequest"
-			}
-		}
-	},
-	"workflows": {
-		"workflows/process-video.ts": {
-			"processVideoWorkflow": {
-				"workflowId": "workflow//./workflows/process-video//processVideoWorkflow",
-				"graph": {
-					"nodes": [
-						{
-							"id": "start",
-							"type": "workflowStart",
-							"data": {
-								"label": "Start: processVideoWorkflow",
-								"nodeKind": "workflow_start"
-							}
-						},
-						{
-							"id": "end",
-							"type": "workflowEnd",
-							"data": {
-								"label": "Return",
-								"nodeKind": "workflow_end"
-							}
-						}
-					],
-					"edges": [
-						{
-							"id": "e_start_end",
-							"source": "start",
-							"target": "end",
-							"type": "default"
-						}
-					]
-				}
-			}
-		},
-		"workflows/import-loom-video.ts": {
-			"importLoomVideoWorkflow": {
-				"workflowId": "workflow//./workflows/import-loom-video//importLoomVideoWorkflow",
-				"graph": {
-					"nodes": [
-						{
-							"id": "start",
-							"type": "workflowStart",
-							"data": {
-								"label": "Start: importLoomVideoWorkflow",
-								"nodeKind": "workflow_start"
-							}
-						},
-						{
-							"id": "end",
-							"type": "workflowEnd",
-							"data": {
-								"label": "Return",
-								"nodeKind": "workflow_end"
-							}
-						}
-					],
-					"edges": [
-						{
-							"id": "e_start_end",
-							"source": "start",
-							"target": "end",
-							"type": "default"
-						}
-					]
-				}
-			}
-		},
-		"workflows/generate-ai.ts": {
-			"generateAiWorkflow": {
-				"workflowId": "workflow//./workflows/generate-ai//generateAiWorkflow",
-				"graph": {
-					"nodes": [
-						{
-							"id": "start",
-							"type": "workflowStart",
-							"data": {
-								"label": "Start: generateAiWorkflow",
-								"nodeKind": "workflow_start"
-							}
-						},
-						{
-							"id": "end",
-							"type": "workflowEnd",
-							"data": {
-								"label": "Return",
-								"nodeKind": "workflow_end"
-							}
-						}
-					],
-					"edges": [
-						{
-							"id": "e_start_end",
-							"source": "start",
-							"target": "end",
-							"type": "default"
-						}
-					]
-				}
-			}
-		},
-		"workflows/transcribe.ts": {
-			"transcribeVideoWorkflow": {
-				"workflowId": "workflow//./workflows/transcribe//transcribeVideoWorkflow",
-				"graph": {
-					"nodes": [
-						{
-							"id": "start",
-							"type": "workflowStart",
-							"data": {
-								"label": "Start: transcribeVideoWorkflow",
-								"nodeKind": "workflow_start"
-							}
-						},
-						{
-							"id": "end",
-							"type": "workflowEnd",
-							"data": {
-								"label": "Return",
-								"nodeKind": "workflow_end"
-							}
-						}
-					],
-					"edges": [
-						{
-							"id": "e_start_end",
-							"source": "start",
-							"target": "end",
-							"type": "default"
-						}
-					]
-				}
-			}
-		},
-		"workflows/edit-video.ts": {
-			"editVideoWorkflow": {
-				"workflowId": "workflow//./workflows/edit-video//editVideoWorkflow",
-				"graph": {
-					"nodes": [
-						{
-							"id": "start",
-							"type": "workflowStart",
-							"data": {
-								"label": "Start: editVideoWorkflow",
-								"nodeKind": "workflow_start"
-							}
-						},
-						{
-							"id": "end",
-							"type": "workflowEnd",
-							"data": {
-								"label": "Return",
-								"nodeKind": "workflow_end"
-							}
-						}
-					],
-					"edges": [
-						{
-							"id": "e_start_end",
-							"source": "start",
-							"target": "end",
-							"type": "default"
-						}
-					]
-				}
-			}
-		}
-	},
-	"classes": {}
+  "version": "1.0.0",
+  "steps": {
+    "workflows/process-video.ts": {
+      "cleanupRawUpload": {
+        "stepId": "step//./workflows/process-video//cleanupRawUpload"
+      },
+      "processVideoOnMediaServer": {
+        "stepId": "step//./workflows/process-video//processVideoOnMediaServer"
+      },
+      "saveMetadataAndComplete": {
+        "stepId": "step//./workflows/process-video//saveMetadataAndComplete"
+      },
+      "setProcessingError": {
+        "stepId": "step//./workflows/process-video//setProcessingError"
+      },
+      "validateProcessingRequest": {
+        "stepId": "step//./workflows/process-video//validateProcessingRequest"
+      }
+    },
+    "workflows/edit-video.ts": {
+      "clearEditProcessingState": {
+        "stepId": "step//./workflows/edit-video//clearEditProcessingState"
+      },
+      "invalidateEditedVideoCache": {
+        "stepId": "step//./workflows/edit-video//invalidateEditedVideoCache"
+      },
+      "queueTranscriptionRegeneration": {
+        "stepId": "step//./workflows/edit-video//queueTranscriptionRegeneration"
+      },
+      "renderVideoEditOnMediaServer": {
+        "stepId": "step//./workflows/edit-video//renderVideoEditOnMediaServer"
+      },
+      "saveEditResultAndComplete": {
+        "stepId": "step//./workflows/edit-video//saveEditResultAndComplete"
+      },
+      "validateEditRequest": {
+        "stepId": "step//./workflows/edit-video//validateEditRequest"
+      }
+    },
+    "node_modules/.pnpm/workflow@4.2.0-beta.73_@nestjs+common@11.1.17_reflect-metadata@0.2.2_rxjs@7.8.2__@nestj_2a6f07c63175c34d8d104665b34a32ad/node_modules/workflow/dist/stdlib.js": {
+      "fetch": {
+        "stepId": "step//workflow@4.2.0-beta.73//fetch"
+      }
+    },
+    "workflows/generate-ai.ts": {
+      "fetchTranscript": {
+        "stepId": "step//./workflows/generate-ai//fetchTranscript"
+      },
+      "generateWithAi": {
+        "stepId": "step//./workflows/generate-ai//generateWithAi"
+      },
+      "markSkipped": {
+        "stepId": "step//./workflows/generate-ai//markSkipped"
+      },
+      "saveResults": {
+        "stepId": "step//./workflows/generate-ai//saveResults"
+      },
+      "validateAndSetProcessing": {
+        "stepId": "step//./workflows/generate-ai//validateAndSetProcessing"
+      }
+    },
+    "workflows/import-loom-video.ts": {
+      "downloadLoomToS3": {
+        "stepId": "step//./workflows/import-loom-video//downloadLoomToS3"
+      },
+      "processVideoOnMediaServer": {
+        "stepId": "step//./workflows/import-loom-video//processVideoOnMediaServer"
+      },
+      "saveMetadataAndComplete": {
+        "stepId": "step//./workflows/import-loom-video//saveMetadataAndComplete"
+      },
+      "setProcessingError": {
+        "stepId": "step//./workflows/import-loom-video//setProcessingError"
+      }
+    },
+    "node_modules/.pnpm/workflow@4.2.0-beta.73_@nestjs+common@11.1.17_reflect-metadata@0.2.2_rxjs@7.8.2__@nestj_2a6f07c63175c34d8d104665b34a32ad/node_modules/workflow/dist/internal/builtins.js": {
+      "__builtin_response_array_buffer": {
+        "stepId": "__builtin_response_array_buffer"
+      },
+      "__builtin_response_json": {
+        "stepId": "__builtin_response_json"
+      },
+      "__builtin_response_text": {
+        "stepId": "__builtin_response_text"
+      }
+    },
+    "workflows/transcribe.ts": {
+      "_enhanceAndSaveAudio": {
+        "stepId": "step//./workflows/transcribe//_enhanceAndSaveAudio"
+      },
+      "_markEnhancedAudioProcessing": {
+        "stepId": "step//./workflows/transcribe//_markEnhancedAudioProcessing"
+      },
+      "cleanupTempAudio": {
+        "stepId": "step//./workflows/transcribe//cleanupTempAudio"
+      },
+      "extractAudio": {
+        "stepId": "step//./workflows/transcribe//extractAudio"
+      },
+      "markNoAudio": {
+        "stepId": "step//./workflows/transcribe//markNoAudio"
+      },
+      "markSkipped": {
+        "stepId": "step//./workflows/transcribe//markSkipped"
+      },
+      "queueAiGeneration": {
+        "stepId": "step//./workflows/transcribe//queueAiGeneration"
+      },
+      "saveTranscription": {
+        "stepId": "step//./workflows/transcribe//saveTranscription"
+      },
+      "transcribeWithDeepgram": {
+        "stepId": "step//./workflows/transcribe//transcribeWithDeepgram"
+      },
+      "validateVideo": {
+        "stepId": "step//./workflows/transcribe//validateVideo"
+      }
+    }
+  },
+  "workflows": {
+    "workflows/process-video.ts": {
+      "processVideoWorkflow": {
+        "workflowId": "workflow//./workflows/process-video//processVideoWorkflow",
+        "graph": {
+          "nodes": [
+            {
+              "id": "start",
+              "type": "workflowStart",
+              "data": {
+                "label": "Start: processVideoWorkflow",
+                "nodeKind": "workflow_start"
+              }
+            },
+            {
+              "id": "end",
+              "type": "workflowEnd",
+              "data": {
+                "label": "Return",
+                "nodeKind": "workflow_end"
+              }
+            }
+          ],
+          "edges": [
+            {
+              "id": "e_start_end",
+              "source": "start",
+              "target": "end",
+              "type": "default"
+            }
+          ]
+        }
+      }
+    },
+    "workflows/edit-video.ts": {
+      "editVideoWorkflow": {
+        "workflowId": "workflow//./workflows/edit-video//editVideoWorkflow",
+        "graph": {
+          "nodes": [
+            {
+              "id": "start",
+              "type": "workflowStart",
+              "data": {
+                "label": "Start: editVideoWorkflow",
+                "nodeKind": "workflow_start"
+              }
+            },
+            {
+              "id": "end",
+              "type": "workflowEnd",
+              "data": {
+                "label": "Return",
+                "nodeKind": "workflow_end"
+              }
+            }
+          ],
+          "edges": [
+            {
+              "id": "e_start_end",
+              "source": "start",
+              "target": "end",
+              "type": "default"
+            }
+          ]
+        }
+      }
+    },
+    "workflows/generate-ai.ts": {
+      "generateAiWorkflow": {
+        "workflowId": "workflow//./workflows/generate-ai//generateAiWorkflow",
+        "graph": {
+          "nodes": [
+            {
+              "id": "start",
+              "type": "workflowStart",
+              "data": {
+                "label": "Start: generateAiWorkflow",
+                "nodeKind": "workflow_start"
+              }
+            },
+            {
+              "id": "end",
+              "type": "workflowEnd",
+              "data": {
+                "label": "Return",
+                "nodeKind": "workflow_end"
+              }
+            }
+          ],
+          "edges": [
+            {
+              "id": "e_start_end",
+              "source": "start",
+              "target": "end",
+              "type": "default"
+            }
+          ]
+        }
+      }
+    },
+    "workflows/import-loom-video.ts": {
+      "importLoomVideoWorkflow": {
+        "workflowId": "workflow//./workflows/import-loom-video//importLoomVideoWorkflow",
+        "graph": {
+          "nodes": [
+            {
+              "id": "start",
+              "type": "workflowStart",
+              "data": {
+                "label": "Start: importLoomVideoWorkflow",
+                "nodeKind": "workflow_start"
+              }
+            },
+            {
+              "id": "end",
+              "type": "workflowEnd",
+              "data": {
+                "label": "Return",
+                "nodeKind": "workflow_end"
+              }
+            }
+          ],
+          "edges": [
+            {
+              "id": "e_start_end",
+              "source": "start",
+              "target": "end",
+              "type": "default"
+            }
+          ]
+        }
+      }
+    },
+    "workflows/transcribe.ts": {
+      "transcribeVideoWorkflow": {
+        "workflowId": "workflow//./workflows/transcribe//transcribeVideoWorkflow",
+        "graph": {
+          "nodes": [
+            {
+              "id": "start",
+              "type": "workflowStart",
+              "data": {
+                "label": "Start: transcribeVideoWorkflow",
+                "nodeKind": "workflow_start"
+              }
+            },
+            {
+              "id": "end",
+              "type": "workflowEnd",
+              "data": {
+                "label": "Return",
+                "nodeKind": "workflow_end"
+              }
+            }
+          ],
+          "edges": [
+            {
+              "id": "e_start_end",
+              "source": "start",
+              "target": "end",
+              "type": "default"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "classes": {}
 }

--- a/apps/web/public/.well-known/workflow/v1/manifest.json
+++ b/apps/web/public/.well-known/workflow/v1/manifest.json
@@ -1,289 +1,289 @@
 {
-  "version": "1.0.0",
-  "steps": {
-    "workflows/process-video.ts": {
-      "cleanupRawUpload": {
-        "stepId": "step//./workflows/process-video//cleanupRawUpload"
-      },
-      "processVideoOnMediaServer": {
-        "stepId": "step//./workflows/process-video//processVideoOnMediaServer"
-      },
-      "saveMetadataAndComplete": {
-        "stepId": "step//./workflows/process-video//saveMetadataAndComplete"
-      },
-      "setProcessingError": {
-        "stepId": "step//./workflows/process-video//setProcessingError"
-      },
-      "validateProcessingRequest": {
-        "stepId": "step//./workflows/process-video//validateProcessingRequest"
-      }
-    },
-    "workflows/edit-video.ts": {
-      "clearEditProcessingState": {
-        "stepId": "step//./workflows/edit-video//clearEditProcessingState"
-      },
-      "invalidateEditedVideoCache": {
-        "stepId": "step//./workflows/edit-video//invalidateEditedVideoCache"
-      },
-      "queueTranscriptionRegeneration": {
-        "stepId": "step//./workflows/edit-video//queueTranscriptionRegeneration"
-      },
-      "renderVideoEditOnMediaServer": {
-        "stepId": "step//./workflows/edit-video//renderVideoEditOnMediaServer"
-      },
-      "saveEditResultAndComplete": {
-        "stepId": "step//./workflows/edit-video//saveEditResultAndComplete"
-      },
-      "validateEditRequest": {
-        "stepId": "step//./workflows/edit-video//validateEditRequest"
-      }
-    },
-    "node_modules/.pnpm/workflow@4.2.0-beta.73_@nestjs+common@11.1.17_reflect-metadata@0.2.2_rxjs@7.8.2__@nestj_2a6f07c63175c34d8d104665b34a32ad/node_modules/workflow/dist/stdlib.js": {
-      "fetch": {
-        "stepId": "step//workflow@4.2.0-beta.73//fetch"
-      }
-    },
-    "workflows/generate-ai.ts": {
-      "fetchTranscript": {
-        "stepId": "step//./workflows/generate-ai//fetchTranscript"
-      },
-      "generateWithAi": {
-        "stepId": "step//./workflows/generate-ai//generateWithAi"
-      },
-      "markSkipped": {
-        "stepId": "step//./workflows/generate-ai//markSkipped"
-      },
-      "saveResults": {
-        "stepId": "step//./workflows/generate-ai//saveResults"
-      },
-      "validateAndSetProcessing": {
-        "stepId": "step//./workflows/generate-ai//validateAndSetProcessing"
-      }
-    },
-    "workflows/import-loom-video.ts": {
-      "downloadLoomToS3": {
-        "stepId": "step//./workflows/import-loom-video//downloadLoomToS3"
-      },
-      "processVideoOnMediaServer": {
-        "stepId": "step//./workflows/import-loom-video//processVideoOnMediaServer"
-      },
-      "saveMetadataAndComplete": {
-        "stepId": "step//./workflows/import-loom-video//saveMetadataAndComplete"
-      },
-      "setProcessingError": {
-        "stepId": "step//./workflows/import-loom-video//setProcessingError"
-      }
-    },
-    "node_modules/.pnpm/workflow@4.2.0-beta.73_@nestjs+common@11.1.17_reflect-metadata@0.2.2_rxjs@7.8.2__@nestj_2a6f07c63175c34d8d104665b34a32ad/node_modules/workflow/dist/internal/builtins.js": {
-      "__builtin_response_array_buffer": {
-        "stepId": "__builtin_response_array_buffer"
-      },
-      "__builtin_response_json": {
-        "stepId": "__builtin_response_json"
-      },
-      "__builtin_response_text": {
-        "stepId": "__builtin_response_text"
-      }
-    },
-    "workflows/transcribe.ts": {
-      "_enhanceAndSaveAudio": {
-        "stepId": "step//./workflows/transcribe//_enhanceAndSaveAudio"
-      },
-      "_markEnhancedAudioProcessing": {
-        "stepId": "step//./workflows/transcribe//_markEnhancedAudioProcessing"
-      },
-      "cleanupTempAudio": {
-        "stepId": "step//./workflows/transcribe//cleanupTempAudio"
-      },
-      "extractAudio": {
-        "stepId": "step//./workflows/transcribe//extractAudio"
-      },
-      "markNoAudio": {
-        "stepId": "step//./workflows/transcribe//markNoAudio"
-      },
-      "markSkipped": {
-        "stepId": "step//./workflows/transcribe//markSkipped"
-      },
-      "queueAiGeneration": {
-        "stepId": "step//./workflows/transcribe//queueAiGeneration"
-      },
-      "saveTranscription": {
-        "stepId": "step//./workflows/transcribe//saveTranscription"
-      },
-      "transcribeWithDeepgram": {
-        "stepId": "step//./workflows/transcribe//transcribeWithDeepgram"
-      },
-      "validateVideo": {
-        "stepId": "step//./workflows/transcribe//validateVideo"
-      }
-    }
-  },
-  "workflows": {
-    "workflows/process-video.ts": {
-      "processVideoWorkflow": {
-        "workflowId": "workflow//./workflows/process-video//processVideoWorkflow",
-        "graph": {
-          "nodes": [
-            {
-              "id": "start",
-              "type": "workflowStart",
-              "data": {
-                "label": "Start: processVideoWorkflow",
-                "nodeKind": "workflow_start"
-              }
-            },
-            {
-              "id": "end",
-              "type": "workflowEnd",
-              "data": {
-                "label": "Return",
-                "nodeKind": "workflow_end"
-              }
-            }
-          ],
-          "edges": [
-            {
-              "id": "e_start_end",
-              "source": "start",
-              "target": "end",
-              "type": "default"
-            }
-          ]
-        }
-      }
-    },
-    "workflows/edit-video.ts": {
-      "editVideoWorkflow": {
-        "workflowId": "workflow//./workflows/edit-video//editVideoWorkflow",
-        "graph": {
-          "nodes": [
-            {
-              "id": "start",
-              "type": "workflowStart",
-              "data": {
-                "label": "Start: editVideoWorkflow",
-                "nodeKind": "workflow_start"
-              }
-            },
-            {
-              "id": "end",
-              "type": "workflowEnd",
-              "data": {
-                "label": "Return",
-                "nodeKind": "workflow_end"
-              }
-            }
-          ],
-          "edges": [
-            {
-              "id": "e_start_end",
-              "source": "start",
-              "target": "end",
-              "type": "default"
-            }
-          ]
-        }
-      }
-    },
-    "workflows/generate-ai.ts": {
-      "generateAiWorkflow": {
-        "workflowId": "workflow//./workflows/generate-ai//generateAiWorkflow",
-        "graph": {
-          "nodes": [
-            {
-              "id": "start",
-              "type": "workflowStart",
-              "data": {
-                "label": "Start: generateAiWorkflow",
-                "nodeKind": "workflow_start"
-              }
-            },
-            {
-              "id": "end",
-              "type": "workflowEnd",
-              "data": {
-                "label": "Return",
-                "nodeKind": "workflow_end"
-              }
-            }
-          ],
-          "edges": [
-            {
-              "id": "e_start_end",
-              "source": "start",
-              "target": "end",
-              "type": "default"
-            }
-          ]
-        }
-      }
-    },
-    "workflows/import-loom-video.ts": {
-      "importLoomVideoWorkflow": {
-        "workflowId": "workflow//./workflows/import-loom-video//importLoomVideoWorkflow",
-        "graph": {
-          "nodes": [
-            {
-              "id": "start",
-              "type": "workflowStart",
-              "data": {
-                "label": "Start: importLoomVideoWorkflow",
-                "nodeKind": "workflow_start"
-              }
-            },
-            {
-              "id": "end",
-              "type": "workflowEnd",
-              "data": {
-                "label": "Return",
-                "nodeKind": "workflow_end"
-              }
-            }
-          ],
-          "edges": [
-            {
-              "id": "e_start_end",
-              "source": "start",
-              "target": "end",
-              "type": "default"
-            }
-          ]
-        }
-      }
-    },
-    "workflows/transcribe.ts": {
-      "transcribeVideoWorkflow": {
-        "workflowId": "workflow//./workflows/transcribe//transcribeVideoWorkflow",
-        "graph": {
-          "nodes": [
-            {
-              "id": "start",
-              "type": "workflowStart",
-              "data": {
-                "label": "Start: transcribeVideoWorkflow",
-                "nodeKind": "workflow_start"
-              }
-            },
-            {
-              "id": "end",
-              "type": "workflowEnd",
-              "data": {
-                "label": "Return",
-                "nodeKind": "workflow_end"
-              }
-            }
-          ],
-          "edges": [
-            {
-              "id": "e_start_end",
-              "source": "start",
-              "target": "end",
-              "type": "default"
-            }
-          ]
-        }
-      }
-    }
-  },
-  "classes": {}
+	"version": "1.0.0",
+	"steps": {
+		"workflows/process-video.ts": {
+			"cleanupRawUpload": {
+				"stepId": "step//./workflows/process-video//cleanupRawUpload"
+			},
+			"processVideoOnMediaServer": {
+				"stepId": "step//./workflows/process-video//processVideoOnMediaServer"
+			},
+			"saveMetadataAndComplete": {
+				"stepId": "step//./workflows/process-video//saveMetadataAndComplete"
+			},
+			"setProcessingError": {
+				"stepId": "step//./workflows/process-video//setProcessingError"
+			},
+			"validateProcessingRequest": {
+				"stepId": "step//./workflows/process-video//validateProcessingRequest"
+			}
+		},
+		"workflows/edit-video.ts": {
+			"clearEditProcessingState": {
+				"stepId": "step//./workflows/edit-video//clearEditProcessingState"
+			},
+			"invalidateEditedVideoCache": {
+				"stepId": "step//./workflows/edit-video//invalidateEditedVideoCache"
+			},
+			"queueTranscriptionRegeneration": {
+				"stepId": "step//./workflows/edit-video//queueTranscriptionRegeneration"
+			},
+			"renderVideoEditOnMediaServer": {
+				"stepId": "step//./workflows/edit-video//renderVideoEditOnMediaServer"
+			},
+			"saveEditResultAndComplete": {
+				"stepId": "step//./workflows/edit-video//saveEditResultAndComplete"
+			},
+			"validateEditRequest": {
+				"stepId": "step//./workflows/edit-video//validateEditRequest"
+			}
+		},
+		"node_modules/.pnpm/workflow@4.2.0-beta.73_@nestjs+common@11.1.17_reflect-metadata@0.2.2_rxjs@7.8.2__@nestj_2a6f07c63175c34d8d104665b34a32ad/node_modules/workflow/dist/stdlib.js": {
+			"fetch": {
+				"stepId": "step//workflow@4.2.0-beta.73//fetch"
+			}
+		},
+		"workflows/generate-ai.ts": {
+			"fetchTranscript": {
+				"stepId": "step//./workflows/generate-ai//fetchTranscript"
+			},
+			"generateWithAi": {
+				"stepId": "step//./workflows/generate-ai//generateWithAi"
+			},
+			"markSkipped": {
+				"stepId": "step//./workflows/generate-ai//markSkipped"
+			},
+			"saveResults": {
+				"stepId": "step//./workflows/generate-ai//saveResults"
+			},
+			"validateAndSetProcessing": {
+				"stepId": "step//./workflows/generate-ai//validateAndSetProcessing"
+			}
+		},
+		"workflows/import-loom-video.ts": {
+			"downloadLoomToS3": {
+				"stepId": "step//./workflows/import-loom-video//downloadLoomToS3"
+			},
+			"processVideoOnMediaServer": {
+				"stepId": "step//./workflows/import-loom-video//processVideoOnMediaServer"
+			},
+			"saveMetadataAndComplete": {
+				"stepId": "step//./workflows/import-loom-video//saveMetadataAndComplete"
+			},
+			"setProcessingError": {
+				"stepId": "step//./workflows/import-loom-video//setProcessingError"
+			}
+		},
+		"node_modules/.pnpm/workflow@4.2.0-beta.73_@nestjs+common@11.1.17_reflect-metadata@0.2.2_rxjs@7.8.2__@nestj_2a6f07c63175c34d8d104665b34a32ad/node_modules/workflow/dist/internal/builtins.js": {
+			"__builtin_response_array_buffer": {
+				"stepId": "__builtin_response_array_buffer"
+			},
+			"__builtin_response_json": {
+				"stepId": "__builtin_response_json"
+			},
+			"__builtin_response_text": {
+				"stepId": "__builtin_response_text"
+			}
+		},
+		"workflows/transcribe.ts": {
+			"_enhanceAndSaveAudio": {
+				"stepId": "step//./workflows/transcribe//_enhanceAndSaveAudio"
+			},
+			"_markEnhancedAudioProcessing": {
+				"stepId": "step//./workflows/transcribe//_markEnhancedAudioProcessing"
+			},
+			"cleanupTempAudio": {
+				"stepId": "step//./workflows/transcribe//cleanupTempAudio"
+			},
+			"extractAudio": {
+				"stepId": "step//./workflows/transcribe//extractAudio"
+			},
+			"markNoAudio": {
+				"stepId": "step//./workflows/transcribe//markNoAudio"
+			},
+			"markSkipped": {
+				"stepId": "step//./workflows/transcribe//markSkipped"
+			},
+			"queueAiGeneration": {
+				"stepId": "step//./workflows/transcribe//queueAiGeneration"
+			},
+			"saveTranscription": {
+				"stepId": "step//./workflows/transcribe//saveTranscription"
+			},
+			"transcribeWithDeepgram": {
+				"stepId": "step//./workflows/transcribe//transcribeWithDeepgram"
+			},
+			"validateVideo": {
+				"stepId": "step//./workflows/transcribe//validateVideo"
+			}
+		}
+	},
+	"workflows": {
+		"workflows/process-video.ts": {
+			"processVideoWorkflow": {
+				"workflowId": "workflow//./workflows/process-video//processVideoWorkflow",
+				"graph": {
+					"nodes": [
+						{
+							"id": "start",
+							"type": "workflowStart",
+							"data": {
+								"label": "Start: processVideoWorkflow",
+								"nodeKind": "workflow_start"
+							}
+						},
+						{
+							"id": "end",
+							"type": "workflowEnd",
+							"data": {
+								"label": "Return",
+								"nodeKind": "workflow_end"
+							}
+						}
+					],
+					"edges": [
+						{
+							"id": "e_start_end",
+							"source": "start",
+							"target": "end",
+							"type": "default"
+						}
+					]
+				}
+			}
+		},
+		"workflows/edit-video.ts": {
+			"editVideoWorkflow": {
+				"workflowId": "workflow//./workflows/edit-video//editVideoWorkflow",
+				"graph": {
+					"nodes": [
+						{
+							"id": "start",
+							"type": "workflowStart",
+							"data": {
+								"label": "Start: editVideoWorkflow",
+								"nodeKind": "workflow_start"
+							}
+						},
+						{
+							"id": "end",
+							"type": "workflowEnd",
+							"data": {
+								"label": "Return",
+								"nodeKind": "workflow_end"
+							}
+						}
+					],
+					"edges": [
+						{
+							"id": "e_start_end",
+							"source": "start",
+							"target": "end",
+							"type": "default"
+						}
+					]
+				}
+			}
+		},
+		"workflows/generate-ai.ts": {
+			"generateAiWorkflow": {
+				"workflowId": "workflow//./workflows/generate-ai//generateAiWorkflow",
+				"graph": {
+					"nodes": [
+						{
+							"id": "start",
+							"type": "workflowStart",
+							"data": {
+								"label": "Start: generateAiWorkflow",
+								"nodeKind": "workflow_start"
+							}
+						},
+						{
+							"id": "end",
+							"type": "workflowEnd",
+							"data": {
+								"label": "Return",
+								"nodeKind": "workflow_end"
+							}
+						}
+					],
+					"edges": [
+						{
+							"id": "e_start_end",
+							"source": "start",
+							"target": "end",
+							"type": "default"
+						}
+					]
+				}
+			}
+		},
+		"workflows/import-loom-video.ts": {
+			"importLoomVideoWorkflow": {
+				"workflowId": "workflow//./workflows/import-loom-video//importLoomVideoWorkflow",
+				"graph": {
+					"nodes": [
+						{
+							"id": "start",
+							"type": "workflowStart",
+							"data": {
+								"label": "Start: importLoomVideoWorkflow",
+								"nodeKind": "workflow_start"
+							}
+						},
+						{
+							"id": "end",
+							"type": "workflowEnd",
+							"data": {
+								"label": "Return",
+								"nodeKind": "workflow_end"
+							}
+						}
+					],
+					"edges": [
+						{
+							"id": "e_start_end",
+							"source": "start",
+							"target": "end",
+							"type": "default"
+						}
+					]
+				}
+			}
+		},
+		"workflows/transcribe.ts": {
+			"transcribeVideoWorkflow": {
+				"workflowId": "workflow//./workflows/transcribe//transcribeVideoWorkflow",
+				"graph": {
+					"nodes": [
+						{
+							"id": "start",
+							"type": "workflowStart",
+							"data": {
+								"label": "Start: transcribeVideoWorkflow",
+								"nodeKind": "workflow_start"
+							}
+						},
+						{
+							"id": "end",
+							"type": "workflowEnd",
+							"data": {
+								"label": "Return",
+								"nodeKind": "workflow_end"
+							}
+						}
+					],
+					"edges": [
+						{
+							"id": "e_start_end",
+							"source": "start",
+							"target": "end",
+							"type": "default"
+						}
+					]
+				}
+			}
+		}
+	},
+	"classes": {}
 }

--- a/packages/database/migrate.ts
+++ b/packages/database/migrate.ts
@@ -4,9 +4,10 @@ import { DrizzleQueryError } from "drizzle-orm";
 import { migrate } from "drizzle-orm/mysql2/migrator";
 
 import { runOrgIdBackfill } from "./migrations/orgid_backfill.ts";
+import { runSpaceMemberRoleBackfill } from "./migrations/space_member_role_backfill.ts";
 
 async function runMigrate() {
-	await migrate(db() as any, {
+	await migrate(db(), {
 		migrationsFolder: path.join(process.cwd(), "/migrations"),
 	});
 }
@@ -20,19 +21,26 @@ function errorIsOrgIdMigration(e: unknown): e is DrizzleQueryError {
 }
 
 export async function migrateDb() {
-	runMigrate()
-		.catch(async (e) => {
-			if (errorIsOrgIdMigration(e)) {
-				console.log("non-null videos.orgId migration failed, running backfill");
+	try {
+		await runMigrate();
+	} catch (e) {
+		if (!errorIsOrgIdMigration(e)) throw e;
 
-				await runOrgIdBackfill();
-				await runMigrate();
-			} else throw e;
-		})
-		.catch((e) => {
-			if (errorIsOrgIdMigration(e))
+		console.log("non-null videos.orgId migration failed, running backfill");
+
+		await runOrgIdBackfill();
+
+		try {
+			await runMigrate();
+		} catch (retryError) {
+			if (errorIsOrgIdMigration(retryError)) {
 				throw new Error(
 					"videos.orgId backfill failed, you will need to manually update the videos.orgId column before attempting to migrate again.",
 				);
-		});
+			}
+			throw retryError;
+		}
+	}
+
+	await runSpaceMemberRoleBackfill();
 }

--- a/packages/database/migrations/0025_demonic_mother_askani.sql
+++ b/packages/database/migrations/0025_demonic_mother_askani.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `organizations` ADD `shareableLinkIconUrl` varchar(1024);

--- a/packages/database/migrations/meta/0025_snapshot.json
+++ b/packages/database/migrations/meta/0025_snapshot.json
@@ -1,0 +1,3564 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "0df93b03-9847-42d2-b71f-9d0cbc968216",
+  "prevId": "ae365232-4098-4426-a0ba-b8b6aa46fb3b",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_in": {
+          "name": "expires_in",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_in": {
+          "name": "refresh_token_expires_in",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "tempColumn": {
+          "name": "tempColumn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "provider_account_id_idx": {
+          "name": "provider_account_id_idx",
+          "columns": [
+            "providerAccountId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "accounts_id": {
+          "name": "accounts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "auth_api_keys": {
+      "name": "auth_api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "auth_api_keys_id": {
+          "name": "auth_api_keys_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "videoId": {
+          "name": "videoId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "parentCommentId": {
+          "name": "parentCommentId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "video_type_created_idx": {
+          "name": "video_type_created_idx",
+          "columns": [
+            "videoId",
+            "type",
+            "createdAt",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "author_id_idx": {
+          "name": "author_id_idx",
+          "columns": [
+            "authorId"
+          ],
+          "isUnique": false
+        },
+        "parent_comment_id_idx": {
+          "name": "parent_comment_id_idx",
+          "columns": [
+            "parentCommentId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comments_id": {
+          "name": "comments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "developer_api_keys": {
+      "name": "developer_api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyType": {
+          "name": "keyType",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyPrefix": {
+          "name": "keyPrefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encryptedKey": {
+          "name": "encryptedKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "key_hash_idx": {
+          "name": "key_hash_idx",
+          "columns": [
+            "keyHash"
+          ],
+          "isUnique": true
+        },
+        "app_key_type_idx": {
+          "name": "app_key_type_idx",
+          "columns": [
+            "appId",
+            "keyType"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "developer_api_keys_appId_developer_apps_id_fk": {
+          "name": "developer_api_keys_appId_developer_apps_id_fk",
+          "tableFrom": "developer_api_keys",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "appId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "developer_api_keys_id": {
+          "name": "developer_api_keys_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "developer_app_domains": {
+      "name": "developer_app_domains",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "developer_app_domains_appId_developer_apps_id_fk": {
+          "name": "developer_app_domains_appId_developer_apps_id_fk",
+          "tableFrom": "developer_app_domains",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "appId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "developer_app_domains_id": {
+          "name": "developer_app_domains_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "app_domain_unique": {
+          "name": "app_domain_unique",
+          "columns": [
+            "appId",
+            "domain"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "developer_apps": {
+      "name": "developer_apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logoUrl": {
+          "name": "logoUrl",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "owner_deleted_idx": {
+          "name": "owner_deleted_idx",
+          "columns": [
+            "ownerId",
+            "deletedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "developer_apps_id": {
+          "name": "developer_apps_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "developer_credit_accounts": {
+      "name": "developer_credit_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balanceMicroCredits": {
+          "name": "balanceMicroCredits",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripePaymentMethodId": {
+          "name": "stripePaymentMethodId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "autoTopUpEnabled": {
+          "name": "autoTopUpEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "autoTopUpThresholdMicroCredits": {
+          "name": "autoTopUpThresholdMicroCredits",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "autoTopUpAmountCents": {
+          "name": "autoTopUpAmountCents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "app_id_unique": {
+          "name": "app_id_unique",
+          "columns": [
+            "appId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "developer_credit_accounts_appId_developer_apps_id_fk": {
+          "name": "developer_credit_accounts_appId_developer_apps_id_fk",
+          "tableFrom": "developer_credit_accounts",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "appId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "developer_credit_accounts_id": {
+          "name": "developer_credit_accounts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "developer_credit_transactions": {
+      "name": "developer_credit_transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amountMicroCredits": {
+          "name": "amountMicroCredits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balanceAfterMicroCredits": {
+          "name": "balanceAfterMicroCredits",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referenceType": {
+          "name": "referenceType",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "account_type_created_idx": {
+          "name": "account_type_created_idx",
+          "columns": [
+            "accountId",
+            "type",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "account_ref_dedup_idx": {
+          "name": "account_ref_dedup_idx",
+          "columns": [
+            "accountId",
+            "referenceId",
+            "referenceType"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "dev_credit_txn_account_fk": {
+          "name": "dev_credit_txn_account_fk",
+          "tableFrom": "developer_credit_transactions",
+          "tableTo": "developer_credit_accounts",
+          "columnsFrom": [
+            "accountId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "developer_credit_transactions_id": {
+          "name": "developer_credit_transactions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "developer_daily_storage_snapshots": {
+      "name": "developer_daily_storage_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshotDate": {
+          "name": "snapshotDate",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "totalDurationMinutes": {
+          "name": "totalDurationMinutes",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "videoCount": {
+          "name": "videoCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "microCreditsCharged": {
+          "name": "microCreditsCharged",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "developer_daily_storage_snapshots_appId_developer_apps_id_fk": {
+          "name": "developer_daily_storage_snapshots_appId_developer_apps_id_fk",
+          "tableFrom": "developer_daily_storage_snapshots",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "appId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "developer_daily_storage_snapshots_id": {
+          "name": "developer_daily_storage_snapshots_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "app_date_unique": {
+          "name": "app_date_unique",
+          "columns": [
+            "appId",
+            "snapshotDate"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "developer_videos": {
+      "name": "developer_videos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "externalUserId": {
+          "name": "externalUserId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Untitled'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fps": {
+          "name": "fps",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "s3Key": {
+          "name": "s3Key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcriptionStatus": {
+          "name": "transcriptionStatus",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "app_created_idx": {
+          "name": "app_created_idx",
+          "columns": [
+            "appId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "app_user_idx": {
+          "name": "app_user_idx",
+          "columns": [
+            "appId",
+            "externalUserId"
+          ],
+          "isUnique": false
+        },
+        "app_deleted_idx": {
+          "name": "app_deleted_idx",
+          "columns": [
+            "appId",
+            "deletedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "developer_videos_appId_developer_apps_id_fk": {
+          "name": "developer_videos_appId_developer_apps_id_fk",
+          "tableFrom": "developer_videos",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "appId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "developer_videos_id": {
+          "name": "developer_videos_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "folders": {
+      "name": "folders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'normal'"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "organization_id_idx": {
+          "name": "organization_id_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "created_by_id_idx": {
+          "name": "created_by_id_idx",
+          "columns": [
+            "createdById"
+          ],
+          "isUnique": false
+        },
+        "parent_id_idx": {
+          "name": "parent_id_idx",
+          "columns": [
+            "parentId"
+          ],
+          "isUnique": false
+        },
+        "space_id_idx": {
+          "name": "space_id_idx",
+          "columns": [
+            "spaceId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "folders_id": {
+          "name": "folders_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "imported_videos": {
+      "name": "imported_videos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orgId": {
+          "name": "orgId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "imported_videos_orgId_source_source_id_pk": {
+          "name": "imported_videos_orgId_source_source_id_pk",
+          "columns": [
+            "orgId",
+            "source",
+            "source_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "messenger_conversations": {
+      "name": "messenger_conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'agent'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anonymousId": {
+          "name": "anonymousId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "takeoverByUserId": {
+          "name": "takeoverByUserId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "takeoverAt": {
+          "name": "takeoverAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "user_last_message_idx": {
+          "name": "user_last_message_idx",
+          "columns": [
+            "userId",
+            "lastMessageAt"
+          ],
+          "isUnique": false
+        },
+        "anonymous_last_message_idx": {
+          "name": "anonymous_last_message_idx",
+          "columns": [
+            "anonymousId",
+            "lastMessageAt"
+          ],
+          "isUnique": false
+        },
+        "mode_last_message_idx": {
+          "name": "mode_last_message_idx",
+          "columns": [
+            "mode",
+            "lastMessageAt"
+          ],
+          "isUnique": false
+        },
+        "updated_at_idx": {
+          "name": "updated_at_idx",
+          "columns": [
+            "updatedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "messenger_conversations_id": {
+          "name": "messenger_conversations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "messenger_messages": {
+      "name": "messenger_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anonymousId": {
+          "name": "anonymousId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "conversation_created_at_idx": {
+          "name": "conversation_created_at_idx",
+          "columns": [
+            "conversationId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "role_created_at_idx": {
+          "name": "role_created_at_idx",
+          "columns": [
+            "role",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messenger_messages_conversationId_messenger_conversations_id_fk": {
+          "name": "messenger_messages_conversationId_messenger_conversations_id_fk",
+          "tableFrom": "messenger_messages",
+          "tableTo": "messenger_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "messenger_messages_id": {
+          "name": "messenger_messages_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orgId": {
+          "name": "orgId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipientId": {
+          "name": "recipientId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "videoId": {
+          "name": "videoId",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dedupKey": {
+          "name": "dedupKey",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "org_id_idx": {
+          "name": "org_id_idx",
+          "columns": [
+            "orgId"
+          ],
+          "isUnique": false
+        },
+        "type_idx": {
+          "name": "type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "read_at_idx": {
+          "name": "read_at_idx",
+          "columns": [
+            "readAt"
+          ],
+          "isUnique": false
+        },
+        "created_at_idx": {
+          "name": "created_at_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "recipient_read_idx": {
+          "name": "recipient_read_idx",
+          "columns": [
+            "recipientId",
+            "readAt"
+          ],
+          "isUnique": false
+        },
+        "recipient_created_idx": {
+          "name": "recipient_created_idx",
+          "columns": [
+            "recipientId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "dedup_key_idx": {
+          "name": "dedup_key_idx",
+          "columns": [
+            "dedupKey"
+          ],
+          "isUnique": true
+        },
+        "type_recipient_created_idx": {
+          "name": "type_recipient_created_idx",
+          "columns": [
+            "type",
+            "recipientId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "type_recipient_video_created_idx": {
+          "name": "type_recipient_video_created_idx",
+          "columns": [
+            "type",
+            "recipientId",
+            "videoId",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notifications_id": {
+          "name": "notifications_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_invites": {
+      "name": "organization_invites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invitedEmail": {
+          "name": "invitedEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invitedByUserId": {
+          "name": "invitedByUserId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_id_idx": {
+          "name": "organization_id_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "invited_email_idx": {
+          "name": "invited_email_idx",
+          "columns": [
+            "invitedEmail"
+          ],
+          "isUnique": false
+        },
+        "invited_by_user_id_idx": {
+          "name": "invited_by_user_id_idx",
+          "columns": [
+            "invitedByUserId"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_invites_id": {
+          "name": "organization_invites_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hasProSeat": {
+          "name": "hasProSeat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "organization_id_idx": {
+          "name": "organization_id_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "user_id_organization_id_idx": {
+          "name": "user_id_organization_id_idx",
+          "columns": [
+            "userId",
+            "organizationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_members_id": {
+          "name": "organization_members_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tombstoneAt": {
+          "name": "tombstoneAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowedEmailDomain": {
+          "name": "allowedEmailDomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customDomain": {
+          "name": "customDomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domainVerified": {
+          "name": "domainVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "iconUrl": {
+          "name": "iconUrl",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shareableLinkIconUrl": {
+          "name": "shareableLinkIconUrl",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "workosOrganizationId": {
+          "name": "workosOrganizationId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workosConnectionId": {
+          "name": "workosConnectionId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "owner_id_tombstone_idx": {
+          "name": "owner_id_tombstone_idx",
+          "columns": [
+            "ownerId",
+            "tombstoneAt"
+          ],
+          "isUnique": false
+        },
+        "custom_domain_idx": {
+          "name": "custom_domain_idx",
+          "columns": [
+            "customDomain"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organizations_id": {
+          "name": "organizations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "s3_buckets": {
+      "name": "s3_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bucketName": {
+          "name": "bucketName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessKeyId": {
+          "name": "accessKeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secretAccessKey": {
+          "name": "secretAccessKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('aws')"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "owner_organization_idx": {
+          "name": "owner_organization_idx",
+          "columns": [
+            "ownerId",
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "organization_id_idx": {
+          "name": "organization_id_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "organization_active_idx": {
+          "name": "organization_active_idx",
+          "columns": [
+            "organizationId",
+            "active",
+            "updatedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "s3_buckets_id": {
+          "name": "s3_buckets_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "session_token_idx": {
+          "name": "session_token_idx",
+          "columns": [
+            "sessionToken"
+          ],
+          "isUnique": true
+        },
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sessions_id": {
+          "name": "sessions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "shared_videos": {
+      "name": "shared_videos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "videoId": {
+          "name": "videoId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sharedByUserId": {
+          "name": "sharedByUserId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sharedAt": {
+          "name": "sharedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "folder_id_idx": {
+          "name": "folder_id_idx",
+          "columns": [
+            "folderId"
+          ],
+          "isUnique": false
+        },
+        "organization_id_idx": {
+          "name": "organization_id_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "shared_by_user_id_idx": {
+          "name": "shared_by_user_id_idx",
+          "columns": [
+            "sharedByUserId"
+          ],
+          "isUnique": false
+        },
+        "video_id_organization_id_idx": {
+          "name": "video_id_organization_id_idx",
+          "columns": [
+            "videoId",
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "video_id_folder_id_idx": {
+          "name": "video_id_folder_id_idx",
+          "columns": [
+            "videoId",
+            "folderId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "shared_videos_id": {
+          "name": "shared_videos_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "space_members": {
+      "name": "space_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "space_members_id": {
+          "name": "space_members_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "space_id_user_id_unique": {
+          "name": "space_id_user_id_unique",
+          "columns": [
+            "spaceId",
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "space_videos": {
+      "name": "space_videos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "videoId": {
+          "name": "videoId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addedById": {
+          "name": "addedById",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addedAt": {
+          "name": "addedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "folder_id_idx": {
+          "name": "folder_id_idx",
+          "columns": [
+            "folderId"
+          ],
+          "isUnique": false
+        },
+        "video_id_idx": {
+          "name": "video_id_idx",
+          "columns": [
+            "videoId"
+          ],
+          "isUnique": false
+        },
+        "added_by_id_idx": {
+          "name": "added_by_id_idx",
+          "columns": [
+            "addedById"
+          ],
+          "isUnique": false
+        },
+        "space_id_video_id_idx": {
+          "name": "space_id_video_id_idx",
+          "columns": [
+            "spaceId",
+            "videoId"
+          ],
+          "isUnique": false
+        },
+        "space_id_folder_id_idx": {
+          "name": "space_id_folder_id_idx",
+          "columns": [
+            "spaceId",
+            "folderId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "space_videos_id": {
+          "name": "space_videos_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "spaces": {
+      "name": "spaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "primary": {
+          "name": "primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iconUrl": {
+          "name": "iconUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "privacy": {
+          "name": "privacy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Private'"
+        }
+      },
+      "indexes": {
+        "organization_id_idx": {
+          "name": "organization_id_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "created_by_id_idx": {
+          "name": "created_by_id_idx",
+          "columns": [
+            "createdById"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "spaces_id": {
+          "name": "spaces_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "storage_integrations": {
+      "name": "storage_integrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "encryptedConfig": {
+          "name": "encryptedConfig",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "googleDriveAccessToken": {
+          "name": "googleDriveAccessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "googleDriveAccessTokenExpiresAt": {
+          "name": "googleDriveAccessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "googleDriveTokenRefreshLeaseId": {
+          "name": "googleDriveTokenRefreshLeaseId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "googleDriveTokenRefreshLeaseExpiresAt": {
+          "name": "googleDriveTokenRefreshLeaseExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "googleDriveStorageQuotaCache": {
+          "name": "googleDriveStorageQuotaCache",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "owner_provider_idx": {
+          "name": "owner_provider_idx",
+          "columns": [
+            "ownerId",
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "owner_active_idx": {
+          "name": "owner_active_idx",
+          "columns": [
+            "ownerId",
+            "active"
+          ],
+          "isUnique": false
+        },
+        "organization_provider_idx": {
+          "name": "organization_provider_idx",
+          "columns": [
+            "organizationId",
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "organization_active_idx": {
+          "name": "organization_active_idx",
+          "columns": [
+            "organizationId",
+            "active",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "storage_integrations_id": {
+          "name": "storage_integrations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "storage_objects": {
+      "name": "storage_objects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "videoId": {
+          "name": "videoId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "objectKey": {
+          "name": "objectKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "objectKeyHash": {
+          "name": "objectKeyHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerObjectId": {
+          "name": "providerObjectId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploadSessionUrl": {
+          "name": "uploadSessionUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uploadStatus": {
+          "name": "uploadStatus",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contentLength": {
+          "name": "contentLength",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "integration_key_hash_idx": {
+          "name": "integration_key_hash_idx",
+          "columns": [
+            "integrationId",
+            "objectKeyHash"
+          ],
+          "isUnique": true
+        },
+        "integration_status_idx": {
+          "name": "integration_status_idx",
+          "columns": [
+            "integrationId",
+            "uploadStatus"
+          ],
+          "isUnique": false
+        },
+        "video_id_idx": {
+          "name": "video_id_idx",
+          "columns": [
+            "videoId"
+          ],
+          "isUnique": false
+        },
+        "owner_id_idx": {
+          "name": "owner_id_idx",
+          "columns": [
+            "ownerId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "storage_objects_integrationId_storage_integrations_id_fk": {
+          "name": "storage_objects_integrationId_storage_integrations_id_fk",
+          "tableFrom": "storage_objects",
+          "tableTo": "storage_integrations",
+          "columnsFrom": [
+            "integrationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "storage_objects_id": {
+          "name": "storage_objects_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thirdPartyStripeSubscriptionId": {
+          "name": "thirdPartyStripeSubscriptionId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripeSubscriptionStatus": {
+          "name": "stripeSubscriptionStatus",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripeSubscriptionPriceId": {
+          "name": "stripeSubscriptionPriceId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('null')"
+        },
+        "activeOrganizationId": {
+          "name": "activeOrganizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "onboardingSteps": {
+          "name": "onboardingSteps",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customBucket": {
+          "name": "customBucket",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inviteQuota": {
+          "name": "inviteQuota",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "defaultOrgId": {
+          "name": "defaultOrgId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_idx": {
+          "name": "email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "verification_tokens": {
+      "name": "verification_tokens",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier": {
+          "name": "verification_tokens_identifier",
+          "columns": [
+            "identifier"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "video_edits": {
+      "name": "video_edits",
+      "columns": {
+        "videoId": {
+          "name": "videoId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sourceKey": {
+          "name": "sourceKey",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "editSpec": {
+          "name": "editSpec",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "video_edits_videoId_videos_id_fk": {
+          "name": "video_edits_videoId_videos_id_fk",
+          "tableFrom": "video_edits",
+          "tableTo": "videos",
+          "columnsFrom": [
+            "videoId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "video_edits_videoId": {
+          "name": "video_edits_videoId",
+          "columns": [
+            "videoId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "video_uploads": {
+      "name": "video_uploads",
+      "columns": {
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploaded": {
+          "name": "uploaded",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total": {
+          "name": "total",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'uploading'"
+        },
+        "processing_progress": {
+          "name": "processing_progress",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "processing_message": {
+          "name": "processing_message",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processing_error": {
+          "name": "processing_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_file_key": {
+          "name": "raw_file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "video_uploads_video_id": {
+          "name": "video_uploads_video_id",
+          "columns": [
+            "video_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "videos": {
+      "name": "videos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orgId": {
+          "name": "orgId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'My Video'"
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storageIntegrationId": {
+          "name": "storageIntegrationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fps": {
+          "name": "fps",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcriptionStatus": {
+          "name": "transcriptionStatus",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('{\"type\":\"MediaConvert\"}')"
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "effectiveCreatedAt": {
+          "name": "effectiveCreatedAt",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "COALESCE(\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%s.%fZ'),\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%sZ'),\n          `createdAt`\n        )",
+            "type": "stored"
+          }
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "xStreamInfo": {
+          "name": "xStreamInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "firstViewEmailSentAt": {
+          "name": "firstViewEmailSentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isScreenshot": {
+          "name": "isScreenshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "awsRegion": {
+          "name": "awsRegion",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "awsBucket": {
+          "name": "awsBucket",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "videoStartTime": {
+          "name": "videoStartTime",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audioStartTime": {
+          "name": "audioStartTime",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jobId": {
+          "name": "jobId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jobStatus": {
+          "name": "jobStatus",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skipProcessing": {
+          "name": "skipProcessing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "owner_id_idx": {
+          "name": "owner_id_idx",
+          "columns": [
+            "ownerId"
+          ],
+          "isUnique": false
+        },
+        "is_public_idx": {
+          "name": "is_public_idx",
+          "columns": [
+            "public"
+          ],
+          "isUnique": false
+        },
+        "folder_id_idx": {
+          "name": "folder_id_idx",
+          "columns": [
+            "folderId"
+          ],
+          "isUnique": false
+        },
+        "storage_integration_id_idx": {
+          "name": "storage_integration_id_idx",
+          "columns": [
+            "storageIntegrationId"
+          ],
+          "isUnique": false
+        },
+        "org_owner_folder_idx": {
+          "name": "org_owner_folder_idx",
+          "columns": [
+            "orgId",
+            "ownerId",
+            "folderId"
+          ],
+          "isUnique": false
+        },
+        "org_effective_created_idx": {
+          "name": "org_effective_created_idx",
+          "columns": [
+            "orgId",
+            "effectiveCreatedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "videos_storageIntegrationId_storage_integrations_id_fk": {
+          "name": "videos_storageIntegrationId_storage_integrations_id_fk",
+          "tableFrom": "videos",
+          "tableTo": "storage_integrations",
+          "columnsFrom": [
+            "storageIntegrationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "videos_id": {
+          "name": "videos_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/0025_snapshot.json
+++ b/packages/database/migrations/meta/0025_snapshot.json
@@ -1,3564 +1,3258 @@
 {
-  "version": "5",
-  "dialect": "mysql",
-  "id": "0df93b03-9847-42d2-b71f-9d0cbc968216",
-  "prevId": "ae365232-4098-4426-a0ba-b8b6aa46fb3b",
-  "tables": {
-    "accounts": {
-      "name": "accounts",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "provider": {
-          "name": "provider",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "providerAccountId": {
-          "name": "providerAccountId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "access_token": {
-          "name": "access_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "expires_in": {
-          "name": "expires_in",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "id_token": {
-          "name": "id_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "refresh_token": {
-          "name": "refresh_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "refresh_token_expires_in": {
-          "name": "refresh_token_expires_in",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "scope": {
-          "name": "scope",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "token_type": {
-          "name": "token_type",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "tempColumn": {
-          "name": "tempColumn",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        }
-      },
-      "indexes": {
-        "user_id_idx": {
-          "name": "user_id_idx",
-          "columns": [
-            "userId"
-          ],
-          "isUnique": false
-        },
-        "provider_account_id_idx": {
-          "name": "provider_account_id_idx",
-          "columns": [
-            "providerAccountId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "accounts_id": {
-          "name": "accounts_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "auth_api_keys": {
-      "name": "auth_api_keys",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(36)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "auth_api_keys_id": {
-          "name": "auth_api_keys_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "comments": {
-      "name": "comments",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(6)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "content": {
-          "name": "content",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "timestamp": {
-          "name": "timestamp",
-          "type": "float",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "authorId": {
-          "name": "authorId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "videoId": {
-          "name": "videoId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "parentCommentId": {
-          "name": "parentCommentId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        }
-      },
-      "indexes": {
-        "video_type_created_idx": {
-          "name": "video_type_created_idx",
-          "columns": [
-            "videoId",
-            "type",
-            "createdAt",
-            "id"
-          ],
-          "isUnique": false
-        },
-        "author_id_idx": {
-          "name": "author_id_idx",
-          "columns": [
-            "authorId"
-          ],
-          "isUnique": false
-        },
-        "parent_comment_id_idx": {
-          "name": "parent_comment_id_idx",
-          "columns": [
-            "parentCommentId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "comments_id": {
-          "name": "comments_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "developer_api_keys": {
-      "name": "developer_api_keys",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "appId": {
-          "name": "appId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "keyType": {
-          "name": "keyType",
-          "type": "varchar(8)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "keyPrefix": {
-          "name": "keyPrefix",
-          "type": "varchar(12)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "keyHash": {
-          "name": "keyHash",
-          "type": "varchar(64)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "encryptedKey": {
-          "name": "encryptedKey",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "lastUsedAt": {
-          "name": "lastUsedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "revokedAt": {
-          "name": "revokedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "key_hash_idx": {
-          "name": "key_hash_idx",
-          "columns": [
-            "keyHash"
-          ],
-          "isUnique": true
-        },
-        "app_key_type_idx": {
-          "name": "app_key_type_idx",
-          "columns": [
-            "appId",
-            "keyType"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {
-        "developer_api_keys_appId_developer_apps_id_fk": {
-          "name": "developer_api_keys_appId_developer_apps_id_fk",
-          "tableFrom": "developer_api_keys",
-          "tableTo": "developer_apps",
-          "columnsFrom": [
-            "appId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "developer_api_keys_id": {
-          "name": "developer_api_keys_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "developer_app_domains": {
-      "name": "developer_app_domains",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "appId": {
-          "name": "appId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "domain": {
-          "name": "domain",
-          "type": "varchar(253)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "developer_app_domains_appId_developer_apps_id_fk": {
-          "name": "developer_app_domains_appId_developer_apps_id_fk",
-          "tableFrom": "developer_app_domains",
-          "tableTo": "developer_apps",
-          "columnsFrom": [
-            "appId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "developer_app_domains_id": {
-          "name": "developer_app_domains_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {
-        "app_domain_unique": {
-          "name": "app_domain_unique",
-          "columns": [
-            "appId",
-            "domain"
-          ]
-        }
-      },
-      "checkConstraint": {}
-    },
-    "developer_apps": {
-      "name": "developer_apps",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ownerId": {
-          "name": "ownerId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "environment": {
-          "name": "environment",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "logoUrl": {
-          "name": "logoUrl",
-          "type": "varchar(1024)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "deletedAt": {
-          "name": "deletedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "owner_deleted_idx": {
-          "name": "owner_deleted_idx",
-          "columns": [
-            "ownerId",
-            "deletedAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "developer_apps_id": {
-          "name": "developer_apps_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "developer_credit_accounts": {
-      "name": "developer_credit_accounts",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "appId": {
-          "name": "appId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ownerId": {
-          "name": "ownerId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "balanceMicroCredits": {
-          "name": "balanceMicroCredits",
-          "type": "bigint unsigned",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "stripeCustomerId": {
-          "name": "stripeCustomerId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "stripePaymentMethodId": {
-          "name": "stripePaymentMethodId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "autoTopUpEnabled": {
-          "name": "autoTopUpEnabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
-        },
-        "autoTopUpThresholdMicroCredits": {
-          "name": "autoTopUpThresholdMicroCredits",
-          "type": "bigint unsigned",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "autoTopUpAmountCents": {
-          "name": "autoTopUpAmountCents",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "app_id_unique": {
-          "name": "app_id_unique",
-          "columns": [
-            "appId"
-          ],
-          "isUnique": true
-        }
-      },
-      "foreignKeys": {
-        "developer_credit_accounts_appId_developer_apps_id_fk": {
-          "name": "developer_credit_accounts_appId_developer_apps_id_fk",
-          "tableFrom": "developer_credit_accounts",
-          "tableTo": "developer_apps",
-          "columnsFrom": [
-            "appId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "developer_credit_accounts_id": {
-          "name": "developer_credit_accounts_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "developer_credit_transactions": {
-      "name": "developer_credit_transactions",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "accountId": {
-          "name": "accountId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "amountMicroCredits": {
-          "name": "amountMicroCredits",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "balanceAfterMicroCredits": {
-          "name": "balanceAfterMicroCredits",
-          "type": "bigint unsigned",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "referenceId": {
-          "name": "referenceId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "referenceType": {
-          "name": "referenceType",
-          "type": "varchar(32)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "account_type_created_idx": {
-          "name": "account_type_created_idx",
-          "columns": [
-            "accountId",
-            "type",
-            "createdAt"
-          ],
-          "isUnique": false
-        },
-        "account_ref_dedup_idx": {
-          "name": "account_ref_dedup_idx",
-          "columns": [
-            "accountId",
-            "referenceId",
-            "referenceType"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {
-        "dev_credit_txn_account_fk": {
-          "name": "dev_credit_txn_account_fk",
-          "tableFrom": "developer_credit_transactions",
-          "tableTo": "developer_credit_accounts",
-          "columnsFrom": [
-            "accountId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "developer_credit_transactions_id": {
-          "name": "developer_credit_transactions_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "developer_daily_storage_snapshots": {
-      "name": "developer_daily_storage_snapshots",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "appId": {
-          "name": "appId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "snapshotDate": {
-          "name": "snapshotDate",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "totalDurationMinutes": {
-          "name": "totalDurationMinutes",
-          "type": "float",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "videoCount": {
-          "name": "videoCount",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "microCreditsCharged": {
-          "name": "microCreditsCharged",
-          "type": "bigint unsigned",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "processedAt": {
-          "name": "processedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "developer_daily_storage_snapshots_appId_developer_apps_id_fk": {
-          "name": "developer_daily_storage_snapshots_appId_developer_apps_id_fk",
-          "tableFrom": "developer_daily_storage_snapshots",
-          "tableTo": "developer_apps",
-          "columnsFrom": [
-            "appId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "developer_daily_storage_snapshots_id": {
-          "name": "developer_daily_storage_snapshots_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {
-        "app_date_unique": {
-          "name": "app_date_unique",
-          "columns": [
-            "appId",
-            "snapshotDate"
-          ]
-        }
-      },
-      "checkConstraint": {}
-    },
-    "developer_videos": {
-      "name": "developer_videos",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "appId": {
-          "name": "appId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "externalUserId": {
-          "name": "externalUserId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'Untitled'"
-        },
-        "duration": {
-          "name": "duration",
-          "type": "float",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "width": {
-          "name": "width",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "height": {
-          "name": "height",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "fps": {
-          "name": "fps",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "s3Key": {
-          "name": "s3Key",
-          "type": "varchar(512)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "transcriptionStatus": {
-          "name": "transcriptionStatus",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "deletedAt": {
-          "name": "deletedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "app_created_idx": {
-          "name": "app_created_idx",
-          "columns": [
-            "appId",
-            "createdAt"
-          ],
-          "isUnique": false
-        },
-        "app_user_idx": {
-          "name": "app_user_idx",
-          "columns": [
-            "appId",
-            "externalUserId"
-          ],
-          "isUnique": false
-        },
-        "app_deleted_idx": {
-          "name": "app_deleted_idx",
-          "columns": [
-            "appId",
-            "deletedAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {
-        "developer_videos_appId_developer_apps_id_fk": {
-          "name": "developer_videos_appId_developer_apps_id_fk",
-          "tableFrom": "developer_videos",
-          "tableTo": "developer_apps",
-          "columnsFrom": [
-            "appId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "developer_videos_id": {
-          "name": "developer_videos_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "folders": {
-      "name": "folders",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "color": {
-          "name": "color",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'normal'"
-        },
-        "organizationId": {
-          "name": "organizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "createdById": {
-          "name": "createdById",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "parentId": {
-          "name": "parentId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "spaceId": {
-          "name": "spaceId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "organization_id_idx": {
-          "name": "organization_id_idx",
-          "columns": [
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "created_by_id_idx": {
-          "name": "created_by_id_idx",
-          "columns": [
-            "createdById"
-          ],
-          "isUnique": false
-        },
-        "parent_id_idx": {
-          "name": "parent_id_idx",
-          "columns": [
-            "parentId"
-          ],
-          "isUnique": false
-        },
-        "space_id_idx": {
-          "name": "space_id_idx",
-          "columns": [
-            "spaceId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "folders_id": {
-          "name": "folders_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "imported_videos": {
-      "name": "imported_videos",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "orgId": {
-          "name": "orgId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "source": {
-          "name": "source",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "source_id": {
-          "name": "source_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "imported_videos_orgId_source_source_id_pk": {
-          "name": "imported_videos_orgId_source_source_id_pk",
-          "columns": [
-            "orgId",
-            "source",
-            "source_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "messenger_conversations": {
-      "name": "messenger_conversations",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "agent": {
-          "name": "agent",
-          "type": "varchar(32)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "mode": {
-          "name": "mode",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'agent'"
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "anonymousId": {
-          "name": "anonymousId",
-          "type": "varchar(64)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "takeoverByUserId": {
-          "name": "takeoverByUserId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "takeoverAt": {
-          "name": "takeoverAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "lastMessageAt": {
-          "name": "lastMessageAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "user_last_message_idx": {
-          "name": "user_last_message_idx",
-          "columns": [
-            "userId",
-            "lastMessageAt"
-          ],
-          "isUnique": false
-        },
-        "anonymous_last_message_idx": {
-          "name": "anonymous_last_message_idx",
-          "columns": [
-            "anonymousId",
-            "lastMessageAt"
-          ],
-          "isUnique": false
-        },
-        "mode_last_message_idx": {
-          "name": "mode_last_message_idx",
-          "columns": [
-            "mode",
-            "lastMessageAt"
-          ],
-          "isUnique": false
-        },
-        "updated_at_idx": {
-          "name": "updated_at_idx",
-          "columns": [
-            "updatedAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "messenger_conversations_id": {
-          "name": "messenger_conversations_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "messenger_messages": {
-      "name": "messenger_messages",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "conversationId": {
-          "name": "conversationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "role": {
-          "name": "role",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "content": {
-          "name": "content",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "anonymousId": {
-          "name": "anonymousId",
-          "type": "varchar(64)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "conversation_created_at_idx": {
-          "name": "conversation_created_at_idx",
-          "columns": [
-            "conversationId",
-            "createdAt"
-          ],
-          "isUnique": false
-        },
-        "role_created_at_idx": {
-          "name": "role_created_at_idx",
-          "columns": [
-            "role",
-            "createdAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {
-        "messenger_messages_conversationId_messenger_conversations_id_fk": {
-          "name": "messenger_messages_conversationId_messenger_conversations_id_fk",
-          "tableFrom": "messenger_messages",
-          "tableTo": "messenger_conversations",
-          "columnsFrom": [
-            "conversationId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "messenger_messages_id": {
-          "name": "messenger_messages_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "notifications": {
-      "name": "notifications",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "orgId": {
-          "name": "orgId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "recipientId": {
-          "name": "recipientId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "data": {
-          "name": "data",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "videoId": {
-          "name": "videoId",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "dedupKey": {
-          "name": "dedupKey",
-          "type": "varchar(128)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "readAt": {
-          "name": "readAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "org_id_idx": {
-          "name": "org_id_idx",
-          "columns": [
-            "orgId"
-          ],
-          "isUnique": false
-        },
-        "type_idx": {
-          "name": "type_idx",
-          "columns": [
-            "type"
-          ],
-          "isUnique": false
-        },
-        "read_at_idx": {
-          "name": "read_at_idx",
-          "columns": [
-            "readAt"
-          ],
-          "isUnique": false
-        },
-        "created_at_idx": {
-          "name": "created_at_idx",
-          "columns": [
-            "createdAt"
-          ],
-          "isUnique": false
-        },
-        "recipient_read_idx": {
-          "name": "recipient_read_idx",
-          "columns": [
-            "recipientId",
-            "readAt"
-          ],
-          "isUnique": false
-        },
-        "recipient_created_idx": {
-          "name": "recipient_created_idx",
-          "columns": [
-            "recipientId",
-            "createdAt"
-          ],
-          "isUnique": false
-        },
-        "dedup_key_idx": {
-          "name": "dedup_key_idx",
-          "columns": [
-            "dedupKey"
-          ],
-          "isUnique": true
-        },
-        "type_recipient_created_idx": {
-          "name": "type_recipient_created_idx",
-          "columns": [
-            "type",
-            "recipientId",
-            "createdAt"
-          ],
-          "isUnique": false
-        },
-        "type_recipient_video_created_idx": {
-          "name": "type_recipient_video_created_idx",
-          "columns": [
-            "type",
-            "recipientId",
-            "videoId",
-            "createdAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "notifications_id": {
-          "name": "notifications_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "organization_invites": {
-      "name": "organization_invites",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "organizationId": {
-          "name": "organizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "invitedEmail": {
-          "name": "invitedEmail",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "invitedByUserId": {
-          "name": "invitedByUserId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "role": {
-          "name": "role",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "status": {
-          "name": "status",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'pending'"
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "expiresAt": {
-          "name": "expiresAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        }
-      },
-      "indexes": {
-        "organization_id_idx": {
-          "name": "organization_id_idx",
-          "columns": [
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "invited_email_idx": {
-          "name": "invited_email_idx",
-          "columns": [
-            "invitedEmail"
-          ],
-          "isUnique": false
-        },
-        "invited_by_user_id_idx": {
-          "name": "invited_by_user_id_idx",
-          "columns": [
-            "invitedByUserId"
-          ],
-          "isUnique": false
-        },
-        "status_idx": {
-          "name": "status_idx",
-          "columns": [
-            "status"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "organization_invites_id": {
-          "name": "organization_invites_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "organization_members": {
-      "name": "organization_members",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "organizationId": {
-          "name": "organizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "role": {
-          "name": "role",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "hasProSeat": {
-          "name": "hasProSeat",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "organization_id_idx": {
-          "name": "organization_id_idx",
-          "columns": [
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "user_id_organization_id_idx": {
-          "name": "user_id_organization_id_idx",
-          "columns": [
-            "userId",
-            "organizationId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "organization_members_id": {
-          "name": "organization_members_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "organizations": {
-      "name": "organizations",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ownerId": {
-          "name": "ownerId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "tombstoneAt": {
-          "name": "tombstoneAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "allowedEmailDomain": {
-          "name": "allowedEmailDomain",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "customDomain": {
-          "name": "customDomain",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "domainVerified": {
-          "name": "domainVerified",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "settings": {
-          "name": "settings",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "iconUrl": {
-          "name": "iconUrl",
-          "type": "varchar(1024)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "shareableLinkIconUrl": {
-          "name": "shareableLinkIconUrl",
-          "type": "varchar(1024)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "workosOrganizationId": {
-          "name": "workosOrganizationId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "workosConnectionId": {
-          "name": "workosConnectionId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        }
-      },
-      "indexes": {
-        "owner_id_tombstone_idx": {
-          "name": "owner_id_tombstone_idx",
-          "columns": [
-            "ownerId",
-            "tombstoneAt"
-          ],
-          "isUnique": false
-        },
-        "custom_domain_idx": {
-          "name": "custom_domain_idx",
-          "columns": [
-            "customDomain"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "organizations_id": {
-          "name": "organizations_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "s3_buckets": {
-      "name": "s3_buckets",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ownerId": {
-          "name": "ownerId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "organizationId": {
-          "name": "organizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "region": {
-          "name": "region",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "endpoint": {
-          "name": "endpoint",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "bucketName": {
-          "name": "bucketName",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "accessKeyId": {
-          "name": "accessKeyId",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "secretAccessKey": {
-          "name": "secretAccessKey",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "provider": {
-          "name": "provider",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "('aws')"
-        },
-        "active": {
-          "name": "active",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": true
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "owner_organization_idx": {
-          "name": "owner_organization_idx",
-          "columns": [
-            "ownerId",
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "organization_id_idx": {
-          "name": "organization_id_idx",
-          "columns": [
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "organization_active_idx": {
-          "name": "organization_active_idx",
-          "columns": [
-            "organizationId",
-            "active",
-            "updatedAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "s3_buckets_id": {
-          "name": "s3_buckets_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "sessions": {
-      "name": "sessions",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "sessionToken": {
-          "name": "sessionToken",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "expires": {
-          "name": "expires",
-          "type": "datetime",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "session_token_idx": {
-          "name": "session_token_idx",
-          "columns": [
-            "sessionToken"
-          ],
-          "isUnique": true
-        },
-        "user_id_idx": {
-          "name": "user_id_idx",
-          "columns": [
-            "userId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "sessions_id": {
-          "name": "sessions_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "shared_videos": {
-      "name": "shared_videos",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "videoId": {
-          "name": "videoId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "folderId": {
-          "name": "folderId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "organizationId": {
-          "name": "organizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "sharedByUserId": {
-          "name": "sharedByUserId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "sharedAt": {
-          "name": "sharedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "folder_id_idx": {
-          "name": "folder_id_idx",
-          "columns": [
-            "folderId"
-          ],
-          "isUnique": false
-        },
-        "organization_id_idx": {
-          "name": "organization_id_idx",
-          "columns": [
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "shared_by_user_id_idx": {
-          "name": "shared_by_user_id_idx",
-          "columns": [
-            "sharedByUserId"
-          ],
-          "isUnique": false
-        },
-        "video_id_organization_id_idx": {
-          "name": "video_id_organization_id_idx",
-          "columns": [
-            "videoId",
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "video_id_folder_id_idx": {
-          "name": "video_id_folder_id_idx",
-          "columns": [
-            "videoId",
-            "folderId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "shared_videos_id": {
-          "name": "shared_videos_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "space_members": {
-      "name": "space_members",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "spaceId": {
-          "name": "spaceId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "role": {
-          "name": "role",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'member'"
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "user_id_idx": {
-          "name": "user_id_idx",
-          "columns": [
-            "userId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "space_members_id": {
-          "name": "space_members_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {
-        "space_id_user_id_unique": {
-          "name": "space_id_user_id_unique",
-          "columns": [
-            "spaceId",
-            "userId"
-          ]
-        }
-      },
-      "checkConstraint": {}
-    },
-    "space_videos": {
-      "name": "space_videos",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "spaceId": {
-          "name": "spaceId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "folderId": {
-          "name": "folderId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "videoId": {
-          "name": "videoId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "addedById": {
-          "name": "addedById",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "addedAt": {
-          "name": "addedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "folder_id_idx": {
-          "name": "folder_id_idx",
-          "columns": [
-            "folderId"
-          ],
-          "isUnique": false
-        },
-        "video_id_idx": {
-          "name": "video_id_idx",
-          "columns": [
-            "videoId"
-          ],
-          "isUnique": false
-        },
-        "added_by_id_idx": {
-          "name": "added_by_id_idx",
-          "columns": [
-            "addedById"
-          ],
-          "isUnique": false
-        },
-        "space_id_video_id_idx": {
-          "name": "space_id_video_id_idx",
-          "columns": [
-            "spaceId",
-            "videoId"
-          ],
-          "isUnique": false
-        },
-        "space_id_folder_id_idx": {
-          "name": "space_id_folder_id_idx",
-          "columns": [
-            "spaceId",
-            "folderId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "space_videos_id": {
-          "name": "space_videos_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "spaces": {
-      "name": "spaces",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "primary": {
-          "name": "primary",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "organizationId": {
-          "name": "organizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "createdById": {
-          "name": "createdById",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "iconUrl": {
-          "name": "iconUrl",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "description": {
-          "name": "description",
-          "type": "varchar(1000)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "settings": {
-          "name": "settings",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "password": {
-          "name": "password",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "privacy": {
-          "name": "privacy",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'Private'"
-        }
-      },
-      "indexes": {
-        "organization_id_idx": {
-          "name": "organization_id_idx",
-          "columns": [
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "created_by_id_idx": {
-          "name": "created_by_id_idx",
-          "columns": [
-            "createdById"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "spaces_id": {
-          "name": "spaces_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "storage_integrations": {
-      "name": "storage_integrations",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ownerId": {
-          "name": "ownerId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "organizationId": {
-          "name": "organizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "provider": {
-          "name": "provider",
-          "type": "varchar(64)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "displayName": {
-          "name": "displayName",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "status": {
-          "name": "status",
-          "type": "varchar(32)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'active'"
-        },
-        "active": {
-          "name": "active",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
-        },
-        "encryptedConfig": {
-          "name": "encryptedConfig",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "googleDriveAccessToken": {
-          "name": "googleDriveAccessToken",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "googleDriveAccessTokenExpiresAt": {
-          "name": "googleDriveAccessTokenExpiresAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "googleDriveTokenRefreshLeaseId": {
-          "name": "googleDriveTokenRefreshLeaseId",
-          "type": "varchar(64)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "googleDriveTokenRefreshLeaseExpiresAt": {
-          "name": "googleDriveTokenRefreshLeaseExpiresAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "googleDriveStorageQuotaCache": {
-          "name": "googleDriveStorageQuotaCache",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "owner_provider_idx": {
-          "name": "owner_provider_idx",
-          "columns": [
-            "ownerId",
-            "provider"
-          ],
-          "isUnique": false
-        },
-        "owner_active_idx": {
-          "name": "owner_active_idx",
-          "columns": [
-            "ownerId",
-            "active"
-          ],
-          "isUnique": false
-        },
-        "organization_provider_idx": {
-          "name": "organization_provider_idx",
-          "columns": [
-            "organizationId",
-            "provider"
-          ],
-          "isUnique": false
-        },
-        "organization_active_idx": {
-          "name": "organization_active_idx",
-          "columns": [
-            "organizationId",
-            "active",
-            "status"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "storage_integrations_id": {
-          "name": "storage_integrations_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "storage_objects": {
-      "name": "storage_objects",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "integrationId": {
-          "name": "integrationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ownerId": {
-          "name": "ownerId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "videoId": {
-          "name": "videoId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "objectKey": {
-          "name": "objectKey",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "objectKeyHash": {
-          "name": "objectKeyHash",
-          "type": "varchar(64)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "providerObjectId": {
-          "name": "providerObjectId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "uploadSessionUrl": {
-          "name": "uploadSessionUrl",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "uploadStatus": {
-          "name": "uploadStatus",
-          "type": "varchar(32)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'pending'"
-        },
-        "contentType": {
-          "name": "contentType",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "contentLength": {
-          "name": "contentLength",
-          "type": "bigint unsigned",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "integration_key_hash_idx": {
-          "name": "integration_key_hash_idx",
-          "columns": [
-            "integrationId",
-            "objectKeyHash"
-          ],
-          "isUnique": true
-        },
-        "integration_status_idx": {
-          "name": "integration_status_idx",
-          "columns": [
-            "integrationId",
-            "uploadStatus"
-          ],
-          "isUnique": false
-        },
-        "video_id_idx": {
-          "name": "video_id_idx",
-          "columns": [
-            "videoId"
-          ],
-          "isUnique": false
-        },
-        "owner_id_idx": {
-          "name": "owner_id_idx",
-          "columns": [
-            "ownerId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {
-        "storage_objects_integrationId_storage_integrations_id_fk": {
-          "name": "storage_objects_integrationId_storage_integrations_id_fk",
-          "tableFrom": "storage_objects",
-          "tableTo": "storage_integrations",
-          "columnsFrom": [
-            "integrationId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "restrict",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "storage_objects_id": {
-          "name": "storage_objects_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "users": {
-      "name": "users",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "lastName": {
-          "name": "lastName",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "email": {
-          "name": "email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "emailVerified": {
-          "name": "emailVerified",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "image": {
-          "name": "image",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "stripeCustomerId": {
-          "name": "stripeCustomerId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "stripeSubscriptionId": {
-          "name": "stripeSubscriptionId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "thirdPartyStripeSubscriptionId": {
-          "name": "thirdPartyStripeSubscriptionId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "stripeSubscriptionStatus": {
-          "name": "stripeSubscriptionStatus",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "stripeSubscriptionPriceId": {
-          "name": "stripeSubscriptionPriceId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "preferences": {
-          "name": "preferences",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false,
-          "default": "('null')"
-        },
-        "activeOrganizationId": {
-          "name": "activeOrganizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "onboardingSteps": {
-          "name": "onboardingSteps",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "onboarding_completed_at": {
-          "name": "onboarding_completed_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "customBucket": {
-          "name": "customBucket",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "inviteQuota": {
-          "name": "inviteQuota",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 1
-        },
-        "defaultOrgId": {
-          "name": "defaultOrgId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        }
-      },
-      "indexes": {
-        "email_idx": {
-          "name": "email_idx",
-          "columns": [
-            "email"
-          ],
-          "isUnique": true
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "users_id": {
-          "name": "users_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "verification_tokens": {
-      "name": "verification_tokens",
-      "columns": {
-        "identifier": {
-          "name": "identifier",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "token": {
-          "name": "token",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "expires": {
-          "name": "expires",
-          "type": "datetime",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "verification_tokens_identifier": {
-          "name": "verification_tokens_identifier",
-          "columns": [
-            "identifier"
-          ]
-        }
-      },
-      "uniqueConstraints": {
-        "verification_tokens_token_unique": {
-          "name": "verification_tokens_token_unique",
-          "columns": [
-            "token"
-          ]
-        }
-      },
-      "checkConstraint": {}
-    },
-    "video_edits": {
-      "name": "video_edits",
-      "columns": {
-        "videoId": {
-          "name": "videoId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "sourceKey": {
-          "name": "sourceKey",
-          "type": "varchar(512)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "editSpec": {
-          "name": "editSpec",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "video_edits_videoId_videos_id_fk": {
-          "name": "video_edits_videoId_videos_id_fk",
-          "tableFrom": "video_edits",
-          "tableTo": "videos",
-          "columnsFrom": [
-            "videoId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "video_edits_videoId": {
-          "name": "video_edits_videoId",
-          "columns": [
-            "videoId"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "video_uploads": {
-      "name": "video_uploads",
-      "columns": {
-        "video_id": {
-          "name": "video_id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "uploaded": {
-          "name": "uploaded",
-          "type": "bigint unsigned",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "total": {
-          "name": "total",
-          "type": "bigint unsigned",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "started_at": {
-          "name": "started_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "mode": {
-          "name": "mode",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "phase": {
-          "name": "phase",
-          "type": "varchar(32)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'uploading'"
-        },
-        "processing_progress": {
-          "name": "processing_progress",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "processing_message": {
-          "name": "processing_message",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "processing_error": {
-          "name": "processing_error",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "raw_file_key": {
-          "name": "raw_file_key",
-          "type": "varchar(512)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "video_uploads_video_id": {
-          "name": "video_uploads_video_id",
-          "columns": [
-            "video_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "videos": {
-      "name": "videos",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ownerId": {
-          "name": "ownerId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "orgId": {
-          "name": "orgId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'My Video'"
-        },
-        "bucket": {
-          "name": "bucket",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "storageIntegrationId": {
-          "name": "storageIntegrationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "duration": {
-          "name": "duration",
-          "type": "float",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "width": {
-          "name": "width",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "height": {
-          "name": "height",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "fps": {
-          "name": "fps",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "public": {
-          "name": "public",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": true
-        },
-        "settings": {
-          "name": "settings",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "transcriptionStatus": {
-          "name": "transcriptionStatus",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "source": {
-          "name": "source",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "('{\"type\":\"MediaConvert\"}')"
-        },
-        "folderId": {
-          "name": "folderId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "effectiveCreatedAt": {
-          "name": "effectiveCreatedAt",
-          "type": "datetime",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false,
-          "generated": {
-            "as": "COALESCE(\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%s.%fZ'),\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%sZ'),\n          `createdAt`\n        )",
-            "type": "stored"
-          }
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "password": {
-          "name": "password",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "xStreamInfo": {
-          "name": "xStreamInfo",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "firstViewEmailSentAt": {
-          "name": "firstViewEmailSentAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "isScreenshot": {
-          "name": "isScreenshot",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
-        },
-        "awsRegion": {
-          "name": "awsRegion",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "awsBucket": {
-          "name": "awsBucket",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "videoStartTime": {
-          "name": "videoStartTime",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "audioStartTime": {
-          "name": "audioStartTime",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "jobId": {
-          "name": "jobId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "jobStatus": {
-          "name": "jobStatus",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "skipProcessing": {
-          "name": "skipProcessing",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
-        }
-      },
-      "indexes": {
-        "owner_id_idx": {
-          "name": "owner_id_idx",
-          "columns": [
-            "ownerId"
-          ],
-          "isUnique": false
-        },
-        "is_public_idx": {
-          "name": "is_public_idx",
-          "columns": [
-            "public"
-          ],
-          "isUnique": false
-        },
-        "folder_id_idx": {
-          "name": "folder_id_idx",
-          "columns": [
-            "folderId"
-          ],
-          "isUnique": false
-        },
-        "storage_integration_id_idx": {
-          "name": "storage_integration_id_idx",
-          "columns": [
-            "storageIntegrationId"
-          ],
-          "isUnique": false
-        },
-        "org_owner_folder_idx": {
-          "name": "org_owner_folder_idx",
-          "columns": [
-            "orgId",
-            "ownerId",
-            "folderId"
-          ],
-          "isUnique": false
-        },
-        "org_effective_created_idx": {
-          "name": "org_effective_created_idx",
-          "columns": [
-            "orgId",
-            "effectiveCreatedAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {
-        "videos_storageIntegrationId_storage_integrations_id_fk": {
-          "name": "videos_storageIntegrationId_storage_integrations_id_fk",
-          "tableFrom": "videos",
-          "tableTo": "storage_integrations",
-          "columnsFrom": [
-            "storageIntegrationId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "restrict",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "videos_id": {
-          "name": "videos_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    }
-  },
-  "views": {},
-  "_meta": {
-    "schemas": {},
-    "tables": {},
-    "columns": {}
-  },
-  "internal": {
-    "tables": {},
-    "indexes": {}
-  }
+	"version": "5",
+	"dialect": "mysql",
+	"id": "0df93b03-9847-42d2-b71f-9d0cbc968216",
+	"prevId": "ae365232-4098-4426-a0ba-b8b6aa46fb3b",
+	"tables": {
+		"accounts": {
+			"name": "accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerAccountId": {
+					"name": "providerAccountId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_in": {
+					"name": "expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_in": {
+					"name": "refresh_token_expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"tempColumn": {
+					"name": "tempColumn",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				},
+				"provider_account_id_idx": {
+					"name": "provider_account_id_idx",
+					"columns": ["providerAccountId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"accounts_id": {
+					"name": "accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"auth_api_keys": {
+			"name": "auth_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(36)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"auth_api_keys_id": {
+					"name": "auth_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"comments": {
+			"name": "comments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(6)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"authorId": {
+					"name": "authorId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"parentCommentId": {
+					"name": "parentCommentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"video_type_created_idx": {
+					"name": "video_type_created_idx",
+					"columns": ["videoId", "type", "createdAt", "id"],
+					"isUnique": false
+				},
+				"author_id_idx": {
+					"name": "author_id_idx",
+					"columns": ["authorId"],
+					"isUnique": false
+				},
+				"parent_comment_id_idx": {
+					"name": "parent_comment_id_idx",
+					"columns": ["parentCommentId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"comments_id": {
+					"name": "comments_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_api_keys": {
+			"name": "developer_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyType": {
+					"name": "keyType",
+					"type": "varchar(8)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyPrefix": {
+					"name": "keyPrefix",
+					"type": "varchar(12)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyHash": {
+					"name": "keyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"encryptedKey": {
+					"name": "encryptedKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"lastUsedAt": {
+					"name": "lastUsedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"revokedAt": {
+					"name": "revokedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"key_hash_idx": {
+					"name": "key_hash_idx",
+					"columns": ["keyHash"],
+					"isUnique": true
+				},
+				"app_key_type_idx": {
+					"name": "app_key_type_idx",
+					"columns": ["appId", "keyType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_api_keys_appId_developer_apps_id_fk": {
+					"name": "developer_api_keys_appId_developer_apps_id_fk",
+					"tableFrom": "developer_api_keys",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_api_keys_id": {
+					"name": "developer_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_app_domains": {
+			"name": "developer_app_domains",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"domain": {
+					"name": "domain",
+					"type": "varchar(253)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_app_domains_appId_developer_apps_id_fk": {
+					"name": "developer_app_domains_appId_developer_apps_id_fk",
+					"tableFrom": "developer_app_domains",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_app_domains_id": {
+					"name": "developer_app_domains_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_domain_unique": {
+					"name": "app_domain_unique",
+					"columns": ["appId", "domain"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_apps": {
+			"name": "developer_apps",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"environment": {
+					"name": "environment",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"logoUrl": {
+					"name": "logoUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_deleted_idx": {
+					"name": "owner_deleted_idx",
+					"columns": ["ownerId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"developer_apps_id": {
+					"name": "developer_apps_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_accounts": {
+			"name": "developer_credit_accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceMicroCredits": {
+					"name": "balanceMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripePaymentMethodId": {
+					"name": "stripePaymentMethodId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"autoTopUpEnabled": {
+					"name": "autoTopUpEnabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"autoTopUpThresholdMicroCredits": {
+					"name": "autoTopUpThresholdMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"autoTopUpAmountCents": {
+					"name": "autoTopUpAmountCents",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_id_unique": {
+					"name": "app_id_unique",
+					"columns": ["appId"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"developer_credit_accounts_appId_developer_apps_id_fk": {
+					"name": "developer_credit_accounts_appId_developer_apps_id_fk",
+					"tableFrom": "developer_credit_accounts",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_accounts_id": {
+					"name": "developer_credit_accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_transactions": {
+			"name": "developer_credit_transactions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amountMicroCredits": {
+					"name": "amountMicroCredits",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceAfterMicroCredits": {
+					"name": "balanceAfterMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"referenceId": {
+					"name": "referenceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"referenceType": {
+					"name": "referenceType",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"account_type_created_idx": {
+					"name": "account_type_created_idx",
+					"columns": ["accountId", "type", "createdAt"],
+					"isUnique": false
+				},
+				"account_ref_dedup_idx": {
+					"name": "account_ref_dedup_idx",
+					"columns": ["accountId", "referenceId", "referenceType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"dev_credit_txn_account_fk": {
+					"name": "dev_credit_txn_account_fk",
+					"tableFrom": "developer_credit_transactions",
+					"tableTo": "developer_credit_accounts",
+					"columnsFrom": ["accountId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_transactions_id": {
+					"name": "developer_credit_transactions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_daily_storage_snapshots": {
+			"name": "developer_daily_storage_snapshots",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"snapshotDate": {
+					"name": "snapshotDate",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"totalDurationMinutes": {
+					"name": "totalDurationMinutes",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"videoCount": {
+					"name": "videoCount",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"microCreditsCharged": {
+					"name": "microCreditsCharged",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processedAt": {
+					"name": "processedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_daily_storage_snapshots_appId_developer_apps_id_fk": {
+					"name": "developer_daily_storage_snapshots_appId_developer_apps_id_fk",
+					"tableFrom": "developer_daily_storage_snapshots",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_daily_storage_snapshots_id": {
+					"name": "developer_daily_storage_snapshots_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_date_unique": {
+					"name": "app_date_unique",
+					"columns": ["appId", "snapshotDate"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_videos": {
+			"name": "developer_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"externalUserId": {
+					"name": "externalUserId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Untitled'"
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"s3Key": {
+					"name": "s3Key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_created_idx": {
+					"name": "app_created_idx",
+					"columns": ["appId", "createdAt"],
+					"isUnique": false
+				},
+				"app_user_idx": {
+					"name": "app_user_idx",
+					"columns": ["appId", "externalUserId"],
+					"isUnique": false
+				},
+				"app_deleted_idx": {
+					"name": "app_deleted_idx",
+					"columns": ["appId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_videos_appId_developer_apps_id_fk": {
+					"name": "developer_videos_appId_developer_apps_id_fk",
+					"tableFrom": "developer_videos",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_videos_id": {
+					"name": "developer_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"folders": {
+			"name": "folders",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"color": {
+					"name": "color",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'normal'"
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parentId": {
+					"name": "parentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				},
+				"parent_id_idx": {
+					"name": "parent_id_idx",
+					"columns": ["parentId"],
+					"isUnique": false
+				},
+				"space_id_idx": {
+					"name": "space_id_idx",
+					"columns": ["spaceId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"folders_id": {
+					"name": "folders_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"imported_videos": {
+			"name": "imported_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"imported_videos_orgId_source_source_id_pk": {
+					"name": "imported_videos_orgId_source_source_id_pk",
+					"columns": ["orgId", "source", "source_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_conversations": {
+			"name": "messenger_conversations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent": {
+					"name": "agent",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'agent'"
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverByUserId": {
+					"name": "takeoverByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverAt": {
+					"name": "takeoverAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"lastMessageAt": {
+					"name": "lastMessageAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_last_message_idx": {
+					"name": "user_last_message_idx",
+					"columns": ["userId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"anonymous_last_message_idx": {
+					"name": "anonymous_last_message_idx",
+					"columns": ["anonymousId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"mode_last_message_idx": {
+					"name": "mode_last_message_idx",
+					"columns": ["mode", "lastMessageAt"],
+					"isUnique": false
+				},
+				"updated_at_idx": {
+					"name": "updated_at_idx",
+					"columns": ["updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"messenger_conversations_id": {
+					"name": "messenger_conversations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_messages": {
+			"name": "messenger_messages",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"conversationId": {
+					"name": "conversationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"conversation_created_at_idx": {
+					"name": "conversation_created_at_idx",
+					"columns": ["conversationId", "createdAt"],
+					"isUnique": false
+				},
+				"role_created_at_idx": {
+					"name": "role_created_at_idx",
+					"columns": ["role", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"messenger_messages_conversationId_messenger_conversations_id_fk": {
+					"name": "messenger_messages_conversationId_messenger_conversations_id_fk",
+					"tableFrom": "messenger_messages",
+					"tableTo": "messenger_conversations",
+					"columnsFrom": ["conversationId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"messenger_messages_id": {
+					"name": "messenger_messages_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"notifications": {
+			"name": "notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recipientId": {
+					"name": "recipientId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"data": {
+					"name": "data",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dedupKey": {
+					"name": "dedupKey",
+					"type": "varchar(128)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"readAt": {
+					"name": "readAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"org_id_idx": {
+					"name": "org_id_idx",
+					"columns": ["orgId"],
+					"isUnique": false
+				},
+				"type_idx": {
+					"name": "type_idx",
+					"columns": ["type"],
+					"isUnique": false
+				},
+				"read_at_idx": {
+					"name": "read_at_idx",
+					"columns": ["readAt"],
+					"isUnique": false
+				},
+				"created_at_idx": {
+					"name": "created_at_idx",
+					"columns": ["createdAt"],
+					"isUnique": false
+				},
+				"recipient_read_idx": {
+					"name": "recipient_read_idx",
+					"columns": ["recipientId", "readAt"],
+					"isUnique": false
+				},
+				"recipient_created_idx": {
+					"name": "recipient_created_idx",
+					"columns": ["recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"dedup_key_idx": {
+					"name": "dedup_key_idx",
+					"columns": ["dedupKey"],
+					"isUnique": true
+				},
+				"type_recipient_created_idx": {
+					"name": "type_recipient_created_idx",
+					"columns": ["type", "recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"type_recipient_video_created_idx": {
+					"name": "type_recipient_video_created_idx",
+					"columns": ["type", "recipientId", "videoId", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"notifications_id": {
+					"name": "notifications_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_invites": {
+			"name": "organization_invites",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedEmail": {
+					"name": "invitedEmail",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedByUserId": {
+					"name": "invitedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"invited_email_idx": {
+					"name": "invited_email_idx",
+					"columns": ["invitedEmail"],
+					"isUnique": false
+				},
+				"invited_by_user_id_idx": {
+					"name": "invited_by_user_id_idx",
+					"columns": ["invitedByUserId"],
+					"isUnique": false
+				},
+				"status_idx": {
+					"name": "status_idx",
+					"columns": ["status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_invites_id": {
+					"name": "organization_invites_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_members": {
+			"name": "organization_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"hasProSeat": {
+					"name": "hasProSeat",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"user_id_organization_id_idx": {
+					"name": "user_id_organization_id_idx",
+					"columns": ["userId", "organizationId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_members_id": {
+					"name": "organization_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organizations": {
+			"name": "organizations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tombstoneAt": {
+					"name": "tombstoneAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"allowedEmailDomain": {
+					"name": "allowedEmailDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customDomain": {
+					"name": "customDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"domainVerified": {
+					"name": "domainVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"shareableLinkIconUrl": {
+					"name": "shareableLinkIconUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"workosOrganizationId": {
+					"name": "workosOrganizationId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"workosConnectionId": {
+					"name": "workosConnectionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"owner_id_tombstone_idx": {
+					"name": "owner_id_tombstone_idx",
+					"columns": ["ownerId", "tombstoneAt"],
+					"isUnique": false
+				},
+				"custom_domain_idx": {
+					"name": "custom_domain_idx",
+					"columns": ["customDomain"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organizations_id": {
+					"name": "organizations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"s3_buckets": {
+			"name": "s3_buckets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"region": {
+					"name": "region",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"endpoint": {
+					"name": "endpoint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"bucketName": {
+					"name": "bucketName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accessKeyId": {
+					"name": "accessKeyId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"secretAccessKey": {
+					"name": "secretAccessKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('aws')"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_organization_idx": {
+					"name": "owner_organization_idx",
+					"columns": ["ownerId", "organizationId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"s3_buckets_id": {
+					"name": "s3_buckets_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"sessions": {
+			"name": "sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sessionToken": {
+					"name": "sessionToken",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"session_token_idx": {
+					"name": "session_token_idx",
+					"columns": ["sessionToken"],
+					"isUnique": true
+				},
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"sessions_id": {
+					"name": "sessions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"shared_videos": {
+			"name": "shared_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedByUserId": {
+					"name": "sharedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedAt": {
+					"name": "sharedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"shared_by_user_id_idx": {
+					"name": "shared_by_user_id_idx",
+					"columns": ["sharedByUserId"],
+					"isUnique": false
+				},
+				"video_id_organization_id_idx": {
+					"name": "video_id_organization_id_idx",
+					"columns": ["videoId", "organizationId"],
+					"isUnique": false
+				},
+				"video_id_folder_id_idx": {
+					"name": "video_id_folder_id_idx",
+					"columns": ["videoId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"shared_videos_id": {
+					"name": "shared_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"space_members": {
+			"name": "space_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'member'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_members_id": {
+					"name": "space_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"space_id_user_id_unique": {
+					"name": "space_id_user_id_unique",
+					"columns": ["spaceId", "userId"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"space_videos": {
+			"name": "space_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedById": {
+					"name": "addedById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedAt": {
+					"name": "addedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"added_by_id_idx": {
+					"name": "added_by_id_idx",
+					"columns": ["addedById"],
+					"isUnique": false
+				},
+				"space_id_video_id_idx": {
+					"name": "space_id_video_id_idx",
+					"columns": ["spaceId", "videoId"],
+					"isUnique": false
+				},
+				"space_id_folder_id_idx": {
+					"name": "space_id_folder_id_idx",
+					"columns": ["spaceId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_videos_id": {
+					"name": "space_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"spaces": {
+			"name": "spaces",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"primary": {
+					"name": "primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "varchar(1000)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"privacy": {
+					"name": "privacy",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Private'"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"spaces_id": {
+					"name": "spaces_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_integrations": {
+			"name": "storage_integrations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"displayName": {
+					"name": "displayName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"encryptedConfig": {
+					"name": "encryptedConfig",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"googleDriveAccessToken": {
+					"name": "googleDriveAccessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveAccessTokenExpiresAt": {
+					"name": "googleDriveAccessTokenExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseId": {
+					"name": "googleDriveTokenRefreshLeaseId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseExpiresAt": {
+					"name": "googleDriveTokenRefreshLeaseExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveStorageQuotaCache": {
+					"name": "googleDriveStorageQuotaCache",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_provider_idx": {
+					"name": "owner_provider_idx",
+					"columns": ["ownerId", "provider"],
+					"isUnique": false
+				},
+				"owner_active_idx": {
+					"name": "owner_active_idx",
+					"columns": ["ownerId", "active"],
+					"isUnique": false
+				},
+				"organization_provider_idx": {
+					"name": "organization_provider_idx",
+					"columns": ["organizationId", "provider"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"storage_integrations_id": {
+					"name": "storage_integrations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_objects": {
+			"name": "storage_objects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"integrationId": {
+					"name": "integrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"objectKey": {
+					"name": "objectKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"objectKeyHash": {
+					"name": "objectKeyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerObjectId": {
+					"name": "providerObjectId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploadSessionUrl": {
+					"name": "uploadSessionUrl",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"uploadStatus": {
+					"name": "uploadStatus",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"contentType": {
+					"name": "contentType",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"contentLength": {
+					"name": "contentLength",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"integration_key_hash_idx": {
+					"name": "integration_key_hash_idx",
+					"columns": ["integrationId", "objectKeyHash"],
+					"isUnique": true
+				},
+				"integration_status_idx": {
+					"name": "integration_status_idx",
+					"columns": ["integrationId", "uploadStatus"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"storage_objects_integrationId_storage_integrations_id_fk": {
+					"name": "storage_objects_integrationId_storage_integrations_id_fk",
+					"tableFrom": "storage_objects",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["integrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"storage_objects_id": {
+					"name": "storage_objects_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"lastName": {
+					"name": "lastName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionId": {
+					"name": "stripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"thirdPartyStripeSubscriptionId": {
+					"name": "thirdPartyStripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionStatus": {
+					"name": "stripeSubscriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionPriceId": {
+					"name": "stripeSubscriptionPriceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preferences": {
+					"name": "preferences",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "('null')"
+				},
+				"activeOrganizationId": {
+					"name": "activeOrganizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"onboardingSteps": {
+					"name": "onboardingSteps",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"onboarding_completed_at": {
+					"name": "onboarding_completed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customBucket": {
+					"name": "customBucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"inviteQuota": {
+					"name": "inviteQuota",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"defaultOrgId": {
+					"name": "defaultOrgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"email_idx": {
+					"name": "email_idx",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"users_id": {
+					"name": "users_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"verification_tokens": {
+			"name": "verification_tokens",
+			"columns": {
+				"identifier": {
+					"name": "identifier",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"verification_tokens_identifier": {
+					"name": "verification_tokens_identifier",
+					"columns": ["identifier"]
+				}
+			},
+			"uniqueConstraints": {
+				"verification_tokens_token_unique": {
+					"name": "verification_tokens_token_unique",
+					"columns": ["token"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"video_edits": {
+			"name": "video_edits",
+			"columns": {
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sourceKey": {
+					"name": "sourceKey",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"editSpec": {
+					"name": "editSpec",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"video_edits_videoId_videos_id_fk": {
+					"name": "video_edits_videoId_videos_id_fk",
+					"tableFrom": "video_edits",
+					"tableTo": "videos",
+					"columnsFrom": ["videoId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"video_edits_videoId": {
+					"name": "video_edits_videoId",
+					"columns": ["videoId"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"video_uploads": {
+			"name": "video_uploads",
+			"columns": {
+				"video_id": {
+					"name": "video_id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploaded": {
+					"name": "uploaded",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"total": {
+					"name": "total",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phase": {
+					"name": "phase",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'uploading'"
+				},
+				"processing_progress": {
+					"name": "processing_progress",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processing_message": {
+					"name": "processing_message",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"processing_error": {
+					"name": "processing_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"raw_file_key": {
+					"name": "raw_file_key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"video_uploads_video_id": {
+					"name": "video_uploads_video_id",
+					"columns": ["video_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"videos": {
+			"name": "videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'My Video'"
+				},
+				"bucket": {
+					"name": "bucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"storageIntegrationId": {
+					"name": "storageIntegrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('{\"type\":\"MediaConvert\"}')"
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"effectiveCreatedAt": {
+					"name": "effectiveCreatedAt",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"generated": {
+						"as": "COALESCE(\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%s.%fZ'),\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%sZ'),\n          `createdAt`\n        )",
+						"type": "stored"
+					}
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"xStreamInfo": {
+					"name": "xStreamInfo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"firstViewEmailSentAt": {
+					"name": "firstViewEmailSentAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"isScreenshot": {
+					"name": "isScreenshot",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"awsRegion": {
+					"name": "awsRegion",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"awsBucket": {
+					"name": "awsBucket",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoStartTime": {
+					"name": "videoStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"audioStartTime": {
+					"name": "audioStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobId": {
+					"name": "jobId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobStatus": {
+					"name": "jobStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"skipProcessing": {
+					"name": "skipProcessing",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				},
+				"is_public_idx": {
+					"name": "is_public_idx",
+					"columns": ["public"],
+					"isUnique": false
+				},
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"storage_integration_id_idx": {
+					"name": "storage_integration_id_idx",
+					"columns": ["storageIntegrationId"],
+					"isUnique": false
+				},
+				"org_owner_folder_idx": {
+					"name": "org_owner_folder_idx",
+					"columns": ["orgId", "ownerId", "folderId"],
+					"isUnique": false
+				},
+				"org_effective_created_idx": {
+					"name": "org_effective_created_idx",
+					"columns": ["orgId", "effectiveCreatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"videos_storageIntegrationId_storage_integrations_id_fk": {
+					"name": "videos_storageIntegrationId_storage_integrations_id_fk",
+					"tableFrom": "videos",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["storageIntegrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"videos_id": {
+					"name": "videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		}
+	},
+	"views": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"tables": {},
+		"indexes": {}
+	}
 }

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -1,181 +1,188 @@
 {
-	"version": "5",
-	"dialect": "mysql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "5",
-			"when": 1743020179593,
-			"tag": "0000_brown_sunfire",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "5",
-			"when": 1749268354138,
-			"tag": "0001_white_young_avengers",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "5",
-			"when": 1750935538683,
-			"tag": "0002_dusty_maginty",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "5",
-			"when": 1761710697286,
-			"tag": "0003_thin_gressill",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "5",
-			"when": 1761711378574,
-			"tag": "0004_video-org-id",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "5",
-			"when": 1761711605408,
-			"tag": "0005_video-org-id-required",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "5",
-			"when": 1762410865419,
-			"tag": "0006_hesitant_stone_men",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "5",
-			"when": 1762428551824,
-			"tag": "0007_public_toxin",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "5",
-			"when": 1762428905323,
-			"tag": "0008_fat_ender_wiggin",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "5",
-			"when": 1768139432782,
-			"tag": "0009_easy_ulik",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "5",
-			"when": 1738505600000,
-			"tag": "0010_video_uploads_bigint",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "5",
-			"when": 1771325011010,
-			"tag": "0011_public_inhumans",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "5",
-			"when": 1772534950328,
-			"tag": "0012_lethal_lilith",
-			"breakpoints": true
-		},
-		{
-			"idx": 13,
-			"version": "5",
-			"when": 1772573402457,
-			"tag": "0013_faithful_marvex",
-			"breakpoints": true
-		},
-		{
-			"idx": 14,
-			"version": "5",
-			"when": 1772576220593,
-			"tag": "0014_modern_triton",
-			"breakpoints": true
-		},
-		{
-			"idx": 15,
-			"version": "5",
-			"when": 1772582468257,
-			"tag": "0015_closed_tigra",
-			"breakpoints": true
-		},
-		{
-			"idx": 16,
-			"version": "5",
-			"when": 1772641549840,
-			"tag": "0016_bouncy_hellcat",
-			"breakpoints": true
-		},
-		{
-			"idx": 17,
-			"version": "5",
-			"when": 1778099532336,
-			"tag": "0017_productive_betty_brant",
-			"breakpoints": true
-		},
-		{
-			"idx": 18,
-			"version": "5",
-			"when": 1778153157657,
-			"tag": "0018_loud_mongu",
-			"breakpoints": true
-		},
-		{
-			"idx": 19,
-			"version": "5",
-			"when": 1778154209547,
-			"tag": "0019_solid_paibok",
-			"breakpoints": true
-		},
-		{
-			"idx": 20,
-			"version": "5",
-			"when": 1778157016497,
-			"tag": "0020_orange_talkback",
-			"breakpoints": true
-		},
-		{
-			"idx": 21,
-			"version": "5",
-			"when": 1778249922872,
-			"tag": "0021_glorious_khan",
-			"breakpoints": true
-		},
-		{
-			"idx": 22,
-			"version": "5",
-			"when": 1778252207674,
-			"tag": "0022_dazzling_namor",
-			"breakpoints": true
-		},
-		{
-			"idx": 23,
-			"version": "5",
-			"when": 1778434170430,
-			"tag": "0023_misty_luckman",
-			"breakpoints": true
-		},
-		{
-			"idx": 24,
-			"version": "5",
-			"when": 1778776694053,
-			"tag": "0024_many_speed",
-			"breakpoints": true
-		}
-	]
+  "version": "5",
+  "dialect": "mysql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "5",
+      "when": 1743020179593,
+      "tag": "0000_brown_sunfire",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1749268354138,
+      "tag": "0001_white_young_avengers",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "5",
+      "when": 1750935538683,
+      "tag": "0002_dusty_maginty",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "5",
+      "when": 1761710697286,
+      "tag": "0003_thin_gressill",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "5",
+      "when": 1761711378574,
+      "tag": "0004_video-org-id",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "5",
+      "when": 1761711605408,
+      "tag": "0005_video-org-id-required",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "5",
+      "when": 1762410865419,
+      "tag": "0006_hesitant_stone_men",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "5",
+      "when": 1762428551824,
+      "tag": "0007_public_toxin",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "5",
+      "when": 1762428905323,
+      "tag": "0008_fat_ender_wiggin",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "5",
+      "when": 1768139432782,
+      "tag": "0009_easy_ulik",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "5",
+      "when": 1738505600000,
+      "tag": "0010_video_uploads_bigint",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "5",
+      "when": 1771325011010,
+      "tag": "0011_public_inhumans",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "5",
+      "when": 1772534950328,
+      "tag": "0012_lethal_lilith",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "5",
+      "when": 1772573402457,
+      "tag": "0013_faithful_marvex",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "5",
+      "when": 1772576220593,
+      "tag": "0014_modern_triton",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "5",
+      "when": 1772582468257,
+      "tag": "0015_closed_tigra",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "5",
+      "when": 1772641549840,
+      "tag": "0016_bouncy_hellcat",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "5",
+      "when": 1778099532336,
+      "tag": "0017_productive_betty_brant",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "5",
+      "when": 1778153157657,
+      "tag": "0018_loud_mongu",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "5",
+      "when": 1778154209547,
+      "tag": "0019_solid_paibok",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "5",
+      "when": 1778157016497,
+      "tag": "0020_orange_talkback",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "5",
+      "when": 1778249922872,
+      "tag": "0021_glorious_khan",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "5",
+      "when": 1778252207674,
+      "tag": "0022_dazzling_namor",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "5",
+      "when": 1778434170430,
+      "tag": "0023_misty_luckman",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "5",
+      "when": 1778776694053,
+      "tag": "0024_many_speed",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "5",
+      "when": 1778858762935,
+      "tag": "0025_demonic_mother_askani",
+      "breakpoints": true
+    }
+  ]
 }

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -1,188 +1,188 @@
 {
-  "version": "5",
-  "dialect": "mysql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "5",
-      "when": 1743020179593,
-      "tag": "0000_brown_sunfire",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "5",
-      "when": 1749268354138,
-      "tag": "0001_white_young_avengers",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "5",
-      "when": 1750935538683,
-      "tag": "0002_dusty_maginty",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "5",
-      "when": 1761710697286,
-      "tag": "0003_thin_gressill",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "5",
-      "when": 1761711378574,
-      "tag": "0004_video-org-id",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "5",
-      "when": 1761711605408,
-      "tag": "0005_video-org-id-required",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "5",
-      "when": 1762410865419,
-      "tag": "0006_hesitant_stone_men",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "5",
-      "when": 1762428551824,
-      "tag": "0007_public_toxin",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "5",
-      "when": 1762428905323,
-      "tag": "0008_fat_ender_wiggin",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "5",
-      "when": 1768139432782,
-      "tag": "0009_easy_ulik",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "5",
-      "when": 1738505600000,
-      "tag": "0010_video_uploads_bigint",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "5",
-      "when": 1771325011010,
-      "tag": "0011_public_inhumans",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "5",
-      "when": 1772534950328,
-      "tag": "0012_lethal_lilith",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "5",
-      "when": 1772573402457,
-      "tag": "0013_faithful_marvex",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "5",
-      "when": 1772576220593,
-      "tag": "0014_modern_triton",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "5",
-      "when": 1772582468257,
-      "tag": "0015_closed_tigra",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "5",
-      "when": 1772641549840,
-      "tag": "0016_bouncy_hellcat",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "5",
-      "when": 1778099532336,
-      "tag": "0017_productive_betty_brant",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "5",
-      "when": 1778153157657,
-      "tag": "0018_loud_mongu",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "5",
-      "when": 1778154209547,
-      "tag": "0019_solid_paibok",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "5",
-      "when": 1778157016497,
-      "tag": "0020_orange_talkback",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "5",
-      "when": 1778249922872,
-      "tag": "0021_glorious_khan",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "5",
-      "when": 1778252207674,
-      "tag": "0022_dazzling_namor",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "5",
-      "when": 1778434170430,
-      "tag": "0023_misty_luckman",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "5",
-      "when": 1778776694053,
-      "tag": "0024_many_speed",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "5",
-      "when": 1778858762935,
-      "tag": "0025_demonic_mother_askani",
-      "breakpoints": true
-    }
-  ]
+	"version": "5",
+	"dialect": "mysql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "5",
+			"when": 1743020179593,
+			"tag": "0000_brown_sunfire",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "5",
+			"when": 1749268354138,
+			"tag": "0001_white_young_avengers",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "5",
+			"when": 1750935538683,
+			"tag": "0002_dusty_maginty",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "5",
+			"when": 1761710697286,
+			"tag": "0003_thin_gressill",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "5",
+			"when": 1761711378574,
+			"tag": "0004_video-org-id",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "5",
+			"when": 1761711605408,
+			"tag": "0005_video-org-id-required",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "5",
+			"when": 1762410865419,
+			"tag": "0006_hesitant_stone_men",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "5",
+			"when": 1762428551824,
+			"tag": "0007_public_toxin",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "5",
+			"when": 1762428905323,
+			"tag": "0008_fat_ender_wiggin",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "5",
+			"when": 1768139432782,
+			"tag": "0009_easy_ulik",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "5",
+			"when": 1738505600000,
+			"tag": "0010_video_uploads_bigint",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "5",
+			"when": 1771325011010,
+			"tag": "0011_public_inhumans",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "5",
+			"when": 1772534950328,
+			"tag": "0012_lethal_lilith",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "5",
+			"when": 1772573402457,
+			"tag": "0013_faithful_marvex",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "5",
+			"when": 1772576220593,
+			"tag": "0014_modern_triton",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "5",
+			"when": 1772582468257,
+			"tag": "0015_closed_tigra",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "5",
+			"when": 1772641549840,
+			"tag": "0016_bouncy_hellcat",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "5",
+			"when": 1778099532336,
+			"tag": "0017_productive_betty_brant",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "5",
+			"when": 1778153157657,
+			"tag": "0018_loud_mongu",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "5",
+			"when": 1778154209547,
+			"tag": "0019_solid_paibok",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "5",
+			"when": 1778157016497,
+			"tag": "0020_orange_talkback",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "5",
+			"when": 1778249922872,
+			"tag": "0021_glorious_khan",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "5",
+			"when": 1778252207674,
+			"tag": "0022_dazzling_namor",
+			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "5",
+			"when": 1778434170430,
+			"tag": "0023_misty_luckman",
+			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "5",
+			"when": 1778776694053,
+			"tag": "0024_many_speed",
+			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "5",
+			"when": 1778858762935,
+			"tag": "0025_demonic_mother_askani",
+			"breakpoints": true
+		}
+	]
 }

--- a/packages/database/migrations/space_member_role_backfill.ts
+++ b/packages/database/migrations/space_member_role_backfill.ts
@@ -1,0 +1,10 @@
+import { db } from "@cap/database";
+import { spaceMembers } from "@cap/database/schema";
+import { sql } from "drizzle-orm";
+
+export async function runSpaceMemberRoleBackfill() {
+	await db()
+		.update(spaceMembers)
+		.set({ role: "admin" })
+		.where(sql`LOWER(${spaceMembers.role}) = 'admin'`);
+}

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -200,8 +200,13 @@ export const organizations = mysqlTable(
 			disableReactions?: boolean;
 			disableTranscript?: boolean;
 			disableComments?: boolean;
+			hideShareableLinkCapLogo?: boolean;
+			shareableLinkUseOrganizationIcon?: boolean;
 		}>(),
 		iconUrl: varchar("iconUrl", {
+			length: 1024,
+		}).$type<ImageUpload.ImageUrlOrKey>(),
+		shareableLinkIconUrl: varchar("shareableLinkIconUrl", {
 			length: 1024,
 		}).$type<ImageUpload.ImageUrlOrKey>(),
 		createdAt: timestamp("createdAt").notNull().defaultNow(),
@@ -218,7 +223,7 @@ export const organizations = mysqlTable(
 	}),
 );
 
-export type OrganisationMemberRole = "owner" | "member";
+export type OrganisationMemberRole = "owner" | "admin" | "member";
 export const organizationMembers = mysqlTable(
 	"organization_members",
 	{
@@ -963,7 +968,7 @@ export const spaceMembers = mysqlTable(
 		role: varchar("role", { length: 255 })
 			.notNull()
 			.default("member")
-			.$type<"member" | "Admin">(),
+			.$type<"admin" | "member">(),
 		createdAt: timestamp("createdAt").notNull().defaultNow(),
 		updatedAt: timestamp("updatedAt").notNull().defaultNow().onUpdateNow(),
 	},

--- a/packages/web-api-contract/src/desktop.ts
+++ b/packages/web-api-contract/src/desktop.ts
@@ -15,7 +15,7 @@ export const DesktopOrganization = z.object({
 	id: z.string(),
 	name: z.string(),
 	ownerId: z.string(),
-	role: z.enum(["owner", "member"]),
+	role: z.enum(["owner", "admin", "member"]),
 	canEditBrand: z.boolean(),
 	iconUrl: z.string().nullable(),
 	brandColors: OrganizationBrandColors,

--- a/packages/web-backend/src/Folders/FoldersPolicy.ts
+++ b/packages/web-backend/src/Folders/FoldersPolicy.ts
@@ -1,4 +1,4 @@
-import { type Folder, Policy } from "@cap/web-domain";
+import { type Folder, Policy, type Space } from "@cap/web-domain";
 import { Effect } from "effect";
 
 import { Database } from "../Database.ts";
@@ -15,6 +15,22 @@ export class FoldersPolicy extends Effect.Service<FoldersPolicy>()(
 			const spacesPolicy = yield* SpacesPolicy;
 			const orgsPolicy = yield* OrganisationsPolicy;
 			const spaces = yield* Spaces;
+			const canManageSpaceOrOrg = (spaceId: Space.SpaceIdOrOrganisationId) =>
+				Effect.gen(function* () {
+					const spaceOrOrg = yield* spaces.getSpaceOrOrg(spaceId);
+					if (!spaceOrOrg) return false;
+
+					if (spaceOrOrg.variant === "space") {
+						yield* Policy.any(
+							spacesPolicy.isAdmin(spaceOrOrg.space.id),
+							orgsPolicy.isAdminOrOwner(spaceOrOrg.space.organizationId),
+						);
+					} else {
+						yield* orgsPolicy.isAdminOrOwner(spaceOrOrg.organization.id);
+					}
+
+					return true;
+				});
 
 			const canEdit = (id: Folder.FolderId) =>
 				Policy.policy((user) =>
@@ -31,15 +47,16 @@ export class FoldersPolicy extends Effect.Service<FoldersPolicy>()(
 						const spaceOrOrg = yield* spaces.getSpaceOrOrg(folder.spaceId);
 						if (!spaceOrOrg) return false;
 
-						if (spaceOrOrg.variant === "space")
-							yield* spacesPolicy.isMember(spaceOrOrg.space.id);
-						else yield* orgsPolicy.isOwner(spaceOrOrg.organization.id);
+						yield* canManageSpaceOrOrg(folder.spaceId);
 
 						return true;
 					}),
 				);
 
-			return { canEdit };
+			const canCreateIn = (spaceId: Space.SpaceIdOrOrganisationId) =>
+				Policy.policy(() => canManageSpaceOrOrg(spaceId));
+
+			return { canEdit, canCreateIn };
 		}),
 		dependencies: [
 			FoldersRepo.Default,

--- a/packages/web-backend/src/Folders/index.ts
+++ b/packages/web-backend/src/Folders/index.ts
@@ -80,6 +80,10 @@ export class Folders extends Effect.Service<Folders>()("Folders", {
 			}) {
 				const user = yield* CurrentUser;
 
+				if (Option.isSome(data.spaceId)) {
+					yield* policy.canCreateIn(data.spaceId.value);
+				}
+
 				if (Option.isSome(data.parentId)) {
 					const parentId = data.parentId.value;
 

--- a/packages/web-backend/src/Organisations/OrganisationsPolicy.ts
+++ b/packages/web-backend/src/Organisations/OrganisationsPolicy.ts
@@ -33,7 +33,10 @@ export class OrganisationsPolicy extends Effect.Service<OrganisationsPolicy>()(
 					repo.membership(user.id, orgId).pipe(
 						Effect.map((v) =>
 							v.pipe(
-								Option.filter((v) => v.role === "owner" || v.role === "admin"),
+								Option.filter((v) => {
+									const role = String(v.role).toLowerCase();
+									return role === "owner" || role === "admin";
+								}),
 								Option.isSome,
 							),
 						),

--- a/packages/web-backend/src/Organisations/OrganisationsPolicy.ts
+++ b/packages/web-backend/src/Organisations/OrganisationsPolicy.ts
@@ -28,7 +28,19 @@ export class OrganisationsPolicy extends Effect.Service<OrganisationsPolicy>()(
 					),
 				);
 
-			return { isMember, isOwner };
+			const isAdminOrOwner = (orgId: Organisation.OrganisationId) =>
+				Policy.policy((user) =>
+					repo.membership(user.id, orgId).pipe(
+						Effect.map((v) =>
+							v.pipe(
+								Option.filter((v) => v.role === "owner" || v.role === "admin"),
+								Option.isSome,
+							),
+						),
+					),
+				);
+
+			return { isMember, isOwner, isAdminOrOwner };
 		}),
 		dependencies: [
 			OrganisationsRepo.Default,

--- a/packages/web-backend/src/Organisations/OrganisationsRepo.ts
+++ b/packages/web-backend/src/Organisations/OrganisationsRepo.ts
@@ -37,17 +37,44 @@ export class OrganisationsRepo extends Effect.Service<OrganisationsRepo>()(
 							db
 								.select({
 									membershipId: Db.organizationMembers.id,
+									ownerId: Db.organizations.ownerId,
 									role: Db.organizationMembers.role,
 								})
-								.from(Db.organizationMembers)
+								.from(Db.organizations)
+								.leftJoin(
+									Db.organizationMembers,
+									Dz.and(
+										Dz.eq(
+											Db.organizationMembers.organizationId,
+											Db.organizations.id,
+										),
+										Dz.eq(Db.organizationMembers.userId, userId),
+									),
+								)
 								.where(
 									Dz.and(
-										Dz.eq(Db.organizationMembers.userId, userId),
-										Dz.eq(Db.organizationMembers.organizationId, orgId),
+										Dz.eq(Db.organizations.id, orgId),
+										Dz.or(
+											Dz.eq(Db.organizations.ownerId, userId),
+											Dz.eq(Db.organizationMembers.userId, userId),
+										),
 									),
 								),
 						)
-						.pipe(Effect.map(Array.get(0))),
+						.pipe(
+							Effect.map(Array.get(0)),
+							Effect.map(
+								Option.map((row) => ({
+									membershipId: row.membershipId,
+									role:
+										row.ownerId === userId
+											? ("owner" as const)
+											: row.role === "owner"
+												? ("member" as const)
+												: row.role,
+								})),
+							),
+						),
 				allowedEmailDomain: (orgId: Organisation.OrganisationId) =>
 					db
 						.use((db) =>

--- a/packages/web-backend/src/Organisations/index.ts
+++ b/packages/web-backend/src/Organisations/index.ts
@@ -31,7 +31,7 @@ export class Organisations extends Effect.Service<Organisations>()(
 							"NoSuchElementException",
 							() => new Organisation.NotFoundError(),
 						),
-						Policy.withPolicy(policy.isOwner(payload.id)),
+						Policy.withPolicy(policy.isAdminOrOwner(payload.id)),
 					);
 
 				if (payload.image) {
@@ -55,7 +55,6 @@ export class Organisations extends Effect.Service<Organisations>()(
 
 				yield* Policy.withPolicy(policy.isOwner(id))(Effect.void);
 
-				// Perform tombstone, find other org, and update user in a single transaction
 				yield* db.use((db) =>
 					db.transaction(async (tx) => {
 						await tx
@@ -63,7 +62,6 @@ export class Organisations extends Effect.Service<Organisations>()(
 							.set({ tombstoneAt: new Date() })
 							.where(Dz.eq(Db.organizations.id, id));
 
-						// Find another active organization owned by the user
 						const [otherOrg] = await tx
 							.select({ id: Db.organizations.id })
 							.from(Db.organizations)

--- a/packages/web-backend/src/Spaces/SpacesPolicy.ts
+++ b/packages/web-backend/src/Spaces/SpacesPolicy.ts
@@ -36,10 +36,9 @@ export class SpacesPolicy extends Effect.Service<SpacesPolicy>()(
 						repo.membership(user.id, spaceId).pipe(
 							Effect.map((v) =>
 								v.pipe(
-									Option.filter((v) => {
-										const role = String(v.role);
-										return role === "admin" || role === "Admin";
-									}),
+									Option.filter(
+										(v) => String(v.role).toLowerCase() === "admin",
+									),
 									Option.isSome,
 								),
 							),

--- a/packages/web-backend/src/Spaces/SpacesPolicy.ts
+++ b/packages/web-backend/src/Spaces/SpacesPolicy.ts
@@ -29,7 +29,25 @@ export class SpacesPolicy extends Effect.Service<SpacesPolicy>()(
 			const isMember = (spaceId: Space.SpaceIdOrOrganisationId) =>
 				Policy.any(isOwner(spaceId), hasMembership(spaceId));
 
-			return { isMember, isOwner };
+			const isAdmin = (spaceId: Space.SpaceIdOrOrganisationId) =>
+				Policy.any(
+					isOwner(spaceId),
+					Policy.policy((user) =>
+						repo.membership(user.id, spaceId).pipe(
+							Effect.map((v) =>
+								v.pipe(
+									Option.filter((v) => {
+										const role = String(v.role);
+										return role === "admin" || role === "Admin";
+									}),
+									Option.isSome,
+								),
+							),
+						),
+					),
+				);
+
+			return { isMember, isOwner, isAdmin };
 		}),
 		dependencies: [
 			OrganisationsRepo.Default,

--- a/packages/web-backend/src/Spaces/index.ts
+++ b/packages/web-backend/src/Spaces/index.ts
@@ -55,7 +55,12 @@ export class Spaces extends Effect.Service<Spaces>()("Spaces", {
 			]);
 			if (space)
 				return yield* Effect.succeed({ variant: "space" as const, space }).pipe(
-					Policy.withPolicy(spacesPolicy.isMember(space.id)),
+					Policy.withPolicy(
+						Policy.any(
+							spacesPolicy.isMember(space.id),
+							orgsPolicy.isAdminOrOwner(space.organizationId),
+						),
+					),
 				);
 			if (org)
 				return yield* Effect.succeed({

--- a/packages/web-domain/src/Space.ts
+++ b/packages/web-domain/src/Space.ts
@@ -11,7 +11,7 @@ export const SpaceMemberId = Schema.String.pipe(Schema.brand("SpaceMemberId"));
 export type SpaceMemberId = typeof SpaceMemberId.Type;
 
 export const SpaceMemberRole = Schema.Union(
-	Schema.Literal("Admin"),
+	Schema.Literal("admin"),
 	Schema.Literal("member"),
 );
 export type SpaceMemberRole = typeof SpaceMemberRole.Type;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,7 +115,7 @@ importers:
         version: 0.14.10(solid-js@1.9.6)
       '@solidjs/start':
         specifier: ^1.1.3
-        version: 1.1.3(@testing-library/jest-dom@6.5.0)(@types/node@22.15.17)(jiti@2.6.1)(solid-js@1.9.6)(terser@5.44.0)(vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.0)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1))(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
+        version: 1.1.3(@testing-library/jest-dom@6.5.0)(@types/node@22.15.17)(jiti@2.6.1)(solid-js@1.9.6)(terser@5.44.0)(vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.1)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1))(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
       '@tanstack/solid-query':
         specifier: ^5.51.21
         version: 5.75.4(solid-js@1.9.6)
@@ -205,7 +205,7 @@ importers:
         version: 9.0.1
       vinxi:
         specifier: ^0.5.6
-        version: 0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.0)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1)
+        version: 0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.1)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1)
       webcodecs:
         specifier: ^0.1.0
         version: 0.1.0
@@ -301,16 +301,25 @@ importers:
 
   apps/media-server:
     dependencies:
+      '@mediabunny/server':
+        specifier: ^1.45.2
+        version: 1.45.2(mediabunny@1.45.2)
       hono:
         specifier: ^4.12.12
         version: 4.12.12
+      mediabunny:
+        specifier: ^1.45.2
+        version: 1.45.2
+      node-av:
+        specifier: ^5.2.4
+        version: 5.2.4
       zod:
         specifier: ^3.24.2
         version: 3.25.76
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.11
+        version: 1.3.14
 
   apps/storybook:
     dependencies:
@@ -464,7 +473,7 @@ importers:
         version: 3.10.0(react-hook-form@7.56.2(react@19.2.4))
       '@kubiks/otel-drizzle':
         specifier: ^2.1.0
-        version: 2.1.0(@opentelemetry/api@1.9.0)(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))
+        version: 2.1.0(@opentelemetry/api@1.9.0)(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))
       '@mux/mux-node':
         specifier: ^8.5.1
         version: 8.8.0(encoding@0.1.13)
@@ -602,7 +611,7 @@ importers:
         version: 16.5.0
       drizzle-orm:
         specifier: 0.44.6
-        version: 0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2)
+        version: 0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2)
       dub:
         specifier: ^0.64.0
         version: 0.64.0(@modelcontextprotocol/sdk@1.6.1)(zod@3.25.76)
@@ -966,7 +975,7 @@ importers:
         version: 0.47.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)(ioredis@5.6.1))(@effect/platform@0.92.1(effect@3.18.4))(@effect/sql@0.44.2(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)(ioredis@5.6.1))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)
       '@kubiks/otel-drizzle':
         specifier: ^2.1.0
-        version: 2.1.0(@opentelemetry/api@1.9.0)(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))
+        version: 2.1.0(@opentelemetry/api@1.9.0)(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))
       '@mattrax/mysql-planetscale':
         specifier: ^0.0.3
         version: 0.0.3
@@ -987,7 +996,7 @@ importers:
         version: 1.0.5(react@19.1.1)
       drizzle-orm:
         specifier: 0.44.6
-        version: 0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2)
+        version: 0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2)
       dub:
         specifier: ^0.64.0
         version: 0.64.0(@modelcontextprotocol/sdk@1.6.1)(zod@3.25.76)
@@ -1391,7 +1400,7 @@ importers:
         version: 3.1.0(@aws-sdk/credential-provider-web-identity@3.972.26)
       drizzle-orm:
         specifier: 0.44.6
-        version: 0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2)
+        version: 0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2)
       effect:
         specifier: ^3.18.4
         version: 3.18.4
@@ -3616,6 +3625,14 @@ packages:
   '@fastify/busboy@3.1.1':
     resolution: {integrity: sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw==}
 
+  '@fidm/asn1@1.0.4':
+    resolution: {integrity: sha512-esd1jyNvRb2HVaQGq2Gg8Z0kbQPXzV9Tq5Z14KNIov6KfFD6PTaRIO8UpcsYiTNzOqJpmyzWgVTrUwFV3UF4TQ==}
+    engines: {node: '>= 8'}
+
+  '@fidm/x509@1.2.1':
+    resolution: {integrity: sha512-nwc2iesjyc9hkuzcrMCBXQRn653XuAUKorfWM8PZyJawiy1QzLj4vahwzaI25+pfpwOLvMzbJ0uKpWLDNmo16w==}
+    engines: {node: '>= 8'}
+
   '@floating-ui/core@1.7.0':
     resolution: {integrity: sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==}
 
@@ -4067,6 +4084,9 @@ packages:
       '@opentelemetry/api': '>=1.9.0 <2.0.0'
       drizzle-orm: '>=0.28.0'
 
+  '@leichtgewicht/ip-codec@2.0.5':
+    resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
+
   '@logdna/tail-file@2.2.0':
     resolution: {integrity: sha512-XGSsWDweP80Fks16lwkAUIr54ICyBs6PsI4mpfTLQaWgEJRtY9xEV+PeyDpJ+sJEGZxqINlpmAwe/6tS1pP8Ng==}
     engines: {node: '>=10.3.0'}
@@ -4095,6 +4115,14 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@mediabunny/server@1.45.2':
+    resolution: {integrity: sha512-ut2glM8gwHg0vKqQMgxiumV9LfGjo1ZZBe2kUYKeMHntjINniVb0PkMC8iZH8lbMrq4pepe5VKBB8DE5Lfcgdg==}
+    peerDependencies:
+      mediabunny: ^1.45.0
+
+  '@minhducsun2002/leb128@1.0.0':
+    resolution: {integrity: sha512-eFrYUPDVHeuwWHluTG1kwNQUEUcFjVKYwPkU8z9DR1JH3AW7JtJsG9cRVGmwz809kKtGfwGJj58juCZxEvnI/g==}
 
   '@modelcontextprotocol/sdk@1.6.1':
     resolution: {integrity: sha512-oxzMzYCkZHMntzuyerehK3fV6A2Kwh5BD6CGEJSVDU2QNEhfLOptf2X7esQgaHZXHZY0oHmMsOtIDLP71UJXgA==}
@@ -4447,6 +4475,10 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -4880,8 +4912,8 @@ packages:
     resolution: {integrity: sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==}
     engines: {node: '>=14'}
 
-  '@oxc-project/types@0.129.0':
-    resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
+  '@oxc-project/types@0.130.0':
+    resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
 
   '@oxc-project/types@0.94.0':
     resolution: {integrity: sha512-+UgQT/4o59cZfH6Cp7G0hwmqEQ0wE+AdIwhikdwnhWI9Dp8CgSY081+Q3O67/wq3VJu8mgUEB93J9EHHn70fOw==}
@@ -4986,16 +5018,53 @@ packages:
     resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
     engines: {node: '>= 10.0.0'}
 
+  '@peculiar/asn1-cms@2.7.0':
+    resolution: {integrity: sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==}
+
+  '@peculiar/asn1-csr@2.7.0':
+    resolution: {integrity: sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==}
+
+  '@peculiar/asn1-ecc@2.7.0':
+    resolution: {integrity: sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==}
+
+  '@peculiar/asn1-pfx@2.7.0':
+    resolution: {integrity: sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==}
+
+  '@peculiar/asn1-pkcs8@2.7.0':
+    resolution: {integrity: sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==}
+
+  '@peculiar/asn1-pkcs9@2.7.0':
+    resolution: {integrity: sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==}
+
+  '@peculiar/asn1-rsa@2.7.0':
+    resolution: {integrity: sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==}
+
   '@peculiar/asn1-schema@2.3.15':
     resolution: {integrity: sha512-QPeD8UA8axQREpgR5UTAfu2mqQmm97oUqahDtNdBcfj3qAnoXzFdQW+aNf/tD2WVXF8Fhmftxoj0eMIT++gX2w==}
+
+  '@peculiar/asn1-schema@2.7.0':
+    resolution: {integrity: sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==}
+
+  '@peculiar/asn1-x509-attr@2.7.0':
+    resolution: {integrity: sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==}
+
+  '@peculiar/asn1-x509@2.7.0':
+    resolution: {integrity: sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==}
 
   '@peculiar/json-schema@1.1.12':
     resolution: {integrity: sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==}
     engines: {node: '>=8.0.0'}
 
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+
   '@peculiar/webcrypto@1.5.0':
     resolution: {integrity: sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==}
     engines: {node: '>=10.12.0'}
+
+  '@peculiar/x509@1.14.3':
+    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+    engines: {node: '>=20.0.0'}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5825,23 +5894,17 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0
 
-  '@rolldown/binding-android-arm64@1.0.0':
-    resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-android-arm64@1.0.0-beta.42':
     resolution: {integrity: sha512-W5ZKF3TP3bOWuBfotAGp+UGjxOkGV7jRmIRbBA7NFjggx7Oi6vOmGDqpHEIX7kDCiry1cnIsWQaxNvWbMdkvzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0':
-    resolution: {integrity: sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==}
+  '@rolldown/binding-android-arm64@1.0.1':
+    resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
+    os: [android]
 
   '@rolldown/binding-darwin-arm64@1.0.0-beta.42':
     resolution: {integrity: sha512-abw/wtgJA8OCgaTlL+xJxnN/Z01BwV1rfzIp5Hh9x+IIO6xOBfPsQ0nzi0+rWx3TyZ9FZXyC7bbC+5NpQ9EaXQ==}
@@ -5849,10 +5912,10 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0':
-    resolution: {integrity: sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==}
+  '@rolldown/binding-darwin-arm64@1.0.1':
+    resolution: {integrity: sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
+    cpu: [arm64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.0-beta.42':
@@ -5861,11 +5924,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0':
-    resolution: {integrity: sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==}
+  '@rolldown/binding-darwin-x64@1.0.1':
+    resolution: {integrity: sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
-    os: [freebsd]
+    os: [darwin]
 
   '@rolldown/binding-freebsd-x64@1.0.0-beta.42':
     resolution: {integrity: sha512-zRM0oOk7BZiy6DoWBvdV4hyEg+j6+WcBZIMHVirMEZRu8hd18kZdJkg+bjVMfCEhwpWeFUfBfZ1qcaZ5UdYzlQ==}
@@ -5873,11 +5936,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
-    resolution: {integrity: sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==}
+  '@rolldown/binding-freebsd-x64@1.0.1':
+    resolution: {integrity: sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
+    cpu: [x64]
+    os: [freebsd]
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.42':
     resolution: {integrity: sha512-6RjFaC52QNwo7ilU8C5H7swbGlgfTkG9pudXwzr3VYyT18s0C9gLg3mvc7OMPIGqNxnQ0M5lU8j6aQCk2DTRVg==}
@@ -5885,10 +5948,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0':
-    resolution: {integrity: sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+    resolution: {integrity: sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
+    cpu: [arm]
     os: [linux]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.42':
@@ -5897,8 +5960,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0':
-    resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+    resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -5909,22 +5972,22 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
-    resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+    resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0':
-    resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+    resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
-    os: [linux]
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0':
-    resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [linux]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.42':
@@ -5933,8 +5996,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0':
-    resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
+    resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -5945,11 +6008,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0':
-    resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
+    cpu: [x64]
+    os: [linux]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.42':
     resolution: {integrity: sha512-BmWoeJJyeZXmZBcfoxG6J9+rl2G7eO47qdTkAzEegj4n3aC6CBIHOuDcbE8BvhZaEjQR0nh0nJrtEDlt65Q7Sw==}
@@ -5957,24 +6020,30 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0':
-    resolution: {integrity: sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==}
+  '@rolldown/binding-openharmony-arm64@1.0.1':
+    resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
+    cpu: [arm64]
+    os: [openharmony]
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.42':
     resolution: {integrity: sha512-2Ft32F7uiDTrGZUKws6CLNTlvTWHC33l4vpXrzUucf9rYtUThAdPCOt89Pmn13tNX6AulxjGEP2R0nZjTSW3eQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0':
-    resolution: {integrity: sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==}
+  '@rolldown/binding-wasm32-wasi@1.0.1':
+    resolution: {integrity: sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.42':
+    resolution: {integrity: sha512-hC1kShXW/z221eG+WzQMN06KepvPbMBknF0iGR3VMYJLOe9gwnSTfGxFT5hf8XrPv7CEZqTWRd0GQpkSHRbGsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.42':
-    resolution: {integrity: sha512-hC1kShXW/z221eG+WzQMN06KepvPbMBknF0iGR3VMYJLOe9gwnSTfGxFT5hf8XrPv7CEZqTWRd0GQpkSHRbGsw==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+    resolution: {integrity: sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -5985,14 +6054,14 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0':
-    resolution: {integrity: sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.42':
+    resolution: {integrity: sha512-XpZ0M+tjoEiSc9c+uZR7FCnOI0uxDRNs1elGOMjeB0pUP1QmvVbZGYNsyLbLoP4u7e3VQN8rie1OQ8/mB6rcJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.42':
-    resolution: {integrity: sha512-XpZ0M+tjoEiSc9c+uZR7FCnOI0uxDRNs1elGOMjeB0pUP1QmvVbZGYNsyLbLoP4u7e3VQN8rie1OQ8/mB6rcJg==}
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    resolution: {integrity: sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -6193,6 +6262,54 @@ packages:
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
+  '@seydx/node-av-darwin-arm64@5.2.4':
+    resolution: {integrity: sha512-uQh6jWXDeXtjuaGOXrBx2rszPDcQbRa4W1YFrmlQG+ffOo+IJyczGjhTWfgzebRksB9tMAe9ViztU39THWZAkw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@seydx/node-av-darwin-x64@5.2.4':
+    resolution: {integrity: sha512-S9ptQF7JhvGSbvZH9jVeDAPXyRklA7rySKiFzi4UeLTMJslgFTSWFgY2nJAtHrP4wRdkAPnAVjExqd8U7jRZgg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@seydx/node-av-linux-arm64@5.2.4':
+    resolution: {integrity: sha512-XlQAWIcqFxVItr98VShaxzx57Cfl0y+RPCPciLOHXuEmfeKjON4o/xdbChHg02hHFrVAeSCfaHWQmHNgB9m6eQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@seydx/node-av-linux-x64@5.2.4':
+    resolution: {integrity: sha512-+2LdgZ7irDik++0mO6Bo1odYa2NZvze6xiy4B8jTbcf3F8k46qQEKkPjBwtV0qQu5fn3M+fUc/wk5coHdfxjxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@seydx/node-av-win32-arm64-mingw@5.2.4':
+    resolution: {integrity: sha512-uVNgRQ44uSdtMcR9O6R+nrBou5BWmroTFnGPI3PX8pHR8oe1Nim5zXtWK0qGTTqOiTPNsK5XnSshM3c5/n0/Fg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@seydx/node-av-win32-arm64-msvc@5.2.4':
+    resolution: {integrity: sha512-Gi+Op8j028WHbdl2jR7MnyHqR2J1TfkEogLPludb3jx54Yi+MO1zvouICFUmtSbxd9JC7CAeoU8++CZAMqcEvA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@seydx/node-av-win32-x64-mingw@5.2.4':
+    resolution: {integrity: sha512-gClAhvV/aJa681tuTlG6dTqqMpnTM5k6QVhnWolBgkbpZXMi0qABzoUBTYpuwxnOEd6j2mBBAVwqx6kut55Ukw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@seydx/node-av-win32-x64-msvc@5.2.4':
+    resolution: {integrity: sha512-01s5ij6nudrtZ7ojiAOAgzuUrImvuQYrAE5o6uesoxYqOha6j7yRu5e4qCXRQCDKrh2FBzyO1cGDc7Ht8Ly8wQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@shikijs/core@1.29.2':
     resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
 
@@ -6231,6 +6348,13 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@shinyoshiaki/binary-data@0.6.1':
+    resolution: {integrity: sha512-7HDb/fQAop2bCmvDIzU5+69i+UJaFgIVp99h1VzK1mpg1JwSODOkjbqD7ilTYnqlnadF8C4XjpwpepxDsGY6+w==}
+    engines: {node: '>=6'}
+
+  '@shinyoshiaki/jspack@0.0.6':
+    resolution: {integrity: sha512-SdsNhLjQh4onBlyPrn4ia1Pdx5bXT88G/LIEpOYAjx2u4xeY/m/HB5yHqlkJB1uQR3Zw4R3hBWLj46STRAN0rg==}
 
   '@sigstore/bundle@2.3.2':
     resolution: {integrity: sha512-wueKWDk70QixNLB363yHc2D2ItTgYiMTdPwK8D9dKQMR3ZQ0c35IxP5xnwQ8cNLoCgCRcHf14kE+CLIvNX1zmA==}
@@ -7072,10 +7196,10 @@ packages:
       react-dom:
         optional: true
 
-  '@storybook/builder-vite@10.4.0-alpha.18':
-    resolution: {integrity: sha512-6CSPb2YdposC1AVIt400JrN3weSNL1jdsORF11VrZFwARz/2DMZL113FW3faX8zvPUFmJj5YaG9AaQFicnjtwQ==}
+  '@storybook/builder-vite@10.5.0-alpha.0':
+    resolution: {integrity: sha512-4iCteRr03HHLbeD3osey14D8ZQS8hu5OkamlmARR4JLJUF/o6hjxckZ9xD+Ci7jjeGrlGLom71Y+TneN1iLx4g==}
     peerDependencies:
-      storybook: ^10.4.0-alpha.18
+      storybook: ^10.5.0-alpha.0
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@storybook/core@8.6.12':
@@ -7086,12 +7210,12 @@ packages:
       prettier:
         optional: true
 
-  '@storybook/csf-plugin@10.4.0-alpha.18':
-    resolution: {integrity: sha512-chRHQRzysG4ZcXPTD2Mv2dWT0XVr8diH1XzBSuwd+IAUd+vKPz6931niCTSaTzUCkIGBpgYg6vyd7sEgV76vUQ==}
+  '@storybook/csf-plugin@10.5.0-alpha.0':
+    resolution: {integrity: sha512-XO6PgW7aldty1BsvwL7HFljELSJK4noZsGqgt+nHXvq46mXyl2OXJUpO+z06DoN8KabQGup//y49aYh4uBm/uw==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^10.4.0-alpha.18
+      storybook: ^10.5.0-alpha.0
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -7747,8 +7871,8 @@ packages:
   '@types/braces@3.0.5':
     resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
 
-  '@types/bun@1.3.11':
-    resolution: {integrity: sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==}
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
 
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
@@ -7809,6 +7933,12 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/dom-mediacapture-transform@0.1.11':
+    resolution: {integrity: sha512-Y2p+nGf1bF2XMttBnsVPHUWzRRZzqUoJAKmiP10b5umnO6DDrWI0BrGDJy1pOHoOULVmGSfFNkQrAlC5dcj6nQ==}
+
+  '@types/dom-webcodecs@0.1.13':
+    resolution: {integrity: sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==}
 
   '@types/dom-webcodecs@0.1.14':
     resolution: {integrity: sha512-ba9aF0qARLLQpLihONIRbj8VvAdUxO+5jIxlscVcDAQTcJmq5qVr781+ino5qbQUJUmO21cLP2eLeXYWzao5Vg==}
@@ -8124,6 +8254,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-darwin-arm64@1.7.2':
     resolution: {integrity: sha512-vxtBno4xvowwNmO/ASL0Y45TpHqmNkAaDtz4Jqb+clmcVSSl8XCG/PNFFkGsXXXS6AMjP+ja/TtNCFFa1QwLRg==}
@@ -8680,6 +8811,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  aes-js@3.1.2:
+    resolution: {integrity: sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -9048,6 +9182,9 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
+  bluebird@3.7.2:
+    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -9120,8 +9257,8 @@ packages:
     resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
     engines: {node: '>=18.20'}
 
-  bun-types@1.3.11:
-    resolution: {integrity: sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==}
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -9685,6 +9822,10 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
+    engines: {node: '>=0.11'}
+
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
@@ -9960,6 +10101,10 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
+  dns-packet@5.6.1:
+    resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
+    engines: {node: '>=6'}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -10144,6 +10289,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  duplexer2@0.1.4:
+    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
@@ -11516,6 +11664,9 @@ packages:
   inspect-with-kind@1.0.5:
     resolution: {integrity: sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==}
 
+  int64-buffer@1.1.0:
+    resolution: {integrity: sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -11531,6 +11682,9 @@ packages:
   ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
     engines: {node: '>= 12'}
+
+  ip@2.0.1:
+    resolution: {integrity: sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -11700,6 +11854,10 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-plain-object@2.0.4:
+    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
@@ -11803,6 +11961,10 @@ packages:
   isexe@3.1.1:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
+
+  isobject@3.0.1:
+    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
+    engines: {node: '>=0.10.0'}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -12313,6 +12475,9 @@ packages:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
 
+  mediabunny@1.45.2:
+    resolution: {integrity: sha512-lm34wGClgC263x8SEH5+79Z6aeDcHetoCKMSAeqDhn6Qn4a3A24Bs8uJf9Lxt9h0MEa/uJqZ/5soial/V9TSwQ==}
+
   memoizerific@1.11.3:
     resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
 
@@ -12669,6 +12834,10 @@ packages:
   msgpackr@1.11.5:
     resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
 
+  multicast-dns@7.2.5:
+    resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
+    hasBin: true
+
   multipasta@0.2.7:
     resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
 
@@ -12813,6 +12982,9 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
+  node-av@5.2.4:
+    resolution: {integrity: sha512-L5r+6k+YGvH5MZX8o55JHQbbeRZ+iFieAb1bhKtpa8hrqBEGuSwdkXRwpE4vd414JqVJsq/EQq6s+3qKeviQTg==}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -12854,6 +13026,9 @@ packages:
     resolution: {integrity: sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
     hasBin: true
+
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
   node-mock-http@1.0.0:
     resolution: {integrity: sha512-0uGYQ1WQL1M5kKvGRXWQ3uZCHtLTO8hln3oBjIusM75WoesZ909uQJs/Hb946i2SS+Gsrhkaa6iAO17jRIv6DQ==}
@@ -14033,13 +14208,13 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.0:
-    resolution: {integrity: sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==}
+  rolldown@1.0.0-beta.42:
+    resolution: {integrity: sha512-xaPcckj+BbJhYLsv8gOqezc8EdMcKKe/gk8v47B0KPvgABDrQ0qmNPAiT/gh9n9Foe0bUkEv2qzj42uU5q1WRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.0.0-beta.42:
-    resolution: {integrity: sha512-xaPcckj+BbJhYLsv8gOqezc8EdMcKKe/gk8v47B0KPvgABDrQ0qmNPAiT/gh9n9Foe0bUkEv2qzj42uU5q1WRg==}
+  rolldown@1.0.1:
+    resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -14084,6 +14259,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rx.mini@1.4.0:
+    resolution: {integrity: sha512-8w5cSc1mwNja7fl465DXOkVvIOkpvh2GW4jo31nAIvX4WTXCsRnKJGUfiDBzWtYRInEcHAUYIZfzusjIrea8gA==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -14776,12 +14954,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tauri-plugin-context-menu@0.5.0:
     resolution: {integrity: sha512-CkAjSyxLx26hTXabG5Unbv+GWeH0XYNQB3zTqRxHpp257mWX8I4oASp8YF5T3zxFQEK++ZHqMZHpLrQ3usShRQ==}
@@ -14847,6 +15025,9 @@ packages:
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  thunky@1.1.0:
+    resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -15071,6 +15252,10 @@ packages:
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
 
   tuf-js@2.2.1:
     resolution: {integrity: sha512-GwIJau9XaA8nLVbUXsN3IlFi7WmQ48gBUrl3FTkkL/XLu/POhBzfmX9hd33FNMX1qAsfl6ozO1iMmW9NC8YniA==}
@@ -15473,6 +15658,9 @@ packages:
   unwasm@0.3.9:
     resolution: {integrity: sha512-LDxTx/2DkFURUd+BU1vUsF/moj0JsoTvl+2tcg2AUOiEzVturhGGx17/IMgGvKUYdZwr33EJHtChCJuhu9Ouvg==}
 
+  unzipper@0.12.3:
+    resolution: {integrity: sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==}
+
   upath@1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
     engines: {node: '>=4'}
@@ -15549,6 +15737,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -15557,14 +15746,17 @@ packages:
 
   uuid@8.0.0:
     resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -15892,6 +16084,29 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  werift-common@0.0.3:
+    resolution: {integrity: sha512-ma3E4BqKTyZVLhrdfTVs2T1tg9seeUtKMRn5e64LwgrogWa62+3LAUoLBUSl1yPWhgSkXId7GmcHuWDen9IJeQ==}
+    engines: {node: '>=16'}
+
+  werift-dtls@0.5.7:
+    resolution: {integrity: sha512-z2fjbP7fFUFmu/Ky4bCKXzdgPTtmSY1DYi0TUf3GG2zJT4jMQ3TQmGY8y7BSSNGetvL4h3pRZ5un0EcSOWpPog==}
+    engines: {node: '>=16'}
+
+  werift-ice@0.2.2:
+    resolution: {integrity: sha512-td52pHp+JmFnUn5jfDr/SSNO0dMCbknhuPdN1tFp9cfRj5jaktN63qnAdUuZC20QCC3ETWdsOthcm+RalHpFCQ==}
+
+  werift-rtp@0.8.8:
+    resolution: {integrity: sha512-GiYMSdvCyScQaw5bnEsraSoHUVZpjfokJAiLV4R1FsiB06t6XiebPYPpkqB9nYNNKiA8Z/cYWsym7wISq1sYSQ==}
+    engines: {node: '>=10'}
+
+  werift-sctp@0.0.11:
+    resolution: {integrity: sha512-7109yuI5U7NTEHjqjn0A8VeynytkgVaxM6lRr1Ziv0D8bPcaB8A7U/P88M7WaCpWDoELHoXiRUjQycMWStIgjQ==}
+    engines: {node: '>=10'}
+
+  werift@0.23.0:
+    resolution: {integrity: sha512-/WcIN5DHFG9Ri4anGOmIkp8gxBGFMWSIB/m4sfZ5CWlLfD3iMhiaAUuTBuc+KV3SY9NDmvmLtiN2uaM7k3lVzw==}
+    engines: {node: '>=16'}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -18670,6 +18885,13 @@ snapshots:
 
   '@fastify/busboy@3.1.1': {}
 
+  '@fidm/asn1@1.0.4': {}
+
+  '@fidm/x509@1.2.1':
+    dependencies:
+      '@fidm/asn1': 1.0.4
+      tweetnacl: 1.0.3
+
   '@floating-ui/core@1.7.0':
     dependencies:
       '@floating-ui/utils': 0.2.9
@@ -19072,10 +19294,12 @@ snapshots:
       '@solid-primitives/utils': 6.3.1(solid-js@1.9.6)
       solid-js: 1.9.6
 
-  '@kubiks/otel-drizzle@2.1.0(@opentelemetry/api@1.9.0)(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))':
+  '@kubiks/otel-drizzle@2.1.0(@opentelemetry/api@1.9.0)(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      drizzle-orm: 0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2)
+      drizzle-orm: 0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2)
+
+  '@leichtgewicht/ip-codec@2.0.5': {}
 
   '@logdna/tail-file@2.2.0': {}
 
@@ -19149,6 +19373,15 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
       react: 19.2.4
+
+  '@mediabunny/server@1.45.2(mediabunny@1.45.2)':
+    dependencies:
+      mediabunny: 1.45.2
+      node-av: 5.2.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@minhducsun2002/leb128@1.0.0': {}
 
   '@modelcontextprotocol/sdk@1.6.1':
     dependencies:
@@ -19495,6 +19728,10 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.1':
     optional: true
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.8.0': {}
 
@@ -20099,7 +20336,7 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.37.0': {}
 
-  '@oxc-project/types@0.129.0': {}
+  '@oxc-project/types@0.130.0': {}
 
   '@oxc-project/types@0.94.0': {}
 
@@ -20179,13 +20416,93 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.1
       '@parcel/watcher-win32-x64': 2.5.1
 
+  '@peculiar/asn1-cms@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      '@peculiar/asn1-x509-attr': 2.7.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-csr@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pfx@2.7.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-pkcs8': 2.7.0
+      '@peculiar/asn1-rsa': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs9@2.7.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-pfx': 2.7.0
+      '@peculiar/asn1-pkcs8': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      '@peculiar/asn1-x509-attr': 2.7.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
   '@peculiar/asn1-schema@2.3.15':
     dependencies:
       asn1js: 3.0.6
       pvtsutils: 1.3.6
       tslib: 2.8.1
 
+  '@peculiar/asn1-schema@2.7.0':
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
   '@peculiar/json-schema@1.1.12':
+    dependencies:
+      tslib: 2.8.1
+
+  '@peculiar/utils@2.0.3':
     dependencies:
       tslib: 2.8.1
 
@@ -20196,6 +20513,20 @@ snapshots:
       pvtsutils: 1.3.6
       tslib: 2.8.1
       webcrypto-core: 1.8.1
+
+  '@peculiar/x509@1.14.3':
+    dependencies:
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-csr': 2.7.0
+      '@peculiar/asn1-ecc': 2.7.0
+      '@peculiar/asn1-pkcs9': 2.7.0
+      '@peculiar/asn1-rsa': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.8.1
+      tsyringe: 4.10.0
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -21187,77 +21518,70 @@ snapshots:
       '@rive-app/canvas': 2.27.1
       react: 19.2.4
 
-  '@rolldown/binding-android-arm64@1.0.0':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0':
+  '@rolldown/binding-android-arm64@1.0.1':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0':
+  '@rolldown/binding-darwin-arm64@1.0.1':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0':
+  '@rolldown/binding-darwin-x64@1.0.1':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
+  '@rolldown/binding-freebsd-x64@1.0.1':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0':
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0':
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0':
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0':
+  '@rolldown/binding-linux-x64-musl@1.0.1':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+  '@rolldown/binding-openharmony-arm64@1.0.1':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.42':
@@ -21265,19 +21589,26 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.6
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0':
+  '@rolldown/binding-wasm32-wasi@1.0.1':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.42':
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+    optional: true
+
   '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.42':
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
     optional: true
 
   '@rolldown/pluginutils@1.0.0': {}
@@ -21420,6 +21751,30 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
+  '@seydx/node-av-darwin-arm64@5.2.4':
+    optional: true
+
+  '@seydx/node-av-darwin-x64@5.2.4':
+    optional: true
+
+  '@seydx/node-av-linux-arm64@5.2.4':
+    optional: true
+
+  '@seydx/node-av-linux-x64@5.2.4':
+    optional: true
+
+  '@seydx/node-av-win32-arm64-mingw@5.2.4':
+    optional: true
+
+  '@seydx/node-av-win32-arm64-msvc@5.2.4':
+    optional: true
+
+  '@seydx/node-av-win32-x64-mingw@5.2.4':
+    optional: true
+
+  '@seydx/node-av-win32-x64-msvc@5.2.4':
+    optional: true
+
   '@shikijs/core@1.29.2':
     dependencies:
       '@shikijs/engine-javascript': 1.29.2
@@ -21485,6 +21840,13 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@shinyoshiaki/binary-data@0.6.1':
+    dependencies:
+      generate-function: 2.3.1
+      is-plain-object: 2.0.4
+
+  '@shinyoshiaki/jspack@0.0.6': {}
 
   '@sigstore/bundle@2.3.2':
     dependencies:
@@ -22559,11 +22921,11 @@ snapshots:
     dependencies:
       solid-js: 1.9.6
 
-  '@solidjs/start@1.1.3(@testing-library/jest-dom@6.5.0)(@types/node@22.15.17)(jiti@2.6.1)(solid-js@1.9.6)(terser@5.44.0)(vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.0)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1))(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)':
+  '@solidjs/start@1.1.3(@testing-library/jest-dom@6.5.0)(@types/node@22.15.17)(jiti@2.6.1)(solid-js@1.9.6)(terser@5.44.0)(vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.1)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1))(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)':
     dependencies:
       '@tanstack/server-functions-plugin': 1.119.2(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1)
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.0)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1))
-      '@vinxi/server-components': 0.5.1(vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.0)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.1)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1))
+      '@vinxi/server-components': 0.5.1(vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.1)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1))
       defu: 6.1.4
       error-stack-parser: 2.1.4
       html-to-image: 1.11.13
@@ -22574,7 +22936,7 @@ snapshots:
       source-map-js: 1.2.1
       terracotta: 1.0.6(solid-js@1.9.6)
       tinyglobby: 0.2.13
-      vinxi: 0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.0)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1)
+      vinxi: 0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.1)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1)
       vite-plugin-solid: 2.11.6(@testing-library/jest-dom@6.5.0)(solid-js@1.9.6)(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
@@ -22704,9 +23066,9 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/builder-vite@10.4.0-alpha.18(esbuild@0.25.5)(rollup@4.40.2)(storybook@8.6.12(prettier@3.7.4))(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.5))':
+  '@storybook/builder-vite@10.5.0-alpha.0(esbuild@0.25.5)(rollup@4.40.2)(storybook@8.6.12(prettier@3.7.4))(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.5))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.0-alpha.18(esbuild@0.25.5)(rollup@4.40.2)(storybook@8.6.12(prettier@3.7.4))(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.5))
+      '@storybook/csf-plugin': 10.5.0-alpha.0(esbuild@0.25.5)(rollup@4.40.2)(storybook@8.6.12(prettier@3.7.4))(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.5))
       storybook: 8.6.12(prettier@3.7.4)
       ts-dedent: 2.2.0
       vite: 6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1)
@@ -22736,7 +23098,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@storybook/csf-plugin@10.4.0-alpha.18(esbuild@0.25.5)(rollup@4.40.2)(storybook@8.6.12(prettier@3.7.4))(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.5))':
+  '@storybook/csf-plugin@10.5.0-alpha.0(esbuild@0.25.5)(rollup@4.40.2)(storybook@8.6.12(prettier@3.7.4))(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.5))':
     dependencies:
       storybook: 8.6.12(prettier@3.7.4)
       unplugin: 2.3.11
@@ -23406,9 +23768,9 @@ snapshots:
 
   '@types/braces@3.0.5': {}
 
-  '@types/bun@1.3.11':
+  '@types/bun@1.3.14':
     dependencies:
-      bun-types: 1.3.11
+      bun-types: 1.3.14
 
   '@types/cacheable-request@6.0.3':
     dependencies:
@@ -23474,6 +23836,12 @@ snapshots:
       '@types/ms': 2.1.0
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/dom-mediacapture-transform@0.1.11':
+    dependencies:
+      '@types/dom-webcodecs': 0.1.14
+
+  '@types/dom-webcodecs@0.1.13': {}
 
   '@types/dom-webcodecs@0.1.14': {}
 
@@ -24028,7 +24396,7 @@ snapshots:
       untun: 0.1.3
       uqr: 0.1.2
 
-  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.0)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1))':
+  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.1)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1))':
     dependencies:
       '@babel/parser': 7.27.2
       acorn: 8.14.1
@@ -24039,18 +24407,18 @@ snapshots:
       magicast: 0.2.11
       recast: 0.23.11
       tslib: 2.8.1
-      vinxi: 0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.0)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1)
+      vinxi: 0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.1)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1)
 
-  '@vinxi/server-components@0.5.1(vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.0)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1))':
+  '@vinxi/server-components@0.5.1(vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.1)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1))':
     dependencies:
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.0)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.1)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1))
       acorn: 8.14.1
       acorn-loose: 8.5.0
       acorn-typescript: 1.4.13(acorn@8.14.1)
       astring: 1.9.0
       magicast: 0.2.11
       recast: 0.23.11
-      vinxi: 0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.0)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1)
+      vinxi: 0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.1)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1)
 
   '@virtual-grid/core@2.0.1': {}
 
@@ -24749,6 +25117,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  aes-js@3.1.2: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -25183,6 +25553,8 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
+  bluebird@3.7.2: {}
+
   body-parser@1.20.4:
     dependencies:
       bytes: 3.1.2
@@ -25289,7 +25661,7 @@ snapshots:
 
   builtin-modules@5.0.0: {}
 
-  bun-types@1.3.11:
+  bun-types@1.3.14:
     dependencies:
       '@types/node': 20.19.21
 
@@ -25847,6 +26219,10 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  date-fns@2.30.0:
+    dependencies:
+      '@babel/runtime': 7.27.1
+
   date-fns@4.1.0: {}
 
   dax-sh@0.43.0:
@@ -25856,9 +26232,9 @@ snapshots:
 
   dayjs@1.11.13: {}
 
-  db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2):
+  db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2):
     optionalDependencies:
-      drizzle-orm: 0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2)
+      drizzle-orm: 0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2)
       mysql2: 3.15.2
 
   debounce@2.2.0: {}
@@ -26059,6 +26435,10 @@ snapshots:
 
   dlv@1.1.3: {}
 
+  dns-packet@5.6.1:
+    dependencies:
+      '@leichtgewicht/ip-codec': 2.0.5
+
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
@@ -26136,12 +26516,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2):
+  drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20250507.0
       '@opentelemetry/api': 1.9.0
       '@planetscale/database': 1.19.0
-      bun-types: 1.3.11
+      bun-types: 1.3.14
       mysql2: 3.15.2
 
   dts-resolver@2.1.2: {}
@@ -26157,6 +26537,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  duplexer2@0.1.4:
+    dependencies:
+      readable-stream: 2.3.8
 
   duplexer@0.1.2: {}
 
@@ -26716,7 +27100,7 @@ snapshots:
       eslint: 9.30.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.30.1(jiti@2.6.1))(typescript@5.8.3))(eslint@9.30.1(jiti@2.6.1)))(eslint@9.30.1(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.30.1(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.30.1(jiti@2.6.1))(typescript@5.8.3))(eslint@9.30.1(jiti@2.6.1)))(eslint@9.30.1(jiti@2.6.1)))(eslint@9.30.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.30.1(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.30.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.30.1(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.30.1(jiti@2.6.1))
@@ -26773,7 +27157,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.7.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.30.1(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.30.1(jiti@2.6.1))(typescript@5.8.3))(eslint@9.30.1(jiti@2.6.1)))(eslint@9.30.1(jiti@2.6.1)))(eslint@9.30.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.30.1(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -26828,7 +27212,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.30.1(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.30.1(jiti@2.6.1))(typescript@5.8.3))(eslint@9.30.1(jiti@2.6.1)))(eslint@9.30.1(jiti@2.6.1)))(eslint@9.30.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.30.1(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -28269,6 +28653,8 @@ snapshots:
     dependencies:
       kind-of: 6.0.3
 
+  int64-buffer@1.1.0: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -28295,6 +28681,8 @@ snapshots:
     dependencies:
       jsbn: 1.1.0
       sprintf-js: 1.1.3
+
+  ip@2.0.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -28441,6 +28829,10 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-plain-object@2.0.4:
+    dependencies:
+      isobject: 3.0.1
+
   is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
@@ -28525,6 +28917,8 @@ snapshots:
   isexe@2.0.0: {}
 
   isexe@3.1.1: {}
+
+  isobject@3.0.1: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -29147,6 +29541,11 @@ snapshots:
 
   media-typer@1.1.0: {}
 
+  mediabunny@1.45.2:
+    dependencies:
+      '@types/dom-mediacapture-transform': 0.1.11
+      '@types/dom-webcodecs': 0.1.13
+
   memoizerific@1.11.3:
     dependencies:
       map-or-similar: 1.5.0
@@ -29651,6 +30050,11 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
+  multicast-dns@7.2.5:
+    dependencies:
+      dns-packet: 5.6.1
+      thunky: 1.1.0
+
   multipasta@0.2.7: {}
 
   mustache@4.2.0: {}
@@ -29833,7 +30237,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nitropack@2.11.11(@planetscale/database@1.19.0)(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(encoding@0.1.13)(mysql2@3.15.2)(rolldown@1.0.0)(xml2js@0.6.2):
+  nitropack@2.11.11(@planetscale/database@1.19.0)(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(encoding@0.1.13)(mysql2@3.15.2)(rolldown@1.0.1)(xml2js@0.6.2):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.0
       '@netlify/functions': 3.1.5(encoding@0.1.13)(rollup@4.40.2)
@@ -29855,7 +30259,7 @@ snapshots:
       cookie-es: 2.0.0
       croner: 9.0.0
       crossws: 0.3.5
-      db0: 0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2)
+      db0: 0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2)
       defu: 6.1.4
       destr: 2.0.5
       dot-prop: 9.0.0
@@ -29887,7 +30291,7 @@ snapshots:
       pretty-bytes: 6.1.1
       radix3: 1.1.2
       rollup: 4.40.2
-      rollup-plugin-visualizer: 5.14.0(rolldown@1.0.0)(rollup@4.40.2)
+      rollup-plugin-visualizer: 5.14.0(rolldown@1.0.1)(rollup@4.40.2)
       scule: 1.3.0
       semver: 7.7.2
       serve-placeholder: 2.0.2
@@ -29901,7 +30305,7 @@ snapshots:
       unenv: 2.0.0-rc.15
       unimport: 5.0.1
       unplugin-utils: 0.2.4
-      unstorage: 1.16.0(@planetscale/database@1.19.0)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(ioredis@5.6.1)
+      unstorage: 1.16.0(@planetscale/database@1.19.0)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(ioredis@5.6.1)
       untyped: 2.0.0
       unwasm: 0.3.9
       youch: 4.1.0-beta.7
@@ -29936,6 +30340,22 @@ snapshots:
       - uploadthing
 
   node-addon-api@7.1.1: {}
+
+  node-av@5.2.4:
+    dependencies:
+      unzipper: 0.12.3
+      werift: 0.23.0
+    optionalDependencies:
+      '@seydx/node-av-darwin-arm64': 5.2.4
+      '@seydx/node-av-darwin-x64': 5.2.4
+      '@seydx/node-av-linux-arm64': 5.2.4
+      '@seydx/node-av-linux-x64': 5.2.4
+      '@seydx/node-av-win32-arm64-mingw': 5.2.4
+      '@seydx/node-av-win32-arm64-msvc': 5.2.4
+      '@seydx/node-av-win32-x64-mingw': 5.2.4
+      '@seydx/node-av-win32-x64-msvc': 5.2.4
+    transitivePeerDependencies:
+      - supports-color
 
   node-domexception@1.0.0: {}
 
@@ -29981,6 +30401,8 @@ snapshots:
       which: 4.0.0
     transitivePeerDependencies:
       - supports-color
+
+  node-int64@0.4.0: {}
 
   node-mock-http@1.0.0: {}
 
@@ -31325,7 +31747,7 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rolldown-plugin-dts@0.16.11(rolldown@1.0.0)(typescript@5.8.3):
+  rolldown-plugin-dts@0.16.11(rolldown@1.0.1)(typescript@5.8.3):
     dependencies:
       '@babel/generator': 7.28.3
       '@babel/parser': 7.28.4
@@ -31336,33 +31758,12 @@ snapshots:
       dts-resolver: 2.1.2
       get-tsconfig: 4.11.0
       magic-string: 0.30.19
-      rolldown: 1.0.0
+      rolldown: 1.0.1
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
       - oxc-resolver
       - supports-color
-
-  rolldown@1.0.0:
-    dependencies:
-      '@oxc-project/types': 0.129.0
-      '@rolldown/pluginutils': 1.0.0
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0
-      '@rolldown/binding-darwin-arm64': 1.0.0
-      '@rolldown/binding-darwin-x64': 1.0.0
-      '@rolldown/binding-freebsd-x64': 1.0.0
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0
-      '@rolldown/binding-linux-arm64-musl': 1.0.0
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0
-      '@rolldown/binding-linux-x64-gnu': 1.0.0
-      '@rolldown/binding-linux-x64-musl': 1.0.0
-      '@rolldown/binding-openharmony-arm64': 1.0.0
-      '@rolldown/binding-wasm32-wasi': 1.0.0
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0
-      '@rolldown/binding-win32-x64-msvc': 1.0.0
 
   rolldown@1.0.0-beta.42:
     dependencies:
@@ -31385,6 +31786,27 @@ snapshots:
       '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.42
       '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.42
 
+  rolldown@1.0.1:
+    dependencies:
+      '@oxc-project/types': 0.130.0
+      '@rolldown/pluginutils': 1.0.0
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.1
+      '@rolldown/binding-darwin-arm64': 1.0.1
+      '@rolldown/binding-darwin-x64': 1.0.1
+      '@rolldown/binding-freebsd-x64': 1.0.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.1
+      '@rolldown/binding-linux-arm64-gnu': 1.0.1
+      '@rolldown/binding-linux-arm64-musl': 1.0.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.1
+      '@rolldown/binding-linux-s390x-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-musl': 1.0.1
+      '@rolldown/binding-openharmony-arm64': 1.0.1
+      '@rolldown/binding-wasm32-wasi': 1.0.1
+      '@rolldown/binding-win32-arm64-msvc': 1.0.1
+      '@rolldown/binding-win32-x64-msvc': 1.0.1
+
   rollup-plugin-inject@3.0.2:
     dependencies:
       estree-walker: 0.6.1
@@ -31395,14 +31817,14 @@ snapshots:
     dependencies:
       rollup-plugin-inject: 3.0.2
 
-  rollup-plugin-visualizer@5.14.0(rolldown@1.0.0)(rollup@4.40.2):
+  rollup-plugin-visualizer@5.14.0(rolldown@1.0.1)(rollup@4.40.2):
     dependencies:
       open: 8.4.2
       picomatch: 4.0.3
       source-map: 0.7.4
       yargs: 17.7.2
     optionalDependencies:
-      rolldown: 1.0.0
+      rolldown: 1.0.1
       rollup: 4.40.2
 
   rollup-pluginutils@2.8.2:
@@ -31452,6 +31874,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rx.mini@1.4.0: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -32028,7 +32452,7 @@ snapshots:
 
   storybook-solidjs-vite@1.0.0-beta.7(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.7.4)))(esbuild@0.25.5)(rollup@4.40.2)(solid-js@1.9.6)(storybook@8.6.12(prettier@3.7.4))(vite-plugin-solid@2.11.6(@testing-library/jest-dom@6.5.0)(solid-js@1.9.6)(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1)))(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.5)):
     dependencies:
-      '@storybook/builder-vite': 10.4.0-alpha.18(esbuild@0.25.5)(rollup@4.40.2)(storybook@8.6.12(prettier@3.7.4))(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.5))
+      '@storybook/builder-vite': 10.5.0-alpha.0(esbuild@0.25.5)(rollup@4.40.2)(storybook@8.6.12(prettier@3.7.4))(vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.5))
       '@storybook/types': 9.0.0-alpha.1(storybook@8.6.12(prettier@3.7.4))
       magic-string: 0.30.17
       solid-js: 1.9.6
@@ -32477,6 +32901,8 @@ snapshots:
 
   through@2.3.8: {}
 
+  thunky@1.1.0: {}
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -32669,8 +33095,8 @@ snapshots:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.0.0
-      rolldown-plugin-dts: 0.16.11(rolldown@1.0.0)(typescript@5.8.3)
+      rolldown: 1.0.1
+      rolldown-plugin-dts: 0.16.11(rolldown@1.0.1)(typescript@5.8.3)
       semver: 7.7.2
       tinyexec: 1.0.1
       tinyglobby: 0.2.15
@@ -32724,6 +33150,10 @@ snapshots:
     dependencies:
       tslib: 1.14.1
       typescript: 5.8.3
+
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 1.14.1
 
   tuf-js@2.2.1:
     dependencies:
@@ -33150,7 +33580,7 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.7.2
       '@unrs/resolver-binding-win32-x64-msvc': 1.7.2
 
-  unstorage@1.16.0(@planetscale/database@1.19.0)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(ioredis@5.6.1):
+  unstorage@1.16.0(@planetscale/database@1.19.0)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(ioredis@5.6.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 4.0.3
@@ -33162,7 +33592,7 @@ snapshots:
       ufo: 1.6.1
     optionalDependencies:
       '@planetscale/database': 1.19.0
-      db0: 0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2)
+      db0: 0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2)
       ioredis: 5.6.1
 
   untun@0.1.3:
@@ -33187,6 +33617,14 @@ snapshots:
       pathe: 1.1.2
       pkg-types: 1.3.1
       unplugin: 1.16.1
+
+  unzipper@0.12.3:
+    dependencies:
+      bluebird: 3.7.2
+      duplexer2: 0.1.4
+      fs-extra: 11.3.3
+      graceful-fs: 4.2.11
+      node-int64: 0.4.0
 
   upath@1.2.0: {}
 
@@ -33328,7 +33766,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.0)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1):
+  vinxi@0.5.6(@planetscale/database@1.19.0)(@types/node@22.15.17)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.6.1)(mysql2@3.15.2)(rolldown@1.0.1)(terser@5.44.0)(xml2js@0.6.2)(yaml@2.8.1):
     dependencies:
       '@babel/core': 7.27.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.27.1)
@@ -33350,7 +33788,7 @@ snapshots:
       hookable: 5.5.3
       http-proxy: 1.18.1
       micromatch: 4.0.8
-      nitropack: 2.11.11(@planetscale/database@1.19.0)(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(encoding@0.1.13)(mysql2@3.15.2)(rolldown@1.0.0)(xml2js@0.6.2)
+      nitropack: 2.11.11(@planetscale/database@1.19.0)(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(encoding@0.1.13)(mysql2@3.15.2)(rolldown@1.0.1)(xml2js@0.6.2)
       node-fetch-native: 1.6.6
       path-to-regexp: 6.3.0
       pathe: 1.1.2
@@ -33361,7 +33799,7 @@ snapshots:
       ufo: 1.6.1
       unctx: 2.4.1
       unenv: 1.10.0
-      unstorage: 1.16.0(@planetscale/database@1.19.0)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.11)(mysql2@3.15.2))(mysql2@3.15.2))(ioredis@5.6.1)
+      unstorage: 1.16.0(@planetscale/database@1.19.0)(db0@0.3.2(drizzle-orm@0.44.6(@cloudflare/workers-types@4.20250507.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.14)(mysql2@3.15.2))(mysql2@3.15.2))(ioredis@5.6.1)
       vite: 6.3.5(@types/node@22.15.17)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -33710,6 +34148,75 @@ snapshots:
       - esbuild
       - uglify-js
     optional: true
+
+  werift-common@0.0.3:
+    dependencies:
+      '@shinyoshiaki/jspack': 0.0.6
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  werift-dtls@0.5.7:
+    dependencies:
+      '@fidm/x509': 1.2.1
+      '@noble/curves': 1.9.7
+      '@peculiar/x509': 1.14.3
+      '@shinyoshiaki/binary-data': 0.6.1
+      date-fns: 2.30.0
+      lodash: 4.17.21
+      rx.mini: 1.4.0
+      tweetnacl: 1.0.3
+
+  werift-ice@0.2.2:
+    dependencies:
+      '@shinyoshiaki/jspack': 0.0.6
+      buffer-crc32: 1.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      int64-buffer: 1.1.0
+      ip: 2.0.1
+      lodash: 4.17.21
+      multicast-dns: 7.2.5
+      p-cancelable: 2.1.1
+      rx.mini: 1.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  werift-rtp@0.8.8:
+    dependencies:
+      '@minhducsun2002/leb128': 1.0.0
+      '@shinyoshiaki/jspack': 0.0.6
+      aes-js: 3.1.2
+      buffer: 6.0.3
+      mp4box: 0.5.4
+
+  werift-sctp@0.0.11:
+    dependencies:
+      '@shinyoshiaki/jspack': 0.0.6
+
+  werift@0.23.0:
+    dependencies:
+      '@fidm/x509': 1.2.1
+      '@minhducsun2002/leb128': 1.0.0
+      '@noble/curves': 1.9.7
+      '@peculiar/x509': 1.14.3
+      '@shinyoshiaki/binary-data': 0.6.1
+      '@shinyoshiaki/jspack': 0.0.6
+      aes-js: 3.1.2
+      buffer: 6.0.3
+      debug: 4.4.0
+      fast-deep-equal: 3.1.3
+      int64-buffer: 1.1.0
+      ip: 2.0.1
+      mp4box: 0.5.4
+      multicast-dns: 7.2.5
+      tweetnacl: 1.0.3
+      werift-common: 0.0.3
+      werift-dtls: 0.5.7
+      werift-ice: 0.2.2
+      werift-rtp: 0.8.8
+      werift-sctp: 0.0.11
+    transitivePeerDependencies:
+      - supports-color
 
   whatwg-encoding@3.1.1:
     dependencies:


### PR DESCRIPTION
- Introduces an **organization `admin` role** (alongside `owner` and `member`) with shared settings/member management where appropriate, while keeping **billing and org deletion owner-only** where it already was scoped.
- Adds **permission helpers** and wires **server actions**, **Effect policies** (orgs, spaces, folders), and **dashboard data** so admins and space managers can manage spaces, members, and folders consistently.
- Normalizes **space member roles** to lowercase `admin` (including Loom import and web-domain schema) and updates the **desktop API contract** for the new org role.
- Adds **Pro org shareable link branding**: optional custom icon, use-org-icon preference, hide/show Cap logo on share pages, plus upload/remove actions and org settings UI.
- Small **share page** fix for caption cue iteration when `TextTrackCueList` does not expose `item()`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an org `admin` role (between `owner` and `member`), wires rank-based permission helpers across server actions and Effect policies for orgs/spaces/folders, normalises space-member roles to lowercase `admin`, and adds Pro shareable-link branding (custom icon, org-icon preference, Cap logo toggle) with upload/remove server actions and a new share-page branding component.

- **Permission layer** (`roles.ts`, `authorization.ts`, `space-authorization.ts`, `update-member-role.ts`, `remove-member.ts`): centralised `can*` predicates with outranks-based guards are consistently applied across all org and space management actions; `OrganisationsRepo` and both backend policies are updated to resolve effective roles correctly.
- **Branding feature** (`shareable-link-icon.ts`, `ShareableLinkIcon.tsx`, share page): Pro-gated upload/remove/preference actions backed by the existing `ImageUploads` effect service; `getSharePageBranding` correctly short-circuits for non-Pro orgs.
- **Data migration** (`space_member_role_backfill.ts`, `migrate.ts`): backfill script normalises legacy `'Admin'` to `'admin'` in `space_members` and is now hooked into `migrateDb()`; `FoldersPolicy.canEdit` and the new `canCreateIn` now require admin/owner access, a tighter gate than the previous membership-only check.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all auth changes are additive or tightening, with no regressions in core ownership/billing guards.

The new permission layer is well-structured and consistently applied across all org and space management actions. The three flagged items are scoped to intentional-but-undocumented behaviour changes rather than broken access controls or data loss paths.

packages/database/migrations/space_member_role_backfill.ts (backfill runs on every deploy and touches already-correct rows), packages/web-backend/src/Folders/FoldersPolicy.ts and apps/web/actions/spaces/add-videos.ts (tighter-than-before gates for regular space members worth confirming as intentional).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/lib/permissions/roles.ts | New permission helper module — defines org/space role types, rank comparisons, and all can* predicate functions used throughout the PR. |
| apps/web/actions/organization/authorization.ts | Refactored into layered helpers (access, settingsAccess, settingsManager, owner); correctly delegates permission checks to roles.ts. |
| apps/web/actions/organization/update-member-role.ts | New server action for changing org member roles; validates role input and applies rank-outranks guard before updating. |
| apps/web/actions/organization/remove-member.ts | Upgraded to use canRemoveOrganizationMember with rank check; cascades space-member deletion inside a transaction. |
| apps/web/actions/organization/space-authorization.ts | New server action centralising space-access lookup; exposes requireSpaceManager used across space-management actions. |
| apps/web/actions/organization/shareable-link-icon.ts | New server actions for shareable link icon; gates behind Pro + settings-manager check, validates file type/size. |
| packages/database/schema.ts | Adds shareableLinkIconUrl column and two new settings fields; updates role types to include the new admin variants. |
| packages/database/migrations/space_member_role_backfill.ts | Backfill runs unconditionally on every deploy and LOWER() predicate matches already-correct rows, causing unnecessary writes. |
| packages/web-backend/src/Folders/FoldersPolicy.ts | canEdit changed from member-level to admin-level; new canCreateIn also admin-gated — regular space members can no longer edit or create folders. |
| apps/web/actions/spaces/add-videos.ts | Now requires canManage for non-allSpaces calls, preventing regular space members from adding their own videos. |
| apps/web/app/s/[videoId]/page.tsx | Share page updated with SharePageBranding component; resolves icons via imageUploads, hides/shows Cap logo based on org settings and Pro status. |
| packages/web-backend/src/Organisations/OrganisationsRepo.ts | membership() now joins organizations to return 'owner' for the org owner and defensively downgrades any DB 'owner' memberRole to 'member'. |
| apps/web/app/(org)/dashboard/dashboard-data.ts | Adds currentUserRole and currentUserCanManage to Spaces type; derives space-level manage capability via canManageSpace per row. |
| apps/web/app/(org)/dashboard/settings/organization/components/MembersCard.tsx | Members table now uses role-based can* helpers; adds inline role Select with updateRoleMutation; correctly shows Owner text for owners. |
| apps/web/app/(org)/dashboard/settings/organization/layout.tsx | Settings layout now shows informational card instead of redirecting when user lacks settings access. |
| packages/web-backend/src/Spaces/SpacesPolicy.ts | Adds isAdmin policy using LOWER(role) = 'admin' to handle legacy capitalised values. |
| apps/web/app/s/[videoId]/_components/caption-cues.ts | Defensive fix for TextTrackCueList environments that don't expose item(); falls back to index access. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/web/app/(org)/dashboard/dashboard-data.ts`, line 183-195 ([link](https://github.com/capsoftware/cap/blob/205e005164fe662561ed2c2acaef88778688ece8/apps/web/app/(org)/dashboard/dashboard-data.ts#L183-L195)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Org admins cannot discover or manage private spaces they were never added to**

   The space visibility query requires the user to have created the space, have the space be public, or already be a `space_members` row. An org admin who was never explicitly added to a private space will not see it in this query — `currentUserCanManage` will never be `true` for those spaces because the rows are simply absent from the result set.

   The PR description states admins should be able to manage spaces consistently. If that includes discovering and managing private spaces without being added first, the `OR` clause needs an additional branch. If the intended behaviour is that admins can only manage spaces they can already see, a code comment clarifying this design decision would help future readers.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/app/(org)/dashboard/dashboard-data.ts
   Line: 183-195

   Comment:
   **Org admins cannot discover or manage private spaces they were never added to**

   The space visibility query requires the user to have created the space, have the space be public, or already be a `space_members` row. An org admin who was never explicitly added to a private space will not see it in this query — `currentUserCanManage` will never be `true` for those spaces because the rows are simply absent from the result set.

   The PR description states admins should be able to manage spaces consistently. If that includes discovering and managing private spaces without being added first, the `OR` clause needs an additional branch. If the intended behaviour is that admins can only manage spaces they can already see, a code comment clarifying this design decision would help future readers.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `apps/web/actions/organization/settings.ts`, line 60-65 ([link](https://github.com/capsoftware/cap/blob/205e005164fe662561ed2c2acaef88778688ece8/apps/web/actions/organization/settings.ts#L60-L65)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> Missing `.limit(1)` on what is effectively a primary-key lookup. Semantically harmless since `id` is unique, but every other similar select in the codebase uses `.limit(1)`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/actions/organization/settings.ts
   Line: 60-65

   Comment:
   Missing `.limit(1)` on what is effectively a primary-key lookup. Semantically harmless since `id` is unique, but every other similar select in the codebase uses `.limit(1)`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/database/migrations/space_member_role_backfill.ts:6-9
**Backfill predicate matches already-normalized rows on every deploy**

`LOWER(role) = 'admin'` is true for both the legacy `'Admin'` rows *and* already-correct `'admin'` rows. This means every call to `migrateDb()` issues an UPDATE touching all admin space members, not just the legacy-capitalised ones. For a large `space_members` table this will execute unnecessary write I/O on each deployment.

Use an exact-match predicate so only the rows that actually need changing are touched, e.g. `sql\`${spaceMembers.role} = 'Admin'\`` (or `ne(spaceMembers.role, "admin")` combined with the existing condition).

### Issue 2 of 3
apps/web/actions/spaces/add-videos.ts:27-36
**Regular space members can no longer add/remove their own videos**

Before this PR, any authenticated user could add their own videos to a space (no permission gate existed for the non-`allSpaces` path). The new `canManage` check now restricts this to space admins, org admins, and owners. The same change is mirrored in `remove-videos.ts`.

If regular space members need to be able to "share their recording into a team space" (a common workflow), this is a regression. If the intention is that only managers curate space content, a code comment noting the deliberate restriction would prevent future confusion.

### Issue 3 of 3
packages/web-backend/src/Folders/FoldersPolicy.ts:30-62
**Folder edit and create now require admin access, restricting regular space members**

`canEdit` previously allowed any space member (`spacesPolicy.isMember`) to edit folders; it now requires space admin or org admin/owner via `canManageSpaceOrOrg`. Additionally, `canCreateIn` (also admin-gated) is newly enforced in `Folders/index.ts` for folder creation — previously there was no space-level gate on creation.

Both changes together mean regular space members can no longer create or rename folders they previously managed. If this is intentional (admins own folder structure), a comment to that effect would help future reviewers. If unintentional, `canEdit`/`canCreateIn` should fall back to `isMember`.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(web): cover peer admin rules in org..."](https://github.com/capsoftware/cap/commit/1b1e4250a6efd21a097395a56d5a1ea05222de7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32341688)</sub>

<!-- /greptile_comment -->