### PR TITLE
feat: Add Deeplinks for recording controls and Raycast Extension

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -6,7 +6,9 @@ use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager, Url};
 use tracing::trace;
 
-use crate::{App, ArcLock, recording::StartRecordingInputs, windows::ShowCapWindow};
+use crate::{
+    App, ArcLock, RecordingEvent, recording::StartRecordingInputs, windows::ShowCapWindow,
+};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -129,7 +131,7 @@ impl DeepLinkAction {
                     app.state(),
                     crate::recording::StartRecordingInputs {
                         capture_target: target,
-                        capture_system_audio: Some(settings.system_audio),
+                        capture_system_audio: settings.system_audio,
                         mode,
                         organization_id: settings.organization_id,
                     },
@@ -181,6 +183,7 @@ impl DeepLinkAction {
                 let mut app_state = state.write().await;
                 if let Some(recording) = app_state.current_recording_mut() {
                     recording.pause().await.map_err(|e| e.to_string())?;
+                    RecordingEvent::Paused.emit(app).ok();
                 }
                 Ok(())
             }
@@ -189,6 +192,7 @@ impl DeepLinkAction {
                 let mut app_state = state.write().await;
                 if let Some(recording) = app_state.current_recording_mut() {
                     recording.resume().await.map_err(|e| e.to_string())?;
+                    RecordingEvent::Resumed.emit(app).ok();
                 }
                 Ok(())
             }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -18,6 +18,7 @@ pub enum CaptureMode {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DeepLinkAction {
+    StartDefaultRecording,
     StartRecording {
         capture_mode: CaptureMode,
         camera: Option<DeviceOrModelID>,
@@ -26,6 +27,14 @@ pub enum DeepLinkAction {
         mode: RecordingMode,
     },
     StopRecording,
+    PauseRecording,
+    ResumeRecording,
+    SwitchMic {
+        mic_label: String,
+    },
+    SwitchCamera {
+        camera_id: DeviceOrModelID,
+    },
     OpenEditor {
         project_path: PathBuf,
     },
@@ -108,6 +117,26 @@ impl TryFrom<&Url> for DeepLinkAction {
 impl DeepLinkAction {
     pub async fn execute(self, app: &AppHandle) -> Result<(), String> {
         match self {
+            DeepLinkAction::StartDefaultRecording => {
+                let settings = crate::recording_settings::RecordingSettingsStore::get(app)?
+                    .unwrap_or_default();
+
+                let target = settings.target.ok_or("No capture target selected")?;
+                let mode = settings.mode.unwrap_or(RecordingMode::Studio);
+
+                crate::recording::start_recording(
+                    app.clone(),
+                    app.state(),
+                    crate::recording::StartRecordingInputs {
+                        capture_target: target,
+                        capture_system_audio: Some(settings.system_audio),
+                        mode,
+                        organization_id: settings.organization_id,
+                    },
+                )
+                .await
+                .map(|_| ())
+            }
             DeepLinkAction::StartRecording {
                 capture_mode,
                 camera,
@@ -146,6 +175,30 @@ impl DeepLinkAction {
             }
             DeepLinkAction::StopRecording => {
                 crate::recording::stop_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::PauseRecording => {
+                let state = app.state::<ArcLock<App>>();
+                let mut app_state = state.write().await;
+                if let Some(recording) = app_state.current_recording_mut() {
+                    recording.pause().await.map_err(|e| e.to_string())?;
+                }
+                Ok(())
+            }
+            DeepLinkAction::ResumeRecording => {
+                let state = app.state::<ArcLock<App>>();
+                let mut app_state = state.write().await;
+                if let Some(recording) = app_state.current_recording_mut() {
+                    recording.resume().await.map_err(|e| e.to_string())?;
+                }
+                Ok(())
+            }
+            DeepLinkAction::SwitchMic { mic_label } => {
+                let state = app.state::<ArcLock<App>>();
+                crate::set_mic_input(state.clone(), Some(mic_label)).await
+            }
+            DeepLinkAction::SwitchCamera { camera_id } => {
+                let state = app.state::<ArcLock<App>>();
+                crate::set_camera_input(app.clone(), state.clone(), Some(camera_id), None).await
             }
             DeepLinkAction::OpenEditor { project_path } => {
                 crate::open_project_from_path(Path::new(&project_path), app.clone())

--- a/apps/raycast-extension/package.json
+++ b/apps/raycast-extension/package.json
@@ -55,9 +55,15 @@
       "arguments": [
         {
           "name": "camera_id",
-          "placeholder": "Camera ID",
+          "placeholder": "Camera ID (e.g. from continuity camera)",
           "type": "text",
           "required": true
+        },
+        {
+          "name": "type",
+          "placeholder": "ID Type (device or model)",
+          "type": "text",
+          "required": false
         }
       ]
     }
@@ -76,6 +82,6 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
-    "publish": "npx @raycast/api@latest publish"
+    "publish": "ray publish"
   }
 }

--- a/apps/raycast-extension/package.json
+++ b/apps/raycast-extension/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "cap-raycast-extension",
+  "title": "Cap",
+  "description": "Control Cap recording and settings via Raycast.",
+  "icon": "command-icon.png",
+  "author": "Cap Software",
+  "categories": [
+    "Productivity"
+  ],
+  "license": "MIT",
+  "commands": [
+    {
+      "name": "start-recording",
+      "title": "Start Recording",
+      "description": "Start a new recording in Cap.",
+      "mode": "no-view"
+    },
+    {
+      "name": "stop-recording",
+      "title": "Stop Recording",
+      "description": "Stop the current recording in Cap.",
+      "mode": "no-view"
+    },
+    {
+      "name": "pause-recording",
+      "title": "Pause Recording",
+      "description": "Pause the current recording in Cap.",
+      "mode": "no-view"
+    },
+    {
+      "name": "resume-recording",
+      "title": "Resume Recording",
+      "description": "Resume the current recording in Cap.",
+      "mode": "no-view"
+    },
+    {
+      "name": "switch-mic",
+      "title": "Switch Microphone",
+      "description": "Switch to a specific microphone by name.",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "mic_label",
+          "placeholder": "Microphone Name",
+          "type": "text",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "switch-camera",
+      "title": "Switch Camera",
+      "description": "Switch to a specific camera by ID.",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "camera_id",
+          "placeholder": "Camera ID",
+          "type": "text",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "dependencies": {
+    "@raycast/api": "^1.72.1"
+  },
+  "devDependencies": {
+    "@raycast/utils": "^1.14.2",
+    "@types/node": "20.8.10",
+    "@types/react": "18.2.27",
+    "typescript": "^5.2.2"
+  },
+  "scripts": {
+    "build": "ray build -e dist",
+    "dev": "ray develop",
+    "fix-lint": "ray lint --fix",
+    "lint": "ray lint",
+    "publish": "npx @raycast/api@latest publish"
+  }
+}

--- a/apps/raycast-extension/src/pause-recording.ts
+++ b/apps/raycast-extension/src/pause-recording.ts
@@ -1,0 +1,5 @@
+import { executeCapAction } from "./utils";
+
+export default async function Command() {
+  await executeCapAction("pause_recording");
+}

--- a/apps/raycast-extension/src/resume-recording.ts
+++ b/apps/raycast-extension/src/resume-recording.ts
@@ -1,0 +1,5 @@
+import { executeCapAction } from "./utils";
+
+export default async function Command() {
+  await executeCapAction("resume_recording");
+}

--- a/apps/raycast-extension/src/start-recording.ts
+++ b/apps/raycast-extension/src/start-recording.ts
@@ -1,0 +1,5 @@
+import { executeCapAction } from "./utils";
+
+export default async function Command() {
+  await executeCapAction("start_default_recording");
+}

--- a/apps/raycast-extension/src/stop-recording.ts
+++ b/apps/raycast-extension/src/stop-recording.ts
@@ -1,0 +1,5 @@
+import { executeCapAction } from "./utils";
+
+export default async function Command() {
+  await executeCapAction("stop_recording");
+}

--- a/apps/raycast-extension/src/switch-camera.ts
+++ b/apps/raycast-extension/src/switch-camera.ts
@@ -1,9 +1,12 @@
 import { executeCapAction } from "./utils";
 
-export default async function Command(props: { arguments: { camera_id: string } }) {
+export default async function Command(props: { arguments: { camera_id: string; type?: string } }) {
+  const isModel = props.arguments.type?.toLowerCase() === "model";
   await executeCapAction({
     switch_camera: {
-      camera_id: { DeviceID: props.arguments.camera_id },
+      camera_id: isModel
+        ? { ModelID: props.arguments.camera_id }
+        : { DeviceID: props.arguments.camera_id },
     },
   });
 }

--- a/apps/raycast-extension/src/switch-camera.ts
+++ b/apps/raycast-extension/src/switch-camera.ts
@@ -1,0 +1,9 @@
+import { executeCapAction } from "./utils";
+
+export default async function Command(props: { arguments: { camera_id: string } }) {
+  await executeCapAction({
+    switch_camera: {
+      camera_id: { DeviceID: props.arguments.camera_id },
+    },
+  });
+}

--- a/apps/raycast-extension/src/switch-mic.ts
+++ b/apps/raycast-extension/src/switch-mic.ts
@@ -1,0 +1,9 @@
+import { executeCapAction } from "./utils";
+
+export default async function Command(props: { arguments: { mic_label: string } }) {
+  await executeCapAction({
+    switch_mic: {
+      mic_label: props.arguments.mic_label,
+    },
+  });
+}

--- a/apps/raycast-extension/src/utils.ts
+++ b/apps/raycast-extension/src/utils.ts
@@ -1,0 +1,7 @@
+import { open } from "@raycast/api";
+
+export async function executeCapAction(action: any) {
+  const json = JSON.stringify(action);
+  const url = `cap://action?value=${encodeURIComponent(json)}`;
+  await open(url);
+}

--- a/apps/raycast-extension/src/utils.ts
+++ b/apps/raycast-extension/src/utils.ts
@@ -1,6 +1,11 @@
 import { open } from "@raycast/api";
 
-export async function executeCapAction(action: any) {
+type CapAction =
+  | string
+  | { switch_mic: { mic_label: string } }
+  | { switch_camera: { camera_id: { DeviceID: string } | { ModelID: string } } };
+
+export async function executeCapAction(action: CapAction) {
   const json = JSON.stringify(action);
   const url = `cap://action?value=${encodeURIComponent(json)}`;
   await open(url);


### PR DESCRIPTION
## Description
This PR implements extended deep link support for recording controls and a new Raycast extension, fulfilling the requirements for issue #1540.

### Added Deep Link Actions:
- `start_default_recording`: Starts a recording using the last saved settings.
- `pause_recording`: Pauses the active recording.
- `resume_recording`: Resumes the paused recording.
- `switch_mic`: Switches the microphone input (requires `mic_label`).
- `switch_camera`: Switches the camera input (requires `camera_id` as `DeviceOrModelID`).

### Raycast Extension:
- Located in `apps/raycast-extension`.
- Commands for Start/Stop/Pause/Resume recording.
- Commands for switching Microphone and Camera with arguments.

## Related Issue
Fixes #1540

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds deep link support for five new recording control actions (`start_default_recording`, `pause_recording`, `resume_recording`, `switch_mic`, `switch_camera`) to the Rust backend, and introduces a new Raycast extension that triggers those actions via `cap://` URLs.

- The `StartDefaultRecording` handler has a compile-breaking type error: `capture_system_audio` is `bool` in `StartRecordingInputs` but the new code passes `Some(settings.system_audio)` (`Option<bool>`), which will prevent the desktop app from building.
- The `PauseRecording` and `ResumeRecording` deep link handlers skip the `RecordingEvent::Paused` / `RecordingEvent::Resumed` emissions that the existing Tauri commands fire, leaving the UI out of sync when these actions are triggered via deep link.
- The Raycast extension's `switch-camera` command unconditionally wraps the user input as a `DeviceID`, making cameras identified by `ModelID` unreachable via this command.

<h3>Confidence Score: 2/5</h3>

Not safe to merge: the desktop app will fail to compile due to a type mismatch in the new `StartDefaultRecording` handler, and the pause/resume deep link paths silently skip UI event emissions.

The `StartDefaultRecording` handler passes `Some(settings.system_audio)` (`Option<bool>`) into a field typed `bool`, which is a hard compile error that blocks the entire desktop build. Additionally, the pause/resume handlers omit the `RecordingEvent` emissions that keep the UI in sync, so those actions would silently leave the UI showing stale state even if the compile error were fixed first.

`apps/desktop/src-tauri/src/deeplink_actions.rs` needs the most attention — fix the type mismatch on line 132 and add the missing event emissions in the `PauseRecording`/`ResumeRecording` arms.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/deeplink_actions.rs | Adds 5 new deep link actions; contains a compile-breaking type mismatch (`Option<bool>` passed where `bool` expected) and missing `RecordingEvent` emissions in the pause/resume handlers. |
| apps/raycast-extension/package.json | New Raycast extension manifest declaring 6 commands with correct metadata and dependencies. |
| apps/raycast-extension/src/utils.ts | Shared utility that opens a `cap://action` deep link; uses `any` type, losing type safety for the action payload. |
| apps/raycast-extension/src/switch-camera.ts | Switch-camera command that unconditionally wraps the user input as `DeviceID`, making `ModelID`-identified cameras inaccessible. |
| apps/raycast-extension/src/switch-mic.ts | Switch-mic command that passes the user-supplied label directly; correct and consistent with the Rust handler. |
| apps/raycast-extension/src/start-recording.ts | Minimal command that fires the `start_default_recording` deep link action; straightforward and correct. |
| apps/raycast-extension/src/stop-recording.ts | Minimal command that fires the `stop_recording` deep link action; straightforward and correct. |
| apps/raycast-extension/src/pause-recording.ts | Minimal command that fires the `pause_recording` deep link action; correct on the client side. |
| apps/raycast-extension/src/resume-recording.ts | Minimal command that fires the `resume_recording` deep link action; correct on the client side. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
apps/desktop/src-tauri/src/deeplink_actions.rs:132
**Type mismatch: compile error in `StartDefaultRecording`**

`StartRecordingInputs.capture_system_audio` is typed as `bool` (see `recording.rs` line 515), but this line passes `Some(settings.system_audio)` which is `Option<bool>`. This is a type mismatch that will prevent the project from compiling. The `Some(...)` wrapper must be removed: use `capture_system_audio: settings.system_audio` instead.

### Issue 2 of 4
apps/desktop/src-tauri/src/deeplink_actions.rs:179-193
**Missing `RecordingEvent` emissions after pause/resume**

The existing Tauri commands `pause_recording` and `resume_recording` in `recording.rs` (lines 1516, 1530) emit `RecordingEvent::Paused` and `RecordingEvent::Resumed` after the operation so the UI can update its state. The new deep link handlers call `recording.pause()` / `recording.resume()` but omit those event emissions. As a result, triggering pause or resume via a deep link will leave the UI stuck showing the pre-action recording state (e.g. the pause button will still show as active after pausing).

### Issue 3 of 4
apps/raycast-extension/src/utils.ts:3
Using `any` for the `action` parameter bypasses TypeScript's type checking. Since the action can be either a plain string (for simple actions like `"stop_recording"`) or a structured object (for actions with parameters), a union type provides better safety and documents the API contract.

```suggestion
type CapAction =
  | string
  | { switch_mic: { mic_label: string } }
  | { switch_camera: { camera_id: { DeviceID: string } } };

export async function executeCapAction(action: CapAction) {
```

### Issue 4 of 4
apps/raycast-extension/src/switch-camera.ts:4-8
**`DeviceID` hardcoded; `ModelID` cameras are unreachable**

The Rust enum `DeviceOrModelID` has two variants: `DeviceID` and `ModelID`. The Raycast command always wraps the user-supplied string as `{ DeviceID: ... }`, so any camera that is identified by a model ID (common for virtual or continuity cameras) cannot be switched to via this command. Consider either accepting the variant as a second argument or documenting that only physical device IDs are supported.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add deeplink support for recording..."](https://github.com/capsoftware/cap/commit/16012c282b4c33ae9b134c0ec5a20befda5fd7f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32403708)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->