### PR TITLE
fix(auth): make plan and org fetches non-fatal, always persist auth

### DIFF
--- a/apps/desktop/src-tauri/src/auth.rs
+++ b/apps/desktop/src-tauri/src/auth.rs
@@ -70,45 +70,38 @@ impl AuthStore {
         }
 
         let mut auth = auth;
-        println!(
-            "Fetching plan for user {}",
-            auth.user_id.as_deref().unwrap_or("unknown")
-        );
-        let response = app
+
+        match app
             .authed_api_request("/api/desktop/plan", |client, url| client.get(url))
             .await
-            .map_err(|e| {
-                println!("Failed to fetch plan: {e}");
-                e.to_string()
-            })?;
-        println!("Plan fetch response status: {}", response.status());
-
-        if !response.status().is_success() {
-            let error_msg = format!("Failed to fetch plan: {}", response.status());
-            return Err(error_msg);
+        {
+            Ok(response) if response.status().is_success() => {
+                #[derive(Deserialize)]
+                struct PlanResponse {
+                    upgraded: bool,
+                }
+                match response.json::<PlanResponse>().await {
+                    Ok(plan_response) => {
+                        auth.plan = Some(Plan {
+                            upgraded: plan_response.upgraded,
+                            last_checked: chrono::Utc::now().timestamp() as i32,
+                            manual: auth.plan.as_ref().is_some_and(|p| p.manual),
+                        });
+                    }
+                    Err(e) => tracing::warn!("Failed to parse plan response: {e}"),
+                }
+            }
+            Ok(response) => tracing::warn!("Plan fetch returned {}", response.status()),
+            Err(e) => tracing::warn!("Failed to fetch plan: {e}"),
         }
 
-        #[derive(Deserialize)]
-        struct Response {
-            upgraded: bool,
-        }
-
-        let plan_response: Response = response.json().await.map_err(|e| e.to_string())?;
-
-        auth.plan = Some(Plan {
-            upgraded: plan_response.upgraded,
-            last_checked: chrono::Utc::now().timestamp() as i32,
-            manual: auth.plan.as_ref().is_some_and(|p| p.manual),
-        });
         match api::fetch_organizations(app).await {
             Ok(orgs) => {
                 auth.organizations = orgs;
-                auth.organizations_updated_at = Some(chrono::Utc::now().timestamp() as i32);
             }
-            Err(e) => {
-                tracing::warn!("Failed to fetch organizations: {e}");
-            }
+            Err(e) => tracing::warn!("Failed to fetch organizations: {e}"),
         }
+        auth.organizations_updated_at = Some(chrono::Utc::now().timestamp() as i32);
 
         Self::set(app, Some(auth))?;
 

--- a/apps/desktop/src-tauri/src/auth.rs
+++ b/apps/desktop/src-tauri/src/auth.rs
@@ -98,10 +98,15 @@ impl AuthStore {
         match api::fetch_organizations(app).await {
             Ok(orgs) => {
                 auth.organizations = orgs;
+                auth.organizations_updated_at = Some(chrono::Utc::now().timestamp() as i32);
             }
-            Err(e) => tracing::warn!("Failed to fetch organizations: {e}"),
+            Err(e) => {
+                tracing::warn!("Failed to fetch organizations: {e}");
+                if auth.organizations.is_empty() {
+                    auth.organizations_updated_at = Some(chrono::Utc::now().timestamp() as i32);
+                }
+            }
         }
-        auth.organizations_updated_at = Some(chrono::Utc::now().timestamp() as i32);
 
         Self::set(app, Some(auth))?;
 


### PR DESCRIPTION
## Summary

Even after the org-fetch fix in #1896, auth still didn't persist on self-hosted because organizations_updated_at was never stamped when fetches failed, and hasCompleteOrganizationCache requires it to be set for signedIn() to return true.

Both plan and org fetches are now non-fatal. Whatever succeeds gets saved, and organizations_updated_at is always stamped at the end, so the UI sees a valid cache and stays signed in regardless of what the self-hosted server returns.

Confirmed working against https://demos.alphaomegateam.co/

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the `/api/desktop/plan` and `/api/desktop/organizations` fetches non-fatal inside `update_auth_plan`, and ensures `Self::set` is always called so auth is persisted regardless of which fetches succeed or fail. The fix specifically targets self-hosted deployments where these endpoints may not exist.

- **Plan fetch** now uses a `match` block with `tracing::warn!` on any failure or non-success status, and only updates `auth.plan` on a valid 200 + parseable JSON response.
- **Org fetch failure** now stamps `organizations_updated_at` when `auth.organizations` is empty, which is the key unlock for `signedIn()` to return `true` on self-hosted (where the org endpoint returns 404 and no prior cache exists).
- The `is_empty()` guard on the error branch is a targeted improvement over unconditionally stamping the timestamp, but the cloud-vs-self-hosted ambiguity on a first login (empty cached orgs + transient failure) remains an open concern per the existing review thread.

<h3>Confidence Score: 4/5</h3>

Safe to merge for self-hosted scenarios; the unresolved ambiguity around empty-org stamping on first login still applies to cloud deployments with transient failures.

The auth persistence logic is now correct for the self-hosted case. The is_empty() guard on the error branch reduces the blast radius compared to unconditional stamping, but on a first login against a cloud server where the org endpoint transiently returns an error, organizations_updated_at will still be stamped with an empty org list, leaving the UI in a signed-in-but-no-orgs state. No new functional regressions were introduced beyond what was already flagged in the prior review thread.

apps/desktop/src-tauri/src/auth.rs — specifically the error branch of the org fetch (lines 103–108) and the interaction with the frontend's hasCompleteOrganizationCache freshness check.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/auth.rs | Plan and org fetches made non-fatal; auth is now always persisted via unconditional Self::set; organizations_updated_at is stamped on success or on failure when auth.organizations is empty, with the previous reviewer concern partially addressed by the is_empty() guard. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(auth): only stamp org timestamp on f..."](https://github.com/capsoftware/cap/commit/ec233e7387d4c12bf0f2e60c55ceebec2157ca37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36123486)</sub>

<!-- /greptile_comment -->