### PR TITLE
fix(auth): stop infinite updateAuthPlan loop on self-hosted

### DIFF
--- a/apps/desktop/src/utils/queries.ts
+++ b/apps/desktop/src/utils/queries.ts
@@ -351,6 +351,7 @@ export function createCustomDomainQuery() {
 export function createOrganizationsQuery() {
 	const auth = authStore.createQuery();
 
+	// Bootstrap only: auth.rs stamps organizations_updated_at even on org-fetch failure, stopping the loop on self-hosted where the endpoint is absent.
 	createEffect(() => {
 		if (auth.data?.user_id && !auth.data?.organizations_updated_at) {
 			commands.updateAuthPlan().catch(console.error);

--- a/apps/desktop/src/utils/queries.ts
+++ b/apps/desktop/src/utils/queries.ts
@@ -351,12 +351,8 @@ export function createCustomDomainQuery() {
 export function createOrganizationsQuery() {
 	const auth = authStore.createQuery();
 
-	// Refresh organizations if they're missing
 	createEffect(() => {
-		if (
-			auth.data?.user_id &&
-			(!auth.data?.organizations || auth.data.organizations.length === 0)
-		) {
+		if (auth.data?.user_id && !auth.data?.organizations_updated_at) {
 			commands.updateAuthPlan().catch(console.error);
 		}
 	});


### PR DESCRIPTION
## Summary

The createOrganizationsQuery effect fired every time auth.data changed. 
Since the previous auth fixes (PR #1898) now always write back to the store on every updateAuthPlan call, each write triggered the effect again, creating an infinite loop of plan/org fetch requests on self-hosted instances where the org endpoint always returns an error.

## Fix

Changed the trigger condition from organizations.length === 0 to !organizations_updated_at. 

Since PR #1898 always stamps organizations_updated_at after the first run, the effect fires exactly once on sign-in and never again until the user signs out and back in.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the trigger condition in `createOrganizationsQuery` from `organizations.length === 0` to `!organizations_updated_at` to break an infinite `updateAuthPlan` loop on self-hosted instances introduced by PR #1898 always writing to the auth store.

- The new guard fires exactly once per sign-in cycle for self-hosted users (empty org list), relying on `auth.rs` stamping `organizations_updated_at` in the error path when `auth.organizations.is_empty()`.
- Cloud users upgrading from before PR #1898 may carry a non-empty `organizations` list alongside a null `organizations_updated_at`; if the org fetch fails transiently, `auth.rs` will not stamp the timestamp (the `is_empty()` guard is not met), yet still unconditionally saves the store, re-firing the reactive effect and re-entering the loop.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the self-hosted loop case it targets, but carries a narrow regression risk for cloud users upgrading with existing organizations who hit a transient org-fetch failure.

The fix correctly eliminates the infinite loop for self-hosted users with empty org lists. However, the Rust error path in auth.rs stamps organizations_updated_at only when organizations.is_empty(), meaning cloud users migrating from pre-#1898 stores who have orgs but no timestamp can re-enter the same loop if the org endpoint returns an error during that first run.

The Rust error branch in apps/desktop/src-tauri/src/auth.rs (lines 103-108) warrants a follow-up: stamping organizations_updated_at unconditionally on org-fetch failure would make the JS guard airtight across all migration paths.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/utils/queries.ts | Guard changed from `organizations.length === 0` to `!organizations_updated_at` to break the self-hosted infinite loop; works correctly for empty-org users but can re-enter the loop for cloud users upgrading with non-empty orgs when org fetch fails transiently. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/utils/queries.ts:355-358
**Migration loop for existing cloud users with non-empty org lists**

The fix relies on `auth.rs` stamping `organizations_updated_at` after any `updateAuthPlan` call. This works for self-hosted users (always empty orgs) because the error path in `auth.rs` (lines 105–107) stamps the timestamp only when `auth.organizations.is_empty()`. Users upgrading from before PR #1898 may have a non-empty `organizations` list with `organizations_updated_at = null` — the field simply didn't exist. For these users the new trigger fires, `updateAuthPlan` runs, and if the org fetch happens to fail (transient network error, server hiccup), `organizations_updated_at` is **not** stamped because `!is_empty()`, the store is still saved unconditionally (line 111 of `auth.rs`), the reactive effect re-fires, and the loop restarts indefinitely.

The simplest fix is to stamp `organizations_updated_at` unconditionally in the error branch of `auth.rs`, removing the `is_empty()` guard — the JS logic no longer needs the org-count distinction to prevent the loop.

Also, the inline comment says "stamps `organizations_updated_at` **even** on org-fetch failure" which implies unconditional behaviour; tightening it to mention the `is_empty()` precondition would prevent a future reader from relying on an assumption that doesn't hold.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(auth): add comment explaining org re..."](https://github.com/capsoftware/cap/commit/c19e55c402e0d3e27a079b59be49029d254e99e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36181760)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->