### PR TITLE
fix(proxy): add /download to self-hosted path whitelist

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -48,6 +48,7 @@ export async function proxy(request: NextRequest) {
 				path.startsWith("/signup") ||
 				path.startsWith("/invite") ||
 				path.startsWith("/self-hosting") ||
+				path.startsWith("/download") ||
 				path.startsWith("/terms") ||
 				path.startsWith("/verify-otp")
 			) &&


### PR DESCRIPTION
## Summary

The `/download` path is missing from the self-hosted proxy whitelist in `apps/web/proxy.ts`, so the "Download Cap" button on the empty `/dashboard/caps` page (and any link to `/download/apple-silicon` etc.) gets 307-redirected to `/login` for *every* request — even from authenticated users. Self-hosted Cap users have no path to the desktop-app download page from inside the app.

## Root cause

`apps/web/proxy.ts` runs as middleware for self-hosted instances (`NEXT_PUBLIC_IS_CAP !== "true"`). When the path is not on the whitelist, the request is redirected to `/login`. The whitelist already contains `/login`, `/signup`, `/invite`, `/self-hosting`, `/terms`, `/verify-otp` — but not `/download`.

Cap.so itself is unaffected because `NEXT_PUBLIC_IS_CAP=true` skips the proxy entirely.

## Fix

One line added to the whitelist:

```diff
                  path.startsWith("/signup") ||
                  path.startsWith("/invite") ||
                  path.startsWith("/self-hosting") ||
+                 path.startsWith("/download") ||
                  path.startsWith("/terms") ||
                  path.startsWith("/verify-otp")
              ) &&
```

This covers `/download`, `/download/apple-silicon`, `/download/windows-x86_64`, `/download/apple-intel`, and any future platform paths under `/download/*`.

## Test plan

- [x] `pnpm i --frozen-lockfile` succeeds
- [x] `pnpm run build:web` succeeds
- [x] Verified on a self-hosted instance:
  - `GET /download` → **200** (renders the download page)
  - `GET /download/apple-silicon` → **307** redirect to the CrabNebula CDN (correct behavior — actual download starts)
  - All other unrelated paths still redirect to `/login` as before
- [x] No change on `cap.so` (cap.so skips this proxy entirely via `NEXT_PUBLIC_IS_CAP=true`)

## Compatibility

- No new dependencies.
- No new env vars.
- No schema changes.
- No effect on Cap Cloud or any deployment with `NEXT_PUBLIC_IS_CAP=true`.

## Related

Independent of #1869 (Authentik OIDC), filed as a separate PR per the principle that an unrelated bug fix shouldn't be bundled with a feature.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `/download` to the self-hosted proxy path whitelist in `apps/web/proxy.ts`, fixing a regression where any request to `/download` or its sub-paths (e.g. `/download/apple-silicon`) was 307-redirected to `/login` on self-hosted instances. The change has no effect on Cap Cloud deployments (`NEXT_PUBLIC_IS_CAP=true` skips this proxy entirely).

- One line added to the `startsWith` whitelist alongside the existing entries (`/login`, `/signup`, `/invite`, etc.), following the same pattern.
- Covers all current and future `/download/*` platform paths via `startsWith`, consistent with how every other whitelisted prefix is matched.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line whitelist addition that restores access to a public download page on self-hosted instances without touching any authentication logic or other code paths.

The addition follows the exact same `startsWith` pattern used by every other entry in the whitelist. The `/download` prefix is a publicly accessible page (desktop-app download) that has no business requiring a login gate, and the fix is clearly scoped to self-hosted deployments only.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/proxy.ts | Adds `/download` to the self-hosted path whitelist so desktop-app download pages are reachable without being redirected to `/login` |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(proxy): whitelist /download path for..."](https://github.com/capsoftware/cap/commit/0fb9be4392a32d23f9e3f5042af429cfe55f665d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33663370)</sub>

<!-- /greptile_comment -->