### PR TITLE
Parallelize startup and harden playback/export A/V sync

### DIFF
--- a/apps/desktop/src-tauri/examples/desktop-display-transport-benchmark.rs
+++ b/apps/desktop/src-tauri/examples/desktop-display-transport-benchmark.rs
@@ -8,7 +8,8 @@ use std::{
 use cap_desktop_lib::frame_ws::{WSFrame, WSFrameFormat, create_watch_frame_ws};
 use cap_editor::{
     EditorFrameOutput, Playback, PlaybackRenderOutputFormat, PlaybackSkipReason, PlaybackTelemetry,
-    PlaybackTelemetryEvent, Renderer, start_renderer_layers_creation,
+    PlaybackTelemetryEvent, Renderer, finish_renderer_layers_creation,
+    start_renderer_layers_creation,
 };
 use cap_project::{
     ProjectConfiguration, RecordingMeta, RecordingMetaInner, StudioRecordingMeta,
@@ -229,7 +230,7 @@ async fn main() {
 
     tokio::time::sleep(Duration::from_millis(startup_delay_ms)).await;
 
-    let layers_rx = start_renderer_layers_creation(&render_constants);
+    let layers_rx = start_renderer_layers_creation(&render_constants, &project);
     let segment_medias =
         match cap_editor::create_segments(&recording_meta, meta.as_ref(), false).await {
             Ok(segments) => Arc::new(segments),
@@ -238,6 +239,7 @@ async fn main() {
                 std::process::exit(1);
             }
         };
+    let layers_rx = finish_renderer_layers_creation(layers_rx).await;
 
     let (telemetry, mut telemetry_rx) = PlaybackTelemetry::channel();
     let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<usize>();

--- a/apps/desktop/src-tauri/src/export.rs
+++ b/apps/desktop/src-tauri/src/export.rs
@@ -715,13 +715,19 @@ fn resolve_exporter_binary() -> Result<PathBuf, String> {
 }
 
 fn exporter_binary_candidates(root: &Path) -> Vec<PathBuf> {
-    let mut candidates = vec![
+    let mut candidates = Vec::new();
+
+    if cfg!(debug_assertions) {
+        candidates.extend(debug_exporter_binary_candidates(root));
+    }
+
+    candidates.push(
         root.join("apps")
             .join("desktop")
             .join("src-tauri")
             .join("binaries")
             .join(exporter_bin_name()),
-    ];
+    );
 
     if let Some(target_triple) = current_target_triple() {
         candidates.push(
@@ -734,6 +740,36 @@ fn exporter_binary_candidates(root: &Path) -> Vec<PathBuf> {
                     std::env::consts::EXE_SUFFIX
                 )),
         );
+    }
+
+    candidates
+}
+
+fn debug_exporter_binary_candidates(root: &Path) -> Vec<PathBuf> {
+    let mut candidates = vec![
+        root.join("target").join("debug").join(exporter_bin_name()),
+        root.join("target")
+            .join("debug")
+            .join(format!("cap{}", std::env::consts::EXE_SUFFIX)),
+    ];
+
+    if let Some(target_triple) = current_target_triple() {
+        candidates.push(
+            root.join("target")
+                .join(target_triple)
+                .join("debug")
+                .join(exporter_bin_name()),
+        );
+        candidates.push(
+            root.join("target")
+                .join(target_triple)
+                .join("debug")
+                .join(format!("cap{}", std::env::consts::EXE_SUFFIX)),
+        );
+        candidates.push(root.join("target").join("debug").join(format!(
+            "cap-exporter-{target_triple}{}",
+            std::env::consts::EXE_SUFFIX
+        )));
     }
 
     candidates

--- a/apps/desktop/src-tauri/src/import.rs
+++ b/apps/desktop/src-tauri/src/import.rs
@@ -1483,6 +1483,7 @@ pub async fn start_video_import(app: AppHandle, source_path: PathBuf) -> Result<
                             path: RelativePathBuf::from("content/segments/segment-0/audio.ogg"),
                             start_time: Some(0.0),
                             device_id: None,
+                            gap_summary: None,
                         })
                     } else {
                         None
@@ -1666,6 +1667,7 @@ async fn append_mp4_to_editor_project(
             path: output_audio_relative_path,
             start_time: Some(0.0),
             device_id: None,
+            gap_summary: None,
         })
     } else {
         None

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -480,8 +480,27 @@ export type AppTheme = "system" | "light" | "dark"
 export type AspectRatio = "wide" | "vertical" | "square" | "classic" | "tall"
 export type Audio = { duration: number; sample_rate: number; channels: number; start_time: number }
 export type AudioConfiguration = { mute: boolean; improve: boolean; micVolumeDb: number; micStereoMode: StereoMode; systemVolumeDb: number }
+/**
+ * Overlap-trim accounting captured by the recorder's audio gap tracker, persisted so the
+ * editor can compensate for stale-startup audio drift from typed data instead of scraping
+ * the recording log. See `cap-editor`'s `audio_timing_repair_offset`.
+ */
+export type AudioGapSummary = { 
+/**
+ * Total audio trimmed from overlapping frames over the whole recording, in milliseconds.
+ */
+total_overlap_trimmed_ms: number; 
+/**
+ * Number of whole audio frames dropped because they fully overlapped the committed timeline.
+ */
+overlap_dropped_frames: number; 
+/**
+ * Subset of `overlap_dropped_frames` that dropped within the first few frames — the
+ * signature of a stale buffered burst at capture start.
+ */
+startup_overlap_drops: number }
 export type AudioInputLevelChange = number
-export type AudioMeta = { path: string; start_time?: number | null; device_id?: string | null }
+export type AudioMeta = { path: string; start_time?: number | null; device_id?: string | null; gap_summary?: AudioGapSummary | null }
 export type AuthSecret = { api_key: string } | { token: string; expires: number }
 export type AuthStore = { secret: AuthSecret; user_id: string | null; plan: Plan | null; organizations?: Organization[]; organizations_updated_at?: number | null }
 export type BackgroundBlurConfig = { mode: BackgroundBlurMode }

--- a/crates/audio/src/latency.rs
+++ b/crates/audio/src/latency.rs
@@ -15,9 +15,9 @@
 //! // Create corrector with default settings
 //! let mut corrector = LatencyCorrector::new(hint, LatencyCorrectionConfig::default());
 //!
-//! // Apply initial compensation to audio playhead
+//! // Apply initial output latency to audio playhead
 //! let base_playhead = 5.0; // Current playback position in seconds
-//! let compensated_playhead = base_playhead + corrector.initial_compensation_secs();
+//! let compensated_playhead = base_playhead + corrector.initial_output_latency_secs();
 //! // audio_renderer.set_playhead(compensated_playhead);
 //!
 //! // In audio callback, update latency estimate
@@ -140,6 +140,10 @@ impl LatencyCorrector {
     /// Get the initial latency compensation value (with safety multiplier applied)
     pub fn initial_compensation_secs(&self) -> f64 {
         self.estimator.current_secs().unwrap_or_default() * self.config.initial_safety_multiplier
+    }
+
+    pub fn initial_output_latency_secs(&self) -> f64 {
+        self.estimator.current_secs().unwrap_or_default()
     }
 
     /// Update latency estimate from audio callback and return corrected latency
@@ -1002,7 +1006,27 @@ mod tests {
         let corrector = LatencyCorrector::new(Some(hint), config);
 
         let initial = corrector.initial_compensation_secs();
-        assert_eq!(initial, 0.05 * 2.0); // Default multiplier is 2.0
+        assert_eq!(initial, 0.05 * 2.0);
+        assert_eq!(corrector.initial_output_latency_secs(), 0.05);
+    }
+
+    #[test]
+    fn latency_corrector_reports_floor_constrained_initial_latency() {
+        let hint = OutputLatencyHint::new(0.05, OutputTransportKind::Wireless);
+        let config = LatencyCorrectionConfig {
+            initial_safety_multiplier: 3.0,
+            ..Default::default()
+        };
+        let corrector = LatencyCorrector::new(Some(hint), config);
+
+        assert_eq!(
+            corrector.initial_output_latency_secs(),
+            WIRELESS_MIN_LATENCY_SECS
+        );
+        assert_eq!(
+            corrector.initial_compensation_secs(),
+            WIRELESS_MIN_LATENCY_SECS * 3.0
+        );
     }
 
     #[test]

--- a/crates/audio/src/renderer.rs
+++ b/crates/audio/src/renderer.rs
@@ -25,9 +25,9 @@ pub fn render_audio(
             .iter()
             .filter_map(|t| {
                 let track_samples = t.data.samples().len() / t.data.channels() as usize;
-                let available = track_samples as isize - offset as isize - t.offset;
+                let available = track_samples as i128 - offset as i128 - t.offset as i128;
                 if available > 0 {
-                    Some(available as usize)
+                    usize::try_from(available).ok()
                 } else {
                     None
                 }
@@ -41,7 +41,13 @@ pub fn render_audio(
         let mut right = 0.0;
 
         for track in tracks {
-            let i = i.wrapping_add_signed(track.offset);
+            let source_index = offset as i128 + i as i128 + track.offset as i128;
+            if source_index < 0 {
+                continue;
+            }
+            let Ok(source_index) = usize::try_from(source_index) else {
+                continue;
+            };
 
             let data = track.data;
             let gain = gain_for_db(track.gain);
@@ -51,12 +57,12 @@ pub fn render_audio(
             }
 
             if data.channels() == 1 {
-                if let Some(sample) = data.samples().get(offset + i) {
+                if let Some(sample) = data.samples().get(source_index) {
                     left += sample * 0.707 * gain;
                     right += sample * 0.707 * gain;
                 }
             } else if data.channels() == 2 {
-                let base_idx = offset * 2 + i * 2;
+                let base_idx = source_index.saturating_mul(2);
                 let Some(l_sample) = data.samples().get(base_idx) else {
                     continue;
                 };
@@ -138,6 +144,26 @@ mod tests {
         render_audio(&[track(&data, 2)], 3, 4, 0, &mut out);
         // cursor 3 + track offset 2 -> source frame 5 (value 0.06).
         assert!((out[0] - 0.06).abs() < 1e-6);
+    }
+
+    #[test]
+    fn negative_offset_delays_track_with_leading_silence() {
+        let mut samples = Vec::new();
+        for k in 0..4 {
+            let v = (k as f32 + 1.0) / 10.0;
+            samples.push(v);
+            samples.push(v);
+        }
+        let data = AudioData::from_raw_f32(samples, 2);
+
+        let mut out = vec![0.0; 6 * 2];
+        let rendered = render_audio(&[track(&data, -2)], 0, 6, 0, &mut out);
+
+        assert_eq!(rendered, 6);
+        assert_eq!(out[0], 0.0);
+        assert_eq!(out[2], 0.0);
+        assert!((out[4] - 0.1).abs() < 1e-6);
+        assert!((out[10] - 0.4).abs() < 1e-6);
     }
 
     // Regression guard for commit 2a6dce7: render mixes up to the LONGEST track

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -18,6 +18,10 @@ path = "examples/playback-pipeline-benchmark.rs"
 name = "editor-playback-benchmark"
 path = "examples/editor-playback-benchmark.rs"
 
+[[example]]
+name = "editor-startup-benchmark"
+path = "examples/editor-startup-benchmark.rs"
+
 [dependencies]
 cap-media = { path = "../media" }
 cap-project = { path = "../project" }

--- a/crates/editor/examples/editor-playback-benchmark.rs
+++ b/crates/editor/examples/editor-playback-benchmark.rs
@@ -8,7 +8,7 @@ use std::{
 use cap_editor::{
     EditorFrameOutput, Playback, PlaybackFrameSource, PlaybackRenderOutputFormat,
     PlaybackSkipReason, PlaybackTelemetry, PlaybackTelemetryEvent, Renderer,
-    start_renderer_layers_creation,
+    finish_renderer_layers_creation, start_renderer_layers_creation,
 };
 use cap_project::{
     ProjectConfiguration, RecordingMeta, RecordingMetaInner, StudioRecordingMeta,
@@ -420,6 +420,14 @@ async fn main() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(300u64);
     let resolution_base = parse_resolution(&args);
+    let start_frame_number = arg_value(&args, "--start-frame")
+        .and_then(|s| s.parse().ok())
+        .or_else(|| {
+            arg_value(&args, "--start-time")
+                .and_then(|s| s.parse::<f64>().ok())
+                .map(|seconds| (seconds * fps as f64).round() as u32)
+        })
+        .unwrap_or(0);
 
     println!("{}", "=".repeat(64));
     println!("  CAP EDITOR LIVE PLAYBACK BENCHMARK");
@@ -431,6 +439,7 @@ async fn main() {
         "Resolution base: {}x{}",
         resolution_base.x, resolution_base.y
     );
+    println!("Start frame: {start_frame_number}");
 
     let (recording_meta, meta, project, recordings) = match load_recording(&recording_path).await {
         Ok(recording) => recording,
@@ -460,7 +469,7 @@ async fn main() {
         render_constants.is_software_adapter
     );
 
-    let layers_rx = start_renderer_layers_creation(&render_constants);
+    let layers_rx = start_renderer_layers_creation(&render_constants, &project);
 
     let segment_medias =
         match cap_editor::create_segments(&recording_meta, meta.as_ref(), false).await {
@@ -470,6 +479,7 @@ async fn main() {
                 std::process::exit(1);
             }
         };
+    let layers_rx = finish_renderer_layers_creation(layers_rx).await;
 
     let (telemetry, mut telemetry_rx) = PlaybackTelemetry::channel();
     let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<usize>();
@@ -491,8 +501,6 @@ async fn main() {
     let renderer = match Renderer::spawn_with_telemetry(
         render_constants.clone(),
         frame_cb,
-        &recording_meta,
-        meta.as_ref(),
         layers_rx,
         Some(telemetry.clone()),
     ) {
@@ -507,7 +515,7 @@ async fn main() {
     let playback = Playback {
         renderer: renderer.clone(),
         render_constants,
-        start_frame_number: 0,
+        start_frame_number,
         project: project_rx,
         segment_medias,
         telemetry: Some(telemetry),

--- a/crates/editor/examples/editor-startup-benchmark.rs
+++ b/crates/editor/examples/editor-startup-benchmark.rs
@@ -1,0 +1,256 @@
+use std::{
+    path::PathBuf,
+    sync::{Arc, mpsc},
+    time::{Duration, Instant},
+};
+
+use cap_editor::{
+    EditorFrameOutput, EditorInstance, Renderer, create_segments, finish_renderer_layers_creation,
+    start_renderer_layers_creation,
+};
+use cap_project::{ProjectConfiguration, RecordingMeta, RecordingMetaInner};
+use cap_rendering::{ProjectRecordingsMeta, RenderVideoConstants};
+
+fn arg_value<'a>(args: &'a [String], flag: &str) -> Option<&'a str> {
+    args.iter()
+        .position(|arg| arg == flag)
+        .and_then(|idx| args.get(idx + 1))
+        .map(String::as_str)
+}
+
+fn percentile(data: &[f64], p: f64) -> f64 {
+    let mut sorted: Vec<f64> = data.iter().copied().filter(|v| v.is_finite()).collect();
+    if sorted.is_empty() {
+        return 0.0;
+    }
+
+    sorted.sort_by(|a, b| {
+        a.partial_cmp(b)
+            .expect("finite values should be comparable")
+    });
+    let idx = ((p / 100.0) * (sorted.len() - 1) as f64).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+fn has_flag(args: &[String], flag: &str) -> bool {
+    args.iter().any(|arg| arg == flag)
+}
+
+fn push_stage(stages: &mut Vec<(&'static str, f64)>, name: &'static str, start: &mut Instant) {
+    stages.push((name, start.elapsed().as_secs_f64() * 1000.0));
+    *start = Instant::now();
+}
+
+async fn profile_startup_stages(
+    recording_path: PathBuf,
+) -> Result<Vec<(&'static str, f64)>, String> {
+    let mut stages = Vec::new();
+    let total_start = Instant::now();
+    let mut stage_start = Instant::now();
+
+    let recording_meta = RecordingMeta::load_for_project(&recording_path)
+        .map_err(|e| format!("Failed to load recording meta: {e}"))?;
+    let RecordingMetaInner::Studio(meta) = &recording_meta.inner else {
+        return Err("Cannot edit non-studio recordings".to_string());
+    };
+    push_stage(&mut stages, "load recording metadata", &mut stage_start);
+
+    let project = recording_meta.project_config();
+    push_stage(&mut stages, "load project config", &mut stage_start);
+
+    let recordings = Arc::new(ProjectRecordingsMeta::new(
+        &recording_meta.project_path,
+        meta.as_ref(),
+    )?);
+    push_stage(&mut stages, "recordings metadata", &mut stage_start);
+
+    let render_constants = Arc::new(
+        RenderVideoConstants::new(
+            &recordings.segments,
+            recording_meta.clone(),
+            (**meta).clone(),
+        )
+        .await
+        .map_err(|e| format!("Failed to create render constants: {e}"))?,
+    );
+    push_stage(&mut stages, "render constants", &mut stage_start);
+
+    let layers_rx = start_renderer_layers_creation(&render_constants, &project);
+    push_stage(&mut stages, "start layer warmup", &mut stage_start);
+
+    let _segments = create_segments(&recording_meta, meta.as_ref(), false).await?;
+    push_stage(&mut stages, "create segments", &mut stage_start);
+
+    let layers_rx = finish_renderer_layers_creation(layers_rx).await;
+    push_stage(&mut stages, "finish layer warmup", &mut stage_start);
+
+    let renderer = Renderer::spawn(
+        render_constants,
+        Box::new(|_: EditorFrameOutput| {}),
+        layers_rx,
+    )?;
+    push_stage(&mut stages, "spawn renderer", &mut stage_start);
+    stages.push((
+        "total startup-equivalent",
+        total_start.elapsed().as_secs_f64() * 1000.0,
+    ));
+
+    renderer.stop().await;
+
+    Ok(stages)
+}
+
+async fn run_stage_profile(recording_path: PathBuf, runs: usize) {
+    let mut stage_values: Vec<(&'static str, Vec<f64>)> = Vec::new();
+
+    for _ in 0..runs {
+        let stages = profile_startup_stages(recording_path.clone())
+            .await
+            .expect("Failed to profile startup stages");
+
+        for (stage_idx, (name, value)) in stages.into_iter().enumerate() {
+            if stage_values.len() <= stage_idx {
+                stage_values.push((name, Vec::with_capacity(runs)));
+            }
+            stage_values[stage_idx].1.push(value);
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    println!();
+    println!("{}", "=".repeat(64));
+    println!("  STARTUP STAGES");
+    println!("{}", "=".repeat(64));
+
+    for (name, values) in stage_values {
+        let avg = values.iter().sum::<f64>() / values.len() as f64;
+        let max = values.iter().copied().fold(0.0, f64::max);
+        println!(
+            "{name:<28} avg={avg:>6.1}ms p50={:>6.1}ms p95={:>6.1}ms max={max:>6.1}ms",
+            percentile(&values, 50.0),
+            percentile(&values, 95.0)
+        );
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::WARN.into()),
+        )
+        .init();
+
+    ffmpeg::init().expect("Failed to initialize FFmpeg");
+
+    let args: Vec<String> = std::env::args().collect();
+    let recording_path = arg_value(&args, "--recording-path")
+        .map(PathBuf::from)
+        .expect("Usage: editor-startup-benchmark --recording-path <path> [--runs <count>]");
+    let runs = arg_value(&args, "--runs")
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(3)
+        .max(1);
+    let fps = arg_value(&args, "--fps")
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(60);
+    let preview_frame = arg_value(&args, "--preview-frame")
+        .and_then(|s| s.parse::<u32>().ok())
+        .or_else(|| {
+            arg_value(&args, "--preview-time")
+                .and_then(|s| s.parse::<f64>().ok())
+                .map(|seconds| (seconds * fps as f64).round() as u32)
+        })
+        .unwrap_or(0);
+    let profile_stages = has_flag(&args, "--profile-stages");
+    let resolution_base = cap_project::XY::new(1248, 702);
+
+    println!("{}", "=".repeat(64));
+    println!("  CAP EDITOR STARTUP BENCHMARK");
+    println!("{}", "=".repeat(64));
+    println!("Recording: {}", recording_path.display());
+    println!("Runs: {runs}");
+    println!("Preview frame: {preview_frame}");
+    println!("Profile stages: {profile_stages}");
+
+    let mut values_ms = Vec::with_capacity(runs);
+    let mut preview_values_ms = Vec::with_capacity(runs);
+
+    for run in 0..runs {
+        let before_config = ProjectConfiguration::load(&recording_path).unwrap_or_default();
+        let before_has_timeline = before_config.timeline.is_some();
+        let before_clip_count = before_config.clips.len();
+        let before_meta_loaded = RecordingMeta::load_for_project(&recording_path).is_ok();
+
+        let (frame_tx, frame_rx) = mpsc::channel::<()>();
+        let start = Instant::now();
+        let editor = EditorInstance::new(
+            recording_path.clone(),
+            |_| {},
+            Box::new(move |_: EditorFrameOutput| {
+                let _ = frame_tx.send(());
+            }),
+            None,
+        )
+        .await
+        .expect("Failed to create editor instance");
+        let elapsed = start.elapsed();
+        values_ms.push(elapsed.as_secs_f64() * 1000.0);
+
+        let preview_start = Instant::now();
+        editor
+            .preview_tx
+            .send(Some((preview_frame, fps, resolution_base)))
+            .expect("Failed to request preview frame");
+        let preview_elapsed = if frame_rx.recv_timeout(Duration::from_secs(10)).is_ok() {
+            preview_start.elapsed().as_secs_f64() * 1000.0
+        } else {
+            f64::INFINITY
+        };
+        preview_values_ms.push(preview_elapsed);
+
+        editor.dispose().await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let after_config = ProjectConfiguration::load(&recording_path).unwrap_or_default();
+        println!(
+            "Run {}: {:.1}ms preview={:.1}ms meta_loaded={} timeline {}->{} clips {}->{}",
+            run + 1,
+            elapsed.as_secs_f64() * 1000.0,
+            preview_elapsed,
+            before_meta_loaded,
+            before_has_timeline,
+            after_config.timeline.is_some(),
+            before_clip_count,
+            after_config.clips.len()
+        );
+    }
+
+    let avg = values_ms.iter().sum::<f64>() / values_ms.len() as f64;
+    let max = values_ms.iter().copied().fold(0.0, f64::max);
+
+    println!();
+    println!("{}", "=".repeat(64));
+    println!("  RESULTS");
+    println!("{}", "=".repeat(64));
+    println!(
+        "Startup: avg={avg:.1}ms p50={:.1}ms p95={:.1}ms max={max:.1}ms samples={}",
+        percentile(&values_ms, 50.0),
+        percentile(&values_ms, 95.0),
+        values_ms.len()
+    );
+    let preview_avg = preview_values_ms.iter().sum::<f64>() / preview_values_ms.len() as f64;
+    let preview_max = preview_values_ms.iter().copied().fold(0.0, f64::max);
+    println!(
+        "First preview: avg={preview_avg:.1}ms p50={:.1}ms p95={:.1}ms max={preview_max:.1}ms samples={}",
+        percentile(&preview_values_ms, 50.0),
+        percentile(&preview_values_ms, 95.0),
+        preview_values_ms.len()
+    );
+
+    if profile_stages {
+        run_stage_profile(recording_path, runs).await;
+    }
+}

--- a/crates/editor/examples/playback-pipeline-benchmark.rs
+++ b/crates/editor/examples/playback-pipeline-benchmark.rs
@@ -48,6 +48,7 @@ struct PipelineTimings {
     decode_ms: Vec<f64>,
     render_ms: Vec<f64>,
     total_ms: Vec<f64>,
+    keyframe_decode_ms: Vec<(f64, f64)>,
     decode_failures: usize,
     render_failures: usize,
     frames_rendered: usize,
@@ -81,6 +82,162 @@ impl PipelineTimings {
         print_stats("Decode", &self.decode_ms);
         print_stats("GPU Render+Readback", &self.render_ms);
         print_stats("Total (decode+render)", &self.total_ms);
+        print_keyframe_distance_report(&self.keyframe_decode_ms);
+    }
+}
+
+fn print_keyframe_distance_report(samples: &[(f64, f64)]) {
+    if samples.is_empty() {
+        return;
+    }
+
+    let distances_ms: Vec<f64> = samples
+        .iter()
+        .map(|(distance, _)| distance * 1000.0)
+        .collect();
+    println!();
+    print_stats("Distance after previous keyframe", &distances_ms);
+
+    let avg_distance =
+        samples.iter().map(|(distance, _)| *distance).sum::<f64>() / samples.len() as f64;
+    let avg_decode = samples.iter().map(|(_, decode)| *decode).sum::<f64>() / samples.len() as f64;
+    let covariance = samples
+        .iter()
+        .map(|(distance, decode)| (distance - avg_distance) * (decode - avg_decode))
+        .sum::<f64>();
+    let distance_variance = samples
+        .iter()
+        .map(|(distance, _)| (distance - avg_distance).powi(2))
+        .sum::<f64>();
+    let decode_variance = samples
+        .iter()
+        .map(|(_, decode)| (decode - avg_decode).powi(2))
+        .sum::<f64>();
+    if distance_variance > 0.0 && decode_variance > 0.0 {
+        let correlation = covariance / (distance_variance.sqrt() * decode_variance.sqrt());
+        println!("  Decode/keyframe-distance correlation: {correlation:.2}");
+    }
+
+    const BUCKETS: [(f64, f64, &str); 4] = [
+        (0.0, 0.25, "0-250ms"),
+        (0.25, 0.5, "250-500ms"),
+        (0.5, 0.75, "500-750ms"),
+        (0.75, f64::INFINITY, "750ms+"),
+    ];
+
+    println!("  Decode by distance after previous keyframe:");
+    for (min, max, label) in BUCKETS {
+        let values: Vec<f64> = samples
+            .iter()
+            .filter_map(|(distance, decode)| {
+                (*distance >= min && *distance < max).then_some(*decode)
+            })
+            .collect();
+        if values.is_empty() {
+            println!("    {label}: no samples");
+        } else {
+            let avg = values.iter().sum::<f64>() / values.len() as f64;
+            println!(
+                "    {label}: count={} avg={avg:.2}ms p95={:.2}ms",
+                values.len(),
+                percentile(&values, 95.0)
+            );
+        }
+    }
+}
+
+struct VideoKeyframeStats {
+    keyframes: Vec<(u32, f64)>,
+    fps: f64,
+    duration_secs: f64,
+}
+
+impl VideoKeyframeStats {
+    fn build(path: &Path) -> Result<Self, String> {
+        let mut input = ffmpeg::format::input(path)
+            .map_err(|e| format!("Failed to open video for keyframe scan: {e}"))?;
+
+        let (stream_index, time_base, fps, duration_secs) = {
+            let video_stream = input
+                .streams()
+                .best(ffmpeg::media::Type::Video)
+                .ok_or("No video stream found")?;
+
+            let stream_index = video_stream.index();
+            let time_base = video_stream.time_base();
+            let rate = video_stream.avg_frame_rate();
+            let fps = if rate.denominator() == 0 {
+                30.0
+            } else {
+                rate.numerator() as f64 / rate.denominator() as f64
+            };
+            let duration = video_stream.duration();
+            let duration_secs = if duration > 0 {
+                duration as f64 * time_base.numerator() as f64 / time_base.denominator() as f64
+            } else {
+                0.0
+            };
+
+            (stream_index, time_base, fps, duration_secs)
+        };
+
+        let mut keyframes = Vec::new();
+        for (stream, packet) in input.packets() {
+            if stream.index() != stream_index || !packet.is_key() {
+                continue;
+            }
+
+            let pts = packet.pts().unwrap_or(0);
+            let time_secs =
+                pts as f64 * time_base.numerator() as f64 / time_base.denominator() as f64;
+            let frame_number = (time_secs * fps).round() as u32;
+            keyframes.push((frame_number, time_secs));
+        }
+
+        Ok(Self {
+            keyframes,
+            fps,
+            duration_secs,
+        })
+    }
+
+    fn print_summary(&self, label: &str) {
+        let intervals: Vec<f64> = self
+            .keyframes
+            .windows(2)
+            .map(|pair| pair[1].1 - pair[0].1)
+            .collect();
+        let avg_interval = if intervals.is_empty() {
+            0.0
+        } else {
+            intervals.iter().sum::<f64>() / intervals.len() as f64
+        };
+        let max_interval = intervals.iter().copied().fold(0.0, f64::max);
+
+        println!(
+            "  Keyframes ({label}): count={} fps={:.2} duration={:.2}s avg_interval={avg_interval:.3}s max_interval={max_interval:.3}s",
+            self.keyframes.len(),
+            self.fps,
+            self.duration_secs,
+        );
+    }
+
+    fn distance_after_previous_keyframe(&self, time_secs: f64) -> Option<f64> {
+        if self.keyframes.is_empty() {
+            return None;
+        }
+
+        let target_frame = (time_secs * self.fps).round() as u32;
+        let pos = self
+            .keyframes
+            .binary_search_by_key(&target_frame, |(frame, _)| *frame);
+        let index = match pos {
+            Ok(i) => i,
+            Err(0) => return None,
+            Err(i) => i - 1,
+        };
+
+        Some((time_secs - self.keyframes[index].1).max(0.0))
     }
 }
 
@@ -170,6 +327,7 @@ async fn run_decode_only_benchmark(
     project: &ProjectConfiguration,
     fps: u32,
     frame_count: usize,
+    force_ffmpeg: bool,
 ) -> PipelineTimings {
     let mut timings = PipelineTimings::default();
 
@@ -187,14 +345,21 @@ async fn run_decode_only_benchmark(
         StudioRecordingMeta::MultipleSegments { inner } => inner.segments[0].display.fps,
     };
 
-    let decoder =
-        match spawn_decoder("benchmark-screen", display_path, display_fps, 0.0, false).await {
-            Ok(d) => d,
-            Err(e) => {
-                eprintln!("Failed to create decoder: {e}");
-                return timings;
-            }
-        };
+    let decoder = match spawn_decoder(
+        "benchmark-screen",
+        display_path,
+        display_fps,
+        0.0,
+        force_ffmpeg,
+    )
+    .await
+    {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Failed to create decoder: {e}");
+            return timings;
+        }
+    };
 
     println!("  Decoder type: {}", decoder.decoder_type());
     println!(
@@ -232,15 +397,26 @@ async fn run_decode_only_benchmark(
     timings
 }
 
+struct PipelineBenchmarkConfig {
+    fps: u32,
+    frame_count: usize,
+    resolution_base: XY<u32>,
+    force_ffmpeg: bool,
+}
+
 async fn run_full_pipeline_benchmark(
     recording_meta: &RecordingMeta,
     meta: &StudioRecordingMeta,
     project: &ProjectConfiguration,
     recordings: &ProjectRecordingsMeta,
-    fps: u32,
-    frame_count: usize,
-    resolution_base: XY<u32>,
+    config: PipelineBenchmarkConfig,
 ) -> PipelineTimings {
+    let PipelineBenchmarkConfig {
+        fps,
+        frame_count,
+        resolution_base,
+        force_ffmpeg,
+    } = config;
     let mut timings = PipelineTimings::default();
 
     let render_constants = match RenderVideoConstants::new(
@@ -263,7 +439,7 @@ async fn run_full_pipeline_benchmark(
         render_constants.is_software_adapter
     );
 
-    let segments = match cap_editor::create_segments(recording_meta, meta, false).await {
+    let segments = match cap_editor::create_segments(recording_meta, meta, force_ffmpeg).await {
         Ok(s) => s,
         Err(e) => {
             eprintln!("Failed to create segments: {e}");
@@ -430,6 +606,7 @@ async fn run_scrubbing_benchmark(
     recordings: &ProjectRecordingsMeta,
     fps: u32,
     resolution_base: XY<u32>,
+    force_ffmpeg: bool,
 ) -> PipelineTimings {
     let mut timings = PipelineTimings::default();
 
@@ -447,7 +624,7 @@ async fn run_scrubbing_benchmark(
         }
     };
 
-    let segments = match cap_editor::create_segments(recording_meta, meta, false).await {
+    let segments = match cap_editor::create_segments(recording_meta, meta, force_ffmpeg).await {
         Ok(s) => s,
         Err(e) => {
             eprintln!("Failed to create segments: {e}");
@@ -459,6 +636,31 @@ async fn run_scrubbing_benchmark(
         eprintln!("No segments found");
         return timings;
     }
+
+    let display_paths: Vec<PathBuf> = match meta {
+        StudioRecordingMeta::SingleSegment { segment } => {
+            vec![recording_meta.path(&segment.display.path)]
+        }
+        StudioRecordingMeta::MultipleSegments { inner } => inner
+            .segments
+            .iter()
+            .map(|segment| recording_meta.path(&segment.display.path))
+            .collect(),
+    };
+    let keyframe_stats: Vec<Option<VideoKeyframeStats>> = display_paths
+        .iter()
+        .enumerate()
+        .map(|(index, path)| match VideoKeyframeStats::build(path) {
+            Ok(stats) => {
+                stats.print_summary(&format!("segment {index}"));
+                Some(stats)
+            }
+            Err(e) => {
+                eprintln!("  Failed to scan keyframes for {}: {e}", path.display());
+                None
+            }
+        })
+        .collect();
 
     let mut frame_renderer = FrameRenderer::new(&render_constants);
     let mut layers = RendererLayers::new_with_options(
@@ -541,6 +743,15 @@ async fn run_scrubbing_benchmark(
         };
 
         timings.decode_ms.push(decode_elapsed_ms);
+        if let Some(distance) = keyframe_stats
+            .get(segment.recording_clip as usize)
+            .and_then(|stats| stats.as_ref())
+            .and_then(|stats| stats.distance_after_previous_keyframe(segment_time))
+        {
+            timings
+                .keyframe_decode_ms
+                .push((distance, decode_elapsed_ms));
+        }
 
         let frame_number = (scrub_time * fps as f64).round() as u32;
 
@@ -631,6 +842,7 @@ async fn main() {
         .and_then(|i| args.get(i + 1))
         .and_then(|s| s.parse().ok())
         .unwrap_or(300);
+    let force_ffmpeg = args.iter().any(|arg| arg == "--force-ffmpeg");
 
     println!("{}", "=".repeat(60));
     println!("  CAP PLAYBACK PIPELINE BENCHMARK");
@@ -639,6 +851,7 @@ async fn main() {
     println!("Recording: {}", recording_path.display());
     println!("Target FPS: {fps}");
     println!("Max frames: {frame_count}");
+    println!("Force FFmpeg: {force_ffmpeg}");
     println!();
 
     let (recording_meta, meta, project, recordings) = match load_recording(&recording_path).await {
@@ -663,8 +876,15 @@ async fn main() {
     ];
 
     println!("\n--- DECODE-ONLY BENCHMARK ---");
-    let decode_timings =
-        run_decode_only_benchmark(&recording_meta, meta.as_ref(), &project, fps, frame_count).await;
+    let decode_timings = run_decode_only_benchmark(
+        &recording_meta,
+        meta.as_ref(),
+        &project,
+        fps,
+        frame_count,
+        force_ffmpeg,
+    )
+    .await;
     decode_timings.print_report("DECODE-ONLY");
 
     for (resolution_base, label) in &resolutions {
@@ -674,9 +894,12 @@ async fn main() {
             meta.as_ref(),
             &project,
             &recordings,
-            fps,
-            frame_count,
-            *resolution_base,
+            PipelineBenchmarkConfig {
+                fps,
+                frame_count,
+                resolution_base: *resolution_base,
+                force_ffmpeg,
+            },
         )
         .await;
         pipeline_timings.print_report(&format!("FULL PIPELINE - {label}"));
@@ -690,6 +913,7 @@ async fn main() {
         &recordings,
         fps,
         XY::new(1248, 702),
+        force_ffmpeg,
     )
     .await;
     scrub_timings.print_report("SCRUBBING (Half resolution)");

--- a/crates/editor/src/audio.rs
+++ b/crates/editor/src/audio.rs
@@ -987,6 +987,56 @@ mod tests {
         assert!((left_at_second(&stream, 2) - expected(24000)).abs() < 0.01);
     }
 
+    #[test]
+    fn prerendered_playback_and_export_apply_negative_timing_offset_consistently() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("delayed.wav");
+        write_step_wav(&path, &[12000, 24000]);
+
+        let data = Arc::new(AudioData::from_file(&path).unwrap());
+        let segments = vec![AudioSegment {
+            tracks: vec![
+                AudioSegmentTrack::new(data, gain, stereo, no_offset)
+                    .with_timing_offset_secs(-0.867),
+            ],
+        }];
+        let project = ProjectConfiguration {
+            timeline: Some(TimelineConfiguration {
+                segments: vec![segment(0, 0.0, 3.0, 1.0)],
+                zoom_segments: Vec::new(),
+                scene_segments: Vec::new(),
+                mask_segments: Vec::new(),
+                text_segments: Vec::new(),
+                caption_segments: Vec::new(),
+                keyboard_segments: Vec::new(),
+            }),
+            clips: vec![ClipConfiguration {
+                index: 0,
+                offsets: Default::default(),
+            }],
+            ..Default::default()
+        };
+
+        let mut export_renderer = AudioRenderer::new(segments.clone());
+        let export_stream = render_export_audio(&mut export_renderer, &project, 30, 3 * 30);
+
+        let mut playback_buffer =
+            PrerenderedAudioBuffer::<f32>::new(segments, &project, AudioRenderer::info(), 3.0);
+        let mut playback_stream = vec![0.0; 3 * AudioData::SAMPLE_RATE as usize * 2];
+        playback_buffer.fill(&mut playback_stream);
+
+        for second in 0..3usize {
+            let export_sample = left_at_second(&export_stream, second);
+            let playback_sample = left_at_second(&playback_stream, second);
+            assert!(
+                (export_sample - playback_sample).abs() < 0.01,
+                "second {second}: export {export_sample}, playback {playback_sample}"
+            );
+        }
+        assert_eq!(left_at_second(&export_stream, 0), 0.0);
+        assert_eq!(left_at_second(&playback_stream, 0), 0.0);
+    }
+
     // Time->sample conversion rounds to nearest (not truncates), so a fractional
     // sample position lands on the nearest sample rather than biasing downward.
     #[test]

--- a/crates/editor/src/audio.rs
+++ b/crates/editor/src/audio.rs
@@ -43,6 +43,7 @@ pub struct AudioSegmentTrack {
     get_gain: fn(&AudioConfiguration) -> f32,
     get_stereo_mode: fn(&AudioConfiguration) -> StereoMode,
     get_offset: fn(&ClipOffsets) -> f32,
+    timing_offset_secs: f32,
 }
 
 impl AudioSegmentTrack {
@@ -57,7 +58,13 @@ impl AudioSegmentTrack {
             get_gain,
             get_stereo_mode,
             get_offset,
+            timing_offset_secs: 0.0,
         }
+    }
+
+    pub fn with_timing_offset_secs(mut self, timing_offset_secs: f32) -> Self {
+        self.timing_offset_secs = timing_offset_secs;
+        self
     }
 
     pub fn data(&self) -> &Arc<AudioData> {
@@ -73,7 +80,7 @@ impl AudioSegmentTrack {
     }
 
     pub fn offset(&self, offsets: &ClipOffsets) -> f32 {
-        (self.get_offset)(offsets)
+        (self.get_offset)(offsets) + self.timing_offset_secs
     }
 }
 
@@ -942,6 +949,42 @@ mod tests {
 
     fn expected(value: i16) -> f32 {
         value as f32 / 32768.0
+    }
+
+    #[test]
+    fn export_audio_virtual_negative_timing_offset_inserts_leading_silence() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("delayed.wav");
+        write_step_wav(&path, &[12000, 24000]);
+
+        let data = Arc::new(AudioData::from_file(&path).unwrap());
+        let mut renderer = AudioRenderer::new(vec![AudioSegment {
+            tracks: vec![
+                AudioSegmentTrack::new(data, gain, stereo, no_offset).with_timing_offset_secs(-1.0),
+            ],
+        }]);
+        let project = ProjectConfiguration {
+            timeline: Some(TimelineConfiguration {
+                segments: vec![segment(0, 0.0, 3.0, 1.0)],
+                zoom_segments: Vec::new(),
+                scene_segments: Vec::new(),
+                mask_segments: Vec::new(),
+                text_segments: Vec::new(),
+                caption_segments: Vec::new(),
+                keyboard_segments: Vec::new(),
+            }),
+            clips: vec![ClipConfiguration {
+                index: 0,
+                offsets: Default::default(),
+            }],
+            ..Default::default()
+        };
+
+        let stream = render_export_audio(&mut renderer, &project, 30, 3 * 30);
+
+        assert_eq!(left_at_second(&stream, 0), 0.0);
+        assert!((left_at_second(&stream, 1) - expected(12000)).abs() < 0.01);
+        assert!((left_at_second(&stream, 2) - expected(24000)).abs() < 0.01);
     }
 
     // Time->sample conversion rounds to nearest (not truncates), so a fractional

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use cap_project::{CursorEvents, RecordingMeta, StudioRecordingMeta};
+use cap_project::{CursorEvents, ProjectConfiguration};
 use cap_rendering::{
-    DecodedSegmentFrames, FrameRenderer, Nv12RenderedFrame, ProjectRecordingsMeta, ProjectUniforms,
-    RenderVideoConstants, RenderedFrame, RendererLayers,
+    DecodedSegmentFrames, FrameRenderer, Nv12RenderedFrame, ProjectUniforms, RenderVideoConstants,
+    RenderedFrame, RendererLayers,
 };
 use tokio::sync::{mpsc, oneshot};
 
@@ -41,8 +41,6 @@ pub struct Renderer {
     render_constants: Arc<RenderVideoConstants>,
     layers_rx: RendererLayersReceiver,
     telemetry: Option<PlaybackTelemetry>,
-    #[allow(unused)]
-    total_frames: u32,
 }
 
 pub struct RendererHandle {
@@ -52,9 +50,12 @@ pub struct RendererHandle {
 
 pub fn start_renderer_layers_creation(
     render_constants: &Arc<RenderVideoConstants>,
+    project: &ProjectConfiguration,
 ) -> RendererLayersReceiver {
     let (layers_tx, layers_rx) = oneshot::channel();
     let constants = render_constants.clone();
+    let use_svg = project.cursor.use_svg;
+    let cursor_type = project.cursor.cursor_type().clone();
     std::thread::Builder::new()
         .name("renderer-layers-init".into())
         .spawn(move || {
@@ -63,59 +64,38 @@ pub fn start_renderer_layers_creation(
                 &constants.queue,
                 constants.is_software_adapter,
             );
-            let project = constants.recording_meta.project_config();
-            layers.preload_cursor_assets(
-                &constants,
-                project.cursor.use_svg,
-                project.cursor.cursor_type(),
-            );
+            layers.preload_cursor_assets(&constants, use_svg, &cursor_type);
             let _ = layers_tx.send(layers);
         })
         .expect("failed to spawn renderer layers init thread");
     layers_rx
 }
 
+pub async fn finish_renderer_layers_creation(
+    layers_rx: RendererLayersReceiver,
+) -> RendererLayersReceiver {
+    let (layers_tx, ready_layers_rx) = oneshot::channel();
+    if let Ok(layers) = layers_rx.await {
+        let _ = layers_tx.send(layers);
+    }
+    ready_layers_rx
+}
+
 impl Renderer {
     pub fn spawn(
         render_constants: Arc<RenderVideoConstants>,
         frame_cb: Box<dyn FnMut(EditorFrameOutput) + Send>,
-        recording_meta: &RecordingMeta,
-        meta: &StudioRecordingMeta,
         layers_rx: RendererLayersReceiver,
     ) -> Result<RendererHandle, String> {
-        Self::spawn_with_telemetry(
-            render_constants,
-            frame_cb,
-            recording_meta,
-            meta,
-            layers_rx,
-            None,
-        )
+        Self::spawn_with_telemetry(render_constants, frame_cb, layers_rx, None)
     }
 
     pub fn spawn_with_telemetry(
         render_constants: Arc<RenderVideoConstants>,
         frame_cb: Box<dyn FnMut(EditorFrameOutput) + Send>,
-        recording_meta: &RecordingMeta,
-        meta: &StudioRecordingMeta,
         layers_rx: RendererLayersReceiver,
         telemetry: Option<PlaybackTelemetry>,
     ) -> Result<RendererHandle, String> {
-        let recordings = Arc::new(ProjectRecordingsMeta::new(
-            &recording_meta.project_path,
-            meta,
-        )?);
-        let mut max_duration = recordings.duration();
-
-        if let Some(camera_path) = meta.camera_path()
-            && let Ok(camera_duration) =
-                recordings.get_source_duration(&recording_meta.path(&camera_path))
-        {
-            max_duration = max_duration.max(camera_duration);
-        }
-
-        let total_frames = (30_f64 * max_duration).ceil() as u32;
-
         let (tx, rx) = mpsc::channel(64);
 
         let this = Self {
@@ -124,7 +104,6 @@ impl Renderer {
             render_constants,
             layers_rx,
             telemetry: telemetry.clone(),
-            total_frames,
         };
 
         tokio::spawn(this.run());
@@ -139,7 +118,6 @@ impl Renderer {
             render_constants,
             layers_rx,
             telemetry,
-            total_frames: _,
         } = self;
 
         let mut frame_renderer = FrameRenderer::new(&render_constants);

--- a/crates/editor/src/editor_instance.rs
+++ b/crates/editor/src/editor_instance.rs
@@ -622,9 +622,134 @@ pub struct SegmentAudioTimingRepair {
     pub system_audio_offset_secs: f32,
 }
 
+#[derive(Clone, Copy)]
+enum LegacyAudioLogTrack {
+    Mic,
+    SystemAudio,
+}
+
+impl LegacyAudioLogTrack {
+    fn span(self) -> &'static str {
+        match self {
+            Self::Mic => "mic-out",
+            Self::SystemAudio => "system-audio-out",
+        }
+    }
+}
+
+struct LegacyAudioTimingRepair {
+    log: Option<String>,
+}
+
+impl LegacyAudioTimingRepair {
+    fn load(project_path: &Path) -> Self {
+        let log_path = project_path.join("recording-logs.log");
+        Self {
+            log: std::fs::read_to_string(log_path).ok(),
+        }
+    }
+
+    fn offset(
+        &self,
+        segment_index: usize,
+        track: LegacyAudioLogTrack,
+        structured_summary: Option<&cap_project::AudioGapSummary>,
+    ) -> f32 {
+        let structured_offset = audio_timing_repair_offset(structured_summary);
+        if structured_offset != 0.0 {
+            return structured_offset;
+        }
+
+        let should_try_legacy = match structured_summary {
+            Some(summary) => {
+                summary.startup_overlap_trimmed_ms == 0 && summary.total_overlap_trimmed_ms > 0
+            }
+            None => true,
+        };
+        if !should_try_legacy {
+            return 0.0;
+        }
+
+        self.summary(segment_index, track)
+            .as_ref()
+            .map(|summary| audio_timing_repair_offset(Some(summary)))
+            .unwrap_or(0.0)
+    }
+
+    fn summary(
+        &self,
+        segment_index: usize,
+        track: LegacyAudioLogTrack,
+    ) -> Option<cap_project::AudioGapSummary> {
+        legacy_audio_gap_summary_from_log(self.log.as_deref()?, segment_index, track)
+    }
+}
+
 const MIN_STALE_STARTUP_DROPS: u32 = 3;
 const MIN_STALE_STARTUP_TRIMMED_MS: u32 = 100;
 const MAX_STALE_STARTUP_REPAIR_MS: u32 = 2_000;
+const STARTUP_OVERLAP_DROP_FRAME_COUNT: u32 = 3;
+
+fn parse_u32_log_field(line: &str, field: &str) -> Option<u32> {
+    let value = line
+        .split_once(field)?
+        .1
+        .split(|c: char| !c.is_ascii_digit())
+        .next()?;
+    value.parse().ok()
+}
+
+fn legacy_audio_gap_summary_from_log(
+    log: &str,
+    segment_index: usize,
+    track: LegacyAudioLogTrack,
+) -> Option<cap_project::AudioGapSummary> {
+    let segment_marker = format!("segment{{index={segment_index}}}");
+    let track_marker = format!(":{}:", track.span());
+    let mut summary = cap_project::AudioGapSummary {
+        total_overlap_trimmed_ms: 0,
+        startup_overlap_trimmed_ms: 0,
+        overlap_dropped_frames: 0,
+        startup_overlap_drops: 0,
+    };
+
+    for line in log.lines() {
+        if !line.contains(&segment_marker) || !line.contains(&track_marker) {
+            continue;
+        }
+
+        let dropped = line.contains("Dropping overlapping audio frame");
+        let trimmed = line.contains("Trimmed overlapping audio frame");
+        if !(dropped || trimmed) {
+            continue;
+        }
+
+        let Some(overlap_ms) = parse_u32_log_field(line, "overlap_ms=") else {
+            continue;
+        };
+        let Some(frame_count) = parse_u32_log_field(line, "frame_count=") else {
+            continue;
+        };
+
+        summary.total_overlap_trimmed_ms =
+            summary.total_overlap_trimmed_ms.saturating_add(overlap_ms);
+
+        if frame_count < STARTUP_OVERLAP_DROP_FRAME_COUNT {
+            summary.startup_overlap_trimmed_ms = summary
+                .startup_overlap_trimmed_ms
+                .saturating_add(overlap_ms);
+        }
+
+        if dropped {
+            summary.overlap_dropped_frames = summary.overlap_dropped_frames.saturating_add(1);
+            if frame_count < STARTUP_OVERLAP_DROP_FRAME_COUNT {
+                summary.startup_overlap_drops = summary.startup_overlap_drops.saturating_add(1);
+            }
+        }
+    }
+
+    (summary.total_overlap_trimmed_ms > 0).then_some(summary)
+}
 
 fn audio_timing_repair_offset(summary: Option<&cap_project::AudioGapSummary>) -> f32 {
     let Some(summary) = summary else {
@@ -647,6 +772,8 @@ pub async fn create_segments(
     meta: &StudioRecordingMeta,
     force_ffmpeg: bool,
 ) -> Result<Vec<SegmentMedia>, String> {
+    let legacy_timing_repair = LegacyAudioTimingRepair::load(&recording_meta.project_path);
+
     match &meta {
         cap_project::StudioRecordingMeta::SingleSegment { segment: s } => {
             let audio_task = s.audio.as_ref().map(|audio_meta| {
@@ -695,7 +822,9 @@ pub async fn create_segments(
                 audio,
                 system_audio: None,
                 audio_timing_repair: SegmentAudioTimingRepair {
-                    mic_offset_secs: audio_timing_repair_offset(
+                    mic_offset_secs: legacy_timing_repair.offset(
+                        0,
+                        LegacyAudioLogTrack::Mic,
                         s.audio.as_ref().and_then(|m| m.gap_summary.as_ref()),
                     ),
                     system_audio_offset_secs: 0.0,
@@ -749,10 +878,14 @@ pub async fn create_segments(
                     audio,
                     system_audio,
                     audio_timing_repair: SegmentAudioTimingRepair {
-                        mic_offset_secs: audio_timing_repair_offset(
+                        mic_offset_secs: legacy_timing_repair.offset(
+                            i,
+                            LegacyAudioLogTrack::Mic,
                             s.mic.as_ref().and_then(|m| m.gap_summary.as_ref()),
                         ),
-                        system_audio_offset_secs: audio_timing_repair_offset(
+                        system_audio_offset_secs: legacy_timing_repair.offset(
+                            i,
+                            LegacyAudioLogTrack::SystemAudio,
                             s.system_audio.as_ref().and_then(|m| m.gap_summary.as_ref()),
                         ),
                     },
@@ -827,6 +960,29 @@ mod tests {
         };
 
         assert_eq!(audio_timing_repair_offset(Some(&summary)), -0.867);
+    }
+
+    #[test]
+    fn legacy_audio_timing_repair_reads_startup_trimmed_overlap_from_log() {
+        let log = r#"
+2026-06-01T12:37:20.016795Z DEBUG recording:studio_recording:segment{index=0}:mic-out:{task="mux-audio"}: cap_recording::output_pipeline::core: Trimmed overlapping audio frame frame_count=1 overlap_ms=34 frame_samples=1680 trim_samples=1656 kept_samples=24
+2026-06-01T12:37:20.051756Z DEBUG recording:studio_recording:segment{index=0}:mic-out:{task="mux-audio"}: cap_recording::output_pipeline::core: Dropping overlapping audio frame frame_count=2 overlap_ms=35 frame_samples=1680 trim_samples=1680
+2026-06-01T12:37:20.086773Z DEBUG recording:studio_recording:segment{index=0}:mic-out:{task="mux-audio"}: cap_recording::output_pipeline::core: Dropping overlapping audio frame frame_count=2 overlap_ms=35 frame_samples=1680 trim_samples=1680
+2026-06-01T12:37:20.121809Z DEBUG recording:studio_recording:segment{index=0}:mic-out:{task="mux-audio"}: cap_recording::output_pipeline::core: Dropping overlapping audio frame frame_count=2 overlap_ms=35 frame_samples=1680 trim_samples=1680
+2026-06-01T12:37:30.121809Z DEBUG recording:studio_recording:segment{index=0}:mic-out:{task="mux-audio"}: cap_recording::output_pipeline::core: Dropping overlapping audio frame frame_count=50 overlap_ms=800 frame_samples=1680 trim_samples=1680
+"#;
+
+        let summary = legacy_audio_gap_summary_from_log(log, 0, LegacyAudioLogTrack::Mic).unwrap();
+
+        assert_eq!(summary.total_overlap_trimmed_ms, 939);
+        assert_eq!(summary.startup_overlap_trimmed_ms, 139);
+        assert_eq!(summary.overlap_dropped_frames, 4);
+        assert_eq!(summary.startup_overlap_drops, 3);
+        assert_eq!(audio_timing_repair_offset(Some(&summary)), -0.139);
+        assert_eq!(
+            legacy_audio_gap_summary_from_log(log, 0, LegacyAudioLogTrack::SystemAudio),
+            None
+        );
     }
 
     #[test]

--- a/crates/editor/src/editor_instance.rs
+++ b/crates/editor/src/editor_instance.rs
@@ -638,11 +638,6 @@ const MIN_STALE_STARTUP_DROPS: u32 = 3;
 const MIN_STALE_STARTUP_TRIMMED_MS: u32 = 100;
 const MAX_STALE_STARTUP_REPAIR_MS: u32 = 2_000;
 
-/// Compensating offset (seconds, negative) for stale-startup audio drift the recorder captured
-/// in [`cap_project::AudioGapSummary`]. A burst of whole-frame overlap drops in the first frames
-/// means the recorded audio starts late relative to the timeline, so shifting it earlier by the
-/// trimmed span resyncs it. Scattered mid-recording overlaps and trims outside the expected
-/// startup-drift range are ignored.
 fn audio_timing_repair_offset(summary: Option<&cap_project::AudioGapSummary>) -> f32 {
     let Some(summary) = summary else {
         return 0.0;
@@ -651,12 +646,12 @@ fn audio_timing_repair_offset(summary: Option<&cap_project::AudioGapSummary>) ->
     if summary.startup_overlap_drops < MIN_STALE_STARTUP_DROPS
         || summary.overlap_dropped_frames < MIN_STALE_STARTUP_DROPS
         || !(MIN_STALE_STARTUP_TRIMMED_MS..=MAX_STALE_STARTUP_REPAIR_MS)
-            .contains(&summary.total_overlap_trimmed_ms)
+            .contains(&summary.startup_overlap_trimmed_ms)
     {
         return 0.0;
     }
 
-    -(summary.total_overlap_trimmed_ms as f32 / 1_000.0)
+    -(summary.startup_overlap_trimmed_ms as f32 / 1_000.0)
 }
 
 pub async fn create_segments(
@@ -835,9 +830,10 @@ mod tests {
     use cap_project::AudioGapSummary;
 
     #[test]
-    fn audio_timing_repair_detects_stale_startup_overlap() {
+    fn audio_timing_repair_uses_startup_trimmed_overlap() {
         let summary = AudioGapSummary {
-            total_overlap_trimmed_ms: 867,
+            total_overlap_trimmed_ms: 1_667,
+            startup_overlap_trimmed_ms: 867,
             overlap_dropped_frames: 23,
             startup_overlap_drops: 23,
         };
@@ -852,9 +848,9 @@ mod tests {
 
     #[test]
     fn audio_timing_repair_ignores_overlap_without_startup_signature() {
-        // Plenty of overlap drops, but none in the startup window — a mid-recording artifact.
         let summary = AudioGapSummary {
             total_overlap_trimmed_ms: 867,
+            startup_overlap_trimmed_ms: 867,
             overlap_dropped_frames: 23,
             startup_overlap_drops: 0,
         };
@@ -866,6 +862,7 @@ mod tests {
     fn audio_timing_repair_ignores_trim_outside_expected_range() {
         let too_small = AudioGapSummary {
             total_overlap_trimmed_ms: MIN_STALE_STARTUP_TRIMMED_MS - 1,
+            startup_overlap_trimmed_ms: MIN_STALE_STARTUP_TRIMMED_MS - 1,
             overlap_dropped_frames: 5,
             startup_overlap_drops: 5,
         };
@@ -873,6 +870,7 @@ mod tests {
 
         let too_large = AudioGapSummary {
             total_overlap_trimmed_ms: MAX_STALE_STARTUP_REPAIR_MS + 1,
+            startup_overlap_trimmed_ms: MAX_STALE_STARTUP_REPAIR_MS + 1,
             overlap_dropped_frames: 5,
             startup_overlap_drops: 5,
         };

--- a/crates/editor/src/editor_instance.rs
+++ b/crates/editor/src/editor_instance.rs
@@ -272,15 +272,14 @@ impl EditorInstance {
             Arc::new(rc)
         };
 
-        let layers_rx = editor::start_renderer_layers_creation(&render_constants);
+        let layers_rx = editor::start_renderer_layers_creation(&render_constants, &project);
 
         let segments = create_segments(&recording_meta, meta.as_ref(), false).await?;
+        let layers_rx = editor::finish_renderer_layers_creation(layers_rx).await;
 
         let renderer = Arc::new(editor::Renderer::spawn(
             render_constants.clone(),
             frame_cb,
-            &recording_meta,
-            meta,
             layers_rx,
         )?);
 
@@ -623,9 +622,41 @@ pub struct EditorState {
 pub struct SegmentMedia {
     pub audio: Option<Arc<AudioData>>,
     pub system_audio: Option<Arc<AudioData>>,
+    pub audio_timing_repair: SegmentAudioTimingRepair,
     pub cursor: Arc<CursorEvents>,
     pub keyboard: Arc<cap_project::KeyboardEvents>,
     pub decoders: RecordingSegmentDecoders,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct SegmentAudioTimingRepair {
+    pub mic_offset_secs: f32,
+    pub system_audio_offset_secs: f32,
+}
+
+const MIN_STALE_STARTUP_DROPS: u32 = 3;
+const MIN_STALE_STARTUP_TRIMMED_MS: u32 = 100;
+const MAX_STALE_STARTUP_REPAIR_MS: u32 = 2_000;
+
+/// Compensating offset (seconds, negative) for stale-startup audio drift the recorder captured
+/// in [`cap_project::AudioGapSummary`]. A burst of whole-frame overlap drops in the first frames
+/// means the recorded audio starts late relative to the timeline, so shifting it earlier by the
+/// trimmed span resyncs it. Scattered mid-recording overlaps and trims outside the expected
+/// startup-drift range are ignored.
+fn audio_timing_repair_offset(summary: Option<&cap_project::AudioGapSummary>) -> f32 {
+    let Some(summary) = summary else {
+        return 0.0;
+    };
+
+    if summary.startup_overlap_drops < MIN_STALE_STARTUP_DROPS
+        || summary.overlap_dropped_frames < MIN_STALE_STARTUP_DROPS
+        || !(MIN_STALE_STARTUP_TRIMMED_MS..=MAX_STALE_STARTUP_REPAIR_MS)
+            .contains(&summary.total_overlap_trimmed_ms)
+    {
+        return 0.0;
+    }
+
+    -(summary.total_overlap_trimmed_ms as f32 / 1_000.0)
 }
 
 pub async fn create_segments(
@@ -635,15 +666,12 @@ pub async fn create_segments(
 ) -> Result<Vec<SegmentMedia>, String> {
     match &meta {
         cap_project::StudioRecordingMeta::SingleSegment { segment: s } => {
-            let audio = s
-                .audio
-                .as_ref()
-                .map(|audio_meta| {
-                    AudioData::from_file(recording_meta.path(&audio_meta.path))
-                        .map_err(|e| format!("SingleSegment Audio / {e}"))
-                })
-                .transpose()?
-                .map(Arc::new);
+            let audio_task = s.audio.as_ref().map(|audio_meta| {
+                spawn_audio_load(
+                    recording_meta.path(&audio_meta.path),
+                    "SingleSegment Audio".to_string(),
+                )
+            });
 
             let cursor = Arc::new(
                 s.cursor
@@ -676,11 +704,19 @@ pub async fn create_segments(
                 force_ffmpeg,
             )
             .await
-            .map_err(|e| format!("SingleSegment / {e}"))?;
+            .map_err(|e| format!("SingleSegment / {e}"));
+            let audio = collect_audio_task(audio_task, "SingleSegment Audio").await?;
+            let decoders = decoders?;
 
             Ok(vec![SegmentMedia {
                 audio,
                 system_audio: None,
+                audio_timing_repair: SegmentAudioTimingRepair {
+                    mic_offset_secs: audio_timing_repair_offset(
+                        s.audio.as_ref().and_then(|m| m.gap_summary.as_ref()),
+                    ),
+                    system_audio_offset_secs: 0.0,
+                },
                 cursor,
                 keyboard: Arc::new(Default::default()),
                 decoders,
@@ -690,25 +726,16 @@ pub async fn create_segments(
             let mut segments = vec![];
 
             for (i, s) in inner.segments.iter().enumerate() {
-                let audio = s
+                let audio_label = format!("MultipleSegments {i} Audio");
+                let audio_task = s
                     .mic
                     .as_ref()
-                    .map(|audio| {
-                        AudioData::from_file(recording_meta.path(&audio.path))
-                            .map_err(|e| format!("MultipleSegments {i} Audio / {e}"))
-                    })
-                    .transpose()?
-                    .map(Arc::new);
+                    .map(|audio| spawn_audio_load(recording_meta.path(&audio.path), audio_label));
 
-                let system_audio = s
-                    .system_audio
-                    .as_ref()
-                    .map(|audio| {
-                        AudioData::from_file(recording_meta.path(&audio.path))
-                            .map_err(|e| format!("MultipleSegments {i} System Audio / {e}"))
-                    })
-                    .transpose()?
-                    .map(Arc::new);
+                let system_audio_label = format!("MultipleSegments {i} System Audio");
+                let system_audio_task = s.system_audio.as_ref().map(|audio| {
+                    spawn_audio_load(recording_meta.path(&audio.path), system_audio_label)
+                });
 
                 let cursor = Arc::new(s.cursor_events(recording_meta));
 
@@ -723,13 +750,29 @@ pub async fn create_segments(
                     force_ffmpeg,
                 )
                 .await
-                .map_err(|e| format!("MultipleSegments {i} / {e}"))?;
+                .map_err(|e| format!("MultipleSegments {i} / {e}"));
 
                 let keyboard = Arc::new(s.keyboard_events(recording_meta));
+                let audio =
+                    collect_audio_task(audio_task, &format!("MultipleSegments {i} Audio")).await?;
+                let system_audio = collect_audio_task(
+                    system_audio_task,
+                    &format!("MultipleSegments {i} System Audio"),
+                )
+                .await?;
+                let decoders = decoders?;
 
                 segments.push(SegmentMedia {
                     audio,
                     system_audio,
+                    audio_timing_repair: SegmentAudioTimingRepair {
+                        mic_offset_secs: audio_timing_repair_offset(
+                            s.mic.as_ref().and_then(|m| m.gap_summary.as_ref()),
+                        ),
+                        system_audio_offset_secs: audio_timing_repair_offset(
+                            s.system_audio.as_ref().and_then(|m| m.gap_summary.as_ref()),
+                        ),
+                    },
                     cursor,
                     keyboard,
                     decoders,
@@ -738,6 +781,30 @@ pub async fn create_segments(
 
             Ok(segments)
         }
+    }
+}
+
+fn spawn_audio_load(
+    path: PathBuf,
+    label: String,
+) -> tokio::task::JoinHandle<Result<AudioData, String>> {
+    tokio::task::spawn_blocking(move || {
+        AudioData::from_file(path).map_err(|e| format!("{label} / {e}"))
+    })
+}
+
+async fn collect_audio_task(
+    task: Option<tokio::task::JoinHandle<Result<AudioData, String>>>,
+    label: &str,
+) -> Result<Option<Arc<AudioData>>, String> {
+    match task {
+        Some(task) => {
+            let audio = task
+                .await
+                .map_err(|e| format!("{label} task failed: {e}"))??;
+            Ok(Some(Arc::new(audio)))
+        }
+        None => Ok(None),
     }
 }
 
@@ -759,5 +826,56 @@ fn get_calibration_offset(
     match (camera_id, mic_id) {
         (Some(cam), Some(mic)) => store.get_offset(cam, mic).map(|o| o as f32),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cap_project::AudioGapSummary;
+
+    #[test]
+    fn audio_timing_repair_detects_stale_startup_overlap() {
+        let summary = AudioGapSummary {
+            total_overlap_trimmed_ms: 867,
+            overlap_dropped_frames: 23,
+            startup_overlap_drops: 23,
+        };
+
+        assert_eq!(audio_timing_repair_offset(Some(&summary)), -0.867);
+    }
+
+    #[test]
+    fn audio_timing_repair_ignores_missing_summary() {
+        assert_eq!(audio_timing_repair_offset(None), 0.0);
+    }
+
+    #[test]
+    fn audio_timing_repair_ignores_overlap_without_startup_signature() {
+        // Plenty of overlap drops, but none in the startup window — a mid-recording artifact.
+        let summary = AudioGapSummary {
+            total_overlap_trimmed_ms: 867,
+            overlap_dropped_frames: 23,
+            startup_overlap_drops: 0,
+        };
+
+        assert_eq!(audio_timing_repair_offset(Some(&summary)), 0.0);
+    }
+
+    #[test]
+    fn audio_timing_repair_ignores_trim_outside_expected_range() {
+        let too_small = AudioGapSummary {
+            total_overlap_trimmed_ms: MIN_STALE_STARTUP_TRIMMED_MS - 1,
+            overlap_dropped_frames: 5,
+            startup_overlap_drops: 5,
+        };
+        assert_eq!(audio_timing_repair_offset(Some(&too_small)), 0.0);
+
+        let too_large = AudioGapSummary {
+            total_overlap_trimmed_ms: MAX_STALE_STARTUP_REPAIR_MS + 1,
+            overlap_dropped_frames: 5,
+            startup_overlap_drops: 5,
+        };
+        assert_eq!(audio_timing_repair_offset(Some(&too_large)), 0.0);
     }
 }

--- a/crates/editor/src/editor_instance.rs
+++ b/crates/editor/src/editor_instance.rs
@@ -69,6 +69,20 @@ fn get_video_duration_fallback(path: &Path) -> Option<f64> {
     }
 }
 
+fn display_video_duration(path: &Path) -> Option<f64> {
+    match Video::new(path, 0.0) {
+        Ok(v) => Some(v.duration),
+        Err(e) => {
+            warn!(
+                "Failed to load video for duration calculation: {} (path: {}), trying fallback",
+                e,
+                path.display()
+            );
+            get_video_duration_fallback(path)
+        }
+    }
+}
+
 pub struct EditorInstance {
     pub project_path: PathBuf,
     pub recordings: Arc<ProjectRecordingsMeta>,
@@ -126,29 +140,21 @@ impl EditorInstance {
             let timeline_segments = match meta.as_ref() {
                 StudioRecordingMeta::SingleSegment { segment } => {
                     let display_path = recording_meta.path(&segment.display.path);
-                    let duration = match Video::new(&display_path, 0.0) {
-                        Ok(v) => v.duration,
-                        Err(e) => {
+                    match display_video_duration(&display_path) {
+                        Some(duration) if duration > 0.0 => vec![TimelineSegment {
+                            recording_clip: 0,
+                            start: 0.0,
+                            end: duration,
+                            timescale: 1.0,
+                        }],
+                        _ => {
                             warn!(
-                                "Failed to load video for duration calculation: {} (path: {}), trying fallback",
-                                e,
+                                "Failed to determine display duration for {}, leaving timeline unset",
                                 display_path.display()
                             );
-                            match get_video_duration_fallback(&display_path) {
-                                Some(d) => d,
-                                None => {
-                                    warn!("Fallback also failed, using default duration 5.0s");
-                                    5.0
-                                }
-                            }
+                            Vec::new()
                         }
-                    };
-                    vec![TimelineSegment {
-                        recording_clip: 0,
-                        start: 0.0,
-                        end: duration,
-                        timescale: 1.0,
-                    }]
+                    }
                 }
                 StudioRecordingMeta::MultipleSegments { inner } => inner
                     .segments
@@ -156,30 +162,12 @@ impl EditorInstance {
                     .enumerate()
                     .filter_map(|(i, segment)| {
                         let display_path = recording_meta.path(&segment.display.path);
-                        tracing::debug!("Attempting to get duration for segment {}: {:?}", i, display_path);
-                        let duration = match Video::new(&display_path, 0.0) {
-                            Ok(v) => {
-                                tracing::debug!("Video::new succeeded, duration: {}", v.duration);
-                                v.duration
-                            }
-                            Err(e) => {
-                                warn!(
-                                    "Failed to load video for duration calculation: {} (path: {}), trying fallback",
-                                    e,
-                                    display_path.display()
-                                );
-                                match get_video_duration_fallback(&display_path) {
-                                    Some(d) => {
-                                        tracing::debug!("Fallback succeeded, duration: {}", d);
-                                        d
-                                    }
-                                    None => {
-                                        warn!("Fallback also failed, using default duration 5.0s");
-                                        5.0
-                                    }
-                                }
-                            }
-                        };
+                        tracing::debug!(
+                            "Attempting to get duration for segment {}: {:?}",
+                            i,
+                            display_path
+                        );
+                        let duration = display_video_duration(&display_path)?;
                         tracing::debug!("Final duration for segment {}: {}", i, duration);
                         if duration <= 0.0 {
                             return None;

--- a/crates/editor/src/lib.rs
+++ b/crates/editor/src/lib.rs
@@ -6,7 +6,10 @@ mod segments;
 mod telemetry;
 
 pub use audio::AudioRenderer;
-pub use editor::{EditorFrameOutput, Renderer, RendererHandle, start_renderer_layers_creation};
+pub use editor::{
+    EditorFrameOutput, Renderer, RendererHandle, finish_renderer_layers_creation,
+    start_renderer_layers_creation,
+};
 pub use editor_instance::{EditorInstance, EditorState, SegmentMedia, create_segments};
 pub use playback::{Playback, PlaybackEvent, PlaybackHandle, PlaybackStartError};
 pub use segments::get_audio_segments;

--- a/crates/editor/src/playback.rs
+++ b/crates/editor/src/playback.rs
@@ -19,7 +19,11 @@ use lru::LruCache;
 use std::{
     collections::{HashSet, VecDeque},
     num::NonZeroUsize,
-    sync::{Arc, RwLock, mpsc as std_mpsc},
+    sync::{
+        Arc, RwLock,
+        atomic::{AtomicBool, Ordering},
+        mpsc as std_mpsc,
+    },
     time::{Duration, Instant},
 };
 use tokio::sync::watch;
@@ -1189,15 +1193,7 @@ impl PlaybackHandle {
 /// How long the audio thread waits for the output device's first callback before giving up and
 /// reporting "no audio". Slow transports (e.g. Bluetooth) can take several seconds.
 const AUDIO_FIRST_CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
-
-/// How long the caller waits for the audio thread's ready verdict. This MUST stay strictly larger
-/// than [`AUDIO_FIRST_CALLBACK_TIMEOUT`] plus the thread's setup time so the thread's verdict
-/// always wins the race. The setup includes a synchronous full pre-render of the recording, which
-/// scales with its length, hence the generous headroom. If the caller times out first it concludes
-/// "no audio" and stops feeding the playhead while the audio thread may still start a now-unsynced
-/// stream — the desync this guards against. The thread reports failures immediately, so this only
-/// bounds a genuinely wedged device and is never waited out in normal operation.
-const AUDIO_READY_TIMEOUT: Duration = Duration::from_secs(15);
+const AUDIO_READY_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 struct AudioPlayback {
     segments: Vec<AudioSegment>,
@@ -1219,6 +1215,9 @@ impl AudioPlayback {
         }
 
         let (ready_tx, ready_rx) = std_mpsc::channel();
+        let mut stop_rx_before_ready = self.stop_rx.clone();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let cancelled_for_thread = Arc::clone(&cancelled);
 
         std::thread::spawn(move || {
             let host = cpal::default_host();
@@ -1304,11 +1303,21 @@ impl AudioPlayback {
                 }
             };
 
+            if cancelled_for_thread.load(Ordering::Acquire) || *stop_rx.borrow() {
+                let _ = ready_tx.send(false);
+                return;
+            }
+
             if let Err(e) = stream.play() {
                 error!(
                     "Failed to play audio stream: {}. Skipping audio playback.",
                     e
                 );
+                let _ = ready_tx.send(false);
+                return;
+            }
+
+            if cancelled_for_thread.load(Ordering::Acquire) || *stop_rx.borrow() {
                 let _ = ready_tx.send(false);
                 return;
             }
@@ -1333,7 +1342,18 @@ impl AudioPlayback {
             info!("Audio playback thread finished.");
         });
 
-        ready_rx.recv_timeout(AUDIO_READY_TIMEOUT).unwrap_or(false)
+        loop {
+            match ready_rx.recv_timeout(AUDIO_READY_POLL_INTERVAL) {
+                Ok(ready) => return ready,
+                Err(std_mpsc::RecvTimeoutError::Timeout) => {
+                    if *stop_rx_before_ready.borrow_and_update() {
+                        cancelled.store(true, Ordering::Release);
+                        return false;
+                    }
+                }
+                Err(std_mpsc::RecvTimeoutError::Disconnected) => return false,
+            }
+        }
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/crates/editor/src/playback.rs
+++ b/crates/editor/src/playback.rs
@@ -93,6 +93,10 @@ fn precision_sleep_sync(deadline: Instant) {
     }
 }
 
+fn valid_playback_duration(duration: f64) -> Option<f64> {
+    (duration.is_finite() && duration > 0.0).then_some(duration)
+}
+
 #[derive(Debug)]
 pub enum PlaybackStartError {
     InvalidFps,
@@ -215,17 +219,19 @@ impl Playback {
         let prefetch_stop_rx = stop_rx.clone();
         let mut prefetch_project = self.project.clone();
         let prefetch_segment_medias = self.segment_medias.clone();
-        let (prefetch_duration, has_timeline) =
-            if let Some(timeline) = &self.project.borrow().timeline {
-                (timeline.duration(), true)
-            } else {
-                (f64::MAX, false)
-            };
+        let (prefetch_duration, has_timeline) = self
+            .project
+            .borrow()
+            .timeline
+            .as_ref()
+            .and_then(|timeline| valid_playback_duration(timeline.duration()))
+            .map(|duration| (duration, true))
+            .unwrap_or((0.0, false));
         let segment_media_count = self.segment_medias.len();
 
         tokio::spawn(async move {
             if !has_timeline {
-                warn!("Prefetch: No timeline configuration found");
+                warn!("Prefetch: No valid timeline duration found");
             }
             if segment_media_count == 0 {
                 warn!("Prefetch: No segment media available");
@@ -455,10 +461,17 @@ impl Playback {
         let tokio_handle = tokio::runtime::Handle::current();
 
         let playback_body = move || {
-            let duration = if let Some(timeline) = &self.project.borrow().timeline {
-                timeline.duration()
-            } else {
-                f64::MAX
+            let duration = self
+                .project
+                .borrow()
+                .timeline
+                .as_ref()
+                .and_then(|timeline| valid_playback_duration(timeline.duration()));
+            let Some(duration) = duration else {
+                warn!("Playback: No valid timeline duration found");
+                stop_tx.send(true).ok();
+                event_tx.send(PlaybackEvent::Stop).ok();
+                return;
             };
 
             let (audio_playhead_tx, audio_playhead_rx) =
@@ -1658,6 +1671,12 @@ impl AudioPlayback {
         let buffer_size = output_info.buffer_size;
 
         let playhead = f64::from(start_frame_number) / f64::from(fps);
+
+        if valid_playback_duration(duration_secs).is_none() {
+            return Err(MediaError::TaskLaunch(format!(
+                "Invalid audio pre-render duration: {duration_secs}"
+            )));
+        }
 
         info!(
             duration_secs = duration_secs,

--- a/crates/editor/src/playback.rs
+++ b/crates/editor/src/playback.rs
@@ -716,11 +716,11 @@ impl Playback {
             #[cfg(target_os = "windows")]
             let _timer_guard = WindowsTimerResolution::set_high_precision();
 
-            let start = Instant::now();
             let has_audio = {
                 let _guard = tokio_handle.enter();
                 audio_playback.spawn()
             };
+            let start = Instant::now();
 
             'playback: loop {
                 if self.project.has_changed().unwrap_or(false) {
@@ -1173,6 +1173,19 @@ impl PlaybackHandle {
     }
 }
 
+/// How long the audio thread waits for the output device's first callback before giving up and
+/// reporting "no audio". Slow transports (e.g. Bluetooth) can take several seconds.
+const AUDIO_FIRST_CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How long the caller waits for the audio thread's ready verdict. This MUST stay strictly larger
+/// than [`AUDIO_FIRST_CALLBACK_TIMEOUT`] plus the thread's setup time so the thread's verdict
+/// always wins the race. The setup includes a synchronous full pre-render of the recording, which
+/// scales with its length, hence the generous headroom. If the caller times out first it concludes
+/// "no audio" and stops feeding the playhead while the audio thread may still start a now-unsynced
+/// stream — the desync this guards against. The thread reports failures immediately, so this only
+/// bounds a genuinely wedged device and is never waited out in normal operation.
+const AUDIO_READY_TIMEOUT: Duration = Duration::from_secs(15);
+
 struct AudioPlayback {
     segments: Vec<AudioSegment>,
     stop_rx: watch::Receiver<bool>,
@@ -1192,12 +1205,15 @@ impl AudioPlayback {
             return false;
         }
 
+        let (ready_tx, ready_rx) = std_mpsc::channel();
+
         std::thread::spawn(move || {
             let host = cpal::default_host();
             let device = match host.default_output_device() {
                 Some(d) => d,
                 None => {
                     error!("No default output device found. Skipping audio playback.");
+                    let _ = ready_tx.send(false);
                     return;
                 }
             };
@@ -1208,36 +1224,57 @@ impl AudioPlayback {
                         "Failed to get default output config: {}. Skipping audio playback.",
                         e
                     );
+                    let _ = ready_tx.send(false);
                     return;
                 }
             };
 
             let duration_secs = self.duration_secs;
+            let (first_callback_tx, first_callback_rx) = std_mpsc::channel();
 
             let result = match supported_config.sample_format() {
-                SampleFormat::I16 => {
-                    self.create_stream_prerendered::<i16>(device, supported_config, duration_secs)
-                }
-                SampleFormat::I32 => {
-                    self.create_stream_prerendered::<i32>(device, supported_config, duration_secs)
-                }
-                SampleFormat::F32 => {
-                    self.create_stream_prerendered::<f32>(device, supported_config, duration_secs)
-                }
-                SampleFormat::I64 => {
-                    self.create_stream_prerendered::<i64>(device, supported_config, duration_secs)
-                }
-                SampleFormat::U8 => {
-                    self.create_stream_prerendered::<u8>(device, supported_config, duration_secs)
-                }
-                SampleFormat::F64 => {
-                    self.create_stream_prerendered::<f64>(device, supported_config, duration_secs)
-                }
+                SampleFormat::I16 => self.create_stream_prerendered::<i16>(
+                    device,
+                    supported_config,
+                    duration_secs,
+                    first_callback_tx,
+                ),
+                SampleFormat::I32 => self.create_stream_prerendered::<i32>(
+                    device,
+                    supported_config,
+                    duration_secs,
+                    first_callback_tx,
+                ),
+                SampleFormat::F32 => self.create_stream_prerendered::<f32>(
+                    device,
+                    supported_config,
+                    duration_secs,
+                    first_callback_tx,
+                ),
+                SampleFormat::I64 => self.create_stream_prerendered::<i64>(
+                    device,
+                    supported_config,
+                    duration_secs,
+                    first_callback_tx,
+                ),
+                SampleFormat::U8 => self.create_stream_prerendered::<u8>(
+                    device,
+                    supported_config,
+                    duration_secs,
+                    first_callback_tx,
+                ),
+                SampleFormat::F64 => self.create_stream_prerendered::<f64>(
+                    device,
+                    supported_config,
+                    duration_secs,
+                    first_callback_tx,
+                ),
                 format => {
                     error!(
                         "Unsupported sample format {:?} for simplified volume adjustment, skipping audio playback.",
                         format
                     );
+                    let _ = ready_tx.send(false);
                     return;
                 }
             };
@@ -1249,6 +1286,7 @@ impl AudioPlayback {
                         "Failed to create audio stream: {}. Skipping audio playback.",
                         e
                     );
+                    let _ = ready_tx.send(false);
                     return;
                 }
             };
@@ -1258,14 +1296,31 @@ impl AudioPlayback {
                     "Failed to play audio stream: {}. Skipping audio playback.",
                     e
                 );
+                let _ = ready_tx.send(false);
                 return;
+            }
+
+            match first_callback_rx.recv_timeout(AUDIO_FIRST_CALLBACK_TIMEOUT) {
+                Ok(()) => {
+                    let _ = ready_tx.send(true);
+                }
+                Err(std_mpsc::RecvTimeoutError::Timeout) => {
+                    error!("Audio stream did not produce an output callback before playback start");
+                    let _ = ready_tx.send(false);
+                    return;
+                }
+                Err(std_mpsc::RecvTimeoutError::Disconnected) => {
+                    error!("Audio stream ended before producing an output callback");
+                    let _ = ready_tx.send(false);
+                    return;
+                }
             }
 
             let _ = handle.block_on(stop_rx.changed());
             info!("Audio playback thread finished.");
         });
 
-        true
+        ready_rx.recv_timeout(AUDIO_READY_TIMEOUT).unwrap_or(false)
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -1274,6 +1329,7 @@ impl AudioPlayback {
         self,
         device: cpal::Device,
         supported_config: cpal::SupportedStreamConfig,
+        first_callback_tx: std_mpsc::Sender<()>,
     ) -> Result<(watch::Receiver<bool>, cpal::Stream), MediaError>
     where
         T: FromSampleBytes + cpal::Sample,
@@ -1422,13 +1478,12 @@ impl AudioPlayback {
             let latency_config = LatencyCorrectionConfig::default();
             #[allow(unused_mut)]
             let mut latency_corrector = LatencyCorrector::new(static_latency_hint, latency_config);
-            let initial_compensation_secs = latency_corrector.initial_compensation_secs();
+            let initial_latency_secs = latency_corrector.initial_output_latency_secs();
             let device_sample_rate = sample_rate;
 
             {
                 let project_snapshot = project.borrow();
-                audio_renderer
-                    .set_playhead(playhead + initial_compensation_secs, &project_snapshot);
+                audio_renderer.set_playhead(playhead + initial_latency_secs, &project_snapshot);
 
                 #[cfg(target_os = "windows")]
                 let initial_prefill = headroom_samples * 4;
@@ -1461,6 +1516,7 @@ impl AudioPlayback {
             let headroom_for_stream = headroom_samples;
             let mut playhead_rx_for_stream = playhead_rx.clone();
             let mut last_video_playhead = playhead;
+            let mut first_callback_tx = Some(first_callback_tx.clone());
 
             #[cfg(target_os = "windows")]
             const FIXED_LATENCY_SECS: f64 = 0.08;
@@ -1503,16 +1559,14 @@ impl AudioPlayback {
                             let drift = (video_playhead - audio_playhead).abs();
 
                             if jump > HARD_SEEK_THRESHOLD_SECS {
-                                audio_renderer.set_playhead(
-                                    video_playhead + initial_compensation_secs,
-                                    &project,
-                                );
+                                audio_renderer
+                                    .set_playhead(video_playhead + FIXED_LATENCY_SECS, &project);
                                 callbacks_since_last_sync = 0;
                             } else if drift > SYNC_THRESHOLD_SECS
                                 && callbacks_since_last_sync >= MIN_SYNC_INTERVAL_CALLBACKS
                             {
                                 audio_renderer.set_playhead_smooth(
-                                    video_playhead + initial_compensation_secs,
+                                    video_playhead + FIXED_LATENCY_SECS,
                                     &project,
                                 );
                                 callbacks_since_last_sync = 0;
@@ -1529,10 +1583,8 @@ impl AudioPlayback {
                                 || (video_playhead - last_video_playhead).abs()
                                     > SYNC_THRESHOLD_SECS
                             {
-                                audio_renderer.set_playhead(
-                                    video_playhead + initial_compensation_secs,
-                                    &project,
-                                );
+                                audio_renderer
+                                    .set_playhead(video_playhead + latency_secs, &project);
                             }
                         }
 
@@ -1542,6 +1594,9 @@ impl AudioPlayback {
                     let playback_samples = buffer.len();
                     let min_headroom = headroom_for_stream.max(playback_samples * 2);
                     audio_renderer.fill(buffer, &project, min_headroom);
+                    if let Some(tx) = first_callback_tx.take() {
+                        let _ = tx.send(());
+                    }
                 },
                 |_err| eprintln!("Audio stream error: {_err}"),
                 None,
@@ -1573,6 +1628,7 @@ impl AudioPlayback {
         device: cpal::Device,
         supported_config: cpal::SupportedStreamConfig,
         duration_secs: f64,
+        first_callback_tx: std_mpsc::Sender<()>,
     ) -> Result<(watch::Receiver<bool>, cpal::Stream), MediaError>
     where
         T: FromSampleBytes + cpal::Sample,
@@ -1639,14 +1695,15 @@ impl AudioPlayback {
             LatencyCorrector::new(hint, LatencyCorrectionConfig::default())
         };
         #[cfg(not(target_os = "windows"))]
-        let initial_compensation_secs = latency_corrector.initial_compensation_secs();
+        let initial_latency_secs = latency_corrector.initial_output_latency_secs();
         #[cfg(target_os = "windows")]
-        let initial_compensation_secs = 0.0;
+        let initial_latency_secs = 0.0;
 
-        audio_buffer.set_playhead(playhead + initial_compensation_secs);
+        audio_buffer.set_playhead(playhead + initial_latency_secs);
 
         let mut playhead_rx_for_stream = playhead_rx.clone();
         let mut last_video_playhead = playhead;
+        let mut first_callback_tx = Some(first_callback_tx);
 
         let stream = device
             .build_output_stream(
@@ -1674,6 +1731,9 @@ impl AudioPlayback {
                     }
 
                     audio_buffer.fill(buffer);
+                    if let Some(tx) = first_callback_tx.take() {
+                        let _ = tx.send(());
+                    }
                 },
                 |err| eprintln!("Audio stream error: {err}"),
                 None,

--- a/crates/editor/src/segments.rs
+++ b/crates/editor/src/segments.rs
@@ -19,6 +19,7 @@ pub fn get_audio_segments(segments: &[SegmentMedia]) -> Vec<AudioSegment> {
                         },
                         |o| o.mic,
                     )
+                    .with_timing_offset_secs(s.audio_timing_repair.mic_offset_secs)
                 }),
                 s.system_audio.clone().map(|a| -> AudioSegmentTrack {
                     AudioSegmentTrack::new(
@@ -27,6 +28,7 @@ pub fn get_audio_segments(segments: &[SegmentMedia]) -> Vec<AudioSegment> {
                         |_| cap_audio::StereoMode::Stereo,
                         |o| o.system_audio,
                     )
+                    .with_timing_offset_secs(s.audio_timing_repair.system_audio_offset_secs)
                 }),
             ]
             .into_iter()

--- a/crates/enc-avfoundation/src/mp4.rs
+++ b/crates/enc-avfoundation/src/mp4.rs
@@ -295,7 +295,7 @@ impl MP4Encoder {
                 "recording bitrate: {bitrate}"
             );
 
-            let keyframe_interval = fps as i32;
+            let keyframe_interval = keyframe_interval_for_fps(fps);
 
             let allow_frame_reordering = ultra_quality && !instant_mode;
 
@@ -1051,6 +1051,10 @@ fn get_instant_mode_bitrate(width: f32, height: f32, fps: f32) -> f32 {
     1_500_000.0 + pixel_ratio * 1_500_000.0 + fps_ratio * 500_000.0
 }
 
+fn keyframe_interval_for_fps(fps: f32) -> i32 {
+    (fps * 0.75).floor().max(1.0) as i32
+}
+
 #[cfg(test)]
 #[allow(clippy::items_after_test_module)]
 mod tests {
@@ -1059,6 +1063,13 @@ mod tests {
 
     fn valid_video_config() -> VideoInfo {
         VideoInfo::from_raw(RawVideoFormat::Bgra, 1920, 1080, 30)
+    }
+
+    #[test]
+    fn keyframe_interval_targets_three_quarter_second() {
+        assert_eq!(keyframe_interval_for_fps(30.0), 22);
+        assert_eq!(keyframe_interval_for_fps(60.0), 45);
+        assert_eq!(keyframe_interval_for_fps(1.0), 1);
     }
 
     #[test]
@@ -2119,7 +2130,7 @@ mod tests {
                         cidre::ns::Number::with_f32(bitrate).as_id_ref(),
                         cidre::ns::Number::with_bool(false).as_id_ref(),
                         cidre::ns::Number::with_f32(fps).as_id_ref(),
-                        cidre::ns::Number::with_i32(fps as i32).as_id_ref(),
+                        cidre::ns::Number::with_i32(keyframe_interval_for_fps(fps)).as_id_ref(),
                     ],
                 )
                 .as_id_ref(),
@@ -2432,7 +2443,7 @@ mod tests {
                         cidre::ns::Number::with_f32(bitrate).as_id_ref(),
                         cidre::ns::Number::with_bool(false).as_id_ref(),
                         cidre::ns::Number::with_f32(fps).as_id_ref(),
-                        cidre::ns::Number::with_i32(fps as i32).as_id_ref(),
+                        cidre::ns::Number::with_i32(keyframe_interval_for_fps(fps)).as_id_ref(),
                     ],
                 )
                 .as_id_ref(),

--- a/crates/export/src/mp4.rs
+++ b/crates/export/src/mp4.rs
@@ -252,12 +252,11 @@ impl Mp4ExportSettings {
                     let (pts, samples) =
                         audio_frame_budget(n, sample_rate, fps_u64, audio_sample_cursor)?;
                     audio_sample_cursor = pts as u64 + samples as u64;
-                    audio
+                    let mut frame = audio
                         .render_frame(samples, &project_for_audio)
-                        .map(|mut frame| {
-                            frame.set_pts(Some(pts));
-                            frame
-                        })
+                        .unwrap_or_else(|| silent_audio_frame(samples));
+                    frame.set_pts(Some(pts));
+                    Some(frame)
                 });
 
                 fill_nv12_frame_direct(
@@ -470,6 +469,19 @@ fn audio_frame_budget(
         return None;
     }
     Some((cursor as i64, (end - cursor) as usize))
+}
+
+fn silent_audio_frame(samples: usize) -> ffmpeg::frame::Audio {
+    let mut frame = ffmpeg::frame::Audio::new(
+        AudioRenderer::SAMPLE_FORMAT,
+        samples,
+        ffmpeg::ChannelLayout::STEREO,
+    );
+    frame.set_rate(AudioRenderer::SAMPLE_RATE);
+    for plane in 0..frame.planes() {
+        frame.data_mut(plane).fill(0);
+    }
+    frame
 }
 
 fn fill_nv12_frame_direct(
@@ -776,6 +788,22 @@ mod tests {
                 cursor = pts as u64 + samples as u64;
             }
             assert_eq!(cursor, (frames * sample_rate) / fps);
+        }
+    }
+
+    #[test]
+    fn silent_audio_frame_matches_renderer_format() {
+        ffmpeg::init().unwrap();
+
+        let samples = 1600usize;
+        let frame = silent_audio_frame(samples);
+
+        assert_eq!(frame.samples(), samples);
+        assert_eq!(frame.rate(), AudioRenderer::SAMPLE_RATE);
+        assert_eq!(frame.format(), AudioRenderer::SAMPLE_FORMAT);
+        assert_eq!(frame.channel_layout(), ffmpeg::ChannelLayout::STEREO);
+        for plane in 0..frame.planes() {
+            assert!(frame.data(plane).iter().all(|byte| *byte == 0));
         }
     }
 

--- a/crates/project/src/meta.rs
+++ b/crates/project/src/meta.rs
@@ -49,6 +49,9 @@ pub struct AudioMeta {
 pub struct AudioGapSummary {
     /// Total audio trimmed from overlapping frames over the whole recording, in milliseconds.
     pub total_overlap_trimmed_ms: u32,
+    /// Startup-window trim used for stale-startup repair, excluding mid-recording trims.
+    #[serde(default)]
+    pub startup_overlap_trimmed_ms: u32,
     /// Number of whole audio frames dropped because they fully overlapped the committed timeline.
     pub overlap_dropped_frames: u32,
     /// Subset of `overlap_dropped_frames` that dropped within the first few frames — the

--- a/crates/project/src/meta.rs
+++ b/crates/project/src/meta.rs
@@ -38,6 +38,22 @@ pub struct AudioMeta {
     pub start_time: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub device_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gap_summary: Option<AudioGapSummary>,
+}
+
+/// Overlap-trim accounting captured by the recorder's audio gap tracker, persisted so the
+/// editor can compensate for stale-startup audio drift from typed data instead of scraping
+/// the recording log. See `cap-editor`'s `audio_timing_repair_offset`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct AudioGapSummary {
+    /// Total audio trimmed from overlapping frames over the whole recording, in milliseconds.
+    pub total_overlap_trimmed_ms: u32,
+    /// Number of whole audio frames dropped because they fully overlapped the committed timeline.
+    pub overlap_dropped_frames: u32,
+    /// Subset of `overlap_dropped_frames` that dropped within the first few frames — the
+    /// signature of a stale buffered burst at capture start.
+    pub startup_overlap_drops: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]

--- a/crates/recording/examples/real-device-test-runner.rs
+++ b/crates/recording/examples/real-device-test-runner.rs
@@ -68,6 +68,14 @@ struct Cli {
         help = "Screen recording frame rate (e.g., 30 or 60)"
     )]
     fps: u32,
+
+    #[arg(
+        long,
+        global = true,
+        default_value = "5",
+        help = "Baseline scenario recording duration in seconds"
+    )]
+    duration: u64,
 }
 
 #[derive(Subcommand)]
@@ -147,10 +155,10 @@ struct TestScenario {
 }
 
 impl TestScenario {
-    fn baseline() -> Self {
+    fn baseline(duration: Duration) -> Self {
         Self {
             name: "Baseline".to_string(),
-            actions: vec![TestAction::Record(Duration::from_secs(5))],
+            actions: vec![TestAction::Record(duration)],
             expected_segments: 1,
         }
     }
@@ -2192,11 +2200,11 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let scenarios: Vec<TestScenario> = match cli.command {
-        Some(Commands::Baseline) => vec![TestScenario::baseline()],
+        Some(Commands::Baseline) => vec![TestScenario::baseline(Duration::from_secs(cli.duration))],
         Some(Commands::SinglePause) => vec![TestScenario::single_pause()],
         Some(Commands::MultiplePauses) => vec![TestScenario::multiple_pauses()],
         Some(Commands::Full) | None => vec![
-            TestScenario::baseline(),
+            TestScenario::baseline(Duration::from_secs(cli.duration)),
             TestScenario::single_pause(),
             TestScenario::multiple_pauses(),
         ],
@@ -2280,7 +2288,7 @@ async fn main() -> anyhow::Result<()> {
 
     if cli.benchmark_output {
         let command = format!(
-            "cargo run -p cap-recording --example real-device-test-runner -- {} {}{}{}{}--fps {}",
+            "cargo run -p cap-recording --example real-device-test-runner -- {} {}{}{}{}--fps {} --duration {}",
             match cli.command {
                 Some(Commands::Baseline) => "baseline",
                 Some(Commands::SinglePause) => "single-pause",
@@ -2301,6 +2309,7 @@ async fn main() -> anyhow::Result<()> {
             },
             if cli.mp4_only { "--mp4-only " } else { "" },
             cli.fps,
+            cli.duration,
         );
 
         let benchmark_md =

--- a/crates/recording/src/feeds/microphone.rs
+++ b/crates/recording/src/feeds/microphone.rs
@@ -34,6 +34,7 @@ const SAMPLE_RATE_ESTIMATE_MAX_DELTA: Duration = Duration::from_millis(250);
 const SAMPLE_RATE_ESTIMATE_MAX_PENDING: usize = 32;
 const SAMPLE_RATE_CONFIGURED_TOLERANCE: f64 = 0.05;
 const SAMPLE_RATE_STANDARD_TOLERANCE: f64 = 0.04;
+const PENDING_TIMESTAMP_STALE_MIN: Duration = Duration::from_millis(5);
 // A newly-inferred rate must be observed this many estimation windows in a row before
 // it replaces the active rate. Each window already averages
 // `SAMPLE_RATE_ESTIMATE_MIN_INTERVALS` callbacks, so a single slow/jittery callback
@@ -276,6 +277,100 @@ fn callback_frame_count(data_len: usize, sample_format: SampleFormat, channels: 
     }
 
     data_len / bytes_per_frame
+}
+
+fn timestamp_duration_since(current: Timestamp, start: Timestamp) -> Option<Duration> {
+    match (current, start) {
+        (Timestamp::Instant(current), Timestamp::Instant(start)) => {
+            current.checked_duration_since(start)
+        }
+        (Timestamp::SystemTime(current), Timestamp::SystemTime(start)) => {
+            current.duration_since(start).ok()
+        }
+        #[cfg(windows)]
+        (Timestamp::PerformanceCounter(current), Timestamp::PerformanceCounter(start)) => {
+            current.checked_duration_since(start)
+        }
+        #[cfg(target_os = "macos")]
+        (Timestamp::MachAbsoluteTime(current), Timestamp::MachAbsoluteTime(start)) => {
+            current.checked_duration_since(start)
+        }
+        _ => None,
+    }
+}
+
+fn pending_timestamp_stale_threshold(sample_duration: Duration) -> Duration {
+    let half_duration = Duration::from_secs_f64(sample_duration.as_secs_f64() * 0.5);
+    PENDING_TIMESTAMP_STALE_MIN.max(half_duration)
+}
+
+fn normalize_pending_timestamp(
+    timestamp: &mut Timestamp,
+    expected: Option<Timestamp>,
+    stale_threshold: Duration,
+) -> bool {
+    let Some(expected) = expected else {
+        return false;
+    };
+
+    if timestamp_duration_since(*timestamp, expected).is_some() {
+        return false;
+    }
+
+    let Some(stale_by) = timestamp_duration_since(expected, *timestamp) else {
+        return false;
+    };
+
+    if stale_by < stale_threshold {
+        return false;
+    }
+
+    *timestamp = expected;
+    true
+}
+
+fn microphone_sample_duration(samples: &MicrophoneSamples) -> Duration {
+    let frame_count = callback_frame_count(samples.data.len(), samples.format, samples.channels);
+    if frame_count == 0 || samples.sample_rate == 0 {
+        return Duration::ZERO;
+    }
+
+    Duration::from_secs_f64(frame_count as f64 / samples.sample_rate as f64)
+}
+
+fn normalize_pending_timestamps<'a>(
+    pending_timestamps: impl IntoIterator<Item = (&'a mut Timestamp, Duration)>,
+) -> u32 {
+    let mut next_timestamp = None;
+    let mut adjusted_frames = 0u32;
+
+    for (timestamp, sample_duration) in pending_timestamps {
+        if normalize_pending_timestamp(
+            timestamp,
+            next_timestamp,
+            pending_timestamp_stale_threshold(sample_duration),
+        ) {
+            adjusted_frames = adjusted_frames.saturating_add(1);
+        }
+        next_timestamp = Some(*timestamp + sample_duration);
+    }
+
+    adjusted_frames
+}
+
+fn prepare_pending_samples(pending_samples: &mut VecDeque<MicrophoneSamples>, sample_rate: u32) {
+    let adjusted_frames = normalize_pending_timestamps(pending_samples.iter_mut().map(|pending| {
+        pending.sample_rate = sample_rate;
+        let sample_duration = microphone_sample_duration(pending);
+        (&mut pending.timestamp, sample_duration)
+    }));
+
+    if adjusted_frames > 0 {
+        debug!(
+            adjusted_frames,
+            sample_rate, "Normalized stale pending microphone timestamps"
+        );
+    }
 }
 
 fn enqueue_microphone_samples(
@@ -578,8 +673,8 @@ impl MicrophoneFeed {
                                 pending_samples.push_back(samples);
                                 if pending_samples.len() >= SAMPLE_RATE_ESTIMATE_MAX_PENDING {
                                     let sample_rate = sample_rate_estimator.force_current();
-                                    while let Some(mut pending) = pending_samples.pop_front() {
-                                        pending.sample_rate = sample_rate;
+                                    prepare_pending_samples(&mut pending_samples, sample_rate);
+                                    while let Some(pending) = pending_samples.pop_front() {
                                         enqueue_microphone_samples(
                                             &actor_ref,
                                             &dropped_message_count,
@@ -590,8 +685,11 @@ impl MicrophoneFeed {
                                 return;
                             }
 
-                            while let Some(mut pending) = pending_samples.pop_front() {
-                                pending.sample_rate = effective_sample_rate.sample_rate;
+                            prepare_pending_samples(
+                                &mut pending_samples,
+                                effective_sample_rate.sample_rate,
+                            );
+                            while let Some(pending) = pending_samples.pop_front() {
                                 enqueue_microphone_samples(
                                     &actor_ref,
                                     &dropped_message_count,
@@ -1518,6 +1616,105 @@ mod tests {
             callback_frame_count(960 * 2 * std::mem::size_of::<f32>(), SampleFormat::F32, 2);
 
         assert_eq!(frames, 960);
+    }
+
+    #[test]
+    fn normalize_pending_timestamp_advances_stale_startup_timestamps() {
+        let base = Timestamp::Instant(Instant::now());
+        let expected = base + Duration::from_millis(35);
+        let mut timestamp = base;
+
+        assert!(normalize_pending_timestamp(
+            &mut timestamp,
+            Some(expected),
+            pending_timestamp_stale_threshold(Duration::from_millis(35))
+        ));
+
+        assert_eq!(
+            timestamp_duration_since(timestamp, expected),
+            Some(Duration::ZERO)
+        );
+    }
+
+    #[test]
+    fn normalize_pending_timestamp_keeps_small_startup_jitter() {
+        let base = Timestamp::Instant(Instant::now());
+        let expected = base + Duration::from_millis(35);
+        let jittered = expected - Duration::from_millis(3);
+        let mut timestamp = jittered;
+
+        assert!(!normalize_pending_timestamp(
+            &mut timestamp,
+            Some(expected),
+            pending_timestamp_stale_threshold(Duration::from_millis(35))
+        ));
+
+        assert_eq!(
+            timestamp_duration_since(timestamp, jittered),
+            Some(Duration::ZERO)
+        );
+    }
+
+    #[test]
+    fn normalize_pending_timestamp_keeps_forward_timestamps() {
+        let base = Timestamp::Instant(Instant::now());
+        let expected = base + Duration::from_millis(35);
+        let forward = expected + Duration::from_millis(2);
+        let mut timestamp = forward;
+
+        assert!(!normalize_pending_timestamp(
+            &mut timestamp,
+            Some(expected),
+            pending_timestamp_stale_threshold(Duration::from_millis(35))
+        ));
+
+        assert_eq!(
+            timestamp_duration_since(timestamp, forward),
+            Some(Duration::ZERO)
+        );
+    }
+
+    #[test]
+    fn normalize_pending_timestamps_recovers_repeated_stale_startup_sequence() {
+        let base = Timestamp::Instant(Instant::now());
+        let sample_duration = Duration::from_millis(35);
+        let mut timestamps = [base; 8];
+
+        let adjusted_frames =
+            normalize_pending_timestamps(timestamps.iter_mut().map(|ts| (ts, sample_duration)));
+
+        assert_eq!(adjusted_frames, 7);
+        for (index, timestamp) in timestamps.iter().copied().enumerate() {
+            let expected = base + sample_duration * index as u32;
+            assert_eq!(
+                timestamp_duration_since(timestamp, expected),
+                Some(Duration::ZERO)
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_pending_timestamps_preserves_small_jitter_sequence() {
+        let base = Timestamp::Instant(Instant::now());
+        let sample_duration = Duration::from_millis(35);
+        let mut timestamps = vec![
+            base,
+            base + Duration::from_millis(32),
+            base + Duration::from_millis(64),
+            base + Duration::from_millis(96),
+        ];
+        let original = timestamps.clone();
+
+        let adjusted_frames =
+            normalize_pending_timestamps(timestamps.iter_mut().map(|ts| (ts, sample_duration)));
+
+        assert_eq!(adjusted_frames, 0);
+        for (timestamp, expected) in timestamps.into_iter().zip(original) {
+            assert_eq!(
+                timestamp_duration_since(timestamp, expected),
+                Some(Duration::ZERO)
+            );
+        }
     }
 
     #[test]

--- a/crates/recording/src/output_pipeline/core.rs
+++ b/crates/recording/src/output_pipeline/core.rs
@@ -16,7 +16,7 @@ use std::{
     ops::Deref,
     path::{Path, PathBuf},
     sync::{
-        Arc,
+        Arc, OnceLock,
         atomic::{self, AtomicBool, AtomicU64, Ordering},
     },
     time::{Duration, Instant},
@@ -667,6 +667,20 @@ fn audio_tail_padding_duration(audio_elapsed: Duration, target_elapsed: Duration
         .min(MAX_AUDIO_TAIL_PADDING)
 }
 
+/// A whole-frame overlap drop counts towards the stale-startup signature only while at most this
+/// many frames have been committed — the buffered burst that triggers startup drift lands in the
+/// first frames, before the steady-state capture clock settles.
+const STARTUP_OVERLAP_DROP_FRAME_LIMIT: u64 = 3;
+
+/// Overlap-trim accounting surfaced from the audio mux task at finish so the editor can
+/// compensate for stale-startup drift from typed metadata rather than the recording log.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AudioGapSummary {
+    pub total_overlap_trimmed_ms: u32,
+    pub overlap_dropped_frames: u32,
+    pub startup_overlap_drops: u32,
+}
+
 struct AudioGapTracker {
     first_frame_ts: Option<Timestamp>,
     first_frame_wall_clock: Option<Instant>,
@@ -677,6 +691,7 @@ struct AudioGapTracker {
     last_silence_log: Option<Instant>,
     overlap_event_count: u64,
     overlap_dropped_frames: u64,
+    startup_overlap_drops: u64,
     total_overlap_trimmed: Duration,
 }
 
@@ -696,15 +711,28 @@ impl AudioGapTracker {
             last_silence_log: None,
             overlap_event_count: 0,
             overlap_dropped_frames: 0,
+            startup_overlap_drops: 0,
             total_overlap_trimmed: Duration::ZERO,
         }
     }
 
-    fn record_overlap(&mut self, overlap: Duration, dropped_whole_frame: bool) {
+    fn record_overlap(&mut self, overlap: Duration, dropped_whole_frame: bool, frame_count: u64) {
         self.overlap_event_count += 1;
         self.total_overlap_trimmed = self.total_overlap_trimmed.saturating_add(overlap);
         if dropped_whole_frame {
             self.overlap_dropped_frames += 1;
+            if frame_count <= STARTUP_OVERLAP_DROP_FRAME_LIMIT {
+                self.startup_overlap_drops += 1;
+            }
+        }
+    }
+
+    fn gap_summary(&self) -> AudioGapSummary {
+        AudioGapSummary {
+            total_overlap_trimmed_ms: u32::try_from(self.total_overlap_trimmed.as_millis())
+                .unwrap_or(u32::MAX),
+            overlap_dropped_frames: u32::try_from(self.overlap_dropped_frames).unwrap_or(u32::MAX),
+            startup_overlap_drops: u32::try_from(self.startup_overlap_drops).unwrap_or(u32::MAX),
         }
     }
 
@@ -1555,6 +1583,8 @@ impl<TVideo: VideoSource> OutputPipelineBuilder<HasVideo<TVideo>> {
             video_start_gate.clone(),
         );
 
+        let audio_gap_summary = Arc::new(OnceLock::new());
+
         finish_build(
             setup_ctx,
             audio,
@@ -1568,6 +1598,7 @@ impl<TVideo: VideoSource> OutputPipelineBuilder<HasVideo<TVideo>> {
             true,
             video_start_gate,
             build_ctx.stop_signal,
+            audio_gap_summary.clone(),
         )
         .await?;
 
@@ -1581,6 +1612,7 @@ impl<TVideo: VideoSource> OutputPipelineBuilder<HasVideo<TVideo>> {
             cancel_token: build_ctx.stop_token,
             video_frame_count,
             health_rx: Some(build_ctx.health_rx),
+            audio_gap_summary,
         })
     }
 }
@@ -1634,6 +1666,7 @@ impl OutputPipelineBuilder<NoVideo> {
         .await?;
 
         let shared_pause = SharedWallClockPause::new(build_ctx.pause_flag.clone());
+        let audio_gap_summary = Arc::new(OnceLock::new());
 
         finish_build(
             setup_ctx,
@@ -1648,6 +1681,7 @@ impl OutputPipelineBuilder<NoVideo> {
             false,
             None,
             build_ctx.stop_signal,
+            audio_gap_summary.clone(),
         )
         .await?;
 
@@ -1661,6 +1695,7 @@ impl OutputPipelineBuilder<NoVideo> {
             cancel_token: build_ctx.stop_token,
             video_frame_count: Arc::new(AtomicU64::new(0)),
             health_rx: Some(build_ctx.health_rx),
+            audio_gap_summary,
         })
     }
 }
@@ -1716,6 +1751,7 @@ async fn finish_build(
     has_video: bool,
     video_start_gate: Option<VideoStartGate>,
     stop_signal: PipelineStopSignal,
+    gap_summary_slot: Arc<OnceLock<AudioGapSummary>>,
 ) -> anyhow::Result<()> {
     if let Some(audio) = audio {
         audio.configure(
@@ -1727,6 +1763,7 @@ async fn finish_build(
             shared_pause,
             has_video,
             video_start_gate,
+            gap_summary_slot,
         );
     }
 
@@ -2118,6 +2155,7 @@ impl PreparedAudioSources {
         shared_pause: SharedWallClockPause,
         has_video: bool,
         video_start_gate: Option<VideoStartGate>,
+        gap_summary_slot: Arc<OnceLock<AudioGapSummary>>,
     ) {
         let audio_info = self.audio_info;
         let has_wireless_source = self.has_wireless_source;
@@ -2332,6 +2370,10 @@ impl PreparedAudioSources {
                     );
                 }
 
+                if gap_tracker.overlap_event_count > 0 {
+                    let _ = gap_summary_slot.set(gap_tracker.gap_summary());
+                }
+
                 for source in &mut self.erased_audio_sources {
                     let _ = (source.stop_fn)(source.inner.as_mut()).await;
                 }
@@ -2449,7 +2491,9 @@ async fn process_audio_frame<TMutex: AudioMuxer>(
         let frame_samples = frame.inner.samples();
 
         if trim_samples >= frame_samples {
-            state.gap_tracker.record_overlap(overlap_duration, true);
+            state
+                .gap_tracker
+                .record_overlap(overlap_duration, true, *state.frame_count);
             debug!(
                 frame_count = *state.frame_count,
                 overlap_ms = overlap_duration.as_millis() as u64,
@@ -2462,7 +2506,9 @@ async fn process_audio_frame<TMutex: AudioMuxer>(
 
         if trim_samples > 0 {
             if let Some(trimmed) = trim_audio_frame_front(&frame.inner, trim_samples) {
-                state.gap_tracker.record_overlap(overlap_duration, false);
+                state
+                    .gap_tracker
+                    .record_overlap(overlap_duration, false, *state.frame_count);
                 debug!(
                     frame_count = *state.frame_count,
                     overlap_ms = overlap_duration.as_millis() as u64,
@@ -2669,6 +2715,7 @@ pub struct OutputPipeline {
     cancel_token: CancellationToken,
     video_frame_count: Arc<AtomicU64>,
     health_rx: Option<HealthReceiver>,
+    audio_gap_summary: Arc<OnceLock<AudioGapSummary>>,
 }
 
 pub struct FinishedOutputPipeline {
@@ -2676,6 +2723,7 @@ pub struct FinishedOutputPipeline {
     pub first_timestamp: Timestamp,
     pub video_info: Option<VideoInfo>,
     pub video_frame_count: u64,
+    pub audio_gap_summary: Option<AudioGapSummary>,
 }
 
 #[derive(Clone, Default)]
@@ -2767,6 +2815,7 @@ impl OutputPipeline {
             first_timestamp,
             video_info: self.video_info,
             video_frame_count: self.video_frame_count.load(Ordering::Acquire),
+            audio_gap_summary: self.audio_gap_summary.get().copied(),
         })
     }
 
@@ -3175,6 +3224,29 @@ mod tests {
                 .expect("wall-clock-confirmed stall should insert silence");
 
             assert_eq!(gap, MAX_SILENCE_INSERTION);
+        }
+
+        #[test]
+        fn gap_summary_counts_only_early_whole_frame_drops_as_startup() {
+            let mut tracker = AudioGapTracker::new(false, Timestamps::now());
+
+            // Whole-frame drops within the startup window carry the stale-burst signature.
+            tracker.record_overlap(Duration::from_millis(35), true, 0);
+            tracker.record_overlap(Duration::from_millis(35), true, 2);
+            tracker.record_overlap(
+                Duration::from_millis(35),
+                true,
+                STARTUP_OVERLAP_DROP_FRAME_LIMIT,
+            );
+            // A whole-frame drop past the startup window is a mid-recording overlap, not startup drift.
+            tracker.record_overlap(Duration::from_millis(35), true, 50);
+            // A partial trim keeps the frame, so it is never a startup drop.
+            tracker.record_overlap(Duration::from_millis(10), false, 1);
+
+            let summary = tracker.gap_summary();
+            assert_eq!(summary.startup_overlap_drops, 3);
+            assert_eq!(summary.overlap_dropped_frames, 4);
+            assert_eq!(summary.total_overlap_trimmed_ms, 35 * 4 + 10);
         }
     }
 

--- a/crates/recording/src/output_pipeline/core.rs
+++ b/crates/recording/src/output_pipeline/core.rs
@@ -667,16 +667,14 @@ fn audio_tail_padding_duration(audio_elapsed: Duration, target_elapsed: Duration
         .min(MAX_AUDIO_TAIL_PADDING)
 }
 
-/// A whole-frame overlap drop counts towards the stale-startup signature only while at most this
-/// many frames have been committed — the buffered burst that triggers startup drift lands in the
-/// first frames, before the steady-state capture clock settles.
-const STARTUP_OVERLAP_DROP_FRAME_LIMIT: u64 = 3;
+const STARTUP_OVERLAP_DROP_FRAME_COUNT: u64 = 3;
 
 /// Overlap-trim accounting surfaced from the audio mux task at finish so the editor can
 /// compensate for stale-startup drift from typed metadata rather than the recording log.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct AudioGapSummary {
     pub total_overlap_trimmed_ms: u32,
+    pub startup_overlap_trimmed_ms: u32,
     pub overlap_dropped_frames: u32,
     pub startup_overlap_drops: u32,
 }
@@ -693,6 +691,7 @@ struct AudioGapTracker {
     overlap_dropped_frames: u64,
     startup_overlap_drops: u64,
     total_overlap_trimmed: Duration,
+    startup_overlap_trimmed: Duration,
 }
 
 impl AudioGapTracker {
@@ -713,15 +712,20 @@ impl AudioGapTracker {
             overlap_dropped_frames: 0,
             startup_overlap_drops: 0,
             total_overlap_trimmed: Duration::ZERO,
+            startup_overlap_trimmed: Duration::ZERO,
         }
     }
 
     fn record_overlap(&mut self, overlap: Duration, dropped_whole_frame: bool, frame_count: u64) {
         self.overlap_event_count += 1;
         self.total_overlap_trimmed = self.total_overlap_trimmed.saturating_add(overlap);
+        let is_startup_overlap = frame_count < STARTUP_OVERLAP_DROP_FRAME_COUNT;
+        if is_startup_overlap {
+            self.startup_overlap_trimmed = self.startup_overlap_trimmed.saturating_add(overlap);
+        }
         if dropped_whole_frame {
             self.overlap_dropped_frames += 1;
-            if frame_count <= STARTUP_OVERLAP_DROP_FRAME_LIMIT {
+            if is_startup_overlap {
                 self.startup_overlap_drops += 1;
             }
         }
@@ -730,6 +734,8 @@ impl AudioGapTracker {
     fn gap_summary(&self) -> AudioGapSummary {
         AudioGapSummary {
             total_overlap_trimmed_ms: u32::try_from(self.total_overlap_trimmed.as_millis())
+                .unwrap_or(u32::MAX),
+            startup_overlap_trimmed_ms: u32::try_from(self.startup_overlap_trimmed.as_millis())
                 .unwrap_or(u32::MAX),
             overlap_dropped_frames: u32::try_from(self.overlap_dropped_frames).unwrap_or(u32::MAX),
             startup_overlap_drops: u32::try_from(self.startup_overlap_drops).unwrap_or(u32::MAX),
@@ -2366,6 +2372,8 @@ impl PreparedAudioSources {
                         overlap_events = gap_tracker.overlap_event_count,
                         overlap_dropped_frames = gap_tracker.overlap_dropped_frames,
                         total_overlap_trimmed_ms = gap_tracker.total_overlap_trimmed.as_millis(),
+                        startup_overlap_trimmed_ms =
+                            gap_tracker.startup_overlap_trimmed.as_millis(),
                         "Audio gap tracking summary at finish"
                     );
                 }
@@ -3230,23 +3238,22 @@ mod tests {
         fn gap_summary_counts_only_early_whole_frame_drops_as_startup() {
             let mut tracker = AudioGapTracker::new(false, Timestamps::now());
 
-            // Whole-frame drops within the startup window carry the stale-burst signature.
             tracker.record_overlap(Duration::from_millis(35), true, 0);
+            tracker.record_overlap(Duration::from_millis(35), true, 1);
             tracker.record_overlap(Duration::from_millis(35), true, 2);
             tracker.record_overlap(
                 Duration::from_millis(35),
                 true,
-                STARTUP_OVERLAP_DROP_FRAME_LIMIT,
+                STARTUP_OVERLAP_DROP_FRAME_COUNT,
             );
-            // A whole-frame drop past the startup window is a mid-recording overlap, not startup drift.
             tracker.record_overlap(Duration::from_millis(35), true, 50);
-            // A partial trim keeps the frame, so it is never a startup drop.
             tracker.record_overlap(Duration::from_millis(10), false, 1);
 
             let summary = tracker.gap_summary();
             assert_eq!(summary.startup_overlap_drops, 3);
-            assert_eq!(summary.overlap_dropped_frames, 4);
-            assert_eq!(summary.total_overlap_trimmed_ms, 35 * 4 + 10);
+            assert_eq!(summary.startup_overlap_trimmed_ms, 35 * 3 + 10);
+            assert_eq!(summary.overlap_dropped_frames, 5);
+            assert_eq!(summary.total_overlap_trimmed_ms, 35 * 5 + 10);
         }
     }
 

--- a/crates/recording/src/recovery.rs
+++ b/crates/recording/src/recovery.rs
@@ -1234,6 +1234,7 @@ impl RecoveryManager {
                                 device_id: original_segment
                                     .and_then(|s| s.mic.as_ref())
                                     .and_then(|m| m.device_id.clone()),
+                                gap_summary: None,
                             })
                         } else {
                             None
@@ -1257,6 +1258,7 @@ impl RecoveryManager {
                                 device_id: original_segment
                                     .and_then(|s| s.system_audio.as_ref())
                                     .and_then(|a| a.device_id.clone()),
+                                gap_summary: None,
                             })
                         } else {
                             None

--- a/crates/recording/src/studio_recording.rs
+++ b/crates/recording/src/studio_recording.rs
@@ -428,6 +428,7 @@ fn to_project_gap_summary(
 ) -> Option<cap_project::AudioGapSummary> {
     summary.map(|s| cap_project::AudioGapSummary {
         total_overlap_trimmed_ms: s.total_overlap_trimmed_ms,
+        startup_overlap_trimmed_ms: s.startup_overlap_trimmed_ms,
         overlap_dropped_frames: s.overlap_dropped_frames,
         startup_overlap_drops: s.startup_overlap_drops,
     })

--- a/crates/recording/src/studio_recording.rs
+++ b/crates/recording/src/studio_recording.rs
@@ -14,7 +14,9 @@ use crate::{
     cursor::{CursorActor, Cursors, IncrementalCaptureOutputs, spawn_cursor_recorder},
     feeds::{camera::CameraFeedLock, microphone::MicrophoneFeedLock},
     ffmpeg::{FragmentedAudioMuxer, FragmentedAudioMuxerConfig, OggMuxer},
-    output_pipeline::{DoneFut, FinishedOutputPipeline, OutputPipeline, PipelineDoneError},
+    output_pipeline::{
+        AudioGapSummary, DoneFut, FinishedOutputPipeline, OutputPipeline, PipelineDoneError,
+    },
     screen_capture::ScreenCaptureConfig,
     sources::{self, screen_capture},
 };
@@ -418,6 +420,17 @@ struct SegmentFailureDiagnostics {
 struct SegmentOutput {
     meta: MultipleSegment,
     diagnostics: Option<SegmentFailureDiagnostics>,
+    duration: f64,
+}
+
+fn to_project_gap_summary(
+    summary: Option<AudioGapSummary>,
+) -> Option<cap_project::AudioGapSummary> {
+    summary.map(|s| cap_project::AudioGapSummary {
+        total_overlap_trimmed_ms: s.total_overlap_trimmed_ms,
+        overlap_dropped_frames: s.overlap_dropped_frames,
+        startup_overlap_drops: s.startup_overlap_drops,
+    })
 }
 
 fn record_track_failure(
@@ -984,22 +997,34 @@ async fn stop_recording(
                     track_failures: s.pipeline.track_failures.clone(),
                 });
 
+            let display_fps = s
+                .pipeline
+                .screen
+                .video_info
+                .map(|v| v.fps())
+                .unwrap_or_else(|| {
+                    tracing::warn!(
+                        "Screen video_info missing, using default fps: {}",
+                        DEFAULT_FPS
+                    );
+                    DEFAULT_FPS
+                });
+            // Use the encoded display-media duration (frame_count / fps), not the wall-clock
+            // recording span which includes pipeline-drain latency. This is the timeline the
+            // recorder persists to project-config.json, so it is what un-edited recordings use; the
+            // editor/export fallbacks only synthesize a timeline when none is present and read the
+            // muxed container duration, which this closely (not bit-exactly) matches.
+            let display_media_duration = if display_fps > 0 {
+                s.pipeline.screen.video_frame_count as f64 / f64::from(display_fps)
+            } else {
+                0.0
+            };
+
             SegmentOutput {
                 meta: MultipleSegment {
                     display: VideoMeta {
                         path: make_relative(&s.pipeline.screen.path),
-                        fps: s
-                            .pipeline
-                            .screen
-                            .video_info
-                            .map(|v| v.fps())
-                            .unwrap_or_else(|| {
-                                tracing::warn!(
-                                    "Screen video_info missing, using default fps: {}",
-                                    DEFAULT_FPS
-                                );
-                                DEFAULT_FPS
-                            }),
+                        fps: display_fps,
                         start_time: Some(display_start_time),
                         device_id: None,
                     },
@@ -1019,6 +1044,7 @@ async fn stop_recording(
                         path: make_relative(&mic.path),
                         start_time: mic_start_time,
                         device_id: s.mic_device_id.clone(),
+                        gap_summary: to_project_gap_summary(mic.audio_gap_summary),
                     }),
                     system_audio: s.pipeline.system_audio.map(|audio| {
                         let raw_sys_start = to_start_time(audio.first_timestamp);
@@ -1041,6 +1067,7 @@ async fn stop_recording(
                             path: make_relative(&audio.path),
                             start_time: Some(sys_start_time),
                             device_id: None,
+                            gap_summary: to_project_gap_summary(audio.audio_gap_summary),
                         }
                     }),
                     cursor: s
@@ -1057,7 +1084,20 @@ async fn stop_recording(
                     }),
                 },
                 diagnostics,
+                duration: display_media_duration,
             }
+        })
+        .collect();
+    let timeline_segments: Vec<_> = segment_outputs
+        .iter()
+        .enumerate()
+        .filter_map(|(i, segment)| {
+            (segment.duration > 0.0).then_some(TimelineSegment {
+                recording_clip: i as u32,
+                start: 0.0,
+                end: segment.duration,
+                timescale: 1.0,
+            })
         })
         .collect();
     let segment_failure_diagnostics: Vec<_> = segment_outputs
@@ -1068,6 +1108,19 @@ async fn stop_recording(
         .into_iter()
         .map(|segment| segment.meta)
         .collect();
+    let clip_configs = segment_metas
+        .iter()
+        .all(|segment| segment.camera.is_none())
+        .then(|| {
+            segment_metas
+                .iter()
+                .enumerate()
+                .map(|(i, segment)| ClipConfiguration {
+                    index: i as u32,
+                    offsets: segment.calculate_audio_offsets(),
+                })
+                .collect::<Vec<_>>()
+        });
 
     let needs_remux = if fragmented {
         segment_metas.iter().any(|seg| {
@@ -1109,7 +1162,21 @@ async fn stop_recording(
 
     persist_final_recording_meta(&recording_dir, &meta);
 
-    let project_config = cap_project::ProjectConfiguration::default();
+    let mut project_config = cap_project::ProjectConfiguration::default();
+    if !timeline_segments.is_empty() {
+        project_config.timeline = Some(TimelineConfiguration {
+            segments: timeline_segments,
+            zoom_segments: Vec::new(),
+            scene_segments: Vec::new(),
+            mask_segments: Vec::new(),
+            text_segments: Vec::new(),
+            caption_segments: Vec::new(),
+            keyboard_segments: Vec::new(),
+        });
+    }
+    if let Some(clips) = clip_configs {
+        project_config.clips = clips;
+    }
     project_config
         .write(&recording_dir)
         .map_err(RecordingError::from)?;
@@ -1683,6 +1750,7 @@ mod tests {
             first_timestamp,
             video_info,
             video_frame_count,
+            audio_gap_summary: None,
         }
     }
 

--- a/crates/rendering/src/decoder/avassetreader.rs
+++ b/crates/rendering/src/decoder/avassetreader.rs
@@ -647,6 +647,11 @@ impl AVAssetReaderDecoder {
             let max_requested_frame = pending_requests.iter().map(|r| r.frame).max().unwrap();
             let requested_frame = min_requested_frame;
             let requested_time = requested_frame as f32 / fps as f32;
+            let minimum_fallback_frame = pending_requests
+                .iter()
+                .map(|r| r.frame.saturating_sub(r.max_fallback_distance))
+                .min()
+                .unwrap_or(requested_frame);
 
             let (decoder_idx, was_reset) = this.select_best_decoder(requested_time, is_scrubbing);
 
@@ -695,6 +700,12 @@ impl AVAssetReaderDecoder {
                         pts_to_frame(frame.pts().value, Rational::new(1, frame.pts().scale), fps);
 
                     let position_secs = current_frame as f32 / fps as f32;
+                    last_decoded_position = Some(position_secs);
+                    decoder.is_done = false;
+
+                    if current_frame < minimum_fallback_frame {
+                        continue;
+                    }
 
                     let Some(frame) = frame.image_buf() else {
                         tracing::debug!(
@@ -704,15 +715,11 @@ impl AVAssetReaderDecoder {
                         continue;
                     };
 
-                    last_decoded_position = Some(position_secs);
-
                     let cache_frame = CachedFrame::new(&processor, frame.retained(), current_frame);
 
                     if first_ever_frame.borrow().is_none() {
                         *first_ever_frame.borrow_mut() = Some(cache_frame.data().clone());
                     }
-
-                    decoder.is_done = false;
 
                     let exceeds_cache_bounds = current_frame > cache_max;
                     let too_small_for_cache_bounds = current_frame < cache_min;

--- a/crates/rendering/src/decoder/mod.rs
+++ b/crates/rendering/src/decoder/mod.rs
@@ -459,6 +459,7 @@ pub struct AsyncVideoDecoderHandle {
 
 impl AsyncVideoDecoderHandle {
     const INITIAL_SEEK_TIMEOUT_MS: u64 = 10000;
+    const INITIAL_MAX_FALLBACK_DISTANCE: u32 = 2;
 
     fn normal_timeout_ms(&self) -> u64 {
         let pixels = (self.status.video_width as u64) * (self.status.video_height as u64);
@@ -472,16 +473,26 @@ impl AsyncVideoDecoderHandle {
     }
 
     pub async fn get_frame(&self, time: f32) -> Option<DecodedFrame> {
-        self.get_frame_with_timeout(time, self.normal_timeout_ms())
+        self.get_frame_with_timeout(time, self.normal_timeout_ms(), self.max_fallback_distance)
             .await
     }
 
     pub async fn get_frame_initial(&self, time: f32) -> Option<DecodedFrame> {
-        self.get_frame_with_timeout(time, Self::INITIAL_SEEK_TIMEOUT_MS)
-            .await
+        self.get_frame_with_timeout(
+            time,
+            Self::INITIAL_SEEK_TIMEOUT_MS,
+            self.max_fallback_distance
+                .min(Self::INITIAL_MAX_FALLBACK_DISTANCE),
+        )
+        .await
     }
 
-    async fn get_frame_with_timeout(&self, time: f32, timeout_ms: u64) -> Option<DecodedFrame> {
+    async fn get_frame_with_timeout(
+        &self,
+        time: f32,
+        timeout_ms: u64,
+        max_fallback_distance: u32,
+    ) -> Option<DecodedFrame> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let adjusted_time = self.get_time(time);
 
@@ -489,7 +500,7 @@ impl AsyncVideoDecoderHandle {
             .sender
             .send(VideoDecoderMessage::GetFrame(
                 adjusted_time,
-                self.max_fallback_distance,
+                max_fallback_distance,
                 tx,
             ))
             .is_err()


### PR DESCRIPTION
- Parallelize editor startup (mic/system-audio load + GPU layer warmup overlap decoder creation)
  - Replace audio-timing-repair log-scraping with structured AudioGapSummary metadata (recorder → AudioMeta → editor)
  - Harden audio mixer against offset overflow (i128 intermediates) and skip decode work for sub-fallback frames
  - Synthesize a default timeline for un-edited recordings (decoded media duration) so raw/CLI exports render
  - Gapless export audio on zero-frame fallback; fragmented-recording remux on finalize/export
  - Tighten the audio-ready handshake timeout to prevent unsynced playback

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens A/V sync across playback and export through several coordinated changes: structured `AudioGapSummary` metadata replaces log-scraping for startup-offset repair, GPU layer warmup is parallelised with decoder creation, the video clock is now stamped only after the audio device fires its first callback, and a default timeline is synthesised from encoded frame counts at recording stop so un-edited recordings are immediately exportable.

- **A/V sync**: `start = Instant::now()` moved after `AudioPlayback::spawn()` returns, which blocks on the first device callback via a new channel handshake; initial latency offset switched from `initial_compensation_secs` (2× safety multiplier) to raw `initial_output_latency_secs`; silent audio frame substituted for `None` renders during export to prevent gaps.
- **`AudioGapSummary` pipeline**: structured `startup_overlap_trimmed_ms` / `startup_overlap_drops` counters are accumulated in `AudioGapTracker`, stored in a `OnceLock` on `FinishedOutputPipeline`, written into `AudioMeta.gap_summary`, and consumed by `audio_timing_repair_offset` in the editor—replacing fragile log-scraping while keeping a legacy fallback for old recordings.
- **Overflow hardening**: audio mixer uses `i128` intermediates and `usize::try_from` instead of `isize` and `wrapping_add_signed` to prevent index overflow on large negative track offsets.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the changes are well-tested and correctness-focused, with one open concern around startup latency for very long recordings.

The audio timing-repair rewrite is thorough and well-covered by new unit tests. The `start = Instant::now()` move correctly ties video to the audio device's first callback, fixing the sync regression. The one remaining concern is that `AudioPlayback::spawn()` has no upper-bound timeout for the `PrerenderedAudioBuffer::new()` pre-render phase: for a multi-hour recording the polling loop can silently stall for tens of seconds before playback begins.

crates/editor/src/playback.rs — the spawn() polling loop should have an outer timeout covering the pre-render phase, not just AUDIO_FIRST_CALLBACK_TIMEOUT which starts after stream.play().

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/editor/src/playback.rs | Moves `start = Instant::now()` after `audio_playback.spawn()` to synchronize A/V start; adds first-callback handshake with `AUDIO_FIRST_CALLBACK_TIMEOUT`; hardens `prefetch_duration` and `duration` against invalid timelines; changes initial latency from `initial_compensation_secs` (2× multiplier) to raw `initial_output_latency_secs`. |
| crates/editor/src/editor_instance.rs | Replaces log-scraping A/V timing repair with structured `AudioGapSummary` metadata; adds `LegacyAudioTimingRepair` fallback for old recordings; parallelises audio I/O via `spawn_audio_load`; removes 5 s hardcoded fallback duration; minor redundant guard in `audio_timing_repair_offset`. |
| crates/recording/src/output_pipeline/core.rs | Adds `AudioGapSummary` struct and per-event startup/total accounting to `AudioGapTracker`; passes `frame_count` to `record_overlap`; stores summary in `OnceLock` on `OutputPipeline` and surfaces it in `FinishedOutputPipeline`. |
| crates/recording/src/studio_recording.rs | Synthesizes `TimelineConfiguration` and `ClipConfiguration` from encoded frame_count/fps at recording stop; propagates `gap_summary` into `AudioMeta`; persists populated project config so un-edited recordings have a valid timeline for export/playback. |
| crates/audio/src/renderer.rs | Replaces i32/isize arithmetic with i128 intermediates and `usize::try_from` to prevent overflow on large offsets; fixes stereo base-index calculation; adds regression test for negative offset (leading-silence) behaviour. |
| crates/export/src/mp4.rs | Emits a silent audio frame instead of skipping on zero-frame fallback, ensuring gapless export when the audio renderer returns None for a given time slot. |
| crates/editor/src/editor.rs | Splits `start_renderer_layers_creation` into start + `finish_renderer_layers_creation` so GPU layer warmup overlaps decoder/segment creation; removes now-unused `total_frames` field. |
| crates/recording/src/feeds/microphone.rs | Adds `normalize_pending_timestamps` to correct stale startup burst timestamps before they are enqueued, preventing phantom overlap events that would otherwise inflate the gap summary. |
| crates/rendering/src/decoder/avassetreader.rs | Computes `minimum_fallback_frame` from pending requests and skips decode work for frames below that bound, reducing unnecessary decode overhead during seek. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/editor/src/editor_instance.rs`, line 176-180 ([link](https://github.com/capsoftware/cap/blob/3d42742d6057a2c870fa717fd3d58a053b2338b0/crates/editor/src/editor_instance.rs#L176-L180)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Hardcoded 5.0 s fallback creates incorrect timeline for any recording not ~5 s long**

   When both `Video::new` and `get_video_duration_fallback` fail (e.g., partially written or corrupt display file), the synthesized `TimelineSegment` uses `end: 5.0`. A 30-second recording whose display file is unreadable would export with a 5-second timeline, silently truncating content. Since this fallback is exercised for real on first open (before recovery or remux), the project config is then written with the wrong `end` value and persisted. Returning `None` from the filter in the `MultipleSegments` arm (same as the explicit `duration <= 0.0` guard just below) and warning the user would be safer than silently synthesising an arbitrary duration.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/editor/src/editor_instance.rs
   Line: 176-180

   Comment:
   **Hardcoded 5.0 s fallback creates incorrect timeline for any recording not ~5 s long**

   When both `Video::new` and `get_video_duration_fallback` fail (e.g., partially written or corrupt display file), the synthesized `TimelineSegment` uses `end: 5.0`. A 30-second recording whose display file is unreadable would export with a 5-second timeline, silently truncating content. Since this fallback is exercised for real on first open (before recovery or remux), the project config is then written with the wrong `end` value and persisted. Returning `None` from the filter in the `MultipleSegments` arm (same as the explicit `duration <= 0.0` guard just below) and warning the user would be safer than silently synthesising an arbitrary duration.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
crates/editor/src/playback.rs:1285-1356
**Pre-render phase has no upper-bound timeout in `spawn()`**

`AudioPlayback::spawn()` polls `ready_rx` every 50 ms and only exits when the audio thread sends a value or `stop_rx` fires. The audio thread sends `ready_tx` only _after_ `PrerenderedAudioBuffer::new()` completes **and** the first device callback arrives. `PrerenderedAudioBuffer::new()` is O(recording length), so for a multi-hour recording on modest hardware it can take well over 10–20 s. During that entire window the polling loop spins with no way out except user cancellation.

`AUDIO_FIRST_CALLBACK_TIMEOUT` does not help here: it only starts timing after `stream.play()`, which is called _after_ pre-render finishes. The net effect is that pressing play on a long recording can silently stall for tens of seconds before video begins—trading the previous async desync for a synchronous startup freeze.

### Issue 2 of 2
crates/editor/src/editor_instance.rs:759-762
The `overlap_dropped_frames < MIN_STALE_STARTUP_DROPS` guard is unreachable: `startup_overlap_drops ≤ overlap_dropped_frames` by construction, so if the `startup_overlap_drops` check passes (`>= 3`), `overlap_dropped_frames >= 3` is guaranteed. Removing the redundant condition avoids misleading future readers into thinking total drops could prevent repair when startup drops are sufficient.

```suggestion
    if summary.startup_overlap_drops < MIN_STALE_STARTUP_DROPS
        || !(MIN_STALE_STARTUP_TRIMMED_MS..=MAX_STALE_STARTUP_REPAIR_MS)
            .contains(&summary.startup_overlap_trimmed_ms)
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Add test for negative timing offset cons..."](https://github.com/capsoftware/cap/commit/105ddce09a3f86569acf63158c9ffa26f3478bc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36040067)</sub>

<!-- /greptile_comment -->