### PR TITLE
feat(dashboard): allow starting a new recording from inside a folder

### DIFF
--- a/apps/web/app/(org)/dashboard/folder/[id]/page.tsx
+++ b/apps/web/app/(org)/dashboard/folder/[id]/page.tsx
@@ -13,6 +13,7 @@ import { runPromise } from "@/lib/server";
 
 import { UploadCapButton } from "../../caps/components";
 import FolderCard from "../../caps/components/Folder";
+import { WebRecorderDialog } from "../../caps/components/web-recorder-dialog/web-recorder-dialog";
 import {
 	BreadcrumbItem,
 	ClientMyCapsLink,
@@ -38,9 +39,10 @@ const FolderPage = async (props: PageProps<"/dashboard/folder/[id]">) => {
 
 		return (
 			<div>
-				<div className="flex gap-2 items-center mb-10">
+				<div className="flex flex-wrap gap-2 items-center mb-10">
 					<NewSubfolderButton parentFolderId={folderId} />
 					<UploadCapButton size="sm" />
+					<WebRecorderDialog />
 				</div>
 				<div className="flex justify-between items-center mb-6 w-full">
 					<div className="flex overflow-x-auto items-center font-medium">


### PR DESCRIPTION
## Summary

The caps root (`/dashboard/caps`) shows three top-bar actions: `NewFolderDialog`, `UploadCapButton`, `WebRecorderDialog`. The folder page (`/dashboard/folder/[id]`) shows only `NewSubfolderButton` and `UploadCapButton`, so once a user navigates into a folder they lose access to the in-browser recorder and have to walk back to the caps root to start a new recording.

This PR mounts `WebRecorderDialog` alongside `UploadCapButton` in the folder page top bar, restoring parity with the caps root.

## Repro
1. `/dashboard/caps` → recorder is available in the top bar.
2. Click into any folder → recorder is gone, only Upload / New Subfolder remain.

## Test plan

- [ ] `/dashboard/folder/<id>` shows three actions: New Subfolder, Upload Cap, New Recording.
- [ ] Recorder dialog opens and records as on the caps root.
- [ ] Wrap `flex-wrap` keeps the buttons readable on narrow viewports.

## Notes

The new recording lands at the org root (same behaviour as the caps page) and can then be moved into the current folder via drag-and-drop. I considered auto-attaching it to the current folder but that's a separate UX call and changes the recording flow's contract.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `WebRecorderDialog` button to the folder page (`/dashboard/folder/[id]`) action bar, restoring parity with the caps root page where the in-browser recorder is already available. A `flex-wrap` class is also added to the button row to prevent overflow on narrow viewports.

- `WebRecorderDialog` is imported directly and rendered with no props, matching how it is self-contained via `useDashboardContext()`, which is available to all pages under the dashboard layout.
- The PR explicitly documents that recordings still land at the org root rather than the current folder, keeping the existing recording flow's contract intact.

<h3>Confidence Score: 5/5</h3>

A one-file change that reuses an existing, well-tested component with no new logic.

The change is a straightforward drop-in of an existing self-contained client component onto a new server-rendered page. The component relies on `useDashboardContext()` which is already available to all pages under the dashboard layout. No new data fetching, state management, or authorization logic is introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/(org)/dashboard/folder/[id]/page.tsx | Adds WebRecorderDialog import and renders it in the folder page's action bar alongside NewSubfolderButton and UploadCapButton; also adds flex-wrap for responsive layout. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard): allow starting a new re..."](https://github.com/capsoftware/cap/commit/b9834e80b7250e465f31a2ec0a48bdf2f4bd5247) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35997938)</sub>

<!-- /greptile_comment -->