### PR TITLE
fix(recording): restore mic feed after recording stops regardless of window visibility

### DIFF
--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2303,14 +2303,10 @@ async fn handle_recording_end(
     let _ = app.camera_feed.ask(camera::RemoveInput).await;
 
     let main_window = CapWindowId::Main.get(&handle);
-    let should_restore_mic_preview = main_window
-        .as_ref()
-        .and_then(|window| window.is_visible().ok())
-        .unwrap_or(false);
 
     if let Some(window) = main_window {
         window.unminimize().ok();
-        if should_restore_mic_preview && let Err(err) = app.ensure_selected_mic_ready().await {
+        if let Err(err) = app.ensure_selected_mic_ready().await {
             warn!("Failed to restore microphone preview after recording: {err}");
         }
     } else {


### PR DESCRIPTION
## Summary

After stopping a recording, the mic feed is always torn down via `RemoveInput`. 
The code then checked whether the main window was already visible *before* calling `unminimize()` to decide whether to restore the mic,but when the main window was hidden during recording (the default `Close` behaviour), this check always returned `false`, so `ensure_selected_mic_ready()` was never called. 

The mic feed was left with no attached stream.

The fix removes the stale visibility guard. Since `RemoveInput` is unconditionally called just before, we always need to restore the mic preview when showing the main window.

## Fixes the community-reported issue: 
mic stops capturing after exporting from studio mode and returning to recording mode, the only workaround being to toggle "no mic" → re-select mic.

## Changes

- `apps/desktop/src-tauri/src/recording.rs`: 
drop `should_restore_mic_preview` pre-check, always call `ensure_selected_mic_ready` after `unminimize()`

## Test Plan

- [x] Record → stop → open studio mode → export → return to main window → record again without touching mic selector → confirm audio is present

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the microphone feed was not restored after stopping a recording when the main window was hidden (the default behaviour when closing the window during recording). The root cause was a `is_visible()` pre-check that always evaluated to `false` for a hidden window, preventing `ensure_selected_mic_ready` from ever being called.

- **`recording.rs`**: Removes the `should_restore_mic_preview` visibility guard; since `RemoveInput` is called unconditionally just before, `ensure_selected_mic_ready` must also be called unconditionally after `unminimize()`. The function is a no-op when `selected_mic_label` is `None`, so this is safe for all code paths.

<h3>Confidence Score: 5/5</h3>

The change is a minimal, targeted removal of a faulty visibility guard; calling `ensure_selected_mic_ready` unconditionally is safe because the function is a no-op when no mic is selected.

The one-line logic change has a clear, correct effect: `RemoveInput` is always called before this block, so the mic always needs re-initialisation after `unminimize()`. The `else` branch that nulls out `selected_mic_label` when there is no main window is untouched and continues to work correctly.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/recording.rs | Removes the stale `is_visible()` guard so `ensure_selected_mic_ready` is always called after `unminimize()` when the main window exists; the fix correctly handles the case where the window was hidden during recording. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(recording): restore mic feed after r..."](https://github.com/capsoftware/cap/commit/def761f2cad7446019b0653ec699c113c78104f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33488516)</sub>

<!-- /greptile_comment -->