### PR TITLE
feat(folders): public sharing of a folder via a signed link

### DIFF
--- a/apps/web/actions/folders/share-folder.ts
+++ b/apps/web/actions/folders/share-folder.ts
@@ -43,8 +43,10 @@ export async function enableFolderSharing(folderId: Folder.FolderId) {
 		.where(eq(folders.id, folderId));
 	await db()
 		.update(videos)
-		.set({ public: true })
-		.where(eq(videos.folderId, folderId));
+		.set({ public: true, publicSourcedFromFolderShare: true })
+		.where(
+			and(eq(videos.folderId, folderId), eq(videos.public, false)),
+		);
 	revalidatePath(`/dashboard/folder/${folderId}`);
 	revalidatePath(`/dashboard/caps`);
 	return { slug: signFolderShareSlug(folderId) };
@@ -58,8 +60,13 @@ export async function disableFolderSharing(folderId: Folder.FolderId) {
 		.where(eq(folders.id, folderId));
 	await db()
 		.update(videos)
-		.set({ public: false })
-		.where(eq(videos.folderId, folderId));
+		.set({ public: false, publicSourcedFromFolderShare: false })
+		.where(
+			and(
+				eq(videos.folderId, folderId),
+				eq(videos.publicSourcedFromFolderShare, true),
+			),
+		);
 	revalidatePath(`/dashboard/folder/${folderId}`);
 	revalidatePath(`/dashboard/caps`);
 }

--- a/apps/web/actions/folders/share-folder.ts
+++ b/apps/web/actions/folders/share-folder.ts
@@ -1,0 +1,65 @@
+"use server";
+
+import { db } from "@cap/database";
+import { getCurrentUser } from "@cap/database/auth/session";
+import { folders, videos } from "@cap/database/schema";
+import type { Folder } from "@cap/web-domain";
+import { and, eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { signFolderShareSlug } from "@/lib/folder-share";
+
+const requireOwnedFolder = async (folderId: Folder.FolderId) => {
+	const user = await getCurrentUser();
+	if (!user || !user.activeOrganizationId)
+		throw new Error("Unauthorized or no active organization");
+
+	const [folder] = await db()
+		.select()
+		.from(folders)
+		.where(
+			and(
+				eq(folders.id, folderId),
+				eq(folders.organizationId, user.activeOrganizationId),
+			),
+		);
+
+	if (!folder) throw new Error("Folder not found");
+	return folder;
+};
+
+export async function getFolderShareState(folderId: Folder.FolderId) {
+	const folder = await requireOwnedFolder(folderId);
+	return {
+		isShared: folder.publicShared === true,
+		slug: folder.publicShared ? signFolderShareSlug(folderId) : null,
+	};
+}
+
+export async function enableFolderSharing(folderId: Folder.FolderId) {
+	await requireOwnedFolder(folderId);
+	await db()
+		.update(folders)
+		.set({ publicShared: true })
+		.where(eq(folders.id, folderId));
+	await db()
+		.update(videos)
+		.set({ public: true })
+		.where(eq(videos.folderId, folderId));
+	revalidatePath(`/dashboard/folder/${folderId}`);
+	revalidatePath(`/dashboard/caps`);
+	return { slug: signFolderShareSlug(folderId) };
+}
+
+export async function disableFolderSharing(folderId: Folder.FolderId) {
+	await requireOwnedFolder(folderId);
+	await db()
+		.update(folders)
+		.set({ publicShared: false })
+		.where(eq(folders.id, folderId));
+	await db()
+		.update(videos)
+		.set({ public: false })
+		.where(eq(videos.folderId, folderId));
+	revalidatePath(`/dashboard/folder/${folderId}`);
+	revalidatePath(`/dashboard/caps`);
+}

--- a/apps/web/app/(org)/dashboard/caps/components/Folder.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/Folder.tsx
@@ -14,6 +14,7 @@ import { ConfirmationDialog } from "../../_components/ConfirmationDialog";
 import { useDashboardContext, useTheme } from "../../Contexts";
 import { registerDropTarget } from "../../folder/[id]/components/ClientCapCard";
 import { FoldersDropdown } from "./FoldersDropdown";
+import { ShareFolderDialog } from "./ShareFolderDialog";
 
 export type FolderDataType = {
 	name: string;
@@ -35,6 +36,7 @@ const FolderCard = ({
 	const router = useRouter();
 	const { theme } = useTheme();
 	const [confirmDeleteFolderOpen, setConfirmDeleteFolderOpen] = useState(false);
+	const [shareDialogOpen, setShareDialogOpen] = useState(false);
 	const [isRenaming, setIsRenaming] = useState(false);
 	const [updateName, setUpdateName] = useState(name);
 	const nameRef = useRef<HTMLTextAreaElement>(null);
@@ -402,7 +404,13 @@ const FolderCard = ({
 					parentId={parentId}
 					setIsRenaming={setIsRenaming}
 					setConfirmDeleteFolderOpen={setConfirmDeleteFolderOpen}
+					setShareDialogOpen={spaceId ? undefined : setShareDialogOpen}
 					nameRef={nameRef}
+				/>
+				<ShareFolderDialog
+					open={shareDialogOpen}
+					onOpenChange={setShareDialogOpen}
+					folderId={id}
 				/>
 			</div>
 		</Link>

--- a/apps/web/app/(org)/dashboard/caps/components/FoldersDropdown.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/FoldersDropdown.tsx
@@ -7,6 +7,7 @@ import {
 import {
 	faEllipsis,
 	faPencil,
+	faShareNodes,
 	faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -16,6 +17,7 @@ interface FoldersDropdownProps {
 	id: string;
 	setIsRenaming: (isRenaming: boolean) => void;
 	setConfirmDeleteFolderOpen: (open: boolean) => void;
+	setShareDialogOpen?: (open: boolean) => void;
 	nameRef: RefObject<HTMLTextAreaElement | null>;
 	parentId?: string | null;
 }
@@ -23,6 +25,7 @@ interface FoldersDropdownProps {
 export const FoldersDropdown = ({
 	setIsRenaming,
 	setConfirmDeleteFolderOpen,
+	setShareDialogOpen,
 	nameRef,
 }: FoldersDropdownProps) => {
 	return (
@@ -62,6 +65,15 @@ export const FoldersDropdown = ({
 									}, 0);
 								},
 							},
+							...(setShareDialogOpen
+								? [
+										{
+											label: "Share folder",
+											icon: faShareNodes,
+											onClick: () => setShareDialogOpen(true),
+										} satisfies FolderDropdownItem,
+									]
+								: []),
 							// Only show Duplicate if there is NO active space
 							// ...(!activeSpace
 							//   ? [

--- a/apps/web/app/(org)/dashboard/caps/components/ShareFolderDialog.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/ShareFolderDialog.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import {
+	Button,
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Input,
+} from "@cap/ui";
+import type { Folder } from "@cap/web-domain";
+import {
+	faCopy,
+	faShareNodes,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import {
+	disableFolderSharing,
+	enableFolderSharing,
+	getFolderShareState,
+} from "@/actions/folders/share-folder";
+
+interface Props {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	folderId: Folder.FolderId;
+}
+
+export const ShareFolderDialog: React.FC<Props> = ({
+	open,
+	onOpenChange,
+	folderId,
+}) => {
+	const [isShared, setIsShared] = useState(false);
+	const [slug, setSlug] = useState<string | null>(null);
+	const [loading, setLoading] = useState(false);
+	const [hydrated, setHydrated] = useState(false);
+
+	useEffect(() => {
+		if (!open) return;
+		setHydrated(false);
+		getFolderShareState(folderId)
+			.then((state) => {
+				setIsShared(state.isShared);
+				setSlug(state.slug);
+			})
+			.catch(() => toast.error("Failed to load share state"))
+			.finally(() => setHydrated(true));
+	}, [open, folderId]);
+
+	const baseUrl =
+		typeof window !== "undefined" ? window.location.origin : "";
+	const shareUrl = slug ? `${baseUrl}/share/f/${slug}` : "";
+
+	const handleEnable = async () => {
+		setLoading(true);
+		try {
+			const res = await enableFolderSharing(folderId);
+			setSlug(res.slug);
+			setIsShared(true);
+			toast.success("Folder shared. Link copied to clipboard.");
+			try {
+				await navigator.clipboard.writeText(`${baseUrl}/share/f/${res.slug}`);
+			} catch {}
+		} catch {
+			toast.error("Failed to enable sharing");
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const handleDisable = async () => {
+		setLoading(true);
+		try {
+			await disableFolderSharing(folderId);
+			setIsShared(false);
+			setSlug(null);
+			toast.success("Sharing disabled");
+		} catch {
+			toast.error("Failed to disable sharing");
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const handleCopy = async () => {
+		if (!shareUrl) return;
+		try {
+			await navigator.clipboard.writeText(shareUrl);
+			toast.success("Link copied");
+		} catch {
+			toast.error("Failed to copy");
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="w-[calc(100%-20px)] max-w-[480px]">
+				<DialogHeader
+					icon={<FontAwesomeIcon icon={faShareNodes} className="size-3.5" />}
+				>
+					<DialogTitle>Share folder</DialogTitle>
+				</DialogHeader>
+				<div className="p-5 space-y-4">
+					<p className="text-sm text-gray-10">
+						Anyone with the link can view every video in this folder in
+						read-only mode. No account required. Enabling will also flip
+						every video in the folder to public; disabling reverts them.
+					</p>
+					{hydrated && isShared && shareUrl ? (
+						<div className="space-y-2">
+							<label className="text-xs font-medium text-gray-11">
+								Public link
+							</label>
+							<div className="flex gap-2">
+								<Input value={shareUrl} readOnly className="flex-1 text-xs" />
+								<Button
+									size="sm"
+									variant="gray"
+									onClick={handleCopy}
+									className="flex gap-1.5 items-center"
+								>
+									<FontAwesomeIcon icon={faCopy} className="size-3" />
+									Copy
+								</Button>
+							</div>
+						</div>
+					) : null}
+				</div>
+				<DialogFooter>
+					<Button
+						size="sm"
+						variant="gray"
+						onClick={() => onOpenChange(false)}
+						disabled={loading}
+					>
+						Close
+					</Button>
+					{hydrated && isShared ? (
+						<Button
+							size="sm"
+							variant="destructive"
+							onClick={handleDisable}
+							spinner={loading}
+							disabled={loading}
+						>
+							Disable sharing
+						</Button>
+					) : (
+						<Button
+							size="sm"
+							variant="dark"
+							onClick={handleEnable}
+							spinner={loading}
+							disabled={loading || !hydrated}
+						>
+							Enable sharing
+						</Button>
+					)}
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/apps/web/app/embed/[videoId]/page.tsx
+++ b/apps/web/app/embed/[videoId]/page.tsx
@@ -163,6 +163,7 @@ export default async function EmbedVideoPage(
 					transcriptionStatus: videos.transcriptionStatus,
 					source: videos.source,
 					folderId: videos.folderId,
+					publicSourcedFromFolderShare: videos.publicSourcedFromFolderShare,
 					width: videos.width,
 					height: videos.height,
 					duration: videos.duration,

--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -425,6 +425,7 @@ export default async function ShareVideoPage(props: PageProps<"/s/[videoId]">) {
 					storageIntegrationId: videos.storageIntegrationId,
 					metadata: videos.metadata,
 					public: videos.public,
+					publicSourcedFromFolderShare: videos.publicSourcedFromFolderShare,
 					videoStartTime: videos.videoStartTime,
 					audioStartTime: videos.audioStartTime,
 					awsRegion: videos.awsRegion,

--- a/apps/web/app/share/f/[slug]/page.tsx
+++ b/apps/web/app/share/f/[slug]/page.tsx
@@ -1,0 +1,195 @@
+import { db } from "@cap/database";
+import { folders, s3Buckets, videos } from "@cap/database/schema";
+import { Logo } from "@cap/ui";
+import { S3Buckets } from "@cap/web-backend";
+import { eq } from "drizzle-orm";
+import { Option } from "effect";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { verifyFolderShareSlug } from "@/lib/folder-share";
+import { runPromise } from "@/lib/server";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata(props: {
+	params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+	const { slug } = await props.params;
+	const folderId = verifyFolderShareSlug(slug);
+	if (!folderId) return { title: "Cap" };
+	const [folder] = await db()
+		.select({ name: folders.name, publicShared: folders.publicShared })
+		.from(folders)
+		.where(eq(folders.id, folderId as any));
+	if (!folder || !folder.publicShared) return { title: "Cap" };
+	return {
+		title: `${folder.name} | Cap`,
+		description: `Shared folder: ${folder.name}`,
+		robots: "noindex, nofollow",
+	};
+}
+
+const colorTints: Record<string, string> = {
+	normal: "#9ca3af",
+	blue: "#3b82f6",
+	red: "#ef4444",
+	yellow: "#eab308",
+};
+
+const formatDuration = (s: number | null) => {
+	if (s == null || Number.isNaN(s)) return "";
+	const m = Math.floor(s / 60);
+	const sec = Math.floor(s % 60);
+	return `${m}:${sec.toString().padStart(2, "0")}`;
+};
+
+async function resolveThumbnailUrl(
+	videoId: string,
+	ownerId: string,
+	bucketId: string | null,
+): Promise<string | null> {
+	try {
+		const [bucket] = await S3Buckets.getBucketAccess(
+			Option.fromNullable(bucketId),
+		).pipe(runPromise);
+		const listResponse = await bucket
+			.listObjects({ prefix: `${ownerId}/${videoId}/` })
+			.pipe(runPromise);
+		const contents = listResponse.Contents || [];
+		const thumbnailKey = contents.find((item) =>
+			item.Key?.endsWith("screen-capture.jpg"),
+		)?.Key;
+		if (!thumbnailKey) return null;
+		const url = await bucket
+			.getSignedObjectUrl(thumbnailKey)
+			.pipe(runPromise);
+		return url;
+	} catch {
+		return null;
+	}
+}
+
+export default async function SharedFolderPage(props: {
+	params: Promise<{ slug: string }>;
+}) {
+	const { slug } = await props.params;
+	const folderId = verifyFolderShareSlug(slug);
+	if (!folderId) return notFound();
+
+	const [folder] = await db()
+		.select({
+			id: folders.id,
+			name: folders.name,
+			color: folders.color,
+			publicShared: folders.publicShared,
+		})
+		.from(folders)
+		.where(eq(folders.id, folderId as any));
+
+	if (!folder || !folder.publicShared) return notFound();
+
+	const folderVideos = await db()
+		.select({
+			id: videos.id,
+			name: videos.name,
+			createdAt: videos.createdAt,
+			duration: videos.duration,
+			width: videos.width,
+			height: videos.height,
+			ownerId: videos.ownerId,
+			bucketId: videos.bucket,
+		})
+		.from(videos)
+		.leftJoin(s3Buckets, eq(videos.bucket, s3Buckets.id))
+		.where(eq(videos.folderId, folderId as any));
+
+	const videosWithThumbs = await Promise.all(
+		folderVideos.map(async (v) => ({
+			...v,
+			thumbnailUrl: await resolveThumbnailUrl(v.id, v.ownerId, v.bucketId),
+		})),
+	);
+
+	return (
+		<div className="min-h-screen bg-gray-1">
+			<header className="border-b border-gray-3 bg-gray-2">
+				<div className="mx-auto max-w-6xl px-6 py-4 flex items-center justify-between">
+					<Link href="/" className="flex items-center gap-2">
+						<Logo className="h-7 w-auto" />
+					</Link>
+					<span className="text-xs text-gray-10">Powered by Cap</span>
+				</div>
+			</header>
+			<main className="mx-auto max-w-6xl px-6 py-10">
+				<div className="flex items-center gap-3 mb-2">
+					<div
+						className="w-4 h-4 rounded-sm shrink-0"
+						style={{ backgroundColor: colorTints[folder.color] ?? "#9ca3af" }}
+					/>
+					<h1 className="text-2xl font-semibold text-gray-12">{folder.name}</h1>
+				</div>
+				<p className="text-sm text-gray-10 mb-8">
+					{folderVideos.length}{" "}
+					{folderVideos.length === 1 ? "video" : "videos"}
+				</p>
+
+				{folderVideos.length === 0 ? (
+					<div className="rounded-xl border border-gray-3 bg-gray-2 p-10 text-center text-gray-10">
+						No videos in this folder yet.
+					</div>
+				) : (
+					<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+						{videosWithThumbs.map((v) => {
+							const aspect =
+								v.width && v.height ? v.width / v.height : 16 / 9;
+							return (
+								<Link
+									key={v.id}
+									href={`/s/${v.id}`}
+									className="group flex flex-col rounded-xl border border-gray-3 bg-gray-2 hover:border-blue-10 hover:shadow-md transition-all overflow-hidden"
+								>
+									<div
+										className="relative w-full bg-gray-4 overflow-hidden"
+										style={{ paddingBottom: `${(1 / aspect) * 100}%` }}
+									>
+										{v.thumbnailUrl ? (
+											// eslint-disable-next-line @next/next/no-img-element
+											<img
+												src={v.thumbnailUrl}
+												alt={v.name}
+												className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+												loading="lazy"
+											/>
+										) : (
+											<div className="absolute inset-0 flex items-center justify-center text-xs text-gray-9">
+												No preview
+											</div>
+										)}
+										{v.duration ? (
+											<div className="absolute bottom-2 right-2 rounded bg-black/75 px-1.5 py-0.5 text-xs font-medium text-white">
+												{formatDuration(Number(v.duration))}
+											</div>
+										) : null}
+									</div>
+									<div className="p-4">
+										<p className="text-sm font-medium text-gray-12 truncate group-hover:text-blue-10">
+											{v.name}
+										</p>
+										<p className="text-xs text-gray-10 mt-1">
+											{new Date(v.createdAt).toLocaleDateString(undefined, {
+												day: "numeric",
+												month: "long",
+												year: "numeric",
+											})}
+										</p>
+									</div>
+								</Link>
+							);
+						})}
+					</div>
+				)}
+			</main>
+		</div>
+	);
+}

--- a/apps/web/app/share/f/[slug]/page.tsx
+++ b/apps/web/app/share/f/[slug]/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata(props: {
 	const [folder] = await db()
 		.select({ name: folders.name, publicShared: folders.publicShared })
 		.from(folders)
-		.where(eq(folders.id, folderId as any));
+		.where(eq(folders.id, folderId));
 	if (!folder || !folder.publicShared) return { title: "Cap" };
 	return {
 		title: `${folder.name} | Cap`,
@@ -53,14 +53,7 @@ async function resolveThumbnailUrl(
 		const [bucket] = await S3Buckets.getBucketAccess(
 			Option.fromNullable(bucketId),
 		).pipe(runPromise);
-		const listResponse = await bucket
-			.listObjects({ prefix: `${ownerId}/${videoId}/` })
-			.pipe(runPromise);
-		const contents = listResponse.Contents || [];
-		const thumbnailKey = contents.find((item) =>
-			item.Key?.endsWith("screen-capture.jpg"),
-		)?.Key;
-		if (!thumbnailKey) return null;
+		const thumbnailKey = `${ownerId}/${videoId}/screenshot/screen-capture.jpg`;
 		const url = await bucket
 			.getSignedObjectUrl(thumbnailKey)
 			.pipe(runPromise);
@@ -85,7 +78,7 @@ export default async function SharedFolderPage(props: {
 			publicShared: folders.publicShared,
 		})
 		.from(folders)
-		.where(eq(folders.id, folderId as any));
+		.where(eq(folders.id, folderId));
 
 	if (!folder || !folder.publicShared) return notFound();
 
@@ -102,7 +95,7 @@ export default async function SharedFolderPage(props: {
 		})
 		.from(videos)
 		.leftJoin(s3Buckets, eq(videos.bucket, s3Buckets.id))
-		.where(eq(videos.folderId, folderId as any));
+		.where(eq(videos.folderId, folderId));
 
 	const videosWithThumbs = await Promise.all(
 		folderVideos.map(async (v) => ({

--- a/apps/web/app/share/f/[slug]/page.tsx
+++ b/apps/web/app/share/f/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { db } from "@cap/database";
 import { folders, s3Buckets, videos } from "@cap/database/schema";
 import { Logo } from "@cap/ui";
 import { S3Buckets } from "@cap/web-backend";
+import type { S3Bucket } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
 import { Option } from "effect";
 import type { Metadata } from "next";
@@ -47,16 +48,14 @@ const formatDuration = (s: number | null) => {
 async function resolveThumbnailUrl(
 	videoId: string,
 	ownerId: string,
-	bucketId: string | null,
+	bucketId: S3Bucket.S3BucketId | null,
 ): Promise<string | null> {
 	try {
 		const [bucket] = await S3Buckets.getBucketAccess(
 			Option.fromNullable(bucketId),
 		).pipe(runPromise);
 		const thumbnailKey = `${ownerId}/${videoId}/screenshot/screen-capture.jpg`;
-		const url = await bucket
-			.getSignedObjectUrl(thumbnailKey)
-			.pipe(runPromise);
+		const url = await bucket.getSignedObjectUrl(thumbnailKey).pipe(runPromise);
 		return url;
 	} catch {
 		return null;
@@ -123,8 +122,7 @@ export default async function SharedFolderPage(props: {
 					<h1 className="text-2xl font-semibold text-gray-12">{folder.name}</h1>
 				</div>
 				<p className="text-sm text-gray-10 mb-8">
-					{folderVideos.length}{" "}
-					{folderVideos.length === 1 ? "video" : "videos"}
+					{folderVideos.length} {folderVideos.length === 1 ? "video" : "videos"}
 				</p>
 
 				{folderVideos.length === 0 ? (
@@ -134,8 +132,7 @@ export default async function SharedFolderPage(props: {
 				) : (
 					<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
 						{videosWithThumbs.map((v) => {
-							const aspect =
-								v.width && v.height ? v.width / v.height : 16 / 9;
+							const aspect = v.width && v.height ? v.width / v.height : 16 / 9;
 							return (
 								<Link
 									key={v.id}

--- a/apps/web/lib/folder-share.ts
+++ b/apps/web/lib/folder-share.ts
@@ -1,4 +1,5 @@
-import { createHmac } from "node:crypto";
+import type { Folder } from "@cap/web-domain";
+import { createHmac, timingSafeEqual } from "node:crypto";
 
 const getSecret = () => {
 	const s = process.env.NEXTAUTH_SECRET;
@@ -19,11 +20,13 @@ const toBase64Url = (s: string) =>
 const fromBase64Url = (s: string) =>
 	Buffer.from(s, "base64url").toString("utf8");
 
-export const signFolderShareSlug = (folderId: string): string => {
+export const signFolderShareSlug = (folderId: Folder.FolderId): string => {
 	return `${toBase64Url(folderId)}.${sign(folderId)}`;
 };
 
-export const verifyFolderShareSlug = (slug: string): string | null => {
+export const verifyFolderShareSlug = (
+	slug: string,
+): Folder.FolderId | null => {
 	const parts = slug.split(".");
 	if (parts.length !== 2) return null;
 	const [encodedId, sig] = parts;
@@ -34,6 +37,9 @@ export const verifyFolderShareSlug = (slug: string): string | null => {
 	} catch {
 		return null;
 	}
-	if (sign(folderId) !== sig) return null;
-	return folderId;
+	const expected = Buffer.from(sign(folderId));
+	const actual = Buffer.from(sig);
+	if (expected.length !== actual.length || !timingSafeEqual(expected, actual))
+		return null;
+	return folderId as Folder.FolderId;
 };

--- a/apps/web/lib/folder-share.ts
+++ b/apps/web/lib/folder-share.ts
@@ -1,0 +1,39 @@
+import { createHmac } from "node:crypto";
+
+const getSecret = () => {
+	const s = process.env.NEXTAUTH_SECRET;
+	if (!s) throw new Error("NEXTAUTH_SECRET is required for folder share signing");
+	return s;
+};
+
+const sign = (folderId: string) => {
+	return createHmac("sha256", getSecret())
+		.update(`folder-share:${folderId}`)
+		.digest("base64url")
+		.slice(0, 16);
+};
+
+const toBase64Url = (s: string) =>
+	Buffer.from(s, "utf8").toString("base64url");
+
+const fromBase64Url = (s: string) =>
+	Buffer.from(s, "base64url").toString("utf8");
+
+export const signFolderShareSlug = (folderId: string): string => {
+	return `${toBase64Url(folderId)}.${sign(folderId)}`;
+};
+
+export const verifyFolderShareSlug = (slug: string): string | null => {
+	const parts = slug.split(".");
+	if (parts.length !== 2) return null;
+	const [encodedId, sig] = parts;
+	if (!encodedId || !sig) return null;
+	let folderId: string;
+	try {
+		folderId = fromBase64Url(encodedId);
+	} catch {
+		return null;
+	}
+	if (sign(folderId) !== sig) return null;
+	return folderId;
+};

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -54,7 +54,8 @@ export async function proxy(request: NextRequest) {
 				path.startsWith("/self-hosting") ||
 				path.startsWith("/download") ||
 				path.startsWith("/terms") ||
-				path.startsWith("/verify-otp")
+				path.startsWith("/verify-otp") ||
+				path.startsWith("/share/")
 			) &&
 			process.env.NODE_ENV !== "development"
 		)

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -349,6 +349,9 @@ export const videos = mysqlTable(
 			.notNull()
 			.default({ type: "MediaConvert" }),
 		folderId: nanoIdNullable("folderId").$type<Folder.FolderId>(),
+		publicSourcedFromFolderShare: boolean("publicSourcedFromFolderShare")
+			.notNull()
+			.default(false),
 		createdAt: timestamp("createdAt").notNull().defaultNow(),
 		effectiveCreatedAt: datetime("effectiveCreatedAt").generatedAlwaysAs(
 			sql.raw(

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -298,6 +298,7 @@ export const folders = mysqlTable(
 		spaceId: nanoIdNullable("spaceId").$type<Space.SpaceIdOrOrganisationId>(),
 		createdAt: timestamp("createdAt").notNull().defaultNow(),
 		updatedAt: timestamp("updatedAt").notNull().defaultNow().onUpdateNow(),
+		publicShared: boolean("publicShared").notNull().default(false),
 	},
 	(table) => ({
 		organizationIdIndex: index("organization_id_idx").on(table.organizationId),


### PR DESCRIPTION
## Summary

Adds a per-folder **Share folder** action that produces a public URL anyone with the link can open. The visitor sees a clean index of the folder's videos (thumbnails, names, durations, dates) and clicks through to the existing `/s/<videoId>` player — no account, no signup.

I built this for a self-hosted instance where I needed to hand a client all the videos in one project folder without giving them a Cap account. Felt generally useful so I'm upstreaming it.

## Architecture

- **Schema** — single new column `folders.publicShared boolean default false`. No new table; the slug is derived, not stored.
- **Slug** — `base64url(folderId) + \".\" + hmac(folderId, NEXTAUTH_SECRET)`. Stateless. Rotating `NEXTAUTH_SECRET` revokes every outstanding folder-share link.
- **Action** — `enableFolderSharing(folderId)` flips `folders.publicShared = true` AND `videos.public = true` for every video in the folder so the existing share page keeps working unauthenticated. `disableFolderSharing` reverts both.
- **Public route** — `/share/f/[slug]/page.tsx` (Server Component): verifies the slug, refuses if `publicShared = false`, resolves S3 signed thumbnail URLs server-side (the existing `/api/thumbnail` returns JSON, not the image), renders a responsive grid linking each card to `/s/<videoId>`.
- **Proxy** — `/share/` added to the self-hosted whitelist next to `/embed/` so the route is reachable without auth.
- **UI** — new \"Share folder\" item in the existing `FoldersDropdown` kebab menu (hidden for folders owned by a Space — out of scope for this PR). New `ShareFolderDialog` with state hydration, Enable / Disable buttons, copy-to-clipboard.

## Test plan

- [ ] On `/dashboard/caps`, kebab on any folder → **Share folder** → dialog opens, shows \"Enable sharing\".
- [ ] Click **Enable sharing** → toast confirms, public link appears in the dialog and is copied to clipboard.
- [ ] Open the link in an incognito window → folder index renders with thumbnails / dates / durations, no auth prompt.
- [ ] Click a video → `/s/<videoId>` plays without login.
- [ ] Re-open the dialog on the original folder → still shows the same link.
- [ ] Click **Disable sharing** → toast confirms, opening the public link returns 404; opening any `/s/<videoId>` from that folder requires auth again (videos flipped back to private).
- [ ] Repeat after rotating `NEXTAUTH_SECRET` → previously-generated links return 404. Generating a new link produces a different slug.

## Notes for reviewers

- **Migration not regenerated.** No MySQL on the dev machine that pushed this. Please run `pnpm db:generate` to emit the migration file and journal entry; the schema change is just the new boolean column.
- **\"Set every video to public\" trade-off.** This is the simplest path to making `/s/<videoId>` work for guests without touching the share page. Downside: someone who guesses a video id while a folder is shared can hit it directly. A follow-up could swap this for a signed query param `/s/<videoId>?fs=<slug>` checked against the folder slug, keeping the videos technically private. Kept out of this PR to limit the blast radius.
- **Spaces folders.** Skipped intentionally — the kebab passes `setShareDialogOpen={spaceId ? undefined : ...}`. The Space sharing model is a separate question and I didn't want to overload it here.
- **No password / no expiry.** Conscious v1 scope. Both are clean additions on top (extra column for password hash, extra column for expiresAt) without architecture changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds stateless public folder sharing: a signed slug (`base64url(folderId) + \".\" + truncated-HMAC`) is generated from `NEXTAUTH_SECRET`, and a new `/share/f/[slug]` page renders the folder's video grid for unauthenticated visitors.

- **`disableFolderSharing` is destructive**: it unconditionally bulk-sets all videos in the folder to `public = false`, which permanently makes private any video that was already individually shared before folder sharing was ever enabled. Only videos whose `public` flag was flipped *by* `enableFolderSharing` should be reverted.
- **Timing-unsafe HMAC verification**: `verifyFolderShareSlug` uses `!==` to compare the expected and received HMAC signatures; `crypto.timingSafeEqual` should be used instead.
- The thumbnail resolver in the share page issues 2 sequential S3 API calls (`listObjects` + `getSignedObjectUrl`) for every video; for large folders this causes meaningful latency and could be reduced by constructing the key directly.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is: disabling folder sharing will silently revoke individually-shared videos, and the HMAC verification is not constant-time.

Two issues need resolution before merge. The `disableFolderSharing` action bulk-sets every video in the folder to private without checking whether those videos were already public before folder sharing was enabled — any video a user had independently shared will silently lose its public access. The HMAC verification in `folder-share.ts` uses a plain string comparison instead of `timingSafeEqual`, introducing a timing oracle on a security-critical path.

`apps/web/actions/folders/share-folder.ts` (destructive video visibility reset) and `apps/web/lib/folder-share.ts` (non-constant-time signature check) both need fixes before this lands.

<details open><summary><h3>Security Review</h3></summary>

- **Timing-unsafe HMAC comparison** (`apps/web/lib/folder-share.ts` line 37): `sign(folderId) !== sig` uses a short-circuit string comparison, leaking byte-position timing information. Because the HMAC check runs before any database query, an attacker can probe it freely without needing a real folder ID. Replacing it with `crypto.timingSafeEqual` eliminates the timing oracle.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/lib/folder-share.ts | New HMAC-based slug signing/verification module; uses non-constant-time string comparison in `verifyFolderShareSlug`, which should use `timingSafeEqual` instead. |
| apps/web/actions/folders/share-folder.ts | Server actions for enabling/disabling folder sharing; `disableFolderSharing` unconditionally sets all folder videos to private, destroying the pre-existing public state of videos that were already shared individually before folder sharing was enabled. |
| apps/web/app/share/f/[slug]/page.tsx | New public folder share page; verifies slug and renders video grid, but issues 2 S3 API calls per video for thumbnail resolution and uses `as any` casts to work around Drizzle branded-type mismatches. |
| apps/web/app/(org)/dashboard/caps/components/ShareFolderDialog.tsx | New client dialog for managing folder sharing state; hydration pattern and clipboard handling look correct; minor: clipboard failure is silently swallowed in `handleEnable`. |
| apps/web/app/(org)/dashboard/caps/components/FoldersDropdown.tsx | Adds optional "Share folder" menu item; correctly hidden for space-owned folders via `undefined` prop guard. |
| packages/database/schema.ts | Adds `publicShared boolean NOT NULL DEFAULT false` column to `folders` table; schema change is straightforward, migration not yet generated (noted in PR). |
| apps/web/proxy.ts | Adds `/share/` to the self-hosted auth bypass whitelist alongside `/embed/`; minimal and correct change. |
| apps/web/app/(org)/dashboard/caps/components/Folder.tsx | Wires `ShareFolderDialog` into the folder card; correctly gates the share action behind `!spaceId`. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
apps/web/actions/folders/share-folder.ts:59-62
**`disableFolderSharing` permanently silences pre-existing public videos**

`disableFolderSharing` unconditionally sets `public = false` on every video in the folder, regardless of whether those videos were already public before folder sharing was enabled. A user who individually shared a video via `/s/<videoId>` before ever touching the folder-share feature will silently find that video made private the moment they disable folder sharing — with no way to know it happened.

`enableFolderSharing` should record which videos it flipped (e.g., by filtering on `public = false` before updating, or by storing a flag like `sharedViaFolder`), so `disableFolderSharing` can revert only those videos rather than all of them.

### Issue 2 of 5
apps/web/lib/folder-share.ts:1
The `timingSafeEqual` import is missing when switching to constant-time comparison.

```suggestion
import { createHmac, timingSafeEqual } from "node:crypto";
```

### Issue 3 of 5
apps/web/lib/folder-share.ts:37
**Non-constant-time HMAC verification is susceptible to timing attacks**

`sign(folderId) !== sig` is a standard string comparison that short-circuits on the first differing byte, leaking timing information. Since the HMAC check runs before any DB lookup, an attacker can probe it freely. The fix is to use `timingSafeEqual` from `node:crypto`, which always runs in constant time regardless of where the strings differ.

```suggestion
	const expected = Buffer.from(sign(folderId));
	const actual = Buffer.from(sig);
	if (expected.length !== actual.length || !timingSafeEqual(expected, actual))
		return null;
```

### Issue 4 of 5
apps/web/app/share/f/[slug]/page.tsx:47-71
**N+1 S3 API calls on page load**

`resolveThumbnailUrl` makes two sequential S3 API calls per video (`listObjects` then `getSignedObjectUrl`). For a folder with 30 videos, the page issues 60 S3 calls concurrently via `Promise.all` — each of which fans out to the cloud. This will cause noticeably slow page loads and may hit S3 rate limits on large folders. If the thumbnail key pattern is stable (e.g., `{ownerId}/{videoId}/screen-capture.jpg`), the `listObjects` call can be skipped and the signed URL generated directly from the known key.

### Issue 5 of 5
apps/web/app/share/f/[slug]/page.tsx:24
**`as any` casts suppress Drizzle type safety**

Both WHERE clauses cast `folderId` to `any` (lines 24, 88, 105). This suggests a branded-type mismatch between the decoded string returned by `verifyFolderShareSlug` and the column's declared type (`Folder.FolderId`). The right fix is to cast the return value of `verifyFolderShareSlug` to the correct branded type once, or to type the function return as `Folder.FolderId | null`, instead of silencing the type checker at every call site.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(folders): public sharing of a folde..."](https://github.com/capsoftware/cap/commit/45a652dee5c1e93fbdb2226f622169d6ae7d4087) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35998148)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->