### PR TITLE
docs: Document bring your own Cloud Storage bucket

### DIFF
--- a/apps/web/content/docs/s3-config/google-cloud-storage.mdx
+++ b/apps/web/content/docs/s3-config/google-cloud-storage.mdx
@@ -27,7 +27,7 @@ image: "/docs/s3-config/google-cloud-s3.jpg"
 
 1. **Create Service Account First**:
 
-   - Go to in IAM and Admin > Service Accounts, click "Create service account"
+   - Go to IAM and Admin > Service Accounts, click "Create service account"
    - Set a service account ID (e.g., "cap-app-user")
    - Click "Create and continue"
    - Skip the "Permissions" and "Principals with access" sections.
@@ -44,8 +44,8 @@ image: "/docs/s3-config/google-cloud-s3.jpg"
    - Choose your default storage class or opt for Autoclass (for lower storage but higher networking costs on rarely used recordings)
    - Under "Prevent public access", keep "Enforce public access prevention on this bucket" enabled (recommended)
    - Under "Access control", select "Uniform"
-   - Under "Data protection", decided whether you want to keep "Soft-delete policy" enabled (this will allow you to recover accidentally deleted files)
-     Under "Data protection", keep "Object versioning" disabled
+   - Under "Data protection", decide whether you want to keep "Soft-delete policy" enabled (this will allow you to recover accidentally deleted files)
+   - Under "Data protection", keep "Object versioning" disabled
    - Optional, under "Data encryption", choose your own "encryption key" (in most cases the default Google-managed encryption key is fine)
    - Keep all other settings as default
    - Click "Create bucket" at the bottom of the page
@@ -58,7 +58,7 @@ image: "/docs/s3-config/google-cloud-s3.jpg"
    - Assign the role "Storage Object Admin"
    - Click "Save"
 
-5. **Configure CORS Settings**:
+4. **Configure CORS Settings**:
    - Switch to the "Configuration" tab, scroll down to "Cross-origin resource sharing"
    - Click "Edit" and "Allow cross-origin resource sharing"
    - Add the following CORS configuration:
@@ -68,9 +68,9 @@ image: "/docs/s3-config/google-cloud-s3.jpg"
      - For cache expiry time enter: `3000`
    - Click "Save"
 
-4. **Retrieve your S3 Interoperability credentials**:
+5. **Retrieve your S3 Interoperability credentials**:
    - In Cloud Storage switch to "Settings" via the side panel.
-   - Go to "Interopability" tab
+   - Go to "Interoperability" tab
    - Under "Access keys for service accounts" click "Create key for another service account"
    - Select your service account
    - Click "Create key" and note down your "Access Key ID" and "Secret Access Key".
@@ -83,7 +83,7 @@ image: "/docs/s3-config/google-cloud-s3.jpg"
    - Secret Access Key (from interoperability credentials creation)
    - Endpoint (enter "https://storage.googleapis.com")
    - Bucket Name: Your bucket name
-   - Region: Your bucket's region (e.g., us-east-1)
+   - Region: Your bucket's region (e.g., `us-central1` or `europe-west1`)
 
 ## Step 5: Test and Save the Connection
 

--- a/apps/web/content/docs/s3-config/google-cloud-storage.mdx
+++ b/apps/web/content/docs/s3-config/google-cloud-storage.mdx
@@ -1,0 +1,95 @@
+---
+title: "Cap Apps: S3 Config (Google Cloud)"
+summary: "Connect your own Cloud Storage bucket to Cap and maintain 100% ownership over your data."
+tags: "Cap Apps"
+image: "/docs/s3-config/google-cloud-s3.jpg"
+---
+
+# Connecting Your Google Cloud Bucket to Cap Desktop
+
+> **TL;DR**: Open Cap Desktop → Cap Apps → S3 Config → Configure → Select Other S3 compatible → Enter your Cloud Storage credentials → Configure bucket permissions → Save and test with a shareable link upload.
+
+## Step 1: Launch Cap Desktop and Access Cap Apps
+
+1. **Open the Cap Desktop App**: Click the Cap icon on your desktop or find it in your applications folder to launch the app.
+
+2. **Navigate to Cap Apps**: Once the app is open, locate the 'Cap Apps' tab in Settings.
+
+## Step 2: Click on S3 Config, and then Configure
+
+1. Click on S3 config
+
+2. Click on Configure
+
+3. Select Other S3-compatible from the list of available services.
+
+## Step 3: Configure Cloud Storage Resources
+
+1. **Create Service Account First**:
+
+   - Go to in IAM and Admin > Service Accounts, click "Create service account"
+   - Set a service account ID (e.g., "cap-app-user")
+   - Click "Create and continue"
+   - Skip the "Permissions" and "Principals with access" sections.
+   - Click "Done"
+   - Note down your service account email (e.g., "cap-app-user@example.iam.gserviceaccount.com")
+
+2. **Create Cloud Storage Bucket**:
+
+   - Log into the [Google Cloud Console](https://console.cloud.google.com)
+   - Navigate to Cloud Storage
+   - Click "Create bucket"
+   - Enter a unique bucket name (e.g., "my-cap-uploads")
+   - Choose your preferred Google Cloud Region
+   - Choose your default storage class or opt for Autoclass (for lower storage but higher networking costs on rarely used recordings)
+   - Under "Prevent public access", keep "Enforce public access prevention on this bucket" enabled (recommended)
+   - Under "Access control", select "Uniform"
+   - Under "Data protection", decided whether you want to keep "Soft-delete policy" enabled (this will allow you to recover accidentally deleted files)
+     Under "Data protection", keep "Object versioning" disabled
+   - Optional, under "Data encryption", choose your own "encryption key" (in most cases the default Google-managed encryption key is fine)
+   - Keep all other settings as default
+   - Click "Create bucket" at the bottom of the page
+
+3. **Add your service account to your bucket**:
+
+   - After creating your storage bucket, open it.
+   - Click "Permissions" → "Grant access"
+   - Put your service account email from before as "Principal"
+   - Assign the role "Storage Object Admin"
+   - Click "Save"
+
+5. **Configure CORS Settings**:
+   - Switch to the "Configuration" tab, scroll down to "Cross-origin resource sharing"
+   - Click "Edit" and "Allow cross-origin resource sharing"
+   - Add the following CORS configuration:
+     - Allowed origins: `https://cap.so,https://www.cap.so,https://cap.link,https://www.cap.link`
+     - Under "Specify methods", select "GET", "HEAD", and "PUT"
+     - For allowed response headers enter: `*`
+     - For cache expiry time enter: `3000`
+   - Click "Save"
+
+4. **Retrieve your S3 Interoperability credentials**:
+   - In Cloud Storage switch to "Settings" via the side panel.
+   - Go to "Interopability" tab
+   - Under "Access keys for service accounts" click "Create key for another service account"
+   - Select your service account
+   - Click "Create key" and note down your "Access Key ID" and "Secret Access Key".
+
+## Step 4: Configure Cap Desktop
+
+1. Open Cap Desktop and navigate to S3 Config
+2. Enter the following details:
+   - Access Key ID (from interoperability credentials creation)
+   - Secret Access Key (from interoperability credentials creation)
+   - Endpoint (enter "https://storage.googleapis.com")
+   - Bucket Name: Your bucket name
+   - Region: Your bucket's region (e.g., us-east-1)
+
+## Step 5: Test and Save the Connection
+
+1. Test the Connection: Click on the 'Test Connection' button to verify that Cap can successfully connect to your Cloud Storage bucket.
+2. Save the Configuration: If the test is successful, save the connection settings. Your Cloud Storage bucket is now integrated with Cap Desktop.
+
+## Accessing Your Cloud Storage Files in Cap
+
+Once the connection is established and you have saved your configuration, all new shareable links you create will serve images and videos directly from your configured S3 bucket, giving you full control over your content delivery and storage.


### PR DESCRIPTION
Adds documentation on how to configure cap.so to work with your own Cloud Storage bucket.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new MDX documentation page guiding users through connecting a Google Cloud Storage bucket to Cap Desktop via S3 interoperability credentials.

- The numbered sub-steps inside "Step 3" jump from item 3 to item 5 then back to item 4, inverting the intended order and likely confusing users following the guide sequentially.
- The region example (`us-east-1`) uses AWS naming convention; GCS regions follow a different format (`us-central1`, `europe-west1`) and the wrong value here will cause the Cap Desktop connection to fail.

<h3>Confidence Score: 3/5</h3>

Two factual errors in the guide would cause users to either get confused by mis-ordered steps or end up with a broken Cap Desktop connection due to the wrong region format.

The mis-numbered sub-steps and the incorrect AWS-style region example are both actionable errors that directly affect users following the documentation — one breaks the logical flow and the other leads to a misconfigured connection that won't work.

apps/web/content/docs/s3-config/google-cloud-storage.mdx — step ordering and region identifier need correction before publishing

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/content/docs/s3-config/google-cloud-storage.mdx | New GCS setup guide with two content-accuracy issues (step numbering inverted 3→5→4 and AWS-style region example) plus three prose typos |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
apps/web/content/docs/s3-config/google-cloud-storage.mdx:61-71
Steps 4 and 5 are numbered out of order — the list jumps from item 3 directly to item 5, then back to item 4. A user following the guide sequentially would be confused about whether to do CORS first or retrieve credentials first, and would have no item 4 at first glance.

```suggestion
4. **Configure CORS Settings**:
   - Switch to the "Configuration" tab, scroll down to "Cross-origin resource sharing"
   - Click "Edit" and "Allow cross-origin resource sharing"
   - Add the following CORS configuration:
     - Allowed origins: `https://cap.so,https://www.cap.so,https://cap.link,https://www.cap.link`
     - Under "Specify methods", select "GET", "HEAD", and "PUT"
     - For allowed response headers enter: `*`
     - For cache expiry time enter: `3000`
   - Click "Save"

5. **Retrieve your S3 Interoperability credentials**:
```

### Issue 2 of 5
apps/web/content/docs/s3-config/google-cloud-storage.mdx:86
The example region `us-east-1` is an AWS region identifier format. Google Cloud Storage regions use a different naming convention (e.g., `us-east1`, `us-central1`, `europe-west1`), without the hyphen before the trailing number. Using an AWS-style name will cause the Cap Desktop configuration to fail when the app tries to resolve the GCS endpoint.

```suggestion
   - Region: Your bucket's region (e.g., `us-central1` or `europe-west1`)
```

### Issue 3 of 5
apps/web/content/docs/s3-config/google-cloud-storage.mdx:30
Spurious "in" makes the instruction grammatically incorrect — should read "Go to IAM and Admin".

```suggestion
   - Go to IAM and Admin > Service Accounts, click "Create service account"
```

### Issue 4 of 5
apps/web/content/docs/s3-config/google-cloud-storage.mdx:47-48
"decided" should be "decide" (imperative mood), and the second `Data protection` bullet is missing its leading `- ` so it renders as a continuation of the first bullet rather than a separate list item.

```suggestion
   - Under "Data protection", decide whether you want to keep "Soft-delete policy" enabled (this will allow you to recover accidentally deleted files)
   - Under "Data protection", keep "Object versioning" disabled
```

### Issue 5 of 5
apps/web/content/docs/s3-config/google-cloud-storage.mdx:73
"Interopability" is a misspelling; the correct spelling is "Interoperability". A user searching the GCS UI for the misspelled tab name may not find it.

```suggestion
   - Go to "Interoperability" tab
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: Document bring your own Cloud Stor..."](https://github.com/capsoftware/cap/commit/5971eb08d7cf555ce386c6f40c7f34a71eb2756c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33274916)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->