### PR TITLE
fix(auth): persist plan update even when org fetch fails on self-hosted

### DIFF
--- a/apps/desktop/src-tauri/src/auth.rs
+++ b/apps/desktop/src-tauri/src/auth.rs
@@ -100,10 +100,15 @@ impl AuthStore {
             last_checked: chrono::Utc::now().timestamp() as i32,
             manual: auth.plan.as_ref().is_some_and(|p| p.manual),
         });
-        auth.organizations = api::fetch_organizations(app)
-            .await
-            .map_err(|e| e.to_string())?;
-        auth.organizations_updated_at = Some(chrono::Utc::now().timestamp() as i32);
+        match api::fetch_organizations(app).await {
+            Ok(orgs) => {
+                auth.organizations = orgs;
+                auth.organizations_updated_at = Some(chrono::Utc::now().timestamp() as i32);
+            }
+            Err(e) => {
+                println!("Failed to fetch organizations: {e}");
+            }
+        }
 
         Self::set(app, Some(auth))?;
 

--- a/apps/desktop/src-tauri/src/auth.rs
+++ b/apps/desktop/src-tauri/src/auth.rs
@@ -106,7 +106,7 @@ impl AuthStore {
                 auth.organizations_updated_at = Some(chrono::Utc::now().timestamp() as i32);
             }
             Err(e) => {
-                println!("Failed to fetch organizations: {e}");
+                tracing::warn!("Failed to fetch organizations: {e}");
             }
         }
 


### PR DESCRIPTION
## Summary
The previous auth loop fix stopped the double deep-link delivery, but auth still didn't persist on self-hosted because of a second bug in update_auth_plan.

When fetch_organizations failed (common on self-hosted where the org endpoint returns an unexpected response), the ? operator bailed early and Self::set(app, Some(auth)) was never called, meaning the plan update was computed but never written to disk. 
On next app start, organizations was always empty, hasAvailableOrganizationCache returned false, and the UI showed the login screen even though valid credentials were in the store.

## Fix
Treat org fetch failure as non-fatal, log the error, keep existing organizations, and still persist the plan update to disk.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in `update_auth_plan` where a `?`-operator early-return on `fetch_organizations` failure prevented `Self::set` from ever being called, causing the computed plan update to be silently discarded on self-hosted deployments.

- The `fetch_organizations` call is now wrapped in a `match` so failures are logged via `tracing::warn!` and the existing (stale) organizations are preserved rather than bailing early.
- `Self::set(app, Some(auth))` now always executes after the plan fetch, persisting the plan to disk regardless of whether org refresh succeeded.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted fix that converts one early-return path to a non-fatal branch, with no impact on the plan-fetch success path.

The fix is small and correct: it ensures the plan is always written to the store regardless of whether org fetch succeeds. When org fetch fails, the in-memory auth already holds the previously stored organizations, so persisting it does not accidentally wipe previously cached org data.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/auth.rs | Converts early-return on failed `fetch_organizations` into a non-fatal warning, ensuring `Self::set` is always called and the plan update is always persisted to disk. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(auth): use tracing::warn for org fet..."](https://github.com/capsoftware/cap/commit/9718ab5b48bf06e5b268d19c6ed13d63d79905c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36095606)</sub>

<!-- /greptile_comment -->