### PR TITLE
feat(auth): add Authentik OIDC provider + CAP_DISABLE_EMAIL_AUTH flag

### DIFF
--- a/apps/web/app/(org)/login/form.tsx
+++ b/apps/web/app/(org)/login/form.tsx
@@ -6,6 +6,7 @@ import {
 	faArrowLeft,
 	faEnvelope,
 	faExclamationCircle,
+	faRightToBracket,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { AnimatePresence, motion } from "framer-motion";
@@ -111,6 +112,17 @@ export function LoginForm() {
 			auth_surface: "login",
 		});
 		signIn("google", {
+			...(next && next.length > 0 ? { callbackUrl: next } : {}),
+		});
+	};
+
+	const handleAuthentikSignIn = () => {
+		trackEvent("auth_started", {
+			method: "authentik",
+			is_signup: false,
+			auth_surface: "login",
+		});
+		signIn("authentik", {
 			...(next && next.length > 0 ? { callbackUrl: next } : {}),
 		});
 	};
@@ -326,6 +338,7 @@ export function LoginForm() {
 											loading={loading}
 											oauthError={oauthError}
 											handleGoogleSignIn={handleGoogleSignIn}
+											handleAuthentikSignIn={handleAuthentikSignIn}
 										/>
 									</motion.form>
 								)}
@@ -405,6 +418,7 @@ const NormalLogin = ({
 	loading,
 	oauthError,
 	handleGoogleSignIn,
+	handleAuthentikSignIn,
 }: {
 	setShowOrgInput: (show: boolean) => void;
 	email: string;
@@ -413,6 +427,7 @@ const NormalLogin = ({
 	loading: boolean;
 	oauthError: boolean;
 	handleGoogleSignIn: () => void;
+	handleAuthentikSignIn: () => void;
 }) => {
 	const publicEnv = usePublicEnv();
 
@@ -465,7 +480,9 @@ const NormalLogin = ({
 				</Link>
 			</motion.p>
 
-			{(publicEnv.googleAuthAvailable || publicEnv.workosAuthAvailable) && (
+			{(publicEnv.googleAuthAvailable ||
+				publicEnv.workosAuthAvailable ||
+				publicEnv.authentikAuthAvailable) && (
 				<>
 					<div className="flex gap-4 items-center mt-4 mb-4">
 						<span className="flex-1 h-px bg-gray-5" />
@@ -476,6 +493,18 @@ const NormalLogin = ({
 						layout
 						className="flex flex-col gap-3 justify-center items-center"
 					>
+						{publicEnv.authentikAuthAvailable && !oauthError && (
+							<MotionButton
+								variant="gray"
+								type="button"
+								className="flex gap-2 justify-center items-center w-full text-sm"
+								onClick={handleAuthentikSignIn}
+								disabled={loading || emailSent}
+							>
+								<FontAwesomeIcon className="size-4" icon={faRightToBracket} />
+								Login with Authentik
+							</MotionButton>
+						)}
 						{publicEnv.googleAuthAvailable && !oauthError && (
 							<MotionButton
 								variant="gray"

--- a/apps/web/app/(org)/login/form.tsx
+++ b/apps/web/app/(org)/login/form.tsx
@@ -28,6 +28,7 @@ const MotionLink = motion(Link);
 const MotionButton = motion(Button);
 
 export function LoginForm() {
+	const publicEnv = usePublicEnv();
 	const searchParams = useSearchParams();
 	const router = useRouter();
 	const next = searchParams?.get("next");
@@ -344,29 +345,31 @@ export function LoginForm() {
 								)}
 							</motion.div>
 						</AnimatePresence>
-						<motion.p
-							layout="position"
-							className="pt-3 text-xs text-center text-gray-9"
-						>
-							By typing your email and clicking continue, you acknowledge that
-							you have both read and agree to Cap's{" "}
-							<Link
-								href="/terms"
-								target="_blank"
-								className="text-xs font-semibold text-gray-12 hover:text-blue-300"
+						{!publicEnv.disableEmailAuth && (
+							<motion.p
+								layout="position"
+								className="pt-3 text-xs text-center text-gray-9"
 							>
-								Terms of Service
-							</Link>{" "}
-							and{" "}
-							<Link
-								href="/privacy"
-								target="_blank"
-								className="text-xs font-semibold text-gray-12 hover:text-blue-300"
-							>
-								Privacy Policy
-							</Link>
-							.
-						</motion.p>
+								By typing your email and clicking continue, you acknowledge that
+								you have both read and agree to Cap's{" "}
+								<Link
+									href="/terms"
+									target="_blank"
+									className="text-xs font-semibold text-gray-12 hover:text-blue-300"
+								>
+									Terms of Service
+								</Link>{" "}
+								and{" "}
+								<Link
+									href="/privacy"
+									target="_blank"
+									className="text-xs font-semibold text-gray-12 hover:text-blue-300"
+								>
+									Privacy Policy
+								</Link>
+								.
+							</motion.p>
+						)}
 					</motion.div>
 				</Suspense>
 			</motion.div>

--- a/apps/web/app/(org)/login/form.tsx
+++ b/apps/web/app/(org)/login/form.tsx
@@ -433,29 +433,30 @@ const NormalLogin = ({
 
 	return (
 		<motion.div>
-			<motion.div layout className="flex flex-col space-y-3">
-				<MotionInput
-					id="email"
-					name="email"
-					autoFocus
-					type="email"
-					placeholder={emailSent ? "" : "tim@apple.com"}
-					autoComplete="email"
-					required
-					value={email}
-					disabled={emailSent || loading}
-					onChange={(e) => {
-						setEmail(e.target.value.toLowerCase());
-					}}
-				/>
-				<MotionButton
-					variant="dark"
-					type="submit"
-					disabled={loading || emailSent}
-					icon={<FontAwesomeIcon className="mr-1 size-4" icon={faEnvelope} />}
-				>
-					Login with email
-				</MotionButton>
+			{!publicEnv.disableEmailAuth && (
+				<motion.div layout className="flex flex-col space-y-3">
+					<MotionInput
+						id="email"
+						name="email"
+						autoFocus
+						type="email"
+						placeholder={emailSent ? "" : "tim@apple.com"}
+						autoComplete="email"
+						required
+						value={email}
+						disabled={emailSent || loading}
+						onChange={(e) => {
+							setEmail(e.target.value.toLowerCase());
+						}}
+					/>
+					<MotionButton
+						variant="dark"
+						type="submit"
+						disabled={loading || emailSent}
+						icon={<FontAwesomeIcon className="mr-1 size-4" icon={faEnvelope} />}
+					>
+						Login with email
+					</MotionButton>
 				{/* {NODE_ENV === "development" && (
                   <div className="flex justify-center items-center px-6 py-3 mt-3 bg-red-600 rounded-xl">
                     <p className="text-lg text-white">
@@ -466,19 +467,22 @@ const NormalLogin = ({
                     </p>
                   </div>
                 )} */}
-			</motion.div>
-			<motion.p
-				layout="position"
-				className="mt-3 mb-2 text-xs text-center text-gray-9"
-			>
-				Don't have an account?{" "}
-				<Link
-					href="/signup"
-					className="text-xs font-semibold text-blue-9 hover:text-blue-8"
+				</motion.div>
+			)}
+			{!publicEnv.disableEmailAuth && (
+				<motion.p
+					layout="position"
+					className="mt-3 mb-2 text-xs text-center text-gray-9"
 				>
-					Sign up here
-				</Link>
-			</motion.p>
+					Don't have an account?{" "}
+					<Link
+						href="/signup"
+						className="text-xs font-semibold text-blue-9 hover:text-blue-8"
+					>
+						Sign up here
+					</Link>
+				</motion.p>
+			)}
 
 			{(publicEnv.googleAuthAvailable ||
 				publicEnv.workosAuthAvailable ||

--- a/apps/web/app/(org)/login/form.tsx
+++ b/apps/web/app/(org)/login/form.tsx
@@ -488,11 +488,13 @@ const NormalLogin = ({
 				publicEnv.workosAuthAvailable ||
 				publicEnv.authentikAuthAvailable) && (
 				<>
-					<div className="flex gap-4 items-center mt-4 mb-4">
-						<span className="flex-1 h-px bg-gray-5" />
-						<p className="text-sm text-center text-gray-10">OR</p>
-						<span className="flex-1 h-px bg-gray-5" />
-					</div>
+					{!publicEnv.disableEmailAuth && (
+						<div className="flex gap-4 items-center mt-4 mb-4">
+							<span className="flex-1 h-px bg-gray-5" />
+							<p className="text-sm text-center text-gray-10">OR</p>
+							<span className="flex-1 h-px bg-gray-5" />
+						</div>
+					)}
 					<motion.div
 						layout
 						className="flex flex-col gap-3 justify-center items-center"

--- a/apps/web/app/(org)/signup/form.tsx
+++ b/apps/web/app/(org)/signup/form.tsx
@@ -28,6 +28,7 @@ const MotionLink = motion(Link);
 const MotionButton = motion(Button);
 
 export function SignupForm() {
+	const publicEnv = usePublicEnv();
 	const searchParams = useSearchParams();
 	const router = useRouter();
 	const next = searchParams?.get("next");
@@ -356,29 +357,31 @@ export function SignupForm() {
 								Log in here
 							</Link>
 						</motion.p>
-						<motion.p
-							layout="position"
-							className="text-xs text-center text-gray-9"
-						>
-							By typing your email and clicking continue, you acknowledge that
-							you have both read and agree to Cap's{" "}
-							<Link
-								href="/terms"
-								target="_blank"
-								className="text-xs font-semibold text-gray-12 hover:text-blue-300"
+						{!publicEnv.disableEmailAuth && (
+							<motion.p
+								layout="position"
+								className="text-xs text-center text-gray-9"
 							>
-								Terms of Service
-							</Link>{" "}
-							and{" "}
-							<Link
-								href="/privacy"
-								target="_blank"
-								className="text-xs font-semibold text-gray-12 hover:text-blue-300"
-							>
-								Privacy Policy
-							</Link>
-							.
-						</motion.p>
+								By typing your email and clicking continue, you acknowledge that
+								you have both read and agree to Cap's{" "}
+								<Link
+									href="/terms"
+									target="_blank"
+									className="text-xs font-semibold text-gray-12 hover:text-blue-300"
+								>
+									Terms of Service
+								</Link>{" "}
+								and{" "}
+								<Link
+									href="/privacy"
+									target="_blank"
+									className="text-xs font-semibold text-gray-12 hover:text-blue-300"
+								>
+									Privacy Policy
+								</Link>
+								.
+							</motion.p>
+						)}
 					</motion.div>
 				</Suspense>
 			</motion.div>

--- a/apps/web/app/(org)/signup/form.tsx
+++ b/apps/web/app/(org)/signup/form.tsx
@@ -477,11 +477,13 @@ const NormalSignup = ({
 				publicEnv.workosAuthAvailable ||
 				publicEnv.authentikAuthAvailable) && (
 				<>
-					<div className="flex gap-4 items-center my-4">
-						<span className="flex-1 h-px bg-gray-5" />
-						<p className="text-sm text-center text-gray-10">OR</p>
-						<span className="flex-1 h-px bg-gray-5" />
-					</div>
+					{!publicEnv.disableEmailAuth && (
+						<div className="flex gap-4 items-center my-4">
+							<span className="flex-1 h-px bg-gray-5" />
+							<p className="text-sm text-center text-gray-10">OR</p>
+							<span className="flex-1 h-px bg-gray-5" />
+						</div>
+					)}
 					<motion.div
 						layout
 						className="flex flex-col gap-3 justify-center items-center"

--- a/apps/web/app/(org)/signup/form.tsx
+++ b/apps/web/app/(org)/signup/form.tsx
@@ -447,30 +447,32 @@ const NormalSignup = ({
 
 	return (
 		<motion.div>
-			<motion.div layout className="flex flex-col space-y-3">
-				<MotionInput
-					id="email"
-					name="email"
-					autoFocus
-					type="email"
-					placeholder={emailSent ? "" : "tim@apple.com"}
-					autoComplete="email"
-					required
-					value={email}
-					disabled={emailSent || loading}
-					onChange={(e) => {
-						setEmail(e.target.value.toLowerCase());
-					}}
-				/>
-				<MotionButton
-					variant="dark"
-					type="submit"
-					disabled={loading || emailSent}
-					icon={<FontAwesomeIcon className="mr-1 size-4" icon={faEnvelope} />}
-				>
-					Sign up with email
-				</MotionButton>
-			</motion.div>
+			{!publicEnv.disableEmailAuth && (
+				<motion.div layout className="flex flex-col space-y-3">
+					<MotionInput
+						id="email"
+						name="email"
+						autoFocus
+						type="email"
+						placeholder={emailSent ? "" : "tim@apple.com"}
+						autoComplete="email"
+						required
+						value={email}
+						disabled={emailSent || loading}
+						onChange={(e) => {
+							setEmail(e.target.value.toLowerCase());
+						}}
+					/>
+					<MotionButton
+						variant="dark"
+						type="submit"
+						disabled={loading || emailSent}
+						icon={<FontAwesomeIcon className="mr-1 size-4" icon={faEnvelope} />}
+					>
+						Sign up with email
+					</MotionButton>
+				</motion.div>
+			)}
 			{(publicEnv.googleAuthAvailable ||
 				publicEnv.workosAuthAvailable ||
 				publicEnv.authentikAuthAvailable) && (

--- a/apps/web/app/(org)/signup/form.tsx
+++ b/apps/web/app/(org)/signup/form.tsx
@@ -6,6 +6,7 @@ import {
 	faArrowLeft,
 	faEnvelope,
 	faExclamationCircle,
+	faRightToBracket,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { AnimatePresence, motion } from "framer-motion";
@@ -111,6 +112,17 @@ export function SignupForm() {
 			auth_surface: "signup",
 		});
 		signIn("google", {
+			...(next && next.length > 0 ? { callbackUrl: next } : {}),
+		});
+	};
+
+	const handleAuthentikSignIn = () => {
+		trackEvent("auth_started", {
+			method: "authentik",
+			is_signup: true,
+			auth_surface: "signup",
+		});
+		signIn("authentik", {
 			...(next && next.length > 0 ? { callbackUrl: next } : {}),
 		});
 	};
@@ -326,6 +338,7 @@ export function SignupForm() {
 											loading={loading}
 											oauthError={oauthError}
 											handleGoogleSignIn={handleGoogleSignIn}
+											handleAuthentikSignIn={handleAuthentikSignIn}
 										/>
 									</motion.form>
 								)}
@@ -419,6 +432,7 @@ const NormalSignup = ({
 	loading,
 	oauthError,
 	handleGoogleSignIn,
+	handleAuthentikSignIn,
 }: {
 	setShowOrgInput: (show: boolean) => void;
 	email: string;
@@ -427,6 +441,7 @@ const NormalSignup = ({
 	loading: boolean;
 	oauthError: boolean;
 	handleGoogleSignIn: () => void;
+	handleAuthentikSignIn: () => void;
 }) => {
 	const publicEnv = usePublicEnv();
 
@@ -456,7 +471,9 @@ const NormalSignup = ({
 					Sign up with email
 				</MotionButton>
 			</motion.div>
-			{(publicEnv.googleAuthAvailable || publicEnv.workosAuthAvailable) && (
+			{(publicEnv.googleAuthAvailable ||
+				publicEnv.workosAuthAvailable ||
+				publicEnv.authentikAuthAvailable) && (
 				<>
 					<div className="flex gap-4 items-center my-4">
 						<span className="flex-1 h-px bg-gray-5" />
@@ -467,7 +484,19 @@ const NormalSignup = ({
 						layout
 						className="flex flex-col gap-3 justify-center items-center"
 					>
-						{!oauthError && (
+						{publicEnv.authentikAuthAvailable && !oauthError && (
+							<MotionButton
+								variant="gray"
+								type="button"
+								className="flex gap-2 justify-center items-center w-full text-sm"
+								onClick={handleAuthentikSignIn}
+								disabled={loading}
+							>
+								<FontAwesomeIcon className="size-4" icon={faRightToBracket} />
+								Sign up with Authentik
+							</MotionButton>
+						)}
+						{publicEnv.googleAuthAvailable && !oauthError && (
 							<MotionButton
 								variant="gray"
 								type="button"

--- a/apps/web/app/(org)/signup/page.tsx
+++ b/apps/web/app/(org)/signup/page.tsx
@@ -1,3 +1,4 @@
+import { serverEnv } from "@cap/env";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -8,6 +9,9 @@ import { SignupForm } from "./form";
 export const dynamic = "force-dynamic";
 
 export default async function SignupPage() {
+	if (serverEnv().CAP_DISABLE_EMAIL_AUTH) {
+		redirect("/login");
+	}
 	const session = await getCurrentUser();
 	if (session) {
 		redirect("/dashboard");

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -127,6 +127,7 @@ export default ({ children }: PropsWithChildren) =>
 												workosAuthAvailable: !!serverEnv().WORKOS_CLIENT_ID,
 												googleAuthAvailable: !!serverEnv().GOOGLE_CLIENT_ID,
 												authentikAuthAvailable: !!serverEnv().AUTHENTIK_ISSUER,
+												disableEmailAuth: serverEnv().CAP_DISABLE_EMAIL_AUTH,
 											}}
 										>
 											<ReactQueryProvider>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -126,6 +126,7 @@ export default ({ children }: PropsWithChildren) =>
 												webUrl: buildEnv.NEXT_PUBLIC_WEB_URL,
 												workosAuthAvailable: !!serverEnv().WORKOS_CLIENT_ID,
 												googleAuthAvailable: !!serverEnv().GOOGLE_CLIENT_ID,
+												authentikAuthAvailable: !!serverEnv().AUTHENTIK_ISSUER,
 											}}
 										>
 											<ReactQueryProvider>

--- a/apps/web/app/s/[videoId]/_components/AuthOverlay.tsx
+++ b/apps/web/app/s/[videoId]/_components/AuthOverlay.tsx
@@ -154,6 +154,19 @@ const StepOne = ({
 			callbackUrl: `${window.location.origin}/s/${videoId}`,
 		});
 	};
+	const handleAuthentikSignIn = () => {
+		trackEvent("auth_started", {
+			method: "authentik",
+			is_signup: false,
+			auth_surface: "share_overlay",
+			video_id: videoId,
+		});
+		setLoading(true);
+		signIn("authentik", {
+			redirect: false,
+			callbackUrl: `${window.location.origin}/s/${videoId}`,
+		});
+	};
 	const publicEnv = usePublicEnv();
 
 	return (
@@ -247,7 +260,7 @@ const StepOne = ({
 							variant="gray"
 							type="button"
 							className="flex gap-2 justify-center items-center my-1 w-full text-sm"
-							onClick={() => signIn("authentik")}
+							onClick={handleAuthentikSignIn}
 							disabled={loading}
 						>
 							<FontAwesomeIcon className="size-4" icon={faRightToBracket} />

--- a/apps/web/app/s/[videoId]/_components/AuthOverlay.tsx
+++ b/apps/web/app/s/[videoId]/_components/AuthOverlay.tsx
@@ -200,34 +200,38 @@ const StepOne = ({
 			}}
 			className="flex flex-col gap-3"
 		>
-			<div>
-				<Input
-					id={emailId}
-					name="email"
-					autoFocus
-					type="email"
-					placeholder={emailSent ? "" : "tim@apple.com"}
-					autoComplete="email"
-					required
-					value={email}
-					disabled={emailSent || loading}
-					onChange={(e) => {
-						setEmail(e.target.value.toLowerCase());
-					}}
-				/>
-			</div>
-			<Button
-				variant="dark"
-				type="submit"
-				icon={<FontAwesomeIcon className="mr-1 size-4" icon={faEnvelope} />}
-				disabled={loading || emailSent}
-			>
-				{emailSent
-					? NODE_ENV === "development"
-						? "Email sent to your terminal"
-						: "Email sent to your inbox"
-					: "Continue with Email"}
-			</Button>
+			{!publicEnv.disableEmailAuth && (
+				<>
+					<div>
+						<Input
+							id={emailId}
+							name="email"
+							autoFocus
+							type="email"
+							placeholder={emailSent ? "" : "tim@apple.com"}
+							autoComplete="email"
+							required
+							value={email}
+							disabled={emailSent || loading}
+							onChange={(e) => {
+								setEmail(e.target.value.toLowerCase());
+							}}
+						/>
+					</div>
+					<Button
+						variant="dark"
+						type="submit"
+						icon={<FontAwesomeIcon className="mr-1 size-4" icon={faEnvelope} />}
+						disabled={loading || emailSent}
+					>
+						{emailSent
+							? NODE_ENV === "development"
+								? "Email sent to your terminal"
+								: "Email sent to your inbox"
+							: "Continue with Email"}
+					</Button>
+				</>
+			)}
 			{(publicEnv.googleAuthAvailable ||
 				publicEnv.authentikAuthAvailable) && (
 				<>

--- a/apps/web/app/s/[videoId]/_components/AuthOverlay.tsx
+++ b/apps/web/app/s/[videoId]/_components/AuthOverlay.tsx
@@ -1,6 +1,10 @@
 import { NODE_ENV } from "@cap/env";
 import { Button, Dialog, DialogContent, Input, LogoBadge } from "@cap/ui";
-import { faArrowLeft, faEnvelope } from "@fortawesome/free-solid-svg-icons";
+import {
+	faArrowLeft,
+	faEnvelope,
+	faRightToBracket,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Image from "next/image";
 import Link from "next/link";
@@ -224,23 +228,38 @@ const StepOne = ({
 						: "Email sent to your inbox"
 					: "Continue with Email"}
 			</Button>
-			{publicEnv.googleAuthAvailable && (
+			{(publicEnv.googleAuthAvailable ||
+				publicEnv.authentikAuthAvailable) && (
 				<>
 					<div className="flex gap-4 items-center">
 						<span className="flex-1 h-px bg-gray-5" />
 						<p className="text-sm text-center text-gray-10">OR</p>
 						<span className="flex-1 h-px bg-gray-5" />
 					</div>
-					<Button
-						variant="gray"
-						type="button"
-						className="flex gap-2 justify-center items-center my-1 w-full text-sm"
-						onClick={handleGoogleSignIn}
-						disabled={loading}
-					>
-						<Image src="/google.svg" alt="Google" width={16} height={16} />
-						Login with Google
-					</Button>
+					{publicEnv.authentikAuthAvailable && (
+						<Button
+							variant="gray"
+							type="button"
+							className="flex gap-2 justify-center items-center my-1 w-full text-sm"
+							onClick={() => signIn("authentik")}
+							disabled={loading}
+						>
+							<FontAwesomeIcon className="size-4" icon={faRightToBracket} />
+							Login with Authentik
+						</Button>
+					)}
+					{publicEnv.googleAuthAvailable && (
+						<Button
+							variant="gray"
+							type="button"
+							className="flex gap-2 justify-center items-center my-1 w-full text-sm"
+							onClick={handleGoogleSignIn}
+							disabled={loading}
+						>
+							<Image src="/google.svg" alt="Google" width={16} height={16} />
+							Login with Google
+						</Button>
+					)}
 				</>
 			)}
 		</form>

--- a/apps/web/app/s/[videoId]/_components/AuthOverlay.tsx
+++ b/apps/web/app/s/[videoId]/_components/AuthOverlay.tsx
@@ -235,11 +235,13 @@ const StepOne = ({
 			{(publicEnv.googleAuthAvailable ||
 				publicEnv.authentikAuthAvailable) && (
 				<>
-					<div className="flex gap-4 items-center">
-						<span className="flex-1 h-px bg-gray-5" />
-						<p className="text-sm text-center text-gray-10">OR</p>
-						<span className="flex-1 h-px bg-gray-5" />
-					</div>
+					{!publicEnv.disableEmailAuth && (
+						<div className="flex gap-4 items-center">
+							<span className="flex-1 h-px bg-gray-5" />
+							<p className="text-sm text-center text-gray-10">OR</p>
+							<span className="flex-1 h-px bg-gray-5" />
+						</div>
+					)}
 					{publicEnv.authentikAuthAvailable && (
 						<Button
 							variant="gray"

--- a/apps/web/utils/public-env.tsx
+++ b/apps/web/utils/public-env.tsx
@@ -7,6 +7,7 @@ type PublicEnvContext = {
 	googleAuthAvailable: boolean;
 	workosAuthAvailable: boolean;
 	authentikAuthAvailable: boolean;
+	disableEmailAuth: boolean;
 };
 
 const Context = createContext<PublicEnvContext | null>(null);

--- a/apps/web/utils/public-env.tsx
+++ b/apps/web/utils/public-env.tsx
@@ -6,6 +6,7 @@ type PublicEnvContext = {
 	webUrl: string;
 	googleAuthAvailable: boolean;
 	workosAuthAvailable: boolean;
+	authentikAuthAvailable: boolean;
 };
 
 const Context = createContext<PublicEnvContext | null>(null);

--- a/packages/database/auth/auth-options.ts
+++ b/packages/database/auth/auth-options.ts
@@ -69,13 +69,27 @@ export const authOptions = (): NextAuthOptions => {
 		},
 		get providers() {
 			if (_providers) return _providers;
+			const authentikIssuer = serverEnv().AUTHENTIK_ISSUER;
+			const authentikClientId = serverEnv().AUTHENTIK_CLIENT_ID;
+			const authentikClientSecret = serverEnv().AUTHENTIK_CLIENT_SECRET;
+			if (
+				authentikIssuer &&
+				(!authentikClientId || !authentikClientSecret)
+			) {
+				throw new Error(
+					"AUTHENTIK_ISSUER is set but AUTHENTIK_CLIENT_ID and/or " +
+						"AUTHENTIK_CLIENT_SECRET is missing. All three must be " +
+						"provided together to enable the Authentik OIDC provider.",
+				);
+			}
+
 			_providers = [
-				...(serverEnv().AUTHENTIK_ISSUER
+				...(authentikIssuer && authentikClientId && authentikClientSecret
 					? [
 							AuthentikProvider({
-								clientId: serverEnv().AUTHENTIK_CLIENT_ID as string,
-								clientSecret: serverEnv().AUTHENTIK_CLIENT_SECRET as string,
-								issuer: serverEnv().AUTHENTIK_ISSUER as string,
+								clientId: authentikClientId,
+								clientSecret: authentikClientSecret,
+								issuer: authentikIssuer,
 							}),
 						]
 					: []),

--- a/packages/database/auth/auth-options.ts
+++ b/packages/database/auth/auth-options.ts
@@ -6,6 +6,7 @@ import type { NextAuthOptions } from "next-auth";
 import { getServerSession as _getServerSession } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
 import { decode, type JWT, type JWTDecodeParams } from "next-auth/jwt";
+import AuthentikProvider from "next-auth/providers/authentik";
 import EmailProvider from "next-auth/providers/email";
 import GoogleProvider from "next-auth/providers/google";
 import type { Provider } from "next-auth/providers/index";
@@ -69,6 +70,15 @@ export const authOptions = (): NextAuthOptions => {
 		get providers() {
 			if (_providers) return _providers;
 			_providers = [
+				...(serverEnv().AUTHENTIK_ISSUER
+					? [
+							AuthentikProvider({
+								clientId: serverEnv().AUTHENTIK_CLIENT_ID as string,
+								clientSecret: serverEnv().AUTHENTIK_CLIENT_SECRET as string,
+								issuer: serverEnv().AUTHENTIK_ISSUER as string,
+							}),
+						]
+					: []),
 				GoogleProvider({
 					clientId: serverEnv().GOOGLE_CLIENT_ID as string,
 					clientSecret: serverEnv().GOOGLE_CLIENT_SECRET as string,

--- a/packages/env/server.ts
+++ b/packages/env/server.ts
@@ -72,6 +72,14 @@ function createServerEnv() {
 			WORKOS_CLIENT_ID: z.string().optional(),
 			WORKOS_API_KEY: z.string().optional(),
 
+			/// Authentik OIDC (self-hosted SSO)
+			// Provide these to enable a "Sign in with Authentik" provider.
+			// AUTHENTIK_ISSUER must include the application slug; no trailing slash:
+			//   https://auth.example.com/application/o/<slug>
+			AUTHENTIK_CLIENT_ID: z.string().optional(),
+			AUTHENTIK_CLIENT_SECRET: z.string().optional(),
+			AUTHENTIK_ISSUER: z.string().optional(),
+
 			/// Settings
 			CAP_VIDEOS_DEFAULT_PUBLIC: boolString(true).describe(
 				"Should videos be public or private by default",

--- a/packages/env/server.ts
+++ b/packages/env/server.ts
@@ -88,6 +88,10 @@ function createServerEnv() {
 				.string()
 				.optional()
 				.describe("Comma-separated list of permitted signup domains"),
+			CAP_DISABLE_EMAIL_AUTH: boolString(false).describe(
+				"Hide the email magic-link UI on login/signup/share pages. "
+				+ "The provider stays wired server-side as break-glass.",
+			),
 
 			/// AI providers
 			DEEPGRAM_API_KEY: z.string().optional().describe("Audio transcription"),


### PR DESCRIPTION
## Summary

Adds a NextAuth `authentik` provider to self-hosted Cap so OIDC-only deployments can sign in via Authentik (or any OIDC IdP that respects standard discovery), plus an optional `CAP_DISABLE_EMAIL_AUTH` flag for OIDC-only deployments that want to hide the magic-link UI entirely.

Closes #914 (CAP-453).

The patch is **purely additive** — every change is gated on a new env var, so deployments that don't set them see no behavior change. Cap Cloud and existing self-hosted users are unaffected.

## What this changes

### Authentik OIDC provider (`AUTHENTIK_ISSUER` / `_CLIENT_ID` / `_CLIENT_SECRET`)

- `packages/database/auth/auth-options.ts` — spreads in `AuthentikProvider` from `next-auth/providers/authentik` when `AUTHENTIK_ISSUER` is set.
- `packages/env/server.ts` — adds three optional env keys.
- `apps/web/utils/public-env.tsx` + `app/layout.tsx` — surfaces `authentikAuthAvailable` to client components.
- `apps/web/app/(org)/login/form.tsx`, `app/(org)/signup/form.tsx`, `app/s/[videoId]/_components/AuthOverlay.tsx` — render a "Login/Sign up with Authentik" button alongside the existing Google/WorkOS options, using the same `publicEnv.<provider>AuthAvailable` pattern.

### `CAP_DISABLE_EMAIL_AUTH` flag (default `false`)

For OIDC-only deployments. When `true`:

- Hides the email input + Login/Sign up with email button.
- Hides the OR divider between email and OAuth.
- Hides the "Don't have an account? Sign up here" link on /login.
- Hides the email-specific ToS line ("By typing your email…").
- Redirects `/signup` → `/login` — OAuth users sign up via first sign-in via the database adapter.
- The `EmailProvider` stays wired server-side as a break-glass option for direct API access; this is a UI-only toggle.

## Notes

- The provider uses the upstream-canonical name `authentik`, but works against any OIDC-compliant IdP (Keycloak, Zitadel, Pocket ID, Authelia, etc.) by setting `AUTHENTIK_ISSUER` to that IdP's OIDC discovery URL.
- The `next-auth/providers/authentik` documentation says the issuer should be the application slug URL **without** a trailing slash, so set e.g. `AUTHENTIK_ISSUER=https://auth.example.com/application/o/cap` (no trailing slash). The provider appends `/.well-known/openid-configuration` itself.
- Default callback path is `/api/auth/callback/authentik` — matches NextAuth's convention; that's the URL to register in your Authentik provider config.

## Commits

5 focused commits:

1. **feat(auth): add Authentik OIDC provider for self-hosted SSO** — provider + env keys.
2. **feat(auth): render Authentik sign-in button on login/signup/share pages** — UI buttons + `publicEnv.authentikAuthAvailable`.
3. **feat(auth): CAP_DISABLE_EMAIL_AUTH env to hide magic-link UI** — flag + initial UI gates.
4. **feat(auth): hide OR divider when CAP_DISABLE_EMAIL_AUTH=true** — separator gate.
5. **feat(auth): hide email-specific ToS line + redirect /signup when CAP_DISABLE_EMAIL_AUTH** — ToS gate + signup-page redirect.

## Test plan

- [x] `pnpm i --frozen-lockfile` succeeds.
- [x] `pnpm run build:web` succeeds (built locally as `cap-web:lynton-authentik`, 620 MB).
- [x] Without `AUTHENTIK_ISSUER` set, `/api/auth/providers` returns the existing `{google, workos, email}` set unchanged. Login UI renders as before.
- [x] Without `CAP_DISABLE_EMAIL_AUTH`, the email block, OR divider, ToS line, and signup link all render unchanged.
- [x] With `AUTHENTIK_ISSUER` set: `/api/auth/providers` includes `authentik`; `/login` shows "Login with Authentik".
- [x] POST `/api/auth/signin/authentik` returns a properly signed authorize URL with PKCE `code_challenge_method=S256`, scope `openid email profile`, and the registered redirect_uri.
- [x] End-to-end against a real Authentik instance: Authentik returns 302 to its login page; consent + callback round-trip completes; user record auto-provisioned via DrizzleAdapter; `/dashboard` reachable.
- [x] With `CAP_DISABLE_EMAIL_AUTH=true`: `/signup` 307-redirects to `/login`; `/login` shows only the Authentik button (no email block, no OR, no ToS prose, no signup link).
- [x] No new runtime errors in `cap-web` logs; no new TypeScript errors.

## Compatibility

- No new dependencies. Uses `next-auth/providers/authentik` already shipped with `next-auth@4.24.5`.
- No schema migrations.
- No changes to existing env vars or callback URLs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an Authentik OIDC provider to self-hosted Cap deployments and a `CAP_DISABLE_EMAIL_AUTH` flag that hides magic-link UI for OIDC-only setups. The changes are purely additive and env-gated, leaving existing deployments unaffected.

- **`packages/database/auth/auth-options.ts` / `packages/env/server.ts`**: Registers `AuthentikProvider` when `AUTHENTIK_ISSUER` is set; adds three optional Authentik env vars and the boolean `CAP_DISABLE_EMAIL_AUTH` flag.
- **`login/form.tsx`, `signup/form.tsx`, `signup/page.tsx`**: Renders the Authentik button with analytics and `callbackUrl` support; hides email inputs, OR divider, ToS prose, and signup link behind `disableEmailAuth`; server-redirects `/signup` → `/login` when the flag is on.
- **`AuthOverlay.tsx`**: Adds the Authentik button to the share-page comment overlay, but is missing a `callbackUrl` back to the video and omits analytics tracking — unlike the Google handler in the same file.

<h3>Confidence Score: 3/5</h3>

The login and signup forms are well-implemented, but two issues in AuthOverlay.tsx and a misconfiguration risk in auth-options.ts need fixing before merge.

The AuthOverlay Authentik button drops the video callbackUrl, so users authenticating from a share page are redirected away from the video instead of back to it. Separately, AuthentikProvider is constructed using AUTHENTIK_CLIENT_ID/AUTHENTIK_CLIENT_SECRET cast to string with no validation that they are actually set — a partial configuration silently produces a broken provider whose failures only surface at token-exchange time.

apps/web/app/s/[videoId]/_components/AuthOverlay.tsx and packages/database/auth/auth-options.ts need attention before this is ready to merge.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/database/auth/auth-options.ts | Adds AuthentikProvider gated on AUTHENTIK_ISSUER, but CLIENT_ID/CLIENT_SECRET are not validated alongside it — undefined credentials are cast to string, causing a silent misconfiguration. |
| apps/web/app/s/[videoId]/_components/AuthOverlay.tsx | Adds Authentik button and disableEmailAuth gating, but the Authentik signIn call is missing a callbackUrl back to the video page, and the email ToS paragraph is not gated on disableEmailAuth. |
| packages/env/server.ts | Adds three optional Authentik env vars and the CAP_DISABLE_EMAIL_AUTH boolean flag; schema is correct and follows existing patterns. |
| apps/web/app/(org)/login/form.tsx | Adds Authentik sign-in button with analytics, callbackUrl, and disableEmailAuth gating applied correctly to all relevant UI sections. |
| apps/web/app/(org)/signup/form.tsx | Mirrors login form changes; Authentik button and disableEmailAuth gates applied consistently. |
| apps/web/app/(org)/signup/page.tsx | Adds server-side redirect to /login when CAP_DISABLE_EMAIL_AUTH is set; logic is correct. |
| apps/web/app/layout.tsx | Passes authentikAuthAvailable and disableEmailAuth into the public env context; straightforward and correct. |
| apps/web/utils/public-env.tsx | Extends PublicEnvContext type with authentikAuthAvailable and disableEmailAuth; clean type addition. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/app/s/[videoId]/_components/AuthOverlay.tsx`, line 94-113 ([link](https://github.com/capsoftware/cap/blob/b944571c1d0ec458b987d25da720c24ae2125bd3/apps/web/app/s/[videoId]/_components/AuthOverlay.tsx#L94-L113)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Email ToS text not gated when email auth is disabled**

   The login and signup forms wrap their email-specific ToS paragraph in a `publicEnv.disableEmailAuth` check. The matching paragraph in `AuthOverlay` (rendered outside `StepOne`, always visible on step 1) has no such gate — so "By entering your email…" stays visible when email auth is disabled, even though the email input is hidden and only OAuth buttons are shown.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/app/s/[videoId]/_components/AuthOverlay.tsx
   Line: 94-113

   Comment:
   **Email ToS text not gated when email auth is disabled**

   The login and signup forms wrap their email-specific ToS paragraph in a `publicEnv.disableEmailAuth` check. The matching paragraph in `AuthOverlay` (rendered outside `StepOne`, always visible on step 1) has no such gate — so "By entering your email…" stays visible when email auth is disabled, even though the email input is hidden and only OAuth buttons are shown.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/database/auth/auth-options.ts:73-81
**Missing companion-var validation for Authentik credentials**

`AUTHENTIK_ISSUER` gates provider registration, but `AUTHENTIK_CLIENT_ID` and `AUTHENTIK_CLIENT_SECRET` are each independently optional in the schema. If a deployer sets only `AUTHENTIK_ISSUER` (or sets the issuer but misspells either credential key), `serverEnv().AUTHENTIK_CLIENT_ID` evaluates to `undefined`, the `as string` cast silences TypeScript, and `AuthentikProvider` is registered with empty credentials. The OIDC flow will fail at token exchange with a cryptic IdP error rather than a clear startup-time misconfiguration message.

### Issue 2 of 4
apps/web/app/s/[videoId]/_components/AuthOverlay.tsx:247-254
**Authentik sign-in in `AuthOverlay` drops the video `callbackUrl`**

The Google handler in the same component sets `callbackUrl: \`${window.location.origin}/s/${videoId}\`` so the user is returned to the share page after OAuth. The Authentik button calls `signIn("authentik")` with no options, so NextAuth will redirect to its default post-sign-in URL (typically `/dashboard`) instead of back to the video. A user clicking "Login with Authentik" on a share page will lose their place and the comment dialog will close.

### Issue 3 of 4
apps/web/app/s/[videoId]/_components/AuthOverlay.tsx:245-256
**Authentik sign-in missing analytics tracking**

Every other auth method in this file calls `trackEvent("auth_started", ...)` before `signIn`. The Authentik button skips this, creating a gap in auth-surface analytics. It also doesn't set `loading` or `redirect: false`, making it inconsistent with the Google handler's pattern.

```suggestion
					{publicEnv.authentikAuthAvailable && (
						<Button
							variant="gray"
							type="button"
							className="flex gap-2 justify-center items-center my-1 w-full text-sm"
							onClick={() => {
								trackEvent("auth_started", {
									method: "authentik",
									is_signup: false,
									auth_surface: "share_overlay",
									video_id: videoId,
								});
								setLoading(true);
								signIn("authentik", {
									callbackUrl: `${window.location.origin}/s/${videoId}`,
								});
							}}
							disabled={loading}
						>
							<FontAwesomeIcon className="size-4" icon={faRightToBracket} />
							Login with Authentik
						</Button>
					)}
```

### Issue 4 of 4
apps/web/app/s/[videoId]/_components/AuthOverlay.tsx:94-113
**Email ToS text not gated when email auth is disabled**

The login and signup forms wrap their email-specific ToS paragraph in a `publicEnv.disableEmailAuth` check. The matching paragraph in `AuthOverlay` (rendered outside `StepOne`, always visible on step 1) has no such gate — so "By entering your email…" stays visible when email auth is disabled, even though the email input is hidden and only OAuth buttons are shown.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(auth): hide email-specific ToS line..."](https://github.com/capsoftware/cap/commit/b944571c1d0ec458b987d25da720c24ae2125bd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33661749)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->