### PR TITLE
fix: make recording completion idempotent

### DIFF
--- a/apps/desktop/src-tauri/src/api.rs
+++ b/apps/desktop/src-tauri/src/api.rs
@@ -339,11 +339,18 @@ pub async fn signal_recording_complete(
         .map_err(|err| format!("api/signal_recording_complete/request: {err}"))?;
 
     if !resp.status().is_success() {
-        let status = resp.status().as_u16();
+        let status = resp.status();
         let error_body = resp
             .text()
             .await
             .unwrap_or_else(|_| "<no response body>".to_string());
+        if status == reqwest::StatusCode::CONFLICT
+            && error_body.contains("Muxing already in progress")
+        {
+            return Ok(());
+        }
+
+        let status = status.as_u16();
         return Err(format!("api/signal_recording_complete/{status}: {error_body}").into());
     }
 

--- a/apps/desktop/src-tauri/src/upload.rs
+++ b/apps/desktop/src-tauri/src/upload.rs
@@ -1472,6 +1472,7 @@ impl SegmentUploader {
 
         {
             let mut signal_ok = false;
+            let mut last_signal_error = None::<String>;
             for attempt in 0..3u32 {
                 match api::signal_recording_complete(&app, &video_id).await {
                     Ok(()) => {
@@ -1479,10 +1480,12 @@ impl SegmentUploader {
                         break;
                     }
                     Err(e) => {
+                        let error = e.to_string();
                         warn!(
                             attempt = attempt + 1,
-                            "Failed to signal recording complete: {e}"
+                            "Failed to signal recording complete: {error}"
                         );
+                        last_signal_error = Some(error);
                         if attempt < 2 {
                             tokio::time::sleep(Duration::from_millis(1000 * (1 << attempt) as u64))
                                 .await;
@@ -1504,8 +1507,11 @@ impl SegmentUploader {
 
                 emit_upload_complete(&app, &video_id);
 
+                let detail = last_signal_error
+                    .map(|error| format!(": {error}"))
+                    .unwrap_or_default();
                 return Err(format!(
-                    "Failed to signal recording complete for {video_id} after 3 attempts"
+                    "Failed to signal recording complete for {video_id} after 3 attempts{detail}"
                 )
                 .into());
             }

--- a/apps/web/__tests__/unit/recording-complete-utils.test.ts
+++ b/apps/web/__tests__/unit/recording-complete-utils.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+	getRecordingCompleteIdempotentResult,
+	isMaterializedDesktopRecordingSource,
+	isSegmentedRecordingSource,
+	RECORDING_COMPLETE_UNCLAIMABLE_PHASES,
+} from "@/app/api/upload/[...route]/recording-complete-utils";
+
+describe("recording complete utils", () => {
+	it("treats active mux phases as successful idempotent finalization", () => {
+		expect(
+			getRecordingCompleteIdempotentResult({ phase: "processing" }),
+		).toEqual({
+			success: true,
+			alreadyProcessing: true,
+			phase: "processing",
+		});
+		expect(
+			getRecordingCompleteIdempotentResult({
+				phase: "generating_thumbnail",
+			}),
+		).toEqual({
+			success: true,
+			alreadyProcessing: true,
+			phase: "generating_thumbnail",
+		});
+	});
+
+	it("treats complete uploads as successful idempotent finalization", () => {
+		expect(getRecordingCompleteIdempotentResult({ phase: "complete" })).toEqual(
+			{
+				success: true,
+				alreadyComplete: true,
+				phase: "complete",
+			},
+		);
+	});
+
+	it("does not hide claimable or failed upload phases", () => {
+		expect(getRecordingCompleteIdempotentResult({ phase: "uploading" })).toBe(
+			null,
+		);
+		expect(getRecordingCompleteIdempotentResult({ phase: "error" })).toBe(null);
+		expect(getRecordingCompleteIdempotentResult(null)).toBe(null);
+	});
+
+	it("keeps active and complete phases out of the mux claim update", () => {
+		expect(RECORDING_COMPLETE_UNCLAIMABLE_PHASES).toEqual([
+			"processing",
+			"generating_thumbnail",
+			"complete",
+		]);
+	});
+
+	it("recognizes segmented and already materialized desktop recordings", () => {
+		expect(isSegmentedRecordingSource({ type: "desktopSegments" })).toBe(true);
+		expect(isSegmentedRecordingSource({ type: "desktopMP4" })).toBe(false);
+		expect(isMaterializedDesktopRecordingSource({ type: "desktopMP4" })).toBe(
+			true,
+		);
+		expect(
+			isMaterializedDesktopRecordingSource({ type: "desktopSegments" }),
+		).toBe(false);
+	});
+});

--- a/apps/web/app/api/upload/[...route]/recording-complete-utils.ts
+++ b/apps/web/app/api/upload/[...route]/recording-complete-utils.ts
@@ -1,0 +1,58 @@
+type RecordingCompletePhase =
+	| "uploading"
+	| "processing"
+	| "generating_thumbnail"
+	| "complete"
+	| "error";
+
+export const RECORDING_COMPLETE_UNCLAIMABLE_PHASES = [
+	"processing",
+	"generating_thumbnail",
+	"complete",
+] satisfies RecordingCompletePhase[];
+
+export type RecordingCompleteIdempotentResult =
+	| {
+			success: true;
+			alreadyProcessing: true;
+			phase: "processing" | "generating_thumbnail";
+	  }
+	| {
+			success: true;
+			alreadyComplete: true;
+			phase: "complete";
+	  };
+
+export function isSegmentedRecordingSource(
+	source: { type: string } | null | undefined,
+) {
+	return source?.type === "desktopSegments";
+}
+
+export function isMaterializedDesktopRecordingSource(
+	source: { type: string } | null | undefined,
+) {
+	return source?.type === "desktopMP4";
+}
+
+export function getRecordingCompleteIdempotentResult(
+	upload: { phase: RecordingCompletePhase } | null | undefined,
+): RecordingCompleteIdempotentResult | null {
+	switch (upload?.phase) {
+		case "processing":
+		case "generating_thumbnail":
+			return {
+				success: true,
+				alreadyProcessing: true,
+				phase: upload.phase,
+			};
+		case "complete":
+			return {
+				success: true,
+				alreadyComplete: true,
+				phase: upload.phase,
+			};
+		default:
+			return null;
+	}
+}

--- a/apps/web/app/api/upload/[...route]/recording-complete.ts
+++ b/apps/web/app/api/upload/[...route]/recording-complete.ts
@@ -12,6 +12,12 @@ import { invalidateGoogleDriveStorageQuotaCache } from "@/lib/google-drive-stora
 import { runPromise } from "@/lib/server";
 import { decodeStorageVideo } from "@/lib/video-storage";
 import { withAuth } from "../../utils";
+import {
+	getRecordingCompleteIdempotentResult,
+	isMaterializedDesktopRecordingSource,
+	isSegmentedRecordingSource,
+	RECORDING_COMPLETE_UNCLAIMABLE_PHASES,
+} from "./recording-complete-utils";
 
 const MEDIA_SERVER_PRESIGNED_GET_EXPIRES_SECONDS = 3 * 60 * 60;
 const MEDIA_SERVER_PRESIGNED_PUT_EXPIRES_SECONDS = 3 * 60 * 60;
@@ -39,7 +45,15 @@ export const app = new Hono().post(
 			return c.json({ error: "Video not found" }, 404);
 		}
 
-		if (video.source?.type !== "desktopSegments") {
+		if (isMaterializedDesktopRecordingSource(video.source)) {
+			return c.json({
+				success: true,
+				alreadyComplete: true,
+				source: "desktopMP4",
+			});
+		}
+
+		if (!isSegmentedRecordingSource(video.source)) {
 			return c.json({ error: "Video is not a segmented recording" }, 400);
 		}
 
@@ -59,6 +73,66 @@ export const app = new Hono().post(
 		}
 
 		try {
+			const claimResult = await db()
+				.update(Db.videoUploads)
+				.set({
+					phase: "processing",
+					processingProgress: 0,
+					processingMessage: "Muxing segments into MP4...",
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						eq(Db.videoUploads.videoId, videoId),
+						notInArray(
+							Db.videoUploads.phase,
+							RECORDING_COMPLETE_UNCLAIMABLE_PHASES,
+						),
+					),
+				);
+
+			if ((claimResult[0]?.affectedRows ?? 0) === 0) {
+				const [existing] = await db()
+					.select({ phase: Db.videoUploads.phase })
+					.from(Db.videoUploads)
+					.where(eq(Db.videoUploads.videoId, videoId));
+				const idempotentResult = getRecordingCompleteIdempotentResult(existing);
+
+				if (idempotentResult) {
+					return c.json(idempotentResult);
+				}
+
+				if (!existing) {
+					try {
+						await db().insert(Db.videoUploads).values({
+							videoId,
+							phase: "processing",
+							processingProgress: 0,
+							processingMessage: "Muxing segments into MP4...",
+						});
+					} catch (error) {
+						const [existingAfterRace] = await db()
+							.select({ phase: Db.videoUploads.phase })
+							.from(Db.videoUploads)
+							.where(eq(Db.videoUploads.videoId, videoId));
+						const raceResult =
+							getRecordingCompleteIdempotentResult(existingAfterRace);
+
+						if (raceResult) {
+							return c.json(raceResult);
+						}
+
+						console.error(
+							"[recording-complete] Failed to claim video upload for muxing:",
+							error,
+						);
+						return c.json({ error: "Failed to claim recording complete" }, 500);
+					}
+				} else {
+					return c.json({ error: "Failed to claim recording complete" }, 500);
+				}
+			}
+
 			const muxPayload = await Effect.gen(function* () {
 				const [bucket] = yield* Storage.getAccessForVideo(
 					decodeStorageVideo(video),
@@ -190,46 +264,6 @@ export const app = new Hono().post(
 				};
 			}).pipe(runPromise);
 			await invalidateGoogleDriveStorageQuotaCache(video.storageIntegrationId);
-
-			const claimResult = await db()
-				.update(Db.videoUploads)
-				.set({
-					phase: "processing",
-					processingProgress: 0,
-					processingMessage: "Muxing segments into MP4...",
-					updatedAt: new Date(),
-				})
-				.where(
-					and(
-						eq(Db.videoUploads.videoId, videoId),
-						notInArray(Db.videoUploads.phase, [
-							"processing",
-							"generating_thumbnail",
-						]),
-					),
-				);
-
-			if (claimResult[0].affectedRows === 0) {
-				const [existing] = await db()
-					.select({ phase: Db.videoUploads.phase })
-					.from(Db.videoUploads)
-					.where(eq(Db.videoUploads.videoId, videoId));
-
-				if (existing) {
-					return c.json({ error: "Muxing already in progress" }, 409);
-				}
-
-				try {
-					await db().insert(Db.videoUploads).values({
-						videoId,
-						phase: "processing",
-						processingProgress: 0,
-						processingMessage: "Muxing segments into MP4...",
-					});
-				} catch {
-					return c.json({ error: "Muxing already in progress" }, 409);
-				}
-			}
 
 			const webhookBaseUrl =
 				serverEnv().MEDIA_SERVER_WEBHOOK_URL || serverEnv().WEB_URL;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the recording-completion flow idempotent end-to-end. The server now claims the mux slot before generating presigned URLs (reducing wasted work on concurrent requests), returns HTTP 200 with typed `alreadyProcessing`/`alreadyComplete` responses instead of 409 for duplicate calls, and the Rust desktop client is updated to treat the legacy 409 "Muxing already in progress" response as a success for backward compatibility with older server deployments.

- **Server (`recording-complete.ts`)**: Claim step moved before the expensive presigned-URL/manifest work; `getRecordingCompleteIdempotentResult` handles already-processing and already-complete states gracefully, with a nested insert path and race-condition re-check for the no-prior-record case.
- **Client (`api.rs`, `upload.rs`)**: 409 with the old error message is now silently treated as success; the last retry error is now appended to the terminal failure message.
- **Utilities & tests (`recording-complete-utils.ts`, `*.test.ts`)**: Shared phase logic extracted into a typed utility module with unit test coverage.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; the idempotency logic is well-structured and the existing test suite covers the new utility functions.

The core idempotency logic is sound: claim-before-work is the correct ordering, concurrent-request races are handled at multiple checkpoints, and the catch block correctly resets the phase to error on failure. Two minor rough edges exist — a hard-coded server error message string in the Rust backward-compat check, and an opaque 500 branch reachable via a narrow race condition — but neither affects correctness in normal operation.

The else-branch 500 path in recording-complete.ts (line 132) and the string-match guard in api.rs are worth a second look, but they do not block the change.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/api.rs | Adds backward-compat handling: HTTP 409 "Muxing already in progress" is now treated as success. The string match is brittle but only bridges older server versions. |
| apps/desktop/src-tauri/src/upload.rs | Stores the last signal error and appends it to the final failure message; clean improvement to error observability. |
| apps/web/app/api/upload/[...route]/recording-complete-utils.ts | New utility file extracting phase type, idempotent result logic, and source-type predicates; well-typed and straightforward. |
| apps/web/__tests__/unit/recording-complete-utils.test.ts | Unit tests cover the idempotent-result helper, unclaimable phase list, and both source-type predicates; good coverage of the new utilities. |
| apps/web/app/api/upload/[...route]/recording-complete.ts | Claim step moved before presigned-URL generation and the idempotent-result path is now checked at multiple concurrency boundaries; logic is sound but the else-500 branch on line 132 is opaque. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src-tauri/src/api.rs:342-348
**Brittle backward-compat string match**

The check `error_body.contains("Muxing already in progress")` hard-codes the exact server error message. If that message is ever edited or the server returns a localized/structured JSON body instead of plain text, the condition silently stops matching: the response is treated as an ordinary error, the client retries three times, and the upload fails. Since the updated server now returns HTTP 200 for this case, this path is only exercised against older deployments — but it would be worth at minimum adding a comment that documents what server version this bridges, so a future maintainer knows when it can be removed.

### Issue 2 of 2
apps/web/app/api/upload/[...route]/recording-complete.ts:131-133
**Unreachable-in-theory branch returns an opaque 500**

This `else` arm fires only when the `UPDATE` returned 0 affected rows yet the follow-up `SELECT` found a row whose phase is neither idempotent (`processing` / `generating_thumbnail` / `complete`) nor absent. In normal operation that means the row transitioned from `processing` → `error` between the UPDATE and the SELECT (a tight race with the media-server webhook). Because `error` is claimable, the Rust client's next retry attempt would successfully claim and re-mux — but the 500 response here is indistinguishable from a genuine server failure. Adding a log with the actual `existing.phase` would make this edge case much easier to diagnose in production.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: make recording completion idempoten..."](https://github.com/capsoftware/cap/commit/826b926a9652b818d802695cc59b7a6f90427caf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32618203)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->