### PR TITLE
perf(recording): reduce in-recording memory pressure hotspots

### DIFF
--- a/crates/recording/src/cursor.rs
+++ b/crates/recording/src/cursor.rs
@@ -1,12 +1,15 @@
 use cap_cursor_capture::CursorCropBounds;
 use cap_cursor_info::CursorShape;
 use cap_project::{
-    CursorClickEvent, CursorEvents, CursorMoveEvent, KeyPressEvent, KeyboardEvents, XY,
+    CursorClickEvent, CursorMoveEvent, KeyPressEvent, KeyboardEvents, XY,
 };
 use cap_timestamp::Timestamps;
 use futures::{FutureExt, future::Shared};
+use serde::Serialize;
 use std::{
     collections::HashMap,
+    fs::File,
+    io::BufWriter,
     path::{Path, PathBuf},
     time::Instant,
 };
@@ -50,19 +53,32 @@ impl CursorActor {
 
 const CURSOR_FLUSH_INTERVAL_SECS: u64 = 5;
 
+#[derive(Serialize)]
+struct CursorEventsSnapshot<'a> {
+    clicks: &'a [CursorClickEvent],
+    moves: &'a [CursorMoveEvent],
+}
+
 fn flush_cursor_data(output_path: &Path, moves: &[CursorMoveEvent], clicks: &[CursorClickEvent]) {
-    let events = CursorEvents {
-        clicks: clicks.to_vec(),
-        moves: moves.to_vec(),
-    };
-    if let Ok(json) = serde_json::to_string_pretty(&events)
-        && let Err(e) = std::fs::write(output_path, json)
-    {
-        tracing::error!(
-            "Failed to write cursor data to {}: {}",
-            output_path.display(),
-            e
-        );
+    let events = CursorEventsSnapshot { clicks, moves };
+    match File::create(output_path) {
+        Ok(file) => {
+            let mut writer = BufWriter::new(file);
+            if let Err(e) = serde_json::to_writer(&mut writer, &events) {
+                tracing::error!(
+                    "Failed to serialize cursor data to {}: {}",
+                    output_path.display(),
+                    e
+                );
+            }
+        }
+        Err(e) => {
+            tracing::error!(
+                "Failed to write cursor data to {}: {}",
+                output_path.display(),
+                e
+            );
+        }
     }
 }
 
@@ -227,6 +243,8 @@ pub fn spawn_cursor_recorder(
         let mut last_flush = Instant::now();
         let flush_interval = Duration::from_secs(CURSOR_FLUSH_INTERVAL_SECS);
         let mut last_cursor_id: Option<String> = None;
+        let mut last_flushed_cursor_counts: Option<(usize, usize)> = None;
+        let mut last_flushed_keyboard_count: Option<usize> = None;
 
         loop {
             let sleep = tokio::time::sleep(Duration::from_millis(16));
@@ -361,11 +379,20 @@ pub fn spawn_cursor_recorder(
             last_keys = current_keys;
 
             if last_flush.elapsed() >= flush_interval {
+                let cursor_counts = (response.moves.len(), response.clicks.len());
+                let keyboard_count = response.keyboard_presses.len();
+
                 if let Some(ref path) = incremental_outputs.cursor {
-                    flush_cursor_data(path, &response.moves, &response.clicks);
+                    if last_flushed_cursor_counts != Some(cursor_counts) {
+                        flush_cursor_data(path, &response.moves, &response.clicks);
+                        last_flushed_cursor_counts = Some(cursor_counts);
+                    }
                 }
                 if let Some(ref kb_path) = incremental_outputs.keyboard {
-                    flush_keyboard_data(kb_path, &response.keyboard_presses);
+                    if last_flushed_keyboard_count != Some(keyboard_count) {
+                        flush_keyboard_data(kb_path, &response.keyboard_presses);
+                        last_flushed_keyboard_count = Some(keyboard_count);
+                    }
                 }
                 last_flush = Instant::now();
             }

--- a/crates/recording/src/cursor.rs
+++ b/crates/recording/src/cursor.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use std::{
     collections::HashMap,
     fs::File,
-    io::BufWriter,
+    io::{BufWriter, Write},
     path::{Path, PathBuf},
     time::Instant,
 };
@@ -67,6 +67,12 @@ fn flush_cursor_data(output_path: &Path, moves: &[CursorMoveEvent], clicks: &[Cu
             if let Err(e) = serde_json::to_writer(&mut writer, &events) {
                 tracing::error!(
                     "Failed to serialize cursor data to {}: {}",
+                    output_path.display(),
+                    e
+                );
+            } else if let Err(e) = writer.flush() {
+                tracing::error!(
+                    "Failed to flush cursor data to {}: {}",
                     output_path.display(),
                     e
                 );

--- a/crates/recording/src/output_pipeline/macos.rs
+++ b/crates/recording/src/output_pipeline/macos.rs
@@ -24,7 +24,7 @@ use std::{
 use tracing::*;
 
 const DEFAULT_MP4_MUXER_BUFFER_SIZE: usize = 60;
-const DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT: usize = 240;
+const DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT: usize = 96;
 const DEFAULT_MP4_AUDIO_FINISH_TIMEOUT: Duration = Duration::from_secs(2);
 const DEFAULT_MP4_AUDIO_FINISH_TIMEOUT_INSTANT: Duration = Duration::from_secs(8);
 
@@ -51,14 +51,15 @@ fn get_available_disk_space_mb(path: &std::path::Path) -> Option<u64> {
 }
 
 fn get_mp4_muxer_buffer_size(instant_mode: bool) -> usize {
-    std::env::var("CAP_MP4_MUXER_BUFFER_SIZE")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(if instant_mode {
-            DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT
-        } else {
-            DEFAULT_MP4_MUXER_BUFFER_SIZE
-        })
+    let parse_env = |name: &str| std::env::var(name).ok().and_then(|s| s.parse().ok());
+
+    if instant_mode {
+        parse_env("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT")
+            .or_else(|| parse_env("CAP_MP4_MUXER_BUFFER_SIZE"))
+            .unwrap_or(DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT)
+    } else {
+        parse_env("CAP_MP4_MUXER_BUFFER_SIZE").unwrap_or(DEFAULT_MP4_MUXER_BUFFER_SIZE)
+    }
 }
 
 fn get_mp4_audio_finish_timeout(instant_mode: bool) -> Duration {
@@ -1210,8 +1211,8 @@ mod tests {
         }
 
         #[test]
-        fn instant_mode_default_is_240() {
-            assert_eq!(DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT, 240);
+        fn instant_mode_default_is_96() {
+            assert_eq!(DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT, 96);
         }
 
         #[test]
@@ -1234,6 +1235,22 @@ mod tests {
         }
 
         #[test]
+        fn instant_env_override_takes_precedence_over_global_override() {
+            unsafe {
+                std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", "500");
+                std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT", "120");
+            }
+            let normal = get_mp4_muxer_buffer_size(false);
+            let instant = get_mp4_muxer_buffer_size(true);
+            unsafe {
+                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE");
+                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT");
+            }
+            assert_eq!(normal, 500);
+            assert_eq!(instant, 120);
+        }
+
+        #[test]
         fn invalid_env_falls_back_to_defaults() {
             unsafe {
                 std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", "not_a_number");
@@ -1245,6 +1262,22 @@ mod tests {
             }
             assert_eq!(normal, DEFAULT_MP4_MUXER_BUFFER_SIZE);
             assert_eq!(instant, DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT);
+        }
+
+        #[test]
+        fn invalid_instant_override_falls_back_to_global_override() {
+            unsafe {
+                std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", "80");
+                std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT", "not_a_number");
+            }
+            let normal = get_mp4_muxer_buffer_size(false);
+            let instant = get_mp4_muxer_buffer_size(true);
+            unsafe {
+                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE");
+                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT");
+            }
+            assert_eq!(normal, 80);
+            assert_eq!(instant, 80);
         }
     }
 

--- a/crates/recording/src/output_pipeline/macos.rs
+++ b/crates/recording/src/output_pipeline/macos.rs
@@ -1198,6 +1198,22 @@ mod tests {
     mod mp4_muxer_buffer_size {
         use super::*;
 
+        static MP4_MUXER_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+        fn with_muxer_env_lock(f: impl FnOnce()) {
+            let _guard = MP4_MUXER_ENV_LOCK
+                .lock()
+                .expect("mp4 muxer env lock should not be poisoned");
+            f();
+        }
+
+        fn clear_muxer_env_overrides() {
+            unsafe {
+                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE");
+                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT");
+            }
+        }
+
         #[test]
         fn instant_mode_buffer_is_larger_than_normal() {
             let instant = DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT;
@@ -1222,62 +1238,64 @@ mod tests {
 
         #[test]
         fn env_override_takes_precedence() {
-            unsafe {
-                std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", "500");
-            }
-            let normal = get_mp4_muxer_buffer_size(false);
-            let instant = get_mp4_muxer_buffer_size(true);
-            unsafe {
-                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE");
-            }
-            assert_eq!(normal, 500);
-            assert_eq!(instant, 500);
+            with_muxer_env_lock(|| {
+                clear_muxer_env_overrides();
+                unsafe {
+                    std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", "500");
+                }
+                let normal = get_mp4_muxer_buffer_size(false);
+                let instant = get_mp4_muxer_buffer_size(true);
+                clear_muxer_env_overrides();
+                assert_eq!(normal, 500);
+                assert_eq!(instant, 500);
+            });
         }
 
         #[test]
         fn instant_env_override_takes_precedence_over_global_override() {
-            unsafe {
-                std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", "500");
-                std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT", "120");
-            }
-            let normal = get_mp4_muxer_buffer_size(false);
-            let instant = get_mp4_muxer_buffer_size(true);
-            unsafe {
-                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE");
-                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT");
-            }
-            assert_eq!(normal, 500);
-            assert_eq!(instant, 120);
+            with_muxer_env_lock(|| {
+                clear_muxer_env_overrides();
+                unsafe {
+                    std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", "500");
+                    std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT", "120");
+                }
+                let normal = get_mp4_muxer_buffer_size(false);
+                let instant = get_mp4_muxer_buffer_size(true);
+                clear_muxer_env_overrides();
+                assert_eq!(normal, 500);
+                assert_eq!(instant, 120);
+            });
         }
 
         #[test]
         fn invalid_env_falls_back_to_defaults() {
-            unsafe {
-                std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", "not_a_number");
-            }
-            let normal = get_mp4_muxer_buffer_size(false);
-            let instant = get_mp4_muxer_buffer_size(true);
-            unsafe {
-                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE");
-            }
-            assert_eq!(normal, DEFAULT_MP4_MUXER_BUFFER_SIZE);
-            assert_eq!(instant, DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT);
+            with_muxer_env_lock(|| {
+                clear_muxer_env_overrides();
+                unsafe {
+                    std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", "not_a_number");
+                }
+                let normal = get_mp4_muxer_buffer_size(false);
+                let instant = get_mp4_muxer_buffer_size(true);
+                clear_muxer_env_overrides();
+                assert_eq!(normal, DEFAULT_MP4_MUXER_BUFFER_SIZE);
+                assert_eq!(instant, DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT);
+            });
         }
 
         #[test]
         fn invalid_instant_override_falls_back_to_global_override() {
-            unsafe {
-                std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", "80");
-                std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT", "not_a_number");
-            }
-            let normal = get_mp4_muxer_buffer_size(false);
-            let instant = get_mp4_muxer_buffer_size(true);
-            unsafe {
-                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE");
-                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT");
-            }
-            assert_eq!(normal, 80);
-            assert_eq!(instant, 80);
+            with_muxer_env_lock(|| {
+                clear_muxer_env_overrides();
+                unsafe {
+                    std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", "80");
+                    std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT", "not_a_number");
+                }
+                let normal = get_mp4_muxer_buffer_size(false);
+                let instant = get_mp4_muxer_buffer_size(true);
+                clear_muxer_env_overrides();
+                assert_eq!(normal, 80);
+                assert_eq!(instant, 80);
+            });
         }
     }
 


### PR DESCRIPTION
/claim #109

## Summary
This PR takes a scoped pass on issue #109 (memory/CPU pressure during recording), focusing on two low-risk hotspots that scale with recording duration.

### 1) Cursor incremental flush path: remove full-vector clone/string allocation
- Reworked cursor flush serialization in `crates/recording/src/cursor.rs` to write directly to file via `serde_json::to_writer`.
- Removed the periodic `to_vec()` + `to_string_pretty()` full-copy path for cursor events.
- Added flush change-detection so periodic snapshots only write when event counts changed.

### 2) Lower default instant muxer queue depth + per-mode override
- Reduced `DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT` from `240` to `96` in `crates/recording/src/output_pipeline/macos.rs`.
- Added `CAP_MP4_MUXER_BUFFER_SIZE_INSTANT` env override for instant mode.
- Kept `CAP_MP4_MUXER_BUFFER_SIZE` as the global fallback.
- Added/updated tests for precedence + fallback behavior.

## Why this helps
- The cursor path previously re-allocated/serialized the full event history every flush interval as recordings grew longer.
- Large instant-mode queue capacity can amplify resident memory under sustained encode/upload backpressure.

## Validation
- Environment limitation in this runner: Rust toolchain is unavailable (`cargo`/`rustc` not installed), so I could not execute Rust tests locally here.
- I did run `git diff --check` to ensure clean patch formatting.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces in-recording memory pressure by (1) rewriting cursor flush serialization to stream directly to disk via `BufWriter`/`serde_json::to_writer` instead of cloning the full event vector and pretty-printing it on every interval, and (2) cutting the instant-mode MP4 muxer queue default from 240 to 96 frames with a new per-mode env override.

- `cursor.rs`: The streaming serialization path avoids the O(n) allocation on every 5-second tick; change-detection tracking (`last_flushed_cursor_counts`) correctly skips no-op flushes when no new events have arrived.
- `macos.rs`: The env-var precedence logic (`CAP_MP4_MUXER_BUFFER_SIZE_INSTANT` \u2192 `CAP_MP4_MUXER_BUFFER_SIZE` \u2192 default) is clean, and the new tests cover the key precedence/fallback combinations.

<h3>Confidence Score: 3/5</h3>

The muxer queue change is safe to merge; the cursor serialization rewrite has a real silent-data-loss gap in the BufWriter flush path that should be addressed before shipping.

The cursor flush path drops the BufWriter without an explicit flush call — on a disk-full or I/O error, the final buffered bytes are silently discarded and the cursor file is left truncated with no log message. This can happen during any flush in a long recording and would produce corrupted cursor replay data.

crates/recording/src/cursor.rs — specifically the BufWriter drop path in flush_cursor_data.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/recording/src/cursor.rs | Replaces full-copy serialization with BufWriter-based streaming write and adds change-detection to skip no-op flushes; BufWriter is not explicitly flushed, risking silent truncation on disk errors. |
| crates/recording/src/output_pipeline/macos.rs | Reduces instant-mode muxer queue default from 240 to 96 and adds a per-mode env override; new tests correctly cover precedence but are not isolated from parallel test execution. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
crates/recording/src/cursor.rs:66-73
Silent flush failure on BufWriter drop. `serde_json::to_writer` serializes in chunks via `Write::write_all`, so BufWriter's internal buffer typically still holds the last few KB when serialization finishes. Rust's `BufWriter` drop calls `flush()` but discards the error — if it fails (e.g. disk full), the cursor file is silently truncated. An explicit `writer.flush()` before the block ends captures and logs that error.

```suggestion
            let mut writer = BufWriter::new(file);
            if let Err(e) = serde_json::to_writer(&mut writer, &events) {
                tracing::error!(
                    "Failed to serialize cursor data to {}: {}",
                    output_path.display(),
                    e
                );
            } else if let Err(e) = writer.flush() {
                tracing::error!(
                    "Failed to flush cursor data to {}: {}",
                    output_path.display(),
                    e
                );
            }
```

### Issue 2 of 2
crates/recording/src/output_pipeline/macos.rs:1237-1281
Env-var tests are not safe to run in parallel. Both new tests (`instant_env_override_takes_precedence_over_global_override` and `invalid_instant_override_falls_back_to_global_override`) mutate process-wide env vars (`CAP_MP4_MUXER_BUFFER_SIZE` and `CAP_MP4_MUXER_BUFFER_SIZE_INSTANT`) without any locking. Because `cargo test` runs unit tests on multiple threads by default, these tests — and the pre-existing ones in this module — can observe each other's `set_var`/`remove_var` calls, producing spurious failures or incorrect passing results. The `serial_test` crate (or a shared `Mutex` in a `lazy_static`) is the idiomatic fix.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(recording): reduce cursor flush ove..."](https://github.com/capsoftware/cap/commit/b1ee49c4f87d177da38c366680494723ab6707cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32450491)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->
