### PR TITLE
fix: keep transcript button/back button visible when panel is open

### DIFF
--- a/apps/desktop/src/routes/editor/Header.tsx
+++ b/apps/desktop/src/routes/editor/Header.tsx
@@ -435,7 +435,7 @@ export function Header() {
 						</Show>
 					</div>
 				</Show>
-				<Show when={hasTranscript()}>
+				<Show when={hasTranscript() || isTranscriptOpen()}>
 					<Button
 						variant={isTranscriptOpen() ? "white" : "gray"}
 						class="flex gap-1.5 justify-center h-[40px]"


### PR DESCRIPTION
Allows the user to close the transcript panel even if the caption track has been removed.

Reason: This ensures that when the transcript panel is open, the button remains visible (as "Back") so the user can close the panel, even if the transcript segments themselves have just been deleted.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a case where the transcript panel could get "stuck" open — if the caption track was removed while the transcript panel was open, the button to close it would disappear because its visibility was gated solely on `hasTranscript()`. The fix adds `|| isTranscriptOpen()` so the button remains visible whenever the panel itself is open.

- The `Show` guard on the transcript/back button is widened to `hasTranscript() || isTranscriptOpen()`, ensuring the close path is always reachable.
- The existing `onClick` logic already handles both the open and closed states correctly, so no further changes are needed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line guard fix with no side effects on other code paths.

The fix is minimal and surgical: it widens a single reactive condition so the transcript close button stays visible when captions are removed mid-session. The button's internal click handler already correctly branches on `isTranscriptOpen()`, so no additional changes are needed and no existing paths are disrupted.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/editor/Header.tsx | Single-condition guard on the transcript button expanded from `hasTranscript()` to `hasTranscript() || isTranscriptOpen()`, correctly keeping the close/back button visible when captions are removed while the panel is open. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep transcript button/back button ..."](https://github.com/capsoftware/cap/commit/4a51b6c10cbcad1383dfa5fa4e5aec9bf495b067) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34886439)</sub>

<!-- /greptile_comment -->