### PR TITLE
fix(macos): remove redundant activation policy toggle causing duplicate dock icons

### DIFF
--- a/apps/desktop/src-tauri/src/permissions.rs
+++ b/apps/desktop/src-tauri/src/permissions.rs
@@ -162,7 +162,13 @@ fn macos_sync_activation_policy(app: &tauri::AppHandle, should_show_dock: bool) 
 pub(crate) fn prepare_macos_panel_window(
     app: &tauri::AppHandle,
 ) -> MacosPanelWindowActivationGuard {
-    MACOS_PENDING_PANEL_WINDOWS.fetch_add(1, Ordering::AcqRel);
+    let prev = MACOS_PENDING_PANEL_WINDOWS.fetch_add(1, Ordering::AcqRel);
+
+    if prev == 0 {
+        if let Err(err) = app.set_activation_policy(tauri::ActivationPolicy::Accessory) {
+            tracing::warn!("Failed to prepare macOS panel activation policy: {err}");
+        }
+    }
 
     MacosPanelWindowActivationGuard { app: app.clone() }
 }
@@ -170,6 +176,16 @@ pub(crate) fn prepare_macos_panel_window(
 #[cfg(target_os = "macos")]
 pub(crate) fn sync_macos_dock_visibility(app: &tauri::AppHandle) {
     if MACOS_PENDING_PANEL_WINDOWS.load(Ordering::Acquire) > 0 {
+        return;
+    }
+
+    let has_visible_panel_window = app.webview_windows().iter().any(|(label, window)| {
+        CapWindowId::from_str(label)
+            .map(|id| !id.activates_dock() && window.is_visible().unwrap_or(false))
+            .unwrap_or(false)
+    });
+
+    if has_visible_panel_window {
         return;
     }
 

--- a/apps/desktop/src-tauri/src/permissions.rs
+++ b/apps/desktop/src-tauri/src/permissions.rs
@@ -164,10 +164,6 @@ pub(crate) fn prepare_macos_panel_window(
 ) -> MacosPanelWindowActivationGuard {
     MACOS_PENDING_PANEL_WINDOWS.fetch_add(1, Ordering::AcqRel);
 
-    if let Err(err) = app.set_activation_policy(tauri::ActivationPolicy::Accessory) {
-        tracing::warn!("Failed to prepare macOS panel activation policy: {err}");
-    }
-
     MacosPanelWindowActivationGuard { app: app.clone() }
 }
 


### PR DESCRIPTION
## What does this PR fix?
Fixes the bug where multiple Cap app icons appear in the macOS Dock when starting a recording.

## Root cause
`prepare_macos_panel_window` eagerly called `set_activation_policy(Accessory)` on every panel window creation. During recording start, multiple panel windows are created in sequence, causing rapid `Accessory → Regular` policy toggling that confuses macOS Dock into registering duplicate app tiles.

## Fix
Removed the eager `set_activation_policy(Accessory)` call — the existing `MACOS_PENDING_PANEL_WINDOWS` counter already blocks the dock sync from firing during panel creation, making it redundant.

## Changes
- `apps/desktop/src-tauri/src/permissions.rs`: removed 4 lines from `prepare_macos_panel_window`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two cooperative guards in `permissions.rs` to prevent duplicate Dock icons that appeared when multiple panel windows were opened during recording start. The root cause was a race window where `MACOS_PENDING_PANEL_WINDOWS` could briefly reach zero between sequential window creations, letting a deferred `sync_macos_dock_visibility` run and flip the activation policy back to `Regular` before the next `prepare_macos_panel_window` call set it to `Accessory` again.

- `prepare_macos_panel_window` now calls `set_activation_policy(Accessory)` only when transitioning from 0→1 pending windows (`prev == 0`), eliminating redundant policy writes for every subsequent panel window in a batch.
- `sync_macos_dock_visibility` gains a new early-return that skips dock synchronization whenever any panel window is currently visible — a second line of defense that catches the brief-counter-zero race the pending counter alone couldn't block.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are narrowly scoped to macOS dock-state management and cannot regress on non-macOS targets.

The two changes are tightly complementary and each independently correct: the 0→1 guard prevents redundant Accessory policy writes, and the visible-panel-window early-return closes the brief-zero-counter race that was the actual source of duplicate Dock tiles. The existing atomic counter and 100ms debounced sync remain intact and interact correctly with both new guards. No data races, no missing error paths, and the fallback in the visibility check errs conservatively.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/permissions.rs | Two complementary guards added: `set_activation_policy(Accessory)` now only fires on the 0→1 transition, and `sync_macos_dock_visibility` bails early when any panel window is still visible — both correct and coherent with the existing atomic counter logic. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;fix/macos-duplicate-dock-i..."](https://github.com/capsoftware/cap/commit/7b0615d48f9ec574baac8dede08715895bca7160) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33137642)</sub>

<!-- /greptile_comment -->