### PR TITLE
fix(web): allow /.well-known/ paths through proxy for workflow engine on self-hosted Docker

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -49,7 +49,8 @@ export async function proxy(request: NextRequest) {
 				path.startsWith("/invite") ||
 				path.startsWith("/self-hosting") ||
 				path.startsWith("/terms") ||
-				path.startsWith("/verify-otp")
+				path.startsWith("/verify-otp") ||
+				path.startsWith("/.well-known/")
 			) &&
 			process.env.NODE_ENV !== "development"
 		)
@@ -110,6 +111,6 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
 	matcher: [
-		"/((?!api|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)",
+		"/((?!api|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|\\.well-known).*)",
 	],
 };


### PR DESCRIPTION
## Problem

On self-hosted Docker deployments (where `NEXT_PUBLIC_IS_CAP` is not set), `proxy.ts` redirects all unrecognized paths to `/login`. This silently breaks the workflow engine.

The `@workflow/world-local` queue dispatches steps by HTTP-POSTing to itself at `/.well-known/workflow/v1/{flow,step}`. Those POSTs hit the proxy's catch-all redirect to `/login`, get back HTML, and the queue cannot proceed.

Visible symptom: video uploads complete and persist to S3, but no transcoding, transcription, or AI summary runs. The workflow run sits in `status: "running"` indefinitely.

## Fix

Add `/.well-known/` to two allow-lists in `apps/web/proxy.ts`:
1. The path-prefix allow-list inside `if (buildEnv.NEXT_PUBLIC_IS_CAP !== "true")`
2. The `config.matcher` exclusion pattern

Both are needed: the first prevents the redirect; the second prevents the proxy from running at all for these paths (matching how `/api` is already excluded).

3 lines changed, no logic changes — purely an allow-list extension.

## Relationship to #1832

I opened this after end-to-end validating #1832 against current upstream `main` on a clean self-hosted deployment. **Both fixes are required** for self-hosted transcription to work:
- #1832 prevents the race that corrupts workflow state
- This PR allows the workflow engine to dispatch at all

With #1832 alone, transcription still hangs because the workflow can't run. With this alone, the workflow runs but hits the race. Together: self-hosted transcription works end-to-end.

Happy to fold this into #1832 as one PR if you prefer — they're independent code paths but functionally one user-visible fix. Let me know.

## Validation

- Running in production on our internal self-hosted fork since 2026-03-31. No regressions observed.
- Re-validated 2026-05-17 against clean upstream HEAD: applied this patch on top of #1832 to a fresh deployment built from `upstream/main`, recorded a browser video, confirmed `result.mp4` produced + transcription persisted to `transcription.vtt` + share page renders the transcript.

## Risk

Very low. The change only adds two allow-list entries. Behavior change is limited to: `/.well-known/*` paths now reach their route handlers instead of being redirected to `/login`. This is the intended behavior for hosted Cap as well (the redirect for these paths is incidental, not protective).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes self-hosted Docker deployments where the `/.well-known/` paths required by the `@workflow/world-local` queue were being silently redirected to `/login`, preventing any transcoding, transcription, or AI-summary jobs from running after a video upload.

- Adds `path.startsWith("/.well-known/")` to the self-hosted allow-list so the catch-all `/login` redirect is skipped for those paths.
- Adds `\.well-known` to the `config.matcher` exclusion so the middleware doesn't execute at all for those paths, consistent with how `/api` is already handled.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal allow-list extension with no logic alterations and is directly analogous to the existing `/api` exclusion.

Both changes are additive and narrowly scoped: a path-prefix allow-list entry and a corresponding matcher exclusion. The two-pronged approach mirrors how `/api` is already treated, the dot in the regex is correctly escaped (`\\.well-known` → `\.well-known`), and the trailing-slash guard on the allow-list (`/.well-known/`) prevents accidental prefix collisions. Route handlers at these paths retain responsibility for their own authentication, which is the standard pattern in this codebase. No existing behaviour is removed or altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/proxy.ts | Adds `/.well-known/` to the self-hosted path allow-list and the middleware matcher exclusion, mirroring the existing `/api` treatment to let workflow-engine internal POSTs reach their route handlers. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): allow /.well-known/ paths thro..."](https://github.com/capsoftware/cap/commit/14415de38a71bf63806022edab2be98ea4d521e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32508138)</sub>

<!-- /greptile_comment -->