### PR TITLE
Fix contributor guide setup details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 Cap is an open source and privacy focused alternative to Loom. It's a video messaging tool that allows you to record, edit and share videos in seconds.
 
-The development of Cap is still in its early stages, so please bare with us as we build out this guide.
+The development of Cap is still in its early stages, so please bear with us as we build out this guide.
 
 ### What is this guide?
 
@@ -20,7 +20,7 @@ There are many ways to contribute to Cap. You can:
 - [Suggest a feature (via Discord)](https://discord.com/invite/y8gdQ3WRN3)
 - Submit a PR
 
-## Runing Cap
+## Running Cap
 
 ### Development Requirements
 
@@ -28,7 +28,7 @@ Before anything else, make sure you have the following installed:
 
 - Node Version 20+
 - Rust 1.88.0+
-- pnpm 8.10.5+
+- pnpm 10.5.2+
 - Docker ([OrbStack](https://orbstack.dev/) recommended)
 
 ### General Setup
@@ -36,7 +36,7 @@ Before anything else, make sure you have the following installed:
 Run `pnpm install`, then run `pnpm cap-setup` to install native dependencies such as FFmpeg.
 
 On Windows, llvm, clang, and VCPKG must be installed.
-On MacOS, cmake must be installed.
+On macOS, cmake must be installed.
 `pnpm cap-setup` does not yet install these dependencies for you.
 
 Run `pnpm env-setup` to generate a `.env` file configured for your environment.
@@ -61,4 +61,4 @@ and `%programfiles%/so.cap.desktop.dev/recordings` on Windows.
 ### `@cap/web` (cap.so website)
 
 When running `pnpm dev` or `pnpm dev:web`, a MySQL database and MinIO S3 server will also be using Docker.
-If you want to _only_ run the `@cap/web` NextJS app, `cd` into `./apps/web` and run `pnpm dev`.
+If you want to _only_ run the `@cap/web` Next.js app, `cd` into `./apps/web` and run `pnpm dev`.


### PR DESCRIPTION
## Summary

Updates the contributor guide with a few small correctness fixes:

- Fixes typos in the intro and running section heading.
- Updates the documented pnpm requirement to match the repository `packageManager` value (`pnpm@10.5.2`).
- Uses the standard `macOS` and `Next.js` names.

## Validation

- `git diff --check`
- `corepack.cmd pnpm --version` returned `10.5.2`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes five small editorial corrections to `CONTRIBUTING.md`, all of which are accurate and consistent with the repository's actual configuration.

- Fixes two typos: \"bare with us\" → \"bear with us\" and \"Runing Cap\" → \"Running Cap\".
- Updates the documented pnpm requirement from `8.10.5+` to `10.5.2+`, which exactly matches the `\"packageManager\": \"pnpm@10.5.2\"` field in the root `package.json`.
- Corrects the casing of \"MacOS\" → \"macOS\" and \"NextJS\" → \"Next.js\" to match their official brand names.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no runtime impact; all factual claims were verified against the repository.

Every changed value was checked: the pnpm version matches the root packageManager field, and the remaining edits are straightforward spelling and branding corrections with no ambiguity.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CONTRIBUTING.md | Five small correctness fixes: two typos ("bare"→"bear", "Runing"→"Running"), pnpm version updated from 8.10.5+ to 10.5.2+ (matches root packageManager field), "MacOS"→"macOS", and "NextJS"→"Next.js" |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix contributor guide setup details"](https://github.com/capsoftware/cap/commit/6063a570821e5b860872905e273f1fa9dc3a746d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34767213)</sub>

<!-- /greptile_comment -->