### PR TITLE
fix: allow deleting last clip per recording segment in Studio Mode

### DIFF
--- a/apps/desktop/src/routes/editor/ConfigSidebar.tsx
+++ b/apps/desktop/src/routes/editor/ConfigSidebar.tsx
@@ -3809,13 +3809,7 @@ function ClipSegmentConfig(props: {
 					onClick={() => {
 						projectActions.deleteClipSegment(props.segmentIndex);
 					}}
-					disabled={
-						(
-							project.timeline?.segments.filter(
-								(s) => s.recordingSegment === props.segment.recordingSegment,
-							) ?? []
-						).length < 2
-					}
+					disabled={(project.timeline?.segments.length ?? 0) < 2}
 					leftIcon={<IconCapTrash />}
 				>
 					Delete

--- a/apps/desktop/src/routes/editor/context.ts
+++ b/apps/desktop/src/routes/editor/context.ts
@@ -295,14 +295,7 @@ export const [EditorContextProvider, useEditorContext] = createContextProvider(
 			deleteClipSegment: (segmentIndex: number) => {
 				if (!project.timeline) return;
 				const segment = project.timeline.segments[segmentIndex];
-				if (
-					!segment ||
-					!segment.recordingSegment === undefined ||
-					project.timeline.segments.filter(
-						(s) => s.recordingSegment === segment.recordingSegment,
-					).length < 2
-				)
-					return;
+				if (!segment || project.timeline.segments.length < 2) return;
 
 				batch(() => {
 					setProject(


### PR DESCRIPTION
## What does this PR fix?

Fixes #1695, users were unable to delete clips in Studio Mode after pausing a camera-only recording.

## Root cause

`deleteClipSegment` in `context.ts` had a guard that prevented deletion when fewer than 2 timeline segments shared the same `recordingSegment` index (i.e., the same pause interval). 
This meant the "last" clip from any paused segment became permanently undeletable, even when other segments remained in the timeline.

The `ConfigSidebar.tsx` Delete button used the same incorrect condition to disable itself.

Additionally, the condition `!segment.recordingSegment === undefined` in the original guard was always `false` (boolean vs. `undefined` comparison) — dead code that never fired.

## Changes

- **`context.ts`**: Updated `deleteClipSegment` guard — now only blocks deletion when it would leave the timeline completely empty (`segments.length < 2`), rather than blocking when it's the last clip of a specific recording segment.
- **`ConfigSidebar.tsx`**: Updated the Delete button `disabled` prop to use the same corrected logic.

## Testing

1. Record with Camera Only enabled, pause and resume multiple times.
2. Open the recording in Studio Mode.
3. Select a clip from a paused segment and press Delete (or use the Delete button in the sidebar).
4. Verify all clips except the very last one can be deleted.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where clips in a paused camera-only recording segment could not be deleted in Studio Mode. The root cause was a guard that blocked deletion whenever fewer than two clips shared the same `recordingSegment` index, and a dead-code condition (`!segment.recordingSegment === undefined`) that always evaluated to `false`.

- **`context.ts`**: The `deleteClipSegment` guard now only prevents deleting when one segment remains in the entire timeline (`segments.length < 2`), removing both the dead boolean-vs-`undefined` comparison and the per-recording-segment filter.
- **`ConfigSidebar.tsx`**: The Delete button's `disabled` prop is updated to match the new guard, ensuring UI state stays in sync with the action's actual behavior.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it relaxes an overly strict guard and aligns the UI disabled state with the action logic.

Both modified sites (the action guard and the button disabled prop) are now consistent with each other and with the intended behavior: only the very last timeline segment is protected from deletion. The removed dead-code condition never fired, so its removal has no side effects.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/editor/context.ts | Guard in `deleteClipSegment` simplified: dead-code boolean-vs-undefined comparison removed and per-recording-segment filter replaced with a global segment count check (`< 2`). |
| apps/desktop/src/routes/editor/ConfigSidebar.tsx | Delete button `disabled` prop updated to mirror the corrected guard in `context.ts`, now using total segment count instead of per-recording-segment count. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: allow deleting last clip per record..."](https://github.com/capsoftware/cap/commit/159ec2656ee79e2b18c4e16140aa79f70468daff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33112425)</sub>

<!-- /greptile_comment -->