### PR TITLE
fix(macos): always show dock icon setting now works during recording

### DIFF
--- a/apps/desktop/src-tauri/src/permissions.rs
+++ b/apps/desktop/src-tauri/src/permissions.rs
@@ -179,20 +179,20 @@ pub(crate) fn sync_macos_dock_visibility(app: &tauri::AppHandle) {
         return;
     }
 
+    let should_hide_dock = GeneralSettingsStore::get(app)
+        .ok()
+        .flatten()
+        .is_some_and(|settings| settings.hide_dock_icon);
+
     let has_visible_panel_window = app.webview_windows().iter().any(|(label, window)| {
         CapWindowId::from_str(label)
             .map(|id| !id.activates_dock() && window.is_visible().unwrap_or(false))
             .unwrap_or(false)
     });
 
-    if has_visible_panel_window {
+    if has_visible_panel_window && should_hide_dock {
         return;
     }
-
-    let should_hide_dock = GeneralSettingsStore::get(app)
-        .ok()
-        .flatten()
-        .is_some_and(|settings| settings.hide_dock_icon);
 
     let has_visible_dock_window = app.webview_windows().iter().any(|(label, window)| {
         CapWindowId::from_str(label)


### PR DESCRIPTION
## Summary

The "Always show dock icon" in the setting had no effect, the dock icon would still disappear when recording started regardless of the toggle.

A previous fix (preventing duplicate dock icons) added a bail-early in `sync_macos_dock_visibility` that ran before reading the user's preference, so the sync was unconditionally skipped whenever recording was active. 
The toggle existed but did nothing.

The fix reads the `hide_dock_icon` setting first, then only bails when the user actually wants the dock hidden. 
If the setting is off (always show), the sync continues and keeps the dock icon visible throughout the recording.

Fixes #1843

## Changes

- `apps/desktop/src-tauri/src/permissions.rs`: read `hide_dock_icon` before the panel window guard; only bail when both conditions are true

## Test Plan

- [x] Enable "Always show dock icon" → start recording → dock icon stays visible throughout
- [x] Disable "Always show dock icon" → start recording → dock icon hides as expected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the \"Always show dock icon\" setting had no effect during recording on macOS. A prior guard that prevented duplicate dock icons used an unconditional early return whenever a panel window was visible, which ran before the user's `hide_dock_icon` preference was ever read.

- The `should_hide_dock` value is now fetched before the panel-window check, and the early return is conditioned on `has_visible_panel_window && should_hide_dock` — so recording no longer forces the dock to hide when the user has opted to always show it.
- When \"Always show dock icon\" is disabled the behavior is unchanged: the function still bails early during recording, preserving the original duplicate-icon fix.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-file, minimal logic change that correctly restores the dock icon when the user prefers it visible.

The change is surgical: one variable read is moved earlier and one boolean condition is added to the guard. Both branches of the user preference (hide vs. show dock) were manually tested per the test plan, the duplicate-dock-icon fix is preserved when should_hide_dock is true, and there are no side-effects on unrelated code paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/permissions.rs | Moves `should_hide_dock` read before the panel-window bail-early guard and gates the early return on both conditions, fixing dock visibility when "Always show dock icon" is enabled during recording. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(macos): respect hide\_dock\_icon setti..."](https://github.com/capsoftware/cap/commit/57a1359259c44856daff00248029d8828060491f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33786274)</sub>

<!-- /greptile_comment -->