### PR TITLE
feat(desktop): add deeplink actions for pause/resume + mic/camera switching

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -26,6 +26,15 @@ pub enum DeepLinkAction {
         mode: RecordingMode,
     },
     StopRecording,
+    PauseRecording,
+    ResumeRecording,
+    TogglePauseRecording,
+    SetMicInput {
+        label: Option<String>,
+    },
+    SetCameraInput {
+        id: Option<DeviceOrModelID>,
+    },
     OpenEditor {
         project_path: PathBuf,
     },
@@ -146,6 +155,21 @@ impl DeepLinkAction {
             }
             DeepLinkAction::StopRecording => {
                 crate::recording::stop_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::PauseRecording => {
+                crate::recording::pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::ResumeRecording => {
+                crate::recording::resume_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::TogglePauseRecording => {
+                crate::recording::toggle_pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::SetMicInput { label } => {
+                crate::set_mic_input(app.state(), label).await
+            }
+            DeepLinkAction::SetCameraInput { id } => {
+                crate::set_camera_input(app.clone(), app.state(), id, None).await
             }
             DeepLinkAction::OpenEditor { project_path } => {
                 crate::open_project_from_path(Path::new(&project_path), app.clone())


### PR DESCRIPTION
## Summary

Extends the `cap-desktop://action?value=…` deeplink surface so external clients (e.g. a Raycast extension) can drive recording end-to-end. The repo already supported `StartRecording` / `StopRecording` / `OpenEditor` / `OpenSettings`; this PR adds the rest of the verbs the issue calls out:

- `pause_recording`
- `resume_recording`
- `toggle_pause_recording`
- `set_mic_input` (with `label: Option<String>` — `null` clears the mic, matching the existing tauri command)
- `set_camera_input` (with `id: Option<DeviceOrModelID>` — `null` clears the camera)

Each new variant delegates to the existing tauri command of the same name (`crate::recording::pause_recording`, `crate::set_mic_input`, etc.), so behavior matches what the in-app UI already does.

Addresses the deeplinks half of #1540. The Raycast extension itself is intentionally out of scope for this PR — it's a separate deliverable that lives in its own repo, and shipping the underlying deeplinks first means the extension can be iterated on without further desktop-side churn.

## Example URLs

```
cap-desktop://action?value=%22pause_recording%22
cap-desktop://action?value=%22resume_recording%22
cap-desktop://action?value=%22toggle_pause_recording%22
cap-desktop://action?value=%7B%22set_mic_input%22%3A%7B%22label%22%3A%22MacBook%20Pro%20Microphone%22%7D%7D
cap-desktop://action?value=%7B%22set_camera_input%22%3A%7B%22id%22%3A%7B%22DeviceID%22%3A%22FaceTime%20HD%20Camera%22%7D%7D%7D
```

(`value` is the JSON-encoded `DeepLinkAction` with serde `rename_all = "snake_case"`, same as the existing variants.)

## Test plan

- [ ] `cargo check -p cap-desktop`
- [ ] Build the desktop app and start a recording, then trigger each new deeplink from the terminal (`open "cap-desktop://action?value=…"` on macOS / `start ""` equivalent on Windows) and confirm the in-app state matches.

Closes #1540 (deeplinks side).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the `DeepLinkAction` enum with five new verbs — `pause_recording`, `resume_recording`, `toggle_pause_recording`, `set_mic_input`, and `set_camera_input` — and wires each to the matching existing tauri command, enabling external clients to drive recording state end-to-end via deeplink.

- New enum variants follow existing serde `rename_all = "snake_case"` conventions and match the example URL shapes in the PR description exactly.
- Each `execute` branch mirrors the corresponding Tauri command call already used elsewhere in the file (e.g., `StartRecording` already calls `crate::set_mic_input` / `crate::set_camera_input` with the same argument shape).
- No new state, no new error paths, and no changes to existing variants.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, additive delegation to existing tauri commands with no modifications to existing behavior.

Each new deeplink variant is a one-liner that calls a pre-existing, well-tested tauri command using the same call site pattern already established in StartRecording. Serde attributes are correct, DeviceOrModelID already implements Deserialize (used by the existing StartRecording variant), and the skip_camera_window: None argument for SetCameraInput is consistent with how StartRecording calls the same function.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/deeplink_actions.rs | Adds PauseRecording, ResumeRecording, TogglePauseRecording, SetMicInput, and SetCameraInput deeplink variants, each delegating to the matching existing tauri command; follows established patterns in the file exactly. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): add deeplink actions for ..."](https://github.com/capsoftware/cap/commit/3fc7ecf7d645542fe06ca933057c9609a846b78a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33053058)</sub>

<!-- /greptile_comment -->