### PR TITLE
fix(cli): validate fps upper bound, prune stale sessions, add upload progress, retry desktop store read

### DIFF
--- a/apps/cli/src/credentials.rs
+++ b/apps/cli/src/credentials.rs
@@ -45,15 +45,15 @@ fn load_desktop_store() -> Option<Value> {
             let Ok(bytes) = std::fs::read(&path) else {
                 continue;
             };
-            let Ok(store) = serde_json::from_slice::<Value>(&bytes) else {
-                continue;
-            };
-            if store
-                .get("auth")
-                .and_then(|auth| auth.get("secret"))
-                .is_some()
-            {
-                return Some(store);
+            match serde_json::from_slice::<Value>(&bytes) {
+                Ok(store) => {
+                    return store
+                        .get("auth")
+                        .and_then(|auth| auth.get("secret"))
+                        .is_some()
+                        .then_some(store);
+                }
+                Err(_) => continue,
             }
         }
         None

--- a/apps/cli/src/credentials.rs
+++ b/apps/cli/src/credentials.rs
@@ -35,14 +35,28 @@ pub struct Credentials {
 fn load_desktop_store() -> Option<Value> {
     let data_dir = dirs::data_dir()?;
     DESKTOP_BUNDLE_IDS.into_iter().find_map(|id| {
-        let bytes = std::fs::read(data_dir.join(id).join("store")).ok()?;
-        let store: Value = serde_json::from_slice(&bytes).ok()?;
-        // Only accept a store that actually carries an auth secret.
-        store
-            .get("auth")
-            .and_then(|auth| auth.get("secret"))
-            .is_some()
-            .then_some(store)
+        let path = data_dir.join(id).join("store");
+        // Retry a few times: tauri-plugin-store flushes asynchronously, so a concurrent Desktop
+        // write can produce a truncated file on the first read.
+        for attempt in 0..3u8 {
+            if attempt > 0 {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            let Ok(bytes) = std::fs::read(&path) else {
+                continue;
+            };
+            let Ok(store) = serde_json::from_slice::<Value>(&bytes) else {
+                continue;
+            };
+            if store
+                .get("auth")
+                .and_then(|auth| auth.get("secret"))
+                .is_some()
+            {
+                return Some(store);
+            }
+        }
+        None
     })
 }
 

--- a/apps/cli/src/record.rs
+++ b/apps/cli/src/record.rs
@@ -61,8 +61,8 @@ impl RecordParams {
         }) {
             return Err("Duration must be a positive, finite number of seconds".to_string());
         }
-        if self.fps == Some(0) {
-            return Err("--fps must be greater than 0".to_string());
+        if self.fps.is_some_and(|fps| fps == 0 || fps > 120) {
+            return Err("--fps must be between 1 and 120".to_string());
         }
         Ok(())
     }

--- a/apps/cli/src/session.rs
+++ b/apps/cli/src/session.rs
@@ -43,9 +43,50 @@ pub fn now_unix() -> Option<u64> {
 }
 
 pub fn sessions_dir() -> Result<PathBuf, String> {
-    dirs::home_dir()
+    let dir = dirs::home_dir()
         .ok_or_else(|| "Could not determine home directory".to_string())
-        .map(|home| home.join(".cap").join("sessions"))
+        .map(|home| home.join(".cap").join("sessions"))?;
+    prune_old_sessions(&dir);
+    Ok(dir)
+}
+
+const SESSION_MAX_AGE_SECS: u64 = 7 * 24 * 60 * 60;
+
+fn prune_old_sessions(dir: &PathBuf) {
+    let now = now_unix().unwrap_or(0);
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+            continue;
+        };
+        if ext != "json" {
+            continue;
+        }
+        let Ok(body) = std::fs::read(&path) else {
+            continue;
+        };
+        let Ok(session) = serde_json::from_slice::<Session>(&body) else {
+            continue;
+        };
+        if matches!(session.status, SessionStatus::Stopped | SessionStatus::Error) {
+            let age = session
+                .started_at
+                .map(|t| now.saturating_sub(t))
+                .unwrap_or(SESSION_MAX_AGE_SECS + 1);
+            if age > SESSION_MAX_AGE_SECS {
+                let id = &session.recording_id;
+                for f in [session_file(id), stop_file(id), log_file(id)]
+                    .into_iter()
+                    .flatten()
+                {
+                    let _ = std::fs::remove_file(f);
+                }
+            }
+        }
+    }
 }
 
 pub fn session_file(id: &str) -> Result<PathBuf, String> {

--- a/apps/cli/src/session.rs
+++ b/apps/cli/src/session.rs
@@ -78,11 +78,12 @@ fn prune_old_sessions(dir: &PathBuf) {
                 .unwrap_or(SESSION_MAX_AGE_SECS + 1);
             if age > SESSION_MAX_AGE_SECS {
                 let id = &session.recording_id;
-                for f in [session_file(id), stop_file(id), log_file(id)]
-                    .into_iter()
-                    .flatten()
-                {
-                    let _ = std::fs::remove_file(f);
+                for name in [
+                    format!("{id}.json"),
+                    format!("{id}.stop"),
+                    format!("{id}.log"),
+                ] {
+                    let _ = std::fs::remove_file(dir.join(name));
                 }
             }
         }

--- a/apps/cli/src/upload.rs
+++ b/apps/cli/src/upload.rs
@@ -340,17 +340,19 @@ async fn upload_file(
     };
 
     let body = reqwest::Body::wrap_stream(stream);
-    let response = http
+    let send_result = http
         .put(put_url)
         .header(reqwest::header::CONTENT_LENGTH, total_bytes)
         .body(body)
         .send()
         .await
-        .map_err(|e| format!("Upload failed: {e}"))?;
+        .map_err(|e| format!("Upload failed: {e}"));
 
     if let Some(task) = progress_task {
         task.abort();
     }
+
+    let response = send_result?;
 
     if !response.status().is_success() {
         let status = response.status();

--- a/apps/cli/src/upload.rs
+++ b/apps/cli/src/upload.rs
@@ -320,9 +320,9 @@ async fn upload_file(
         chunk
     });
 
-    if format == OutputFormat::Json {
+    let progress_task = if format == OutputFormat::Json {
         let bytes_sent_progress = bytes_sent.clone();
-        tokio::spawn(async move {
+        Some(tokio::spawn(async move {
             loop {
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
                 let sent = bytes_sent_progress.load(Ordering::Relaxed);
@@ -334,8 +334,10 @@ async fn upload_file(
                     break;
                 }
             }
-        });
-    }
+        }))
+    } else {
+        None
+    };
 
     let body = reqwest::Body::wrap_stream(stream);
     let response = http
@@ -345,6 +347,10 @@ async fn upload_file(
         .send()
         .await
         .map_err(|e| format!("Upload failed: {e}"))?;
+
+    if let Some(task) = progress_task {
+        task.abort();
+    }
 
     if !response.status().is_success() {
         let status = response.status();

--- a/apps/cli/src/upload.rs
+++ b/apps/cli/src/upload.rs
@@ -1,13 +1,20 @@
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 use cap_project::RecordingMeta;
 use clap::Args;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use futures::StreamExt;
 use tokio_util::io::ReaderStream;
 
-use crate::{OutputFormat, credentials, export, resolve_format, write_json};
+use crate::{OutputFormat, credentials, export, resolve_format, write_json, write_json_line};
 
 #[derive(Args)]
 pub struct UploadArgs {
@@ -29,6 +36,7 @@ pub struct UploadArgs {
 #[derive(Serialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 enum UploadEvent<'a> {
+    Uploading { bytes_sent: u64, total_bytes: u64 },
     Uploaded { id: &'a str, link: &'a str },
 }
 
@@ -78,7 +86,7 @@ impl UploadArgs {
         let video_id =
             create_video(&http, &server, &auth, &self.name, self.video_id, &meta).await?;
         let put_url = presign_put(&http, &server, &auth, &video_id, &meta).await?;
-        upload_file(&http, &put_url, &file_path).await?;
+        upload_file(&http, &put_url, &file_path, format).await?;
 
         let link = format!("{server}/s/{video_id}");
         match format {
@@ -287,24 +295,52 @@ async fn presign_put(
         .map_err(|e| format!("Unexpected upload-URL response: {e}"))
 }
 
-async fn upload_file(http: &Client, put_url: &str, path: &Path) -> Result<(), String> {
-    // Stream the file rather than buffering it into memory — recordings can be gigabytes, so a
-    // `tokio::fs::read` would OOM on exactly the long unattended recordings agents produce. S3 PUT
-    // needs an explicit Content-Length for a streamed body (it rejects chunked transfer encoding),
-    // mirroring the desktop's singlepart uploader.
+async fn upload_file(
+    http: &Client,
+    put_url: &str,
+    path: &Path,
+    format: OutputFormat,
+) -> Result<(), String> {
     let file = tokio::fs::File::open(path)
         .await
         .map_err(|e| format!("Failed to open {}: {e}", path.display()))?;
-    let total_size = file
+    let total_bytes = file
         .metadata()
         .await
         .map_err(|e| format!("Failed to read {}: {e}", path.display()))?
         .len();
-    let body = reqwest::Body::wrap_stream(ReaderStream::new(file));
 
+    let bytes_sent = Arc::new(AtomicU64::new(0));
+    let bytes_sent_stream = bytes_sent.clone();
+
+    let stream = ReaderStream::new(file).map(move |chunk| {
+        if let Ok(ref bytes) = chunk {
+            bytes_sent_stream.fetch_add(bytes.len() as u64, Ordering::Relaxed);
+        }
+        chunk
+    });
+
+    if format == OutputFormat::Json {
+        let bytes_sent_progress = bytes_sent.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                let sent = bytes_sent_progress.load(Ordering::Relaxed);
+                let _ = write_json_line(&UploadEvent::Uploading {
+                    bytes_sent: sent,
+                    total_bytes,
+                });
+                if sent >= total_bytes {
+                    break;
+                }
+            }
+        });
+    }
+
+    let body = reqwest::Body::wrap_stream(stream);
     let response = http
         .put(put_url)
-        .header(reqwest::header::CONTENT_LENGTH, total_size)
+        .header(reqwest::header::CONTENT_LENGTH, total_bytes)
         .body(body)
         .send()
         .await


### PR DESCRIPTION
Addresses 4 issues found in #1886:

- **fps validation**  ->  --fps 0 was already rejected but the documented 1-120 upper bound wasn't enforced; now rejects values > 120
- **session pruning** -> stopped/errored session files in ~/.cap/sessions were never cleaned up; now pruned after 7 days on next sessions_dir() call
- **upload progress** -> cap upload went silent during file transfer while cap export streams NDJSON progress; now emits {"type":"Uploading","bytes_sent":N,"total_bytes":N} every second in --json mode
- **desktop store retry** -> load_desktop_store() read the tauri-plugin-store file without retrying; a concurrent Desktop flush could produce truncated JSON; now retries up to 3 times with 50ms delay

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses four issues identified in the previous review: FPS upper-bound validation, stale session pruning, upload progress reporting, and retry logic for the Desktop credential store read.

- **`record.rs`**: `--fps` now rejects values outside 1–120 with a clear error message.
- **`session.rs`**: Stopped/Error sessions older than 7 days are pruned on the next `sessions_dir()` call; the previous infinite-recursion issue is resolved by building deletion paths directly from the known `dir` argument.
- **`upload.rs`**: A background task emits `Uploading` progress events every second; `task.abort()` is now correctly placed before `send_result?` so the task is torn down on both network errors and successful uploads before `Uploaded` is written.
- **`credentials.rs`**: Retries up to 3× for truncated JSON; returns early from the closure on a successful parse (whether or not auth is present), eliminating unnecessary 100 ms delays for logged-out users.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the four targeted fixes are implemented correctly and the changes are narrowly scoped.

All four previously reported defects are correctly addressed. The remaining observations are efficiency and edge-case concerns (redundant prune scans per operation, immediate deletion of sessions whose started_at is absent) that don't affect normal operation.

apps/cli/src/session.rs — the prune-on-every-sessions_dir() design causes multiple redundant directory scans per write/cleanup operation, and sessions without a started_at timestamp are pruned immediately rather than conservatively retained.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/cli/src/record.rs | FPS upper-bound validation added correctly with `is_some_and`; error message updated to reflect the 1–120 range. |
| apps/cli/src/session.rs | Session pruning added; recursion from previous review is fixed by building paths directly from `dir`. However, `sessions_dir()` is called multiple times per high-level operation, triggering multiple redundant prune scans. Sessions missing `started_at` are treated as infinitely old and pruned immediately. |
| apps/cli/src/credentials.rs | Desktop store read now retries up to 3 times for truncated JSON; returns early on successful parse (valid JSON with or without auth) to avoid unnecessary retries for logged-out users. |
| apps/cli/src/upload.rs | Upload progress via AtomicU64 + background task; task is now aborted before checking `send_result?`, ensuring the progress task is torn down on both network errors and success paths before `Uploaded` is emitted. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(cli): abort upload progress task on ..."](https://github.com/capsoftware/cap/commit/ed696967528df9a438307440df25004ce6e0eb50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35986756)</sub>

<!-- /greptile_comment -->