### PR TITLE
fix(desktop): restore last confirmed capture area when reopening selector

### DIFF
--- a/apps/desktop/src/routes/capture-area.tsx
+++ b/apps/desktop/src/routes/capture-area.tsx
@@ -94,7 +94,7 @@ export default function CaptureArea() {
 	);
 	createEffect(() => {
 		const id = activeScreenId();
-		if (id && !screenId()) setScreenId(id);
+		if (id && !untrack(screenId)) setScreenId(id);
 	});
 
 	const hasStoredSelection = createMemo(() => {
@@ -312,11 +312,21 @@ export default function CaptureArea() {
 						snapToRatioEnabled={state.snapToRatio}
 						initialCrop={() => {
 							const id = screenId();
-							if (id)
-								return (
-									state.lastSelectedBounds?.find((m) => m.screenId === id)
-										?.bounds ?? CROP_ZERO
-								);
+							if (id) {
+								const stored = state.lastSelectedBounds?.find(
+									(m) => m.screenId === id,
+								)?.bounds;
+								if (stored) return stored;
+								const target = rawOptions.captureTarget;
+								if (target.variant === "area" && target.screen === id) {
+									return {
+										x: target.bounds.position.x,
+										y: target.bounds.position.y,
+										width: target.bounds.size.width,
+										height: target.bounds.size.height,
+									};
+								}
+							}
 							return CROP_ZERO;
 						}}
 						onContextMenu={(e) => showCropOptionsMenu(e, true)}

--- a/apps/desktop/src/routes/capture-area.tsx
+++ b/apps/desktop/src/routes/capture-area.tsx
@@ -8,7 +8,15 @@ import {
 	WebviewWindow,
 } from "@tauri-apps/api/webviewWindow";
 import { type as ostype } from "@tauri-apps/plugin-os";
-import { createMemo, createSignal, onCleanup, onMount, Show } from "solid-js";
+import {
+	createEffect,
+	createMemo,
+	createSignal,
+	onCleanup,
+	onMount,
+	Show,
+	untrack,
+} from "solid-js";
 import { createStore, reconcile } from "solid-js/store";
 import { Transition } from "solid-transition-group";
 import {
@@ -79,12 +87,21 @@ export default function CaptureArea() {
 		return null;
 	});
 
+	// Frozen on first non-null value (from synchronous localStorage load) so that
+	// later async Tauri-store updates carrying stale data cannot reset it.
+	const [screenId, setScreenId] = createSignal<string | null>(
+		untrack(activeScreenId),
+	);
+	createEffect(() => {
+		const id = activeScreenId();
+		if (id && !screenId()) setScreenId(id);
+	});
+
 	const hasStoredSelection = createMemo(() => {
-		const screenId = activeScreenId();
-		if (!screenId) return false;
+		const id = screenId();
+		if (!id) return false;
 		return (
-			state.lastSelectedBounds?.some((entry) => entry.screenId === screenId) ??
-			false
+			state.lastSelectedBounds?.some((entry) => entry.screenId === id) ?? false
 		);
 	});
 
@@ -97,22 +114,22 @@ export default function CaptureArea() {
 		)
 			return;
 
-		const screenId = activeScreenId();
-		if (!screenId) return;
+		const id = screenId();
+		if (!id) return;
 
 		const existingIndex = state.lastSelectedBounds?.findIndex(
-			(item) => item.screenId === screenId,
+			(item) => item.screenId === id,
 		);
 
 		if (existingIndex >= 0) {
 			setState("lastSelectedBounds", existingIndex, {
-				screenId,
+				screenId: id,
 				bounds: currentBounds,
 			});
 		} else {
 			setState("lastSelectedBounds", [
 				...state.lastSelectedBounds,
-				{ screenId, bounds: currentBounds },
+				{ screenId: id, bounds: currentBounds },
 			]);
 		}
 
@@ -121,7 +138,7 @@ export default function CaptureArea() {
 			"captureTarget",
 			reconcile({
 				variant: "area",
-				screen: screenId,
+				screen: id,
 				bounds: {
 					position: { x: b.x, y: b.y },
 					size: { width: b.width, height: b.height },
@@ -155,10 +172,10 @@ export default function CaptureArea() {
 		cropperRef?.reset();
 		setAspect(null);
 
-		const screenId = activeScreenId();
-		if (!screenId) return;
+		const id = screenId();
+		if (!id) return;
 		setState("lastSelectedBounds", (values) =>
-			values?.filter((v) => v.screenId !== screenId),
+			values?.filter((v) => v.screenId !== id),
 		);
 	}
 
@@ -294,10 +311,10 @@ export default function CaptureArea() {
 						onCropChange={setCrop}
 						snapToRatioEnabled={state.snapToRatio}
 						initialCrop={() => {
-							const screenId = activeScreenId();
-							if (screenId)
+							const id = screenId();
+							if (id)
 								return (
-									state.lastSelectedBounds?.find((m) => m.screenId === screenId)
+									state.lastSelectedBounds?.find((m) => m.screenId === id)
 										?.bounds ?? CROP_ZERO
 								);
 							return CROP_ZERO;

--- a/apps/desktop/src/routes/capture-area.tsx
+++ b/apps/desktop/src/routes/capture-area.tsx
@@ -72,11 +72,18 @@ export default function CaptureArea() {
 
 	const { rawOptions, setOptions } = createOptionsQuery();
 
-	const hasStoredSelection = createMemo(() => {
+	const activeScreenId = createMemo(() => {
 		const target = rawOptions.captureTarget;
-		if (target.variant !== "display") return false;
+		if (target.variant === "display") return target.id;
+		if (target.variant === "area") return target.screen;
+		return null;
+	});
+
+	const hasStoredSelection = createMemo(() => {
+		const screenId = activeScreenId();
+		if (!screenId) return false;
 		return (
-			state.lastSelectedBounds?.some((entry) => entry.screenId === target.id) ??
+			state.lastSelectedBounds?.some((entry) => entry.screenId === screenId) ??
 			false
 		);
 	});
@@ -90,22 +97,22 @@ export default function CaptureArea() {
 		)
 			return;
 
-		const target = rawOptions.captureTarget;
-		if (target.variant !== "display") return;
+		const screenId = activeScreenId();
+		if (!screenId) return;
 
 		const existingIndex = state.lastSelectedBounds?.findIndex(
-			(item) => item.screenId === target.id,
+			(item) => item.screenId === screenId,
 		);
 
 		if (existingIndex >= 0) {
 			setState("lastSelectedBounds", existingIndex, {
-				screenId: target.id,
+				screenId,
 				bounds: currentBounds,
 			});
 		} else {
 			setState("lastSelectedBounds", [
 				...state.lastSelectedBounds,
-				{ screenId: target.id, bounds: currentBounds },
+				{ screenId, bounds: currentBounds },
 			]);
 		}
 
@@ -114,7 +121,7 @@ export default function CaptureArea() {
 			"captureTarget",
 			reconcile({
 				variant: "area",
-				screen: target.id,
+				screen: screenId,
 				bounds: {
 					position: { x: b.x, y: b.y },
 					size: { width: b.width, height: b.height },
@@ -148,10 +155,10 @@ export default function CaptureArea() {
 		cropperRef?.reset();
 		setAspect(null);
 
-		const target = rawOptions.captureTarget;
-		if (target.variant !== "display") return;
+		const screenId = activeScreenId();
+		if (!screenId) return;
 		setState("lastSelectedBounds", (values) =>
-			values?.filter((v) => v.screenId !== target.id),
+			values?.filter((v) => v.screenId !== screenId),
 		);
 	}
 
@@ -287,12 +294,11 @@ export default function CaptureArea() {
 						onCropChange={setCrop}
 						snapToRatioEnabled={state.snapToRatio}
 						initialCrop={() => {
-							const target = rawOptions.captureTarget;
-							if (target.variant === "display")
+							const screenId = activeScreenId();
+							if (screenId)
 								return (
-									state.lastSelectedBounds?.find(
-										(m) => m.screenId === target.id,
-									)?.bounds ?? CROP_ZERO
+									state.lastSelectedBounds?.find((m) => m.screenId === screenId)
+										?.bounds ?? CROP_ZERO
 								);
 							return CROP_ZERO;
 						}}

--- a/apps/desktop/src/routes/capture-area.tsx
+++ b/apps/desktop/src/routes/capture-area.tsx
@@ -8,15 +8,7 @@ import {
 	WebviewWindow,
 } from "@tauri-apps/api/webviewWindow";
 import { type as ostype } from "@tauri-apps/plugin-os";
-import {
-	createEffect,
-	createMemo,
-	createSignal,
-	onCleanup,
-	onMount,
-	Show,
-	untrack,
-} from "solid-js";
+import { createMemo, createSignal, onCleanup, onMount, Show } from "solid-js";
 import { createStore, reconcile } from "solid-js/store";
 import { Transition } from "solid-transition-group";
 import {
@@ -87,19 +79,12 @@ export default function CaptureArea() {
 		return null;
 	});
 
-	// Frozen on first non-null value (from synchronous localStorage load) so that
-	// later async Tauri-store updates carrying stale data cannot reset it.
-	const [screenId, setScreenId] = createSignal<string | null>(
-		untrack(activeScreenId),
-	);
-	createEffect(() => {
-		const id = activeScreenId();
-		if (id && !untrack(screenId)) setScreenId(id);
-	});
+	const screenId = activeScreenId;
 
 	const hasStoredSelection = createMemo(() => {
 		const id = screenId();
 		if (!id) return false;
+		if (rawOptions.captureTarget.variant === "area") return true;
 		return (
 			state.lastSelectedBounds?.some((entry) => entry.screenId === id) ?? false
 		);

--- a/apps/desktop/src/routes/capture-area.tsx
+++ b/apps/desktop/src/routes/capture-area.tsx
@@ -317,22 +317,25 @@ export default function CaptureArea() {
 						snapToRatioEnabled={state.snapToRatio}
 						initialCrop={() => {
 							const id = screenId();
-							if (id) {
-								const stored = state.lastSelectedBounds?.find(
-									(m) => m.screenId === id,
-								)?.bounds;
-								if (stored) return stored;
-								const target = rawOptions.captureTarget;
-								if (target.variant === "area" && target.screen === id) {
+							if (!id) return CROP_ZERO;
+
+							const target = rawOptions.captureTarget;
+							if (target.variant === "area" && target.screen === id) {
+								const { width, height } = target.bounds.size;
+								if (width > 1 && height > 1) {
 									return {
 										x: target.bounds.position.x,
 										y: target.bounds.position.y,
-										width: target.bounds.size.width,
-										height: target.bounds.size.height,
+										width,
+										height,
 									};
 								}
 							}
-							return CROP_ZERO;
+
+							return (
+								state.lastSelectedBounds?.find((m) => m.screenId === id)
+									?.bounds ?? CROP_ZERO
+							);
 						}}
 						onContextMenu={(e) => showCropOptionsMenu(e, true)}
 					/>

--- a/apps/desktop/src/routes/capture-area.tsx
+++ b/apps/desktop/src/routes/capture-area.tsx
@@ -167,6 +167,21 @@ export default function CaptureArea() {
 		setState("lastSelectedBounds", (values) =>
 			values?.filter((v) => v.screenId !== id),
 		);
+
+		const target = rawOptions.captureTarget;
+		if (target.variant === "area" && target.screen === id) {
+			setOptions(
+				"captureTarget",
+				reconcile({
+					variant: "area",
+					screen: id,
+					bounds: {
+						position: { x: 0, y: 0 },
+						size: { width: 0, height: 0 },
+					},
+				}),
+			);
+		}
 	}
 
 	async function showCropOptionsMenu(e: UIEvent, positionAtCursor = false) {

--- a/apps/desktop/src/routes/capture-area.tsx
+++ b/apps/desktop/src/routes/capture-area.tsx
@@ -84,7 +84,10 @@ export default function CaptureArea() {
 	const hasStoredSelection = createMemo(() => {
 		const id = screenId();
 		if (!id) return false;
-		if (rawOptions.captureTarget.variant === "area") return true;
+		const target = rawOptions.captureTarget;
+		if (target.variant === "area" && target.screen === id) {
+			return target.bounds.size.width > 1 && target.bounds.size.height > 1;
+		}
 		return (
 			state.lastSelectedBounds?.some((entry) => entry.screenId === id) ?? false
 		);

--- a/apps/desktop/src/routes/capture-area.tsx
+++ b/apps/desktop/src/routes/capture-area.tsx
@@ -84,13 +84,15 @@ export default function CaptureArea() {
 	const hasStoredSelection = createMemo(() => {
 		const id = screenId();
 		if (!id) return false;
+
+		if (state.lastSelectedBounds?.some((entry) => entry.screenId === id))
+			return true;
+
 		const target = rawOptions.captureTarget;
 		if (target.variant === "area" && target.screen === id) {
 			return target.bounds.size.width > 1 && target.bounds.size.height > 1;
 		}
-		return (
-			state.lastSelectedBounds?.some((entry) => entry.screenId === id) ?? false
-		);
+		return false;
 	});
 
 	async function handleConfirm() {

--- a/apps/desktop/src/routes/capture-area.tsx
+++ b/apps/desktop/src/routes/capture-area.tsx
@@ -159,7 +159,6 @@ export default function CaptureArea() {
 	const [aspect, setAspect] = createSignal<Ratio | null>(null);
 
 	function reset() {
-		cropperRef?.reset();
 		setAspect(null);
 
 		const id = screenId();
@@ -170,18 +169,10 @@ export default function CaptureArea() {
 
 		const target = rawOptions.captureTarget;
 		if (target.variant === "area" && target.screen === id) {
-			setOptions(
-				"captureTarget",
-				reconcile({
-					variant: "area",
-					screen: id,
-					bounds: {
-						position: { x: 0, y: 0 },
-						size: { width: 0, height: 0 },
-					},
-				}),
-			);
+			setOptions("captureTarget", reconcile({ variant: "display", id }));
 		}
+
+		cropperRef?.reset();
 	}
 
 	async function showCropOptionsMenu(e: UIEvent, positionAtCursor = false) {

--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -234,6 +234,25 @@ function Inner() {
 		CropBounds | undefined
 	>(undefined);
 
+	const effectiveInitialBounds = createMemo<CropBounds | undefined>(() => {
+		const explicit = initialAreaBounds();
+		if (explicit !== undefined) return explicit;
+		const target = options.captureTarget;
+		if (
+			target.variant === "area" &&
+			params.displayId &&
+			target.screen === params.displayId
+		) {
+			return {
+				x: target.bounds.position.x,
+				y: target.bounds.position.y,
+				width: target.bounds.size.width,
+				height: target.bounds.size.height,
+			};
+		}
+		return undefined;
+	});
+
 	createEffect(() => {
 		const target = options.captureTarget;
 		if (
@@ -725,7 +744,7 @@ function Inner() {
 						() => isInteracting() || isActiveDisplay(),
 					);
 					const shouldShowSelectionHint = createMemo(() => {
-						if (initialAreaBounds() !== undefined) return false;
+						if (effectiveInitialBounds() !== undefined) return false;
 						if (!isActiveDisplay()) return false;
 						const bounds = crop();
 						return bounds.width <= 1 && bounds.height <= 1 && !isInteracting();
@@ -1146,7 +1165,7 @@ function Inner() {
 								ref={cropperRef}
 								onInteraction={setIsInteracting}
 								onCropChange={setCrop}
-								initialCrop={() => initialAreaBounds() ?? CROP_ZERO}
+								initialCrop={() => effectiveInitialBounds() ?? CROP_ZERO}
 								showBounds={isValid()}
 								aspectRatio={aspect() ?? undefined}
 								snapToRatioEnabled={snapToRatioEnabled()}

--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -243,11 +243,13 @@ function Inner() {
 			params.displayId &&
 			target.screen === params.displayId
 		) {
+			const { width, height } = target.bounds.size;
+			if (width <= 1 || height <= 1) return undefined;
 			return {
 				x: target.bounds.position.x,
 				y: target.bounds.position.y,
-				width: target.bounds.size.width,
-				height: target.bounds.size.height,
+				width,
+				height,
 			};
 		}
 		return undefined;


### PR DESCRIPTION
## Problem
When a user had previously selected a capture area and reopened the area selector, it always started blank, forcing them to redraw their selection every time. 
This was reported by multiple users in the community.

The root cause was in `target-select-overlay.tsx`: `initialAreaBounds` (which seeds the Cropper's starting position) was always initialized to `undefined`, even when an existing area target was already set.

## Solution
Added an `effectiveInitialBounds` memo that falls back to the current `captureTarget` area bounds when no explicit `initialAreaBounds` is set. 
Both `initialCrop` and `shouldShowSelectionHint` now use this memo, so:
- Opening the selector with a previously confirmed area pre-loads those bounds
- The "draw a selection" hint is suppressed when bounds are available
- Re-entering area mode within the same session also restores correctly

Also fixed `capture-area.tsx` (the alternate area selection flow) with the same pattern, `activeScreenId` now handles both `"display"` and `"area"` capture target variants.

## Test Plan
- [x] Confirm a capture area → reopen selector → previous selection is pre-loaded ✓
- [x] Adjust the pre-loaded area → close → reopen → shows updated bounds ✓
- [x] Switch to display mode and back to area mode within same session → bounds restored ✓
- [x] First-time use (no previous area) → blank selector with draw hint ✓

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores previously confirmed capture-area bounds when the area selector is reopened, fixing a UX regression where users had to redraw their selection every time. Both the standalone `capture-area.tsx` window and the `target-select-overlay.tsx` overlay are updated to fall back to `options.captureTarget.bounds` when no in-session bounds are stored.

- `target-select-overlay.tsx`: new `effectiveInitialBounds` memo reads `options.captureTarget` when `initialAreaBounds` is unset, wired to both `initialCrop` and `shouldShowSelectionHint`.
- `capture-area.tsx`: new `activeScreenId` memo handles both `"display"` and `"area"` target variants; `initialCrop` and `hasStoredSelection` gain the same `captureTarget` fallback.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the overlay flow; the standalone capture-area window has an incomplete reset that lets old bounds reappear after the user explicitly clears the selection.

The reset() function in capture-area.tsx clears lastSelectedBounds but leaves rawOptions.captureTarget untouched. Because hasStoredSelection and initialCrop now fall back to captureTarget, the reset is visually effective in the current session but the cleared state does not persist — the old area bounds reappear the next time the selector window opens.

apps/desktop/src/routes/capture-area.tsx — specifically the reset() function and how it interacts with the new captureTarget fallback logic.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/capture-area.tsx | Adds `activeScreenId` memo to support both "display" and "area" capture target variants, and falls back to `captureTarget.bounds` when `lastSelectedBounds` is empty — but `reset()` only clears `lastSelectedBounds`, leaving `captureTarget` intact so the fallback still supplies the old bounds on next open. |
| apps/desktop/src/routes/target-select-overlay.tsx | Adds `effectiveInitialBounds` memo that seeds the Cropper from `options.captureTarget` when no explicit `initialAreaBounds` is set; wires it to `initialCrop` and `shouldShowSelectionHint`. Logic is correct and consistent with the existing `initialAreaBounds` signal flow. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(desktop): check lastSelectedBounds b..."](https://github.com/capsoftware/cap/commit/4de6f6dccec308ba9a706d23b30fadda8b69bcc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33957577)</sub>

<!-- /greptile_comment -->