### PR TITLE
perf(recording): reduce recording memory pressure

### DIFF
--- a/crates/recording/src/cursor.rs
+++ b/crates/recording/src/cursor.rs
@@ -7,7 +7,7 @@ use cap_timestamp::Timestamps;
 use futures::{FutureExt, future::Shared};
 use std::{
     collections::HashMap,
-    fs::File,
+    fs::{self, File},
     io::{BufWriter, Write},
     path::{Path, PathBuf},
     time::Instant,
@@ -59,11 +59,20 @@ fn flush_cursor_data(output_path: &Path, moves: &[CursorMoveEvent], clicks: &[Cu
         moves: &'a [CursorMoveEvent],
     }
 
-    let file = match File::create(output_path) {
+    let temp_path = output_path.with_extension(
+        output_path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| format!("{ext}.tmp"))
+            .unwrap_or_else(|| "tmp".to_string()),
+    );
+
+    let file = match File::create(&temp_path) {
         Ok(file) => file,
         Err(e) => {
             tracing::error!(
-                "Failed to create cursor data file {}: {}",
+                "Failed to create temporary cursor data file {} for {}: {}",
+                temp_path.display(),
                 output_path.display(),
                 e
             );
@@ -75,16 +84,36 @@ fn flush_cursor_data(output_path: &Path, moves: &[CursorMoveEvent], clicks: &[Cu
     let mut writer = BufWriter::new(file);
     if let Err(e) = serde_json::to_writer(&mut writer, &events) {
         tracing::error!(
-            "Failed to serialize cursor data to {}: {}",
+            "Failed to serialize cursor data to temporary file {} for {}: {}",
+            temp_path.display(),
             output_path.display(),
             e
         );
-    } else if let Err(e) = writer.write_all(b"\n").and_then(|_| writer.flush()) {
+        let _ = fs::remove_file(&temp_path);
+        return;
+    }
+
+    if let Err(e) = writer.write_all(b"\n").and_then(|_| writer.flush()) {
         tracing::error!(
-            "Failed to flush cursor data to {}: {}",
+            "Failed to flush cursor data to temporary file {} for {}: {}",
+            temp_path.display(),
             output_path.display(),
             e
         );
+        let _ = fs::remove_file(&temp_path);
+        return;
+    }
+
+    drop(writer);
+
+    if let Err(e) = fs::rename(&temp_path, output_path) {
+        tracing::error!(
+            "Failed to replace cursor data file {} with temporary file {}: {}",
+            output_path.display(),
+            temp_path.display(),
+            e
+        );
+        let _ = fs::remove_file(&temp_path);
     }
 }
 

--- a/crates/recording/src/cursor.rs
+++ b/crates/recording/src/cursor.rs
@@ -1,12 +1,14 @@
 use cap_cursor_capture::CursorCropBounds;
 use cap_cursor_info::CursorShape;
 use cap_project::{
-    CursorClickEvent, CursorEvents, CursorMoveEvent, KeyPressEvent, KeyboardEvents, XY,
+    CursorClickEvent, CursorMoveEvent, KeyPressEvent, KeyboardEvents, XY,
 };
 use cap_timestamp::Timestamps;
 use futures::{FutureExt, future::Shared};
 use std::{
     collections::HashMap,
+    fs::File,
+    io::{BufWriter, Write},
     path::{Path, PathBuf},
     time::Instant,
 };
@@ -51,15 +53,35 @@ impl CursorActor {
 const CURSOR_FLUSH_INTERVAL_SECS: u64 = 5;
 
 fn flush_cursor_data(output_path: &Path, moves: &[CursorMoveEvent], clicks: &[CursorClickEvent]) {
-    let events = CursorEvents {
-        clicks: clicks.to_vec(),
-        moves: moves.to_vec(),
+    #[derive(serde::Serialize)]
+    struct BorrowedCursorEvents<'a> {
+        clicks: &'a [CursorClickEvent],
+        moves: &'a [CursorMoveEvent],
+    }
+
+    let file = match File::create(output_path) {
+        Ok(file) => file,
+        Err(e) => {
+            tracing::error!(
+                "Failed to create cursor data file {}: {}",
+                output_path.display(),
+                e
+            );
+            return;
+        }
     };
-    if let Ok(json) = serde_json::to_string_pretty(&events)
-        && let Err(e) = std::fs::write(output_path, json)
-    {
+
+    let events = BorrowedCursorEvents { clicks, moves };
+    let mut writer = BufWriter::new(file);
+    if let Err(e) = serde_json::to_writer(&mut writer, &events) {
         tracing::error!(
-            "Failed to write cursor data to {}: {}",
+            "Failed to serialize cursor data to {}: {}",
+            output_path.display(),
+            e
+        );
+    } else if let Err(e) = writer.write_all(b"\n").and_then(|_| writer.flush()) {
+        tracing::error!(
+            "Failed to flush cursor data to {}: {}",
             output_path.display(),
             e
         );
@@ -226,6 +248,8 @@ pub fn spawn_cursor_recorder(
 
         let mut last_flush = Instant::now();
         let flush_interval = Duration::from_secs(CURSOR_FLUSH_INTERVAL_SECS);
+        let mut last_flushed_cursor_moves = 0;
+        let mut last_flushed_cursor_clicks = 0;
         let mut last_cursor_id: Option<String> = None;
 
         loop {
@@ -362,7 +386,13 @@ pub fn spawn_cursor_recorder(
 
             if last_flush.elapsed() >= flush_interval {
                 if let Some(ref path) = incremental_outputs.cursor {
-                    flush_cursor_data(path, &response.moves, &response.clicks);
+                    if response.moves.len() != last_flushed_cursor_moves
+                        || response.clicks.len() != last_flushed_cursor_clicks
+                    {
+                        flush_cursor_data(path, &response.moves, &response.clicks);
+                        last_flushed_cursor_moves = response.moves.len();
+                        last_flushed_cursor_clicks = response.clicks.len();
+                    }
                 }
                 if let Some(ref kb_path) = incremental_outputs.keyboard {
                     flush_keyboard_data(kb_path, &response.keyboard_presses);
@@ -374,7 +404,11 @@ pub fn spawn_cursor_recorder(
         info!("cursor recorder done");
 
         if let Some(ref path) = incremental_outputs.cursor {
-            flush_cursor_data(path, &response.moves, &response.clicks);
+            if response.moves.len() != last_flushed_cursor_moves
+                || response.clicks.len() != last_flushed_cursor_clicks
+            {
+                flush_cursor_data(path, &response.moves, &response.clicks);
+            }
         }
 
         if let Some(ref kb_path) = incremental_outputs.keyboard {

--- a/crates/recording/src/output_pipeline/macos.rs
+++ b/crates/recording/src/output_pipeline/macos.rs
@@ -24,7 +24,7 @@ use std::{
 use tracing::*;
 
 const DEFAULT_MP4_MUXER_BUFFER_SIZE: usize = 60;
-const DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT: usize = 240;
+const DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT: usize = 96;
 const DEFAULT_MP4_AUDIO_FINISH_TIMEOUT: Duration = Duration::from_secs(2);
 const DEFAULT_MP4_AUDIO_FINISH_TIMEOUT_INSTANT: Duration = Duration::from_secs(8);
 
@@ -51,9 +51,17 @@ fn get_available_disk_space_mb(path: &std::path::Path) -> Option<u64> {
 }
 
 fn get_mp4_muxer_buffer_size(instant_mode: bool) -> usize {
-    std::env::var("CAP_MP4_MUXER_BUFFER_SIZE")
-        .ok()
-        .and_then(|s| s.parse().ok())
+    let instant_override = instant_mode
+        .then(|| std::env::var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT").ok())
+        .flatten()
+        .and_then(|s| s.parse().ok());
+
+    instant_override
+        .or_else(|| {
+            std::env::var("CAP_MP4_MUXER_BUFFER_SIZE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+        })
         .unwrap_or(if instant_mode {
             DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT
         } else {
@@ -1197,6 +1205,37 @@ mod tests {
     mod mp4_muxer_buffer_size {
         use super::*;
 
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+        fn with_muxer_env<T>(
+            global: Option<&str>,
+            instant: Option<&str>,
+            test: impl FnOnce() -> T,
+        ) -> T {
+            let _guard = ENV_LOCK.lock().unwrap();
+            unsafe {
+                match global {
+                    Some(value) => std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", value),
+                    None => std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE"),
+                }
+                match instant {
+                    Some(value) => {
+                        std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT", value)
+                    }
+                    None => std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT"),
+                }
+            }
+
+            let result = test();
+
+            unsafe {
+                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE");
+                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT");
+            }
+
+            result
+        }
+
         #[test]
         fn instant_mode_buffer_is_larger_than_normal() {
             let instant = DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT;
@@ -1210,8 +1249,8 @@ mod tests {
         }
 
         #[test]
-        fn instant_mode_default_is_240() {
-            assert_eq!(DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT, 240);
+        fn instant_mode_default_is_96() {
+            assert_eq!(DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT, 96);
         }
 
         #[test]
@@ -1221,30 +1260,42 @@ mod tests {
 
         #[test]
         fn env_override_takes_precedence() {
-            unsafe {
-                std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", "500");
-            }
-            let normal = get_mp4_muxer_buffer_size(false);
-            let instant = get_mp4_muxer_buffer_size(true);
-            unsafe {
-                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE");
-            }
-            assert_eq!(normal, 500);
-            assert_eq!(instant, 500);
+            with_muxer_env(Some("500"), None, || {
+                let normal = get_mp4_muxer_buffer_size(false);
+                let instant = get_mp4_muxer_buffer_size(true);
+                assert_eq!(normal, 500);
+                assert_eq!(instant, 500);
+            });
+        }
+
+        #[test]
+        fn instant_env_override_takes_precedence_over_global_override() {
+            with_muxer_env(Some("500"), Some("120"), || {
+                let normal = get_mp4_muxer_buffer_size(false);
+                let instant = get_mp4_muxer_buffer_size(true);
+                assert_eq!(normal, 500);
+                assert_eq!(instant, 120);
+            });
+        }
+
+        #[test]
+        fn invalid_instant_override_falls_back_to_global_override() {
+            with_muxer_env(Some("500"), Some("not_a_number"), || {
+                let normal = get_mp4_muxer_buffer_size(false);
+                let instant = get_mp4_muxer_buffer_size(true);
+                assert_eq!(normal, 500);
+                assert_eq!(instant, 500);
+            });
         }
 
         #[test]
         fn invalid_env_falls_back_to_defaults() {
-            unsafe {
-                std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", "not_a_number");
-            }
-            let normal = get_mp4_muxer_buffer_size(false);
-            let instant = get_mp4_muxer_buffer_size(true);
-            unsafe {
-                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE");
-            }
-            assert_eq!(normal, DEFAULT_MP4_MUXER_BUFFER_SIZE);
-            assert_eq!(instant, DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT);
+            with_muxer_env(Some("not_a_number"), None, || {
+                let normal = get_mp4_muxer_buffer_size(false);
+                let instant = get_mp4_muxer_buffer_size(true);
+                assert_eq!(normal, DEFAULT_MP4_MUXER_BUFFER_SIZE);
+                assert_eq!(instant, DEFAULT_MP4_MUXER_BUFFER_SIZE_INSTANT);
+            });
         }
     }
 

--- a/crates/recording/src/output_pipeline/macos.rs
+++ b/crates/recording/src/output_pipeline/macos.rs
@@ -1212,7 +1212,7 @@ mod tests {
             instant: Option<&str>,
             test: impl FnOnce() -> T,
         ) -> T {
-            let _guard = ENV_LOCK.lock().unwrap();
+            let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
             unsafe {
                 match global {
                     Some(value) => std::env::set_var("CAP_MP4_MUXER_BUFFER_SIZE", value),
@@ -1226,14 +1226,17 @@ mod tests {
                 }
             }
 
-            let result = test();
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(test));
 
             unsafe {
                 std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE");
                 std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT");
             }
 
-            result
+            match result {
+                Ok(value) => value,
+                Err(error) => std::panic::resume_unwind(error),
+            }
         }
 
         #[test]


### PR DESCRIPTION
/claim #109

## Summary
- Stream cursor flushes directly to disk without cloning and pretty-printing the full cursor event. history every interval.
- - Skip periodic cursor flushes when no cursor move/click events were added since the last write.
- - Lower instant-mode MP4 muxer queue default from 240 to 96 frames and add CAP_MP4_MUXER_BUFFER_SIZE_INSTANT for instant-only tuning.
- - Serialize muxer env-var tests behind a shared lock so process-wide env mutation does not race under parallel cargo test.
## Why this helps
Long recordings currently reallocateand serialize the entire cursor history on every flush tick, even when no cursor event count changes. Streaming writes and no-op flush skipping reduce duration-scaled allocations. Lowering the instant muxer queue reduces retained frame capacity under encode/upload backpressure while keeping the global override available and adding an instant-specific override.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces recording memory pressure through two independent changes: streaming cursor data directly to disk with borrowed slices instead of cloning and pretty-printing the full history, and lowering the instant-mode MP4 muxer frame queue from 240 to 96 with a new `CAP_MP4_MUXER_BUFFER_SIZE_INSTANT` env override.

- **cursor.rs**: `flush_cursor_data` now uses `File::create` + `BufWriter` + `serde_json::to_writer` with a `BorrowedCursorEvents<'a>` wrapper to avoid allocations; a length-comparison guard skips the flush tick when no new cursor events have been recorded since the last write.
- **macos.rs**: `get_mp4_muxer_buffer_size` gains a two-level env-var lookup (instant-specific override → global override → compile-time default); existing env-mutation tests are refactored behind a shared `ENV_LOCK` mutex but the helper `with_muxer_env` is not panic-safe, which can cause mutex poisoning and cascade-fail the test module.

<h3>Confidence Score: 3/5</h3>

The production recording changes are straightforward and low-risk, but the test refactor in macos.rs introduces a fragility that can make the entire test module fail as a cascade from a single assertion error.

The cursor streaming and muxer queue changes are correct. The concern is the with_muxer_env helper: when any test closure panics, Rust poisons the ENV_LOCK mutex, making every subsequent lock().unwrap() call panic — turning one test failure into a whole-module failure. A secondary issue is that File::create truncates the cursor output file before serialization completes, leaving an empty file on I/O error rather than preserving the last valid snapshot.

crates/recording/src/output_pipeline/macos.rs — specifically the with_muxer_env test helper and its mutex-poisoning exposure on panic.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/recording/src/cursor.rs | Streaming write optimization with BorrowedCursorEvents avoids cloning; skip-flush guard uses length-based comparison; File::create now truncates before serialization, risking data loss on write error. |
| crates/recording/src/output_pipeline/macos.rs | Instant-mode MP4 muxer queue lowered from 240→96; new CAP_MP4_MUXER_BUFFER_SIZE_INSTANT env var added with correct fallback logic; test helper with_muxer_env introduced but not panic-safe — mutex poisoning on test failure will cascade to all sibling tests. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/recording/src/cursor.rs`, line 62-88 ([link](https://github.com/capsoftware/cap/blob/63eea3472093d499376a6d0dbd11aa55fb7305bb/crates/recording/src/cursor.rs#L62-L88)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **File truncated before serialization succeeds**

   `File::create` opens and truncates the output file before `serde_json::to_writer` has written anything. If serialization fails (e.g. mid-stream I/O error on the writer), the file is left empty or with partial bytes flushed on `BufWriter` drop — permanently losing the previously valid cursor data. The old code built the full JSON string in memory first, so the file was not touched on serialization failure. A safer pattern is to write to a temporary file and rename it over the destination only after a successful flush.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/recording/src/cursor.rs
   Line: 62-88

   Comment:
   **File truncated before serialization succeeds**

   `File::create` opens and truncates the output file before `serde_json::to_writer` has written anything. If serialization fails (e.g. mid-stream I/O error on the writer), the file is left empty or with partial bytes flushed on `BufWriter` drop — permanently losing the previously valid cursor data. The old code built the full JSON string in memory first, so the file was not touched on serialization failure. A safer pattern is to write to a temporary file and rename it over the destination only after a successful flush.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
crates/recording/src/output_pipeline/macos.rs:1207-1215
**Mutex poisoning cascades on test failure**

If any test panics inside `with_muxer_env` (e.g. an `assert_eq!` fails), the thread unwinds while holding `_guard`. Rust marks the `Mutex` as poisoned when a thread panics while holding a lock. Every subsequent call to `ENV_LOCK.lock().unwrap()` will then panic with a `PoisonError`, causing all remaining tests in the module to fail regardless of their own correctness. Use `.unwrap_or_else(|e| e.into_inner())` to tolerate a poisoned mutex.

### Issue 2 of 3
crates/recording/src/cursor.rs:62-88
**File truncated before serialization succeeds**

`File::create` opens and truncates the output file before `serde_json::to_writer` has written anything. If serialization fails (e.g. mid-stream I/O error on the writer), the file is left empty or with partial bytes flushed on `BufWriter` drop — permanently losing the previously valid cursor data. The old code built the full JSON string in memory first, so the file was not touched on serialization failure. A safer pattern is to write to a temporary file and rename it over the destination only after a successful flush.

### Issue 3 of 3
crates/recording/src/output_pipeline/macos.rs:1229-1237
Env vars set inside `with_muxer_env` are not cleaned up if `test()` panics. After the panic is caught by the test harness, `CAP_MP4_MUXER_BUFFER_SIZE` / `CAP_MP4_MUXER_BUFFER_SIZE_INSTANT` remain set, which can pollute later tests. Wrapping `test()` in `catch_unwind` and resuming after cleanup ensures the vars are always removed.

```suggestion
            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(test));

            unsafe {
                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE");
                std::env::remove_var("CAP_MP4_MUXER_BUFFER_SIZE_INSTANT");
            }

            match result {
                Ok(v) => v,
                Err(e) => std::panic::resume_unwind(e),
            }
        }
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(recording): reduce recording memory..."](https://github.com/capsoftware/cap/commit/63eea3472093d499376a6d0dbd11aa55fb7305bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32475857)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->