### PR TITLE
test: add local docker compose coverage

### DIFF
--- a/packages/local-docker/docker-compose.test.ts
+++ b/packages/local-docker/docker-compose.test.ts
@@ -1,0 +1,76 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+type ComposeService = {
+	container_name?: string;
+	image?: string;
+	build?: {
+		context?: string;
+		dockerfile?: string;
+	};
+	ports?: Array<number | string>;
+	volumes?: string[];
+	depends_on?: string[];
+	environment?: Record<string, string | number>;
+};
+
+type ComposeFile = {
+	name?: string;
+	services?: Record<string, ComposeService>;
+	volumes?: Record<string, unknown>;
+};
+
+const composePath = fileURLToPath(
+	new URL("./docker-compose.yml", import.meta.url),
+);
+
+async function readCompose() {
+	const source = await readFile(composePath, "utf8");
+	return parse(source) as ComposeFile;
+}
+
+describe("local Docker compose file", () => {
+	it("keeps the expected local development services wired", async () => {
+		const compose = await readCompose();
+
+		expect(compose.name).toBe("cap-so-dev");
+		expect(Object.keys(compose.services ?? {}).sort()).toEqual([
+			"cap-media-server",
+			"createbuckets",
+			"minio",
+			"ps-mysql",
+		]);
+
+		expect(compose.services?.["ps-mysql"]).toMatchObject({
+			image: "mysql:8.0",
+			container_name: "mysql-primary-db",
+		});
+		expect(compose.services?.["cap-media-server"]?.build).toEqual({
+			context: "../..",
+			dockerfile: "apps/media-server/Dockerfile",
+		});
+		expect(compose.services?.minio?.ports).toEqual(["9000:9000", "9001:9001"]);
+		expect(compose.services?.createbuckets?.depends_on).toEqual(["minio"]);
+	});
+
+	it("does not declare stale named volumes", async () => {
+		const compose = await readCompose();
+		const declaredVolumes = new Set(Object.keys(compose.volumes ?? {}));
+		const usedNamedVolumes = new Set(
+			Object.values(compose.services ?? {})
+				.flatMap((service) => service.volumes ?? [])
+				.map((volume) => volume.split(":")[0])
+				.filter(
+					(source) =>
+						source &&
+						!source.startsWith(".") &&
+						!source.startsWith("/") &&
+						!source.startsWith("~"),
+				),
+		);
+
+		expect([...declaredVolumes].sort()).toEqual([...usedNamedVolumes].sort());
+	});
+});

--- a/packages/local-docker/docker-compose.yml
+++ b/packages/local-docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       PORT: 3456
       MEDIA_SERVER_WEBHOOK_SECRET: ${MEDIA_SERVER_WEBHOOK_SECRET:-local-media-server-secret}
 
-  # Local S3 Strorage
+  # Local S3 Storage
   minio:
     container_name: minio-storage
     image: "minio/minio:latest"
@@ -62,5 +62,3 @@ services:
       "
 volumes:
   ps-mysql:
-  minio-data:
-  minio-certs:

--- a/packages/local-docker/package.json
+++ b/packages/local-docker/package.json
@@ -7,9 +7,14 @@
 		"dev": "pnpm docker:up",
 		"docker:up": "docker compose up -d --wait",
 		"docker:stop": "docker compose stop",
-		"docker:clean": "docker compose down -v"
+		"docker:clean": "docker compose down -v",
+		"test": "vitest run"
 	},
 	"engines": {
 		"node": ">=20"
+	},
+	"devDependencies": {
+		"vitest": "~2.1.9",
+		"yaml": "^2.8.1"
 	}
 }

--- a/packages/local-docker/vitest.config.ts
+++ b/packages/local-docker/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+		include: ["**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1087,7 +1087,14 @@ importers:
         specifier: ^22.15.14
         version: 22.15.14
 
-  packages/local-docker: {}
+  packages/local-docker:
+    devDependencies:
+      vitest:
+        specifier: ~2.1.9
+        version: 2.1.9(@types/node@22.15.17)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.44.0)
+      yaml:
+        specifier: ^2.8.1
+        version: 2.8.1
 
   packages/sdk-embed:
     dependencies:


### PR DESCRIPTION
## Summary
- add a package-level Vitest setup for `@cap/local-docker` so it participates in the root Turbo test pipeline
- add an example compose-file test that parses `docker-compose.yml` and verifies the expected local services plus named-volume consistency
- remove stale `minio-data` and `minio-certs` volume declarations that were not used by any service, and fix the local S3 comment typo

This is a narrow, non-overlapping slice for #54; I did not touch the desktop/utils/sdk/env/database testing areas covered by active PRs.

/claim #54

AI-assisted with Codex; I reviewed the diff and kept payment details out of public comments.

## Verification
- `corepack pnpm install --filter @cap/local-docker --frozen-lockfile --ignore-scripts`
- `corepack pnpm --filter @cap/local-docker test`
- `corepack pnpm turbo run test --filter=@cap/local-docker`
- `corepack pnpm exec biome check packages/local-docker/package.json packages/local-docker/vitest.config.ts packages/local-docker/docker-compose.test.ts`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires `@cap/local-docker` into the Turbo test pipeline by adding a Vitest setup and a compose-file smoke test, and cleans up two unused named-volume declarations (`minio-data`, `minio-certs`) from `docker-compose.yml`.

- **New test** (`docker-compose.test.ts`): parses `docker-compose.yml` with the `yaml` package and asserts expected service names, key image/build properties, and that every declared named volume is actually referenced by a service — the stale-volume removal is what makes the second assertion pass.
- **Compose cleanup**: removes `minio-data` and `minio-certs` volume declarations (never used; `minio` already uses a bind-mount at `~/minio/data`) and fixes the "Strorage" typo in the comment.
- **Package wiring**: adds `vitest ~2.1.9` and `yaml ^2.8.1` as dev dependencies, consistent with versions used by `apps/discord-bot` and `apps/desktop`, and locks them in `pnpm-lock.yaml`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the compose cleanup and test addition are narrow and well-scoped with no risk to running services.

The changes are straightforward: two stale volume declarations are removed, a typo is fixed, and a new test correctly validates the resulting compose file. The test logic for named-volume consistency is sound. The only observations are style-level: readCompose() is called once per test rather than shared via beforeAll, and the include glob in vitest.config.ts is broader than needed for a flat package.

No files require special attention; docker-compose.test.ts and vitest.config.ts have minor style-level suggestions worth a quick look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/local-docker/docker-compose.test.ts | New test file parsing docker-compose.yml; correct logic overall, but readCompose() is invoked twice (once per test case) and the include glob in vitest.config.ts is broader than needed |
| packages/local-docker/docker-compose.yml | Removes stale minio-data and minio-certs volume declarations that were never referenced by any service, and fixes the "Strorage" typo in the comment |
| packages/local-docker/package.json | Adds test script and devDependencies for vitest (~2.1.9) and yaml (^2.8.1), consistent with other packages in the monorepo |
| packages/local-docker/vitest.config.ts | Minimal Vitest config; include pattern ["**/*.test.ts"] is broader than necessary for a flat package with a single test file |
| pnpm-lock.yaml | Lock file updated to reflect vitest 2.1.9 and yaml 2.8.1 additions for the local-docker package |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/local-docker/vitest.config.ts:6
The `include` pattern `["**/*.test.ts"]` will recurse through all subdirectories. Since this package's tests live at the root level, scoping it to `["*.test.ts"]` is both cleaner and avoids any accidental discovery of test files that end up in sub-directories (e.g., a future `scripts/` folder).

```suggestion
		include: ["*.test.ts"],
```

### Issue 2 of 2
packages/local-docker/docker-compose.test.ts:34-36
`readCompose()` is called independently inside each `it` block, which reads and parses the YAML file twice per test run. Hoisting the parse into a `beforeAll` and sharing the result removes the duplicate I/O and makes the shared setup intent explicit.

```suggestion
describe("local Docker compose file", () => {
	let compose: ComposeFile;

	beforeAll(async () => {
		compose = await readCompose();
	});

	it("keeps the expected local development services wired", () => {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add local docker compose coverage"](https://github.com/capsoftware/cap/commit/c162363185ef299a618572436b341725033980a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32924377)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->