### PR TITLE
fix(dashboard): bypass Rive in folder create/subfolder dialogs

### DIFF
--- a/apps/web/app/(org)/dashboard/caps/components/NewFolderDialog.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/NewFolderDialog.tsx
@@ -10,24 +10,17 @@ import {
 	Input,
 } from "@cap/ui";
 import type { Folder, Space } from "@cap/web-domain";
-import { faFolderPlus } from "@fortawesome/free-solid-svg-icons";
+import { faFolder, faFolderPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { type RiveFile, useRiveFile } from "@rive-app/react-canvas";
 import clsx from "clsx";
 import { Option } from "effect";
 import { useRouter } from "next/navigation";
-import React, { useEffect, useRef, useState } from "react";
+import type React from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useEffectMutation, useRpcClient } from "@/lib/EffectRuntime";
 import { PublicCollectionField } from "../../_components/PublicCollectionField";
 import { useDashboardContext } from "../../Contexts";
-import {
-	BlueFolder,
-	type FolderHandle,
-	NormalFolder,
-	RedFolder,
-	YellowFolder,
-} from "./Folders";
 
 interface Props {
 	open: boolean;
@@ -36,38 +29,10 @@ interface Props {
 }
 
 const FolderOptions = [
-	{
-		value: "normal",
-		label: "Normal",
-		component: (
-			riveFile: RiveFile | undefined,
-			ref: React.Ref<FolderHandle>,
-		) => <NormalFolder riveFile={riveFile} ref={ref} />,
-	},
-	{
-		value: "blue",
-		label: "Blue",
-		component: (
-			riveFile: RiveFile | undefined,
-			ref: React.Ref<FolderHandle>,
-		) => <BlueFolder riveFile={riveFile} ref={ref} />,
-	},
-	{
-		value: "red",
-		label: "Red",
-		component: (
-			riveFile: RiveFile | undefined,
-			ref: React.Ref<FolderHandle>,
-		) => <RedFolder riveFile={riveFile} ref={ref} />,
-	},
-	{
-		value: "yellow",
-		label: "Yellow",
-		component: (
-			riveFile: RiveFile | undefined,
-			ref: React.Ref<FolderHandle>,
-		) => <YellowFolder riveFile={riveFile} ref={ref} />,
-	},
+	{ value: "normal", label: "Normal", color: "#9ca3af" },
+	{ value: "blue", label: "Blue", color: "#3b82f6" },
+	{ value: "red", label: "Red", color: "#ef4444" },
+	{ value: "yellow", label: "Yellow", color: "#eab308" },
 ] as const;
 
 export const NewFolderDialog: React.FC<Props> = ({
@@ -83,29 +48,12 @@ export const NewFolderDialog: React.FC<Props> = ({
 	const { activeOrganization, setUpgradeModalOpen } = useDashboardContext();
 	const router = useRouter();
 
-	const { riveFile } = useRiveFile({
-		src: "/rive/dashboard.riv",
-	});
-
 	useEffect(() => {
 		if (!open) {
 			setSelectedColor(null);
 			setPublicEnabled(false);
 		}
 	}, [open]);
-
-	const folderRefs = useRef(
-		FolderOptions.reduce(
-			(acc, opt) => {
-				acc[opt.value] = React.createRef<FolderHandle>();
-				return acc;
-			},
-			{} as Record<
-				(typeof FolderOptions)[number]["value"],
-				React.RefObject<FolderHandle | null>
-			>,
-		),
-	);
 
 	const rpc = useRpcClient();
 
@@ -155,12 +103,12 @@ export const NewFolderDialog: React.FC<Props> = ({
 								<button
 									type="button"
 									className={clsx(
-										"flex flex-col flex-1 gap-1 items-center p-2 rounded-xl border transition-colors duration-200 cursor-pointer",
+										"flex flex-col flex-1 gap-2 items-center p-3 rounded-xl border transition-colors duration-200 cursor-pointer",
 										selectedColor === option.value
 											? "border-gray-12 bg-gray-3 hover:bg-gray-3 hover:border-gray-12"
 											: "border-gray-4 hover:bg-gray-3 hover:border-gray-5 bg-transparent",
 									)}
-									key={`rive-${option.value}`}
+									key={`folder-${option.value}`}
 									onClick={() => {
 										if (selectedColor === option.value) {
 											setSelectedColor(null);
@@ -168,23 +116,15 @@ export const NewFolderDialog: React.FC<Props> = ({
 										}
 										setSelectedColor(option.value);
 									}}
-									onMouseEnter={() => {
-										const folderRef = folderRefs.current[option.value]?.current;
-										if (!folderRef) return;
-										folderRef.stop();
-										folderRef.play("folder-open");
-									}}
-									onMouseLeave={() => {
-										const folderRef = folderRefs.current[option.value]?.current;
-										if (!folderRef) return;
-										folderRef.stop();
-										folderRef.play("folder-close");
-									}}
 								>
-									{option.component(
-										riveFile as RiveFile,
-										folderRefs.current[option.value],
-									)}
+									<FontAwesomeIcon
+										icon={faFolder}
+										style={{
+											color: option.color,
+											width: "40px",
+											height: "40px",
+										}}
+									/>
 									<span className="text-xs text-gray-10">{option.label}</span>
 								</button>
 							);

--- a/apps/web/app/(org)/dashboard/folder/[id]/components/SubfolderDialog.tsx
+++ b/apps/web/app/(org)/dashboard/folder/[id]/components/SubfolderDialog.tsx
@@ -10,25 +10,17 @@ import {
 	Input,
 } from "@cap/ui";
 import type { Folder } from "@cap/web-domain";
-import { faFolderPlus } from "@fortawesome/free-solid-svg-icons";
+import { faFolder, faFolderPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import type { RiveFile } from "@rive-app/react-canvas";
-import { useRiveFile } from "@rive-app/react-canvas";
 import clsx from "clsx";
 import { Option } from "effect";
 import { useRouter } from "next/navigation";
-import React, { useEffect, useRef, useState } from "react";
+import type React from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useEffectMutation, useRpcClient } from "@/lib/EffectRuntime";
 import { PublicCollectionField } from "../../../_components/PublicCollectionField";
 import { useDashboardContext } from "../../../Contexts";
-import {
-	BlueFolder,
-	type FolderHandle,
-	NormalFolder,
-	RedFolder,
-	YellowFolder,
-} from "../../../caps/components/Folders";
 
 interface Props {
 	open: boolean;
@@ -37,38 +29,10 @@ interface Props {
 }
 
 const FolderOptions = [
-	{
-		value: "normal",
-		label: "Normal",
-		component: (
-			riveFile: RiveFile | undefined,
-			ref: React.Ref<FolderHandle>,
-		) => <NormalFolder riveFile={riveFile} ref={ref} />,
-	},
-	{
-		value: "blue",
-		label: "Blue",
-		component: (
-			riveFile: RiveFile | undefined,
-			ref: React.Ref<FolderHandle>,
-		) => <BlueFolder riveFile={riveFile} ref={ref} />,
-	},
-	{
-		value: "red",
-		label: "Red",
-		component: (
-			riveFile: RiveFile | undefined,
-			ref: React.Ref<FolderHandle>,
-		) => <RedFolder riveFile={riveFile} ref={ref} />,
-	},
-	{
-		value: "yellow",
-		label: "Yellow",
-		component: (
-			riveFile: RiveFile | undefined,
-			ref: React.Ref<FolderHandle>,
-		) => <YellowFolder riveFile={riveFile} ref={ref} />,
-	},
+	{ value: "normal", label: "Normal", color: "#9ca3af" },
+	{ value: "blue", label: "Blue", color: "#3b82f6" },
+	{ value: "red", label: "Red", color: "#ef4444" },
+	{ value: "yellow", label: "Yellow", color: "#eab308" },
 ] as const;
 
 export const SubfolderDialog: React.FC<Props> = ({
@@ -85,10 +49,6 @@ export const SubfolderDialog: React.FC<Props> = ({
 		useDashboardContext();
 	const router = useRouter();
 
-	const { riveFile } = useRiveFile({
-		src: "/rive/dashboard.riv",
-	});
-
 	useEffect(() => {
 		if (!open) {
 			setSelectedColor(null);
@@ -96,19 +56,6 @@ export const SubfolderDialog: React.FC<Props> = ({
 			setPublicEnabled(false);
 		}
 	}, [open]);
-
-	const folderRefs = useRef(
-		FolderOptions.reduce(
-			(acc, opt) => {
-				acc[opt.value] = React.createRef<FolderHandle>();
-				return acc;
-			},
-			{} as Record<
-				(typeof FolderOptions)[number]["value"],
-				React.RefObject<FolderHandle | null>
-			>,
-		),
-	);
 
 	const rpc = useRpcClient();
 
@@ -158,12 +105,12 @@ export const SubfolderDialog: React.FC<Props> = ({
 								<button
 									type="button"
 									className={clsx(
-										"flex flex-col flex-1 gap-1 items-center p-2 rounded-xl border transition-colors duration-200 cursor-pointer",
+										"flex flex-col flex-1 gap-2 items-center p-3 rounded-xl border transition-colors duration-200 cursor-pointer",
 										selectedColor === option.value
 											? "border-gray-12 bg-gray-3 hover:bg-gray-3 hover:border-gray-12"
 											: "border-gray-4 hover:bg-gray-3 hover:border-gray-5 bg-transparent",
 									)}
-									key={`rive-${option.value}`}
+									key={`folder-${option.value}`}
 									onClick={() => {
 										if (selectedColor === option.value) {
 											setSelectedColor(null);
@@ -171,23 +118,15 @@ export const SubfolderDialog: React.FC<Props> = ({
 										}
 										setSelectedColor(option.value);
 									}}
-									onMouseEnter={() => {
-										const folderRef = folderRefs.current[option.value]?.current;
-										if (!folderRef) return;
-										folderRef.stop();
-										folderRef.play("folder-open");
-									}}
-									onMouseLeave={() => {
-										const folderRef = folderRefs.current[option.value]?.current;
-										if (!folderRef) return;
-										folderRef.stop();
-										folderRef.play("folder-close");
-									}}
 								>
-									{option.component(
-										riveFile as RiveFile,
-										folderRefs.current[option.value],
-									)}
+									<FontAwesomeIcon
+										icon={faFolder}
+										style={{
+											color: option.color,
+											width: "40px",
+											height: "40px",
+										}}
+									/>
 									<span className="text-xs text-gray-10">{option.label}</span>
 								</button>
 							);


### PR DESCRIPTION
## Summary

`NewFolderDialog` and `SubfolderDialog` render four sibling Rive components (`NormalFolder` / `BlueFolder` / `RedFolder` / `YellowFolder`), each calling `useRive` with the **same** `riveFile` returned by a parent `useRiveFile`. On Next 16 + React 19 + `@rive-app/react-canvas@^4.18.7` this triggers a race between the four `useRive` inits when the dialog mounts — the runtime ends up reading `isPlaying` / `stateMachines` on an undefined Rive instance, throws inside `setupRiveListeners`, and the React reconciler bounces between two chunks in an infinite `up/ud` recursion that takes down the whole page.

## Repro
1. Self-host or run main with React 19 / Next 16.
2. Dashboard → caps → click **New Folder**.
3. Page crashes; console shows:
   ```
   Uncaught TypeError: Cannot read properties of undefined (reading 'isPlaying')
   TypeError: Cannot read properties of undefined (reading 'stateMachines')
       at t.setupRiveListeners
   ```
   followed by an infinite `iv → up → ud → up → ud …` stack.

## Fix
Replace the four sibling Rive components in the two creation dialogs with a single `FontAwesomeIcon` (`faFolder`) tinted per colour choice. The dialog still shows four labelled, selectable swatches; only the hover open/close animation is dropped.

Folder cards on the dashboard (`Folder.tsx`) keep their Rive runtime because each card owns its own `useRive` call and never shares a `riveFile` — that path doesn't hit the race.

## Test plan

- [ ] Open `New Folder` → dialog renders, four colour swatches visible.
- [ ] Pick a colour → swatch highlights, Create button enables when a name is typed.
- [ ] Folder created, dashboard refreshes.
- [ ] Same flow from inside a folder via `New Subfolder`.
- [ ] Existing folder cards on the dashboard still animate on hover (Rive unaffected).

## Notes

This is a workaround targeting the race, not an upstream Rive fix. A proper fix probably belongs in `@rive-app/react-canvas` (init sequencing when a shared `riveFile` is consumed by multiple `useRive` hooks). Happy to revert if a newer rive-react release resolves it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash in the New Folder and New Subfolder dialogs caused by a race condition when four sibling Rive components each called `useRive` with the same shared `riveFile` instance under React 19 / Next 16, ultimately triggering an infinite reconciler loop. The fix replaces the animated Rive swatches with static `FontAwesomeIcon` (`faFolder`) icons tinted per colour option, preserving all functional behaviour (colour selection, create mutation, form reset) while sidestepping the upstream `@rive-app/react-canvas` race entirely.

- **NewFolderDialog.tsx** and **SubfolderDialog.tsx**: `useRiveFile`, the four Rive sub-components, `folderRefs`, and `onMouseEnter`/`onMouseLeave` handlers are removed; `FolderOptions` gains a `color` hex string and renders a `FontAwesomeIcon` in their place.
- The Rive runtime is untouched on the dashboard folder cards (`Folder.tsx`), which each own an independent `useRive` call and do not share a `riveFile`.

<h3>Confidence Score: 5/5</h3>

Straightforward removal of a crashing code path; all functional dialog behaviour is preserved.

The change is a targeted deletion of the Rive initialisation code in two symmetrical dialog components. The colour-selection state machine, create mutation, and dialog reset logic are unmodified. No new dependencies are introduced, and the FontAwesomeIcon rendering path has no side-effects that could introduce regressions.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/(org)/dashboard/caps/components/NewFolderDialog.tsx | Replaces four sibling Rive components with a single FontAwesomeIcon per swatch, removing the shared-riveFile race; logic for color selection, create mutation, and public toggle is unchanged. |
| apps/web/app/(org)/dashboard/folder/[id]/components/SubfolderDialog.tsx | Identical treatment to NewFolderDialog — Rive removed, FontAwesomeIcon substituted; subfolder creation mutation and reset logic intact. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): bypass Rive in folder cr..."](https://github.com/capsoftware/cap/commit/42113be59b0d715d20dd2907a558330811cffb28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35997858)</sub>

<!-- /greptile_comment -->