### PR TITLE
fix(macos): fix chipmunk audio on 96 kHz mics (2× duration bug)

### DIFF
--- a/crates/recording/src/feeds/microphone.rs
+++ b/crates/recording/src/feeds/microphone.rs
@@ -362,7 +362,12 @@ fn get_usable_device(
 ) -> Option<(String, Device, SupportedStreamConfig)> {
     let device_name_for_logging = device.name().ok();
 
-    let preferred_rate = cpal::SampleRate(48_000);
+    let native_rate = device
+        .default_input_config()
+        .ok()
+        .map(|c| c.sample_rate().0)
+        .unwrap_or(48_000);
+    let preferred_rate = cpal::SampleRate(native_rate);
 
     let result = device
         .supported_input_configs()


### PR DESCRIPTION
## Problem

On M-series Macs (confirmed M4 Pro) with a built-in mic running at 96 kHz natively, recordings produce `audio-input.ogg` at exactly 2× the video duration, causing chipmunk-speed playback starting ~8–9 seconds in. 
Affects both the editor and exported MP4.

Root cause: 
`get_usable_device` hardcoded `preferred_rate = 48_000` Hz. CPAL's CoreAudio backend opened the stream at 48 kHz but the hardware delivered 96 kHz samples. 
Because `callback_sample_rate` was set from the requested config (48 kHz), not the actual data rate, the resampler was skipped (`target_matches_source = true`) and raw 96 kHz bytes were stamped with a 48 kHz header, doubling the file duration.

## Fix

Read the device's current nominal sample rate via `default_input_config()` and use that as `preferred_rate`. 
When the hardware is at 96 kHz, the stream opens at 96 kHz, `callback_sample_rate` correctly reflects the actual data, and the existing resampler in `sources/microphone.rs` converts 96 kHz → 48 kHz as intended.


## Reported by

mordechai (Discord), audio-input.ogg - 605s vs video - 306s, (almost 2×) on M4 Pro / Sequoia.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a 2× audio duration bug on M-series Macs where microphones native to 96 kHz caused `audio-input.ogg` to be written with a 48 kHz header, making audio play at chipmunk speed. The fix queries `default_input_config()` to obtain the device's actual nominal sample rate and uses that as `preferred_rate`, so the stream opens at the real hardware rate and the existing FFmpeg resampler in `sources/microphone.rs` correctly converts it down to 48 kHz.

- **`get_usable_device` in `feeds/microphone.rs`**: replaces the hardcoded `preferred_rate = 48_000` with a lookup of the device's native rate via `default_input_config()`, falling back to 48 kHz on error.
- **`sources/microphone.rs`** (unchanged): already has a rate-agnostic FFmpeg resampler and new downsampling tests (96 kHz → 48 kHz) that validate the fix end-to-end.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is minimal and targeted, with a well-understood fallback to 48 kHz when the device query fails.

The one-line logical change is backed by the existing resampler that already handles arbitrary rate conversion (validated by the new 96→48 kHz downsampling test). The only finding is a slightly inaccurate inline comment describing when the bug manifests.

No files require special attention beyond the minor comment wording in `get_usable_device`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/recording/src/feeds/microphone.rs | Replaces the hardcoded 48 kHz preferred rate with the device's own default input config rate, preventing CoreAudio from silently delivering 96 kHz data labelled as 48 kHz. Logic and fallback are sound; one minor comment inaccuracy noted. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
crates/recording/src/feeds/microphone.rs:365-368
The parenthetical "when another client has the device open" describes an incidental condition but isn't the root cause. The bug reproduces on the built-in mic regardless of other clients — it's simply that M-series hardware runs natively at 96 kHz. Removing the parenthetical makes the comment more accurate and avoids confusing future readers who can't reproduce it "when another client has the device open".

```suggestion
    // Use the device's current nominal rate so CoreAudio never silently delivers data at a
    // different rate than what was configured (M-series Macs whose mic runs natively at 96 kHz
    // are a known case). The resampler in sources/microphone.rs always converts the captured
    // rate down to 48 kHz, so opening at the hardware rate is safe.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(macos): open mic stream at hardware ..."](https://github.com/capsoftware/cap/commit/0b683284e305e4fa5e47dba90e11598c35b7d27c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34405887)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->