### PR TITLE
fix(macos): sync dock visibility when main window is hidden on close

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4581,6 +4581,9 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
                                 api.prevent_close();
                                 let _ = window.hide();
 
+                                #[cfg(target_os = "macos")]
+                                crate::permissions::schedule_macos_dock_visibility_sync(app);
+
                                 let Some(state) = app.try_state::<ArcLock<App>>() else {
                                     warn!("App state unavailable during main window close request");
                                     return;


### PR DESCRIPTION
## What does this PR fix?

Fixes #1859, 
Cap remains visible in the macOS Dock and App Switcher after closing the main window even when no windows are open.

## Root cause

The `CloseRequested` handler for the Main window calls `api.prevent_close()` and `window.hide()` — the window is never destroyed. 
Since the `Destroyed`event is the only trigger for a dock visibility sync in this flow, no sync ever runs after Main is hidden. 
The activation policy stays `Regular`, keeping Cap in the Dock and App Switcher indefinitely.

## Fix

Added a `schedule_macos_dock_visibility_sync` call immediately after `window.hide()` in the Main window close handler. 
This ensures the dock and app switcher state is correctly updated based on the user's 'Always show dock icon' setting.

## Changes

- `apps/desktop/src-tauri/src/lib.rs`: 3 lines added to Main CloseRequested handler

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a macOS Dock/App Switcher visibility bug where Cap remained present in the Dock after the main window was hidden on close. Because the window is never destroyed (only hidden via `api.prevent_close()` + `window.hide()`), the existing `Destroyed`-event-triggered sync never fired, leaving the activation policy stuck on `Regular`.

- Adds a single `#[cfg(target_os = \"macos\")] schedule_macos_dock_visibility_sync(app)` call right after `window.hide()` in the `CapWindowId::Main` close handler — exactly mirroring the pattern already used in several other places in `windows.rs`.
- The sync function uses a generation-counter debounce (100 ms delay) to coalesce rapid events and avoid races, so the new call integrates cleanly with the rest of the dock-visibility logic.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted addition to a macOS-only code path that follows a well-established pattern already used throughout the codebase.

The three added lines call an existing, well-tested helper that is already invoked in four other window-event handlers. The helper's debounce mechanism means the new call cannot race with or duplicate existing syncs. No existing behaviour is altered on non-macOS builds.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/lib.rs | Adds a macOS-only schedule_macos_dock_visibility_sync call immediately after window.hide() in the Main window CloseRequested handler, using the established debounced-generation pattern already present in the codebase. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(macos): sync dock visibility when ma..."](https://github.com/capsoftware/cap/commit/7b46f847a87fa7d964c2593ad9e76f81a89c38c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33292956)</sub>

<!-- /greptile_comment -->