### PR TITLE
fix(web): initialize caption tracks after load

### DIFF
--- a/apps/web/__tests__/unit/caption-tracks.test.ts
+++ b/apps/web/__tests__/unit/caption-tracks.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { bindCaptionTrackCueText } from "@/app/s/[videoId]/_components/caption-tracks";
+
+type Listener = () => void;
+
+class FakeEventTarget {
+	private listeners = new Map<string, Set<Listener>>();
+
+	addEventListener(type: string, listener: Listener): void {
+		const listeners = this.listeners.get(type) ?? new Set<Listener>();
+		listeners.add(listener);
+		this.listeners.set(type, listeners);
+	}
+
+	removeEventListener(type: string, listener: Listener): void {
+		this.listeners.get(type)?.delete(listener);
+	}
+
+	dispatch(type: string): void {
+		for (const listener of this.listeners.get(type) ?? []) {
+			listener();
+		}
+	}
+}
+
+class FakeTextTrack extends FakeEventTarget {
+	mode: TextTrackMode = "disabled";
+
+	constructor(
+		readonly kind: TextTrackKind,
+		readonly activeCues: TextTrackCueList | null,
+	) {
+		super();
+	}
+}
+
+class FakeTextTrackList extends FakeEventTarget {
+	private tracks: FakeTextTrack[] = [];
+
+	get length(): number {
+		return this.tracks.length;
+	}
+
+	addSilently(track: FakeTextTrack): void {
+		this.tracks.push(track);
+		(this as unknown as Record<number, FakeTextTrack>)[this.tracks.length - 1] =
+			track;
+	}
+}
+
+class FakeTrackElement extends FakeEventTarget {
+	readyState = 0;
+}
+
+class FakeVideo extends FakeEventTarget {
+	constructor(
+		readonly textTracks: FakeTextTrackList,
+		private trackElements: FakeTrackElement[],
+	) {
+		super();
+	}
+
+	querySelectorAll(selector: string): FakeTrackElement[] {
+		return selector === "track" ? this.trackElements : [];
+	}
+}
+
+function createCueList(text: string): TextTrackCueList {
+	return {
+		length: 1,
+		item: () => ({ startTime: 1, text }),
+		getCueById: () => null,
+	} as unknown as TextTrackCueList;
+}
+
+function createVideo(
+	textTracks: FakeTextTrackList,
+	trackElements: FakeTrackElement[],
+): HTMLVideoElement {
+	return new FakeVideo(
+		textTracks,
+		trackElements,
+	) as unknown as HTMLVideoElement;
+}
+
+describe("bindCaptionTrackCueText", () => {
+	it("initializes caption cues when a track element loads after metadata", () => {
+		const textTracks = new FakeTextTrackList();
+		const trackElement = new FakeTrackElement();
+		const video = createVideo(textTracks, [trackElement]);
+		const captionTrack = new FakeTextTrack(
+			"captions",
+			createCueList("Loaded caption"),
+		);
+		const cueTexts: string[] = [];
+
+		const cleanup = bindCaptionTrackCueText(video, (text) => {
+			cueTexts.push(text);
+		});
+
+		video.dispatch("loadedmetadata");
+		textTracks.addSilently(captionTrack);
+		trackElement.readyState = 2;
+		trackElement.dispatch("load");
+		captionTrack.dispatch("cuechange");
+
+		expect(captionTrack.mode).toBe("hidden");
+		expect(cueTexts.at(-1)).toBe("Loaded caption");
+
+		cleanup();
+	});
+});

--- a/apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx
+++ b/apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx
@@ -13,7 +13,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { retryVideoProcessing } from "@/actions/video/retry-processing";
 import CommentStamp from "./CommentStamp";
-import { getActiveCaptionText } from "./caption-cues";
+import { bindCaptionTrackCueText } from "./caption-tracks";
 import {
 	AVC_LEVEL_IOS_HARDWARE_CEILING,
 	createLevelPatchedMp4ObjectUrl,
@@ -407,35 +407,7 @@ export function CapVideoPlayer({
 			setHasError(true);
 		};
 
-		let captionTrack: TextTrack | null = null;
-
-		const handleCueChange = (): void => {
-			setCurrentCue(getActiveCaptionText(captionTrack?.activeCues));
-		};
-
-		const setupTracks = (): void => {
-			const tracks = Array.from(video.textTracks);
-
-			for (const track of tracks) {
-				if (track.kind === "captions" || track.kind === "subtitles") {
-					captionTrack = track;
-					track.mode = "hidden";
-					track.addEventListener("cuechange", handleCueChange);
-					break;
-				}
-			}
-		};
-
-		const ensureTracksHidden = (): void => {
-			const tracks = Array.from(video.textTracks);
-			for (const track of tracks) {
-				if (track.kind === "captions" || track.kind === "subtitles") {
-					if (track.mode !== "hidden") {
-						track.mode = "hidden";
-					}
-				}
-			}
-		};
+		const cleanupCaptionTracks = bindCaptionTrackCueText(video, setCurrentCue);
 
 		const handleLoadedMetadataWithTracks = () => {
 			setVideoLoaded(true);
@@ -443,12 +415,6 @@ export function CapVideoPlayer({
 			if (!hasPlayedOnce) {
 				setShowPlayButton(true);
 			}
-			setupTracks();
-		};
-
-		const handleTrackChange = () => {
-			ensureTracksHidden();
-			setupTracks();
 		};
 
 		video.addEventListener("loadeddata", handleLoadedData);
@@ -456,10 +422,6 @@ export function CapVideoPlayer({
 		video.addEventListener("loadedmetadata", handleLoadedMetadataWithTracks);
 		video.addEventListener("play", handlePlay);
 		video.addEventListener("error", handleError as EventListener);
-
-		video.textTracks.addEventListener("change", handleTrackChange);
-		video.textTracks.addEventListener("addtrack", handleTrackChange);
-		video.textTracks.addEventListener("removetrack", handleTrackChange);
 
 		if (video.readyState === 4) {
 			handleLoadedData();
@@ -474,12 +436,7 @@ export function CapVideoPlayer({
 				"loadedmetadata",
 				handleLoadedMetadataWithTracks,
 			);
-			video.textTracks.removeEventListener("change", handleTrackChange);
-			video.textTracks.removeEventListener("addtrack", handleTrackChange);
-			video.textTracks.removeEventListener("removetrack", handleTrackChange);
-			if (captionTrack) {
-				captionTrack.removeEventListener("cuechange", handleCueChange);
-			}
+			cleanupCaptionTracks();
 		};
 	}, [
 		hasPlayedOnce,

--- a/apps/web/app/s/[videoId]/_components/HLSVideoPlayer.tsx
+++ b/apps/web/app/s/[videoId]/_components/HLSVideoPlayer.tsx
@@ -14,7 +14,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { retryVideoProcessing } from "@/actions/video/retry-processing";
-import { getActiveCaptionText } from "./caption-cues";
+import { bindCaptionTrackCueText } from "./caption-tracks";
 import {
 	canRetryFailedProcessing,
 	getUploadFailureMessage,
@@ -463,71 +463,7 @@ export function HLSVideoPlayer({
 			return;
 		}
 
-		let captionTrack: TextTrack | null = null;
-
-		const handleCueChange = (): void => {
-			setCurrentCue(getActiveCaptionText(captionTrack?.activeCues));
-		};
-
-		const setupTracks = (): void => {
-			const tracks = video.textTracks;
-			for (let i = 0; i < tracks.length; i++) {
-				const track = tracks[i];
-				if (
-					track &&
-					(track.kind === "captions" || track.kind === "subtitles")
-				) {
-					captionTrack = track;
-					track.mode = "hidden";
-					track.addEventListener("cuechange", handleCueChange);
-					break;
-				}
-			}
-		};
-
-		const ensureTracksHidden = (): void => {
-			const tracks = video.textTracks;
-			for (let i = 0; i < tracks.length; i++) {
-				const track = tracks[i];
-				if (
-					track &&
-					(track.kind === "captions" || track.kind === "subtitles")
-				) {
-					if (track.mode !== "hidden") {
-						track.mode = "hidden";
-					}
-				}
-			}
-		};
-
-		const handleLoadedMetadata = (): void => {
-			setupTracks();
-		};
-
-		const handleTrackChange = () => {
-			ensureTracksHidden();
-			setupTracks();
-		};
-
-		video.addEventListener("loadedmetadata", handleLoadedMetadata);
-
-		video.textTracks.addEventListener("change", handleTrackChange);
-		video.textTracks.addEventListener("addtrack", handleTrackChange);
-		video.textTracks.addEventListener("removetrack", handleTrackChange);
-
-		if (video.readyState >= 1) {
-			setupTracks();
-		}
-
-		return () => {
-			video.removeEventListener("loadedmetadata", handleLoadedMetadata);
-			video.textTracks.removeEventListener("change", handleTrackChange);
-			video.textTracks.removeEventListener("addtrack", handleTrackChange);
-			video.textTracks.removeEventListener("removetrack", handleTrackChange);
-			if (captionTrack) {
-				captionTrack.removeEventListener("cuechange", handleCueChange);
-			}
-		};
+		return bindCaptionTrackCueText(video, setCurrentCue);
 	}, [captionsSrc, videoRef.current]);
 
 	const isErrorWhileHlsLoading =

--- a/apps/web/app/s/[videoId]/_components/caption-tracks.ts
+++ b/apps/web/app/s/[videoId]/_components/caption-tracks.ts
@@ -1,0 +1,112 @@
+import { getActiveCaptionText } from "./caption-cues";
+
+const loadedTrackReadyState = 2;
+
+function isCaptionTextTrack(
+	track: TextTrack | null | undefined,
+): track is TextTrack {
+	return track?.kind === "captions" || track?.kind === "subtitles";
+}
+
+function getTextTracks(video: HTMLVideoElement): TextTrack[] {
+	const tracks: TextTrack[] = [];
+
+	for (let index = 0; index < video.textTracks.length; index++) {
+		const track = video.textTracks[index];
+		if (track) tracks.push(track);
+	}
+
+	return tracks;
+}
+
+export function bindCaptionTrackCueText(
+	video: HTMLVideoElement,
+	onCueTextChange: (text: string) => void,
+): () => void {
+	let currentTrack: TextTrack | null = null;
+	const cueTracks = new Set<TextTrack>();
+	const trackLoadHandlers = new Map<HTMLTrackElement, () => void>();
+
+	const updateCueText = (): void => {
+		onCueTextChange(getActiveCaptionText(currentTrack?.activeCues));
+	};
+
+	const syncTracks = (): void => {
+		const tracks = getTextTracks(video);
+
+		for (const track of cueTracks) {
+			if (!tracks.includes(track)) {
+				track.removeEventListener("cuechange", updateCueText);
+				cueTracks.delete(track);
+			}
+		}
+
+		currentTrack = null;
+
+		for (const track of tracks) {
+			if (!isCaptionTextTrack(track)) continue;
+
+			if (!currentTrack) currentTrack = track;
+			if (track.mode !== "hidden") track.mode = "hidden";
+
+			if (!cueTracks.has(track)) {
+				track.addEventListener("cuechange", updateCueText);
+				cueTracks.add(track);
+			}
+		}
+
+		updateCueText();
+	};
+
+	const bindTrackElementLoads = (): void => {
+		for (const trackElement of video.querySelectorAll("track")) {
+			if (trackLoadHandlers.has(trackElement)) continue;
+
+			const handleTrackLoad = (): void => {
+				syncTracks();
+			};
+
+			trackElement.addEventListener("load", handleTrackLoad);
+			trackLoadHandlers.set(trackElement, handleTrackLoad);
+
+			if (trackElement.readyState === loadedTrackReadyState) {
+				syncTracks();
+			}
+		}
+	};
+
+	const handleTrackUpdate = (): void => {
+		bindTrackElementLoads();
+		syncTracks();
+	};
+
+	let mutationObserver: MutationObserver | null = null;
+
+	if (typeof MutationObserver !== "undefined") {
+		mutationObserver = new MutationObserver(handleTrackUpdate);
+		mutationObserver.observe(video, { childList: true });
+	}
+
+	video.addEventListener("loadedmetadata", handleTrackUpdate);
+	video.textTracks.addEventListener("change", handleTrackUpdate);
+	video.textTracks.addEventListener("addtrack", handleTrackUpdate);
+	video.textTracks.addEventListener("removetrack", handleTrackUpdate);
+
+	handleTrackUpdate();
+
+	return () => {
+		mutationObserver?.disconnect();
+		video.removeEventListener("loadedmetadata", handleTrackUpdate);
+		video.textTracks.removeEventListener("change", handleTrackUpdate);
+		video.textTracks.removeEventListener("addtrack", handleTrackUpdate);
+		video.textTracks.removeEventListener("removetrack", handleTrackUpdate);
+
+		for (const [trackElement, handleTrackLoad] of trackLoadHandlers) {
+			trackElement.removeEventListener("load", handleTrackLoad);
+		}
+
+		for (const track of cueTracks) {
+			track.removeEventListener("cuechange", updateCueText);
+		}
+	};
+}


### PR DESCRIPTION
## Summary
- add a shared caption-track binding helper for the web video players
- keep caption/subtitle tracks hidden for the custom overlay while listening for async `<track>` load events
- cover the self-hosted async VTT load path with a focused unit test

Fixes #1773.

## Tests
- pnpm --dir apps/web exec vitest run __tests__/unit/caption-tracks.test.ts
- pnpm --dir apps/web exec vitest run __tests__/unit/caption-tracks.test.ts __tests__/unit/caption-cues.test.ts
- pnpm exec biome check "apps/web/app/s/[videoId]/_components/caption-tracks.ts" "apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx" "apps/web/app/s/[videoId]/_components/HLSVideoPlayer.tsx" apps/web/__tests__/unit/caption-tracks.test.ts
- git diff --check

Note: a broad `pnpm --dir apps/web exec tsc --noEmit --pretty false --incremental false` run was attempted, but it stayed silent for several minutes and was stopped to avoid tying up the sweep environment.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors caption/subtitle track binding into a new shared `bindCaptionTrackCueText` helper and fixes a bug where captions failed to initialize when `<track>` elements loaded their VTT file asynchronously after `loadedmetadata`.

- **`caption-tracks.ts`** – New helper that uses a MutationObserver, per-`<track>`-element `load` listeners, and `textTracks` list events to cover both the synchronous and async VTT-load paths; cleanup function returned to callers handles all teardown.
- **`CapVideoPlayer` / `HLSVideoPlayer`** – Inline track-management code (~35 and ~65 lines respectively) replaced with a single `bindCaptionTrackCueText` call; cleanup wired correctly in both `useEffect` return functions.
- **`caption-tracks.test.ts`** – Focused unit test for the async load path using lightweight fakes for `HTMLVideoElement`, `TextTrackList`, and `HTMLTrackElement`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the refactor is a net simplification and the async-VTT bug fix is well-scoped with no regressions on the single-track path.

The change consolidates duplicated track-management logic into a single, well-tested helper. Cleanup is correctly wired in both players, and the async load path that was the root of the original bug is now explicitly covered by a unit test. The only observations are minor efficiency nits (extra redundant syncTracks call when elements are already loaded, and all-tracks cuechange subscriptions that read only the first track), neither of which affects correctness in the common single-track case.

caption-tracks.ts has two style-level observations worth a quick read-through; the player files are straightforward call-site changes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/s/[videoId]/_components/caption-tracks.ts | New shared helper that fixes async VTT load bug; contains a redundant syncTracks() call and subscribes all caption tracks to cuechange but reads only from the first one |
| apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx | Replaces inline track management with bindCaptionTrackCueText; cleanup is correctly wired and both loadedmetadata listeners co-exist safely |
| apps/web/app/s/[videoId]/_components/HLSVideoPlayer.tsx | Replaces 64-line inline track setup/teardown with a single bindCaptionTrackCueText call; return value used correctly as the useEffect cleanup |
| apps/web/__tests__/unit/caption-tracks.test.ts | Covers the async VTT-load path with a focused integration test; synchronous-init path not tested (flagged in a prior review thread) |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): initialize caption tracks afte..."](https://github.com/capsoftware/cap/commit/a09a3847c2d322744c68de658fa95359eced8215) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35661450)</sub>

<!-- /greptile_comment -->