### PR TITLE
test: add infra stage parser coverage

### DIFF
--- a/infra/package.json
+++ b/infra/package.json
@@ -1,10 +1,13 @@
 {
 	"name": "@cap/infra",
+	"type": "module",
 	"devDependencies": {
-		"sst": "3.17.14"
+		"sst": "3.17.14",
+		"vitest": "~2.1.9"
 	},
 	"scripts": {
-		"sst": "sst"
+		"sst": "sst",
+		"test": "vitest run"
 	},
 	"dependencies": {
 		"@pulumi/github": "^6.7.0",

--- a/infra/sst.config.ts
+++ b/infra/sst.config.ts
@@ -1,5 +1,7 @@
 /// <reference path="./.sst/platform/config.d.ts" />
 
+import { parseStageName } from "./stage";
+
 const GITHUB_ORG = "CapSoftware";
 const _GITHUB_REPO = "Cap";
 const _GITHUB_APP_ID = "1196731";
@@ -12,16 +14,7 @@ const _CLOUDFLARE_ACCOUNT_ID = "3de2dd633194481d80f68f55257bdbaa";
 const AXIOM_API_TOKEN = "xaat-c0704be6-e942-4935-b068-3b491d7cc00f";
 const AXIOM_DATASET = "cap-otel";
 
-const parsedStage = () => {
-	if ($app.stage === "staging") return { variant: "staging" } as const;
-	if ($app.stage === "production") return { variant: "production" } as const;
-	if ($app.stage.startsWith("git-branch-"))
-		return {
-			variant: "git-branch",
-			branch: $app.stage.slice("git-branch-".length),
-		} as const;
-	throw new Error("Unsupported stage");
-};
+const parsedStage = () => parseStageName($app.stage);
 
 export default $config({
 	app(input) {

--- a/infra/stage.test.ts
+++ b/infra/stage.test.ts
@@ -16,5 +16,6 @@ describe("parseStageName", () => {
 
 	it("rejects unsupported stages", () => {
 		expect(() => parseStageName("preview")).toThrow("Unsupported stage");
+		expect(() => parseStageName("git-branch-")).toThrow("Unsupported stage");
 	});
 });

--- a/infra/stage.test.ts
+++ b/infra/stage.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { parseStageName } from "./stage";
+
+describe("parseStageName", () => {
+	it("recognizes fixed deployment stages", () => {
+		expect(parseStageName("staging")).toEqual({ variant: "staging" });
+		expect(parseStageName("production")).toEqual({ variant: "production" });
+	});
+
+	it("extracts branch names from git branch preview stages", () => {
+		expect(parseStageName("git-branch-add-infra-tests")).toEqual({
+			variant: "git-branch",
+			branch: "add-infra-tests",
+		});
+	});
+
+	it("rejects unsupported stages", () => {
+		expect(() => parseStageName("preview")).toThrow("Unsupported stage");
+	});
+});

--- a/infra/stage.ts
+++ b/infra/stage.ts
@@ -6,10 +6,10 @@ export type ParsedStage =
 export function parseStageName(stage: string): ParsedStage {
 	if (stage === "staging") return { variant: "staging" };
 	if (stage === "production") return { variant: "production" };
-	if (stage.startsWith("git-branch-"))
-		return {
-			variant: "git-branch",
-			branch: stage.slice("git-branch-".length),
-		};
+	if (stage.startsWith("git-branch-")) {
+		const branch = stage.slice("git-branch-".length);
+		if (!branch) throw new Error("Unsupported stage");
+		return { variant: "git-branch", branch };
+	}
 	throw new Error("Unsupported stage");
 }

--- a/infra/stage.ts
+++ b/infra/stage.ts
@@ -1,0 +1,15 @@
+export type ParsedStage =
+	| { variant: "staging" }
+	| { variant: "production" }
+	| { variant: "git-branch"; branch: string };
+
+export function parseStageName(stage: string): ParsedStage {
+	if (stage === "staging") return { variant: "staging" };
+	if (stage === "production") return { variant: "production" };
+	if (stage.startsWith("git-branch-"))
+		return {
+			variant: "git-branch",
+			branch: stage.slice("git-branch-".length),
+		};
+	throw new Error("Unsupported stage");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,6 +918,9 @@ importers:
       sst:
         specifier: 3.17.14
         version: 3.17.14
+      vitest:
+        specifier: ~2.1.9
+        version: 2.1.9(@types/node@22.15.17)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.44.0)
 
   packages/config:
     dependencies:


### PR DESCRIPTION
/claim #54

## Summary
- adds a focused Vitest setup for the @cap/infra workspace
- extracts SST stage parsing into a small tested helper
- covers production, staging, git-branch preview stages, and unsupported stages

## Validation
- Direct helper assertion with Node 24 import: staging, production, git-branch parsing, and unsupported-stage throw all passed
- Updated pnpm-lock.yaml importer for @cap/infra with the existing Vitest 2.1.9 lock entry

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the inline `parsedStage` closure in `sst.config.ts` into a standalone `parseStageName` helper in `stage.ts`, and wires up a focused Vitest suite for the `@cap/infra` workspace.

- **`stage.ts`**: New module exporting `ParsedStage` discriminated union and `parseStageName`; logic is a direct lift from the original inline function with no behavioural change.
- **`stage.test.ts`**: Four Vitest cases covering `staging`, `production`, a `git-branch-*` prefix, and an unsupported stage throw; the empty-prefix edge case (`\"git-branch-\"` → empty `branch` string) is not currently tested or guarded.
- **`package.json` / `pnpm-lock.yaml`**: Adds vitest `~2.1.9` as a dev dependency (reuses an existing resolved entry in the lockfile) and a `test` script, making the workspace participate in `pnpm turbo test`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only gap is a silent empty-branch path that was already latent before this change.

The refactor is a straightforward extraction with no changed behaviour. The one unaddressed case — parseStageName("git-branch-") returning an empty branch — was already silently possible before this PR via the inline function, and is not made worse here. The tests and helper both look correct for all documented stage names.

infra/stage.ts and infra/stage.test.ts — the empty-branch guard and corresponding test case.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| infra/stage.ts | New helper extracting stage-parsing logic; clean discriminated-union return type; edge case of empty branch name after the prefix is not guarded. |
| infra/stage.test.ts | New Vitest suite covering the four main cases; missing a test for the "git-branch-" empty-branch edge case. |
| infra/sst.config.ts | Inline parsedStage closure replaced with a call to the new helper; behaviour is identical and no logic was changed. |
| infra/package.json | Adds vitest dev dependency, a test script, and "type": "module"; straightforward and consistent with the rest of the monorepo's ESM setup. |
| pnpm-lock.yaml | Adds the @cap/infra vitest importer entry, reusing an existing resolved version (2.1.9); no new packages introduced. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
infra/stage.test.ts:10-15
**Missing edge-case: empty branch after the prefix**

`parseStageName("git-branch-")` currently returns `{ variant: "git-branch", branch: "" }` — an empty string branch. Downstream in `sst.config.ts`, that value is interpolated directly into a Vercel preview URL, yielding a double-dash segment (`…-git--mc-ilroy.vercel.app`) which Vercel won't resolve. A test asserting that `"git-branch-"` either throws or is treated as unsupported would make the acceptable input contract explicit.

### Issue 2 of 2
infra/stage.ts:9-13
Guard against a bare `"git-branch-"` input (empty branch name). An empty `branch` string propagates silently and produces a malformed Vercel preview URL in `sst.config.ts`.

```suggestion
	if (stage.startsWith("git-branch-")) {
		const branch = stage.slice("git-branch-".length);
		if (!branch) throw new Error("Unsupported stage");
		return { variant: "git-branch", branch };
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add infra stage parser coverage"](https://github.com/capsoftware/cap/commit/2fc82cf4d893c7752d8d676bb3fe2a6eb1d59bec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33640920)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->