### PR TITLE
fix(proxy): allow /.well-known/* and /embed/* on self-hosted

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -51,7 +51,8 @@ export async function proxy(request: NextRequest) {
 				path.startsWith("/download") ||
 				path.startsWith("/terms") ||
 				path.startsWith("/verify-otp") ||
-				path.startsWith("/.well-known/")
+				path.startsWith("/.well-known/") ||
+				path.startsWith("/embed/")
 			) &&
 			process.env.NODE_ENV !== "development"
 		)

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -51,7 +51,7 @@ export async function proxy(request: NextRequest) {
 				path.startsWith("/download") ||
 				path.startsWith("/terms") ||
 				path.startsWith("/verify-otp") ||
-				path.startsWith("/.well-known/") ||
+				path.startsWith("/.well-known/workflow/") ||
 				path.startsWith("/embed/")
 			) &&
 			process.env.NODE_ENV !== "development"

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -50,7 +50,8 @@ export async function proxy(request: NextRequest) {
 				path.startsWith("/self-hosting") ||
 				path.startsWith("/download") ||
 				path.startsWith("/terms") ||
-				path.startsWith("/verify-otp")
+				path.startsWith("/verify-otp") ||
+				path.startsWith("/.well-known/")
 			) &&
 			process.env.NODE_ENV !== "development"
 		)


### PR DESCRIPTION
## Summary

- Two-line fix: add `/.well-known/` and `/embed/` to the self-host proxy whitelist.
- Restores all workflow execution on self-hosted Cap (transcription, AI generation, etc.) and fixes broken iframe embeds.

## Root cause

`apps/web/proxy.ts:40-58` redirects every path not in an allow-list to `/login` when `NEXT_PUBLIC_IS_CAP !== "true"` (i.e., self-hosted builds). `/.well-known/` and `/embed/` were both missing from that list.

### `/.well-known/` (workflows broken)

The Vercel Workflows runtime that Cap uses (`apps/web/app/.well-known/workflow/v1/{step,flow,webhook}/route.js`) dispatches workflow steps by issuing HTTP requests back to itself at those routes. On self-host, those requests get a 307 → `/login`, so workflows are enqueued but never run.

Visible symptom: `transcribeVideo()` is called and logs `[transcribeVideo] Triggering transcription workflow…`, but no subsequent `[transcribe]` step lines ever appear, no Deepgram/Whisper request is made, and `videos.transcriptionStatus` stays `NULL` forever. Same for `aiGenerationStatus`.

### `/embed/` (iframe embeds broken)

`<iframe src=".../embed/...">` embeds on self-hosted instances load the login page instead of the embedded video, because the embed route also fails the proxy whitelist check.

## Fix

```ts
// apps/web/proxy.ts
path.startsWith("/verify-otp") ||
path.startsWith("/.well-known/") ||  // ← added (commit 1)
path.startsWith("/embed/")           // ← added (commit 2)
```

That's it. The matcher in `config.matcher` already excludes `_next/*` etc., and both prefixes are scoped to existing app routes, so widening is safe.

## Verification

Reproduced on a local Docker Compose self-host (`docker-compose.yml`).

**Before this patch**
- `curl http://localhost:3000/.well-known/workflow/v1/manifest.json` returns the Next.js HTML shell (the redirect-to-login response).
- Uploading a video, then triggering transcription via the share page or `POST /api/videos/:id/retry-transcription`, leaves `transcriptionStatus = NULL` forever.

**After this patch**
- Same `curl` returns the workflow manifest JSON (correct route).
- Share-page render fires `transcribeVideo()`; the workflow runs end-to-end: audio extraction → transcription provider → `transcription.vtt` written to S3 → `transcriptionStatus = COMPLETE`. AI generation then runs and writes `metadata.summary` + `metadata.chapters`.

## Related

- Fixes #1774 (`/.well-known/`)
- Fixes #1768 (`/embed/`)
- Root cause behind #1356 and #1550 (self-host transcription/AI never runs)
- May transitively address #1773 (self-host captions toggle), since captions depend on the transcription pipeline running. Not independently verified.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Two-line whitelist addition to the self-hosted proxy gate in `proxy.ts`, restoring `/.well-known/` workflow callbacks and `/embed/` iframe routes that were incorrectly redirected to `/login`.

- `/.well-known/` allows the Vercel Workflows runtime to call back to its own step/flow/webhook routes without being bounced; without this, transcription and AI generation workflows are silently enqueued but never execute.
- `/embed/` allows unauthenticated access to embedded video player routes, which is the correct behaviour for public embeds on self-hosted instances.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix is minimal, targeted, and correctly scoped to routes that must be publicly reachable on self-hosted deployments.

The change is two lines in one file and the logic is easy to verify against the described failure. The only open question is whether the `/.well-known/workflow/v1/webhook` handler validates Vercel's request signature independently, since prefix matching now makes the entire `/.well-known/` tree reachable without the proxy auth check.

The workflow route handlers under `apps/web/app/.well-known/workflow/v1/` are worth a quick glance to confirm they verify the incoming request signature before acting.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/proxy.ts | Adds `/.well-known/` and `/embed/` to the self-host proxy auth bypass list; straightforward fix with prefix-match breadth worth noting |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/proxy.ts:54-55
**Broad bypass scope for future routes**

Both new entries use prefix matching, so every future route added under `/.well-known/` (including any webhook handler) and `/embed/` will automatically bypass the self-host auth redirect — with no indication at the call site that this is happening. The `/.well-known/workflow/v1/webhook` route in particular is publicly reachable as a result; its safety depends entirely on Vercel Workflow's own request-signing, which isn't visible here. Worth confirming the webhook handler validates the signature before relying on this being safe.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(proxy): allow /embed/\* on self-hoste..."](https://github.com/capsoftware/cap/commit/5a3ea5c4b96d3f95c4288bd9407747474689f694) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34750272)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->