### PR TITLE
feat(analytics): video watch percentage and drop-off tracking

### DIFF
--- a/apps/web/actions/videos/get-analytics.ts
+++ b/apps/web/actions/videos/get-analytics.ts
@@ -103,6 +103,9 @@ export async function getVideoAnalytics(
 export async function getVideoEngagement(videoId: string) {
 	if (!videoId) throw new Error("Video ID is required");
 
+	if (!/^[0-9a-zA-Z_-]+$/.test(videoId))
+		throw new Error("Invalid video ID format");
+
 	const user = await getCurrentUser();
 	if (!user?.id) throw new Error("Unauthorized");
 
@@ -114,8 +117,6 @@ export async function getVideoEngagement(videoId: string) {
 
 	if (!video || video.ownerId !== user.id) throw new Error("Unauthorized");
 
-	if (!/^[0-9a-zA-Z_-]+$/.test(videoId))
-		throw new Error("Invalid video ID format");
 	const safeId = videoId;
 
 	return runPromise(

--- a/apps/web/actions/videos/get-analytics.ts
+++ b/apps/web/actions/videos/get-analytics.ts
@@ -135,8 +135,9 @@ export async function getVideoEngagement(videoId: string) {
 					`SELECT count() as total, countIf(max_percent >= 25) as reached_25, countIf(max_percent >= 50) as reached_50, countIf(max_percent >= 75) as reached_75, countIf(max_percent >= 95) as reached_95, round(avg(max_percent)) as avg_percent FROM (SELECT session_id, max(toFloat32(percent_watched)) as max_percent FROM analytics_events WHERE action = 'video_progress' AND video_id = '${safeId}' GROUP BY session_id)`,
 				)
 				.pipe(
-					Effect.catchAll(() =>
-						Effect.succeed({
+					Effect.catchAll((e) => {
+						console.error("tinybird engagement query error", e);
+						return Effect.succeed({
 							data: [] as {
 								total: number;
 								reached_25: number;
@@ -145,8 +146,8 @@ export async function getVideoEngagement(videoId: string) {
 								reached_95: number;
 								avg_percent: number;
 							}[],
-						}),
-					),
+						});
+					}),
 				);
 
 			const row = result.data?.[0];

--- a/apps/web/actions/videos/get-analytics.ts
+++ b/apps/web/actions/videos/get-analytics.ts
@@ -117,7 +117,7 @@ export async function getVideoEngagement(videoId: string) {
 
 	if (!video || video.ownerId !== user.id) throw new Error("Unauthorized");
 
-	const safeId = videoId;
+	const safeId = escapeLiteral(videoId);
 
 	return runPromise(
 		Effect.gen(function* () {

--- a/apps/web/actions/videos/get-analytics.ts
+++ b/apps/web/actions/videos/get-analytics.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { db } from "@cap/database";
+import { getCurrentUser } from "@cap/database/auth/session";
 import { videos } from "@cap/database/schema";
 import { Tinybird } from "@cap/web-backend";
 import { Video } from "@cap/web-domain";
@@ -102,7 +103,18 @@ export async function getVideoAnalytics(
 export async function getVideoEngagement(videoId: string) {
 	if (!videoId) throw new Error("Video ID is required");
 
-	const safeId = videoId.replace(/'/g, "''");
+	const user = await getCurrentUser();
+	if (!user?.id) throw new Error("Unauthorized");
+
+	const [video] = await db()
+		.select({ ownerId: videos.ownerId })
+		.from(videos)
+		.where(eq(videos.id, Video.VideoId.make(videoId)))
+		.limit(1);
+
+	if (!video || video.ownerId !== user.id) throw new Error("Unauthorized");
+
+	const safeId = escapeLiteral(videoId);
 
 	return runPromise(
 		Effect.gen(function* () {

--- a/apps/web/actions/videos/get-analytics.ts
+++ b/apps/web/actions/videos/get-analytics.ts
@@ -114,7 +114,9 @@ export async function getVideoEngagement(videoId: string) {
 
 	if (!video || video.ownerId !== user.id) throw new Error("Unauthorized");
 
-	const safeId = escapeLiteral(videoId);
+	if (!/^[0-9a-zA-Z_-]+$/.test(videoId))
+		throw new Error("Invalid video ID format");
+	const safeId = videoId;
 
 	return runPromise(
 		Effect.gen(function* () {

--- a/apps/web/actions/videos/get-analytics.ts
+++ b/apps/web/actions/videos/get-analytics.ts
@@ -98,3 +98,51 @@ export async function getVideoAnalytics(
 		}),
 	);
 }
+
+export async function getVideoEngagement(videoId: string) {
+	if (!videoId) throw new Error("Video ID is required");
+
+	const safeId = videoId.replace(/'/g, "''");
+
+	return runPromise(
+		Effect.gen(function* () {
+			const tinybird = yield* Tinybird;
+
+			const result = yield* tinybird
+				.querySql<{
+					total: number;
+					reached_25: number;
+					reached_50: number;
+					reached_75: number;
+					reached_95: number;
+					avg_percent: number;
+				}>(
+					`SELECT count() as total, countIf(max_percent >= 25) as reached_25, countIf(max_percent >= 50) as reached_50, countIf(max_percent >= 75) as reached_75, countIf(max_percent >= 95) as reached_95, round(avg(max_percent)) as avg_percent FROM (SELECT session_id, max(toFloat32(percent_watched)) as max_percent FROM analytics_events WHERE action = 'video_progress' AND video_id = '${safeId}' GROUP BY session_id)`,
+				)
+				.pipe(
+					Effect.catchAll(() =>
+						Effect.succeed({
+							data: [] as {
+								total: number;
+								reached_25: number;
+								reached_50: number;
+								reached_75: number;
+								reached_95: number;
+								avg_percent: number;
+							}[],
+						}),
+					),
+				);
+
+			const row = result.data?.[0];
+			return {
+				total: Number(row?.total ?? 0),
+				reached25: Number(row?.reached_25 ?? 0),
+				reached50: Number(row?.reached_50 ?? 0),
+				reached75: Number(row?.reached_75 ?? 0),
+				reached95: Number(row?.reached_95 ?? 0),
+				avgPercent: Number(row?.avg_percent ?? 0),
+			};
+		}),
+	);
+}

--- a/apps/web/app/api/analytics/track/route.ts
+++ b/apps/web/app/api/analytics/track/route.ts
@@ -23,6 +23,8 @@ interface TrackPayload {
 	hostname?: string | null;
 	userAgent?: string;
 	occurredAt?: string;
+	action?: string;
+	percentWatched?: number | null;
 }
 
 const VIEW_TRACKING_DELAY_MS = 2 * 60 * 1000;
@@ -85,6 +87,39 @@ export async function POST(request: NextRequest) {
 		"";
 
 	const pathname = body.pathname ?? `/s/${body.videoId}`;
+	const action = body.action ?? "page_hit";
+
+	if (action === "video_progress") {
+		const sessionId =
+			typeof body.sessionId === "string"
+				? body.sessionId.trim().slice(0, 128) || null
+				: null;
+		const percentWatched =
+			typeof body.percentWatched === "number" &&
+			body.percentWatched >= 0 &&
+			body.percentWatched <= 100
+				? Math.round(body.percentWatched)
+				: null;
+
+		if (percentWatched !== null) {
+			await runPromise(
+				Effect.gen(function* () {
+					const tinybird = yield* Tinybird;
+					yield* tinybird.appendEvents([
+						{
+							timestamp: new Date().toISOString(),
+							action: "video_progress",
+							version: "1.0",
+							session_id: sessionId ?? "anon",
+							video_id: body.videoId,
+							percent_watched: percentWatched,
+						},
+					]);
+				}),
+			);
+		}
+		return Response.json({ success: true });
+	}
 
 	await runPromise(
 		Effect.gen(function* () {

--- a/apps/web/app/api/analytics/track/route.ts
+++ b/apps/web/app/api/analytics/track/route.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { db } from "@cap/database";
 import { videos, videoUploads } from "@cap/database/schema";
 import { provideOptionalAuth, Tinybird } from "@cap/web-backend";
@@ -118,7 +119,7 @@ export async function POST(request: NextRequest) {
 							.limit(1),
 					).pipe(Effect.orElseSucceed(() => [] as { ownerId: string }[]));
 
-					if (videoRecord && userId === videoRecord.ownerId) return;
+					if (!videoRecord || userId === videoRecord.ownerId) return;
 
 					const tinybird = yield* Tinybird;
 					yield* tinybird.appendEvents([
@@ -126,7 +127,7 @@ export async function POST(request: NextRequest) {
 							timestamp: new Date().toISOString(),
 							action: "video_progress",
 							version: "1.0",
-							session_id: sessionId ?? "anon",
+							session_id: sessionId ?? randomUUID(),
 							video_id: body.videoId,
 							percent_watched: percentWatched,
 						},

--- a/apps/web/app/api/analytics/track/route.ts
+++ b/apps/web/app/api/analytics/track/route.ts
@@ -104,6 +104,22 @@ export async function POST(request: NextRequest) {
 		if (percentWatched !== null) {
 			await runPromise(
 				Effect.gen(function* () {
+					const maybeUser = yield* Effect.serviceOption(CurrentUser);
+					const userId = Option.match(maybeUser, {
+						onNone: () => null as string | null,
+						onSome: (user) => (user as { id: string }).id,
+					});
+
+					const [videoRecord] = yield* Effect.tryPromise(() =>
+						db()
+							.select({ ownerId: videos.ownerId })
+							.from(videos)
+							.where(eq(videos.id, Video.VideoId.make(body.videoId)))
+							.limit(1),
+					).pipe(Effect.orElseSucceed(() => [] as { ownerId: string }[]));
+
+					if (videoRecord && userId === videoRecord.ownerId) return;
+
 					const tinybird = yield* Tinybird;
 					yield* tinybird.appendEvents([
 						{
@@ -115,7 +131,7 @@ export async function POST(request: NextRequest) {
 							percent_watched: percentWatched,
 						},
 					]);
-				}),
+				}).pipe(provideOptionalAuth),
 			);
 		}
 		return Response.json({ success: true });

--- a/apps/web/app/api/analytics/track/route.ts
+++ b/apps/web/app/api/analytics/track/route.ts
@@ -91,10 +91,6 @@ export async function POST(request: NextRequest) {
 	const action = body.action ?? "page_hit";
 
 	if (action === "video_progress") {
-		const sessionId =
-			typeof body.sessionId === "string"
-				? body.sessionId.trim().slice(0, 128) || null
-				: null;
 		const percentWatched =
 			typeof body.percentWatched === "number" &&
 			body.percentWatched >= 0 &&
@@ -124,7 +120,7 @@ export async function POST(request: NextRequest) {
 					const tinybird = yield* Tinybird;
 					yield* tinybird.appendEvents([
 						{
-							timestamp: new Date().toISOString(),
+							timestamp: timestamp.toISOString(),
 							action: "video_progress",
 							version: "1.0",
 							session_id: sessionId ?? randomUUID(),

--- a/apps/web/app/api/analytics/track/route.ts
+++ b/apps/web/app/api/analytics/track/route.ts
@@ -124,6 +124,7 @@ export async function POST(request: NextRequest) {
 							action: "video_progress",
 							version: "1.0",
 							session_id: sessionId ?? randomUUID(),
+							tenant_id: videoRecord.ownerId,
 							video_id: body.videoId,
 							percent_watched: percentWatched,
 						},

--- a/apps/web/app/api/analytics/track/route.ts
+++ b/apps/web/app/api/analytics/track/route.ts
@@ -181,7 +181,9 @@ export async function POST(request: NextRequest) {
 				),
 			);
 
-			if (videoRecord && userId === videoRecord.ownerId) {
+			if (!videoRecord) return;
+
+			if (userId === videoRecord.ownerId) {
 				return;
 			}
 
@@ -203,7 +205,7 @@ export async function POST(request: NextRequest) {
 			yield* tinybird.appendEvents([
 				{
 					timestamp: timestamp.toISOString(),
-					session_id: sessionId ?? "anon",
+					session_id: sessionId ?? randomUUID(),
 					action: "page_hit",
 					version: "1.0",
 					tenant_id: tenantId,

--- a/apps/web/app/s/[videoId]/Share.tsx
+++ b/apps/web/app/s/[videoId]/Share.tsx
@@ -164,6 +164,35 @@ const trackVideoView = (payload: {
 	});
 };
 
+const PROGRESS_MILESTONES = [25, 50, 75, 95] as const;
+
+const trackVideoProgress = (videoId: string, percentWatched: number) => {
+	if (typeof window === "undefined") return;
+	const sessionId = ensureAnalyticsSessionId();
+	const body = JSON.stringify({
+		videoId,
+		sessionId,
+		action: "video_progress",
+		percentWatched,
+	});
+	if (
+		typeof navigator !== "undefined" &&
+		typeof navigator.sendBeacon === "function"
+	) {
+		navigator.sendBeacon(
+			"/api/analytics/track",
+			new Blob([body], { type: "application/json" }),
+		);
+	} else {
+		void fetch("/api/analytics/track", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body,
+			keepalive: true,
+		});
+	}
+};
+
 type AiGenerationStatus =
 	| "QUEUED"
 	| "PROCESSING"
@@ -388,6 +417,28 @@ export const Share = ({
 			ownerId: data.owner.id,
 		});
 	}, [data.id, data.orgId, data.owner.id, viewerId]);
+
+	useEffect(() => {
+		if (viewerId && viewerId === data.owner.id) return;
+		const video = playerRef.current;
+		if (!video) return;
+
+		const fired = new Set<number>();
+
+		const onTimeUpdate = () => {
+			if (!video.duration || video.duration === 0) return;
+			const pct = (video.currentTime / video.duration) * 100;
+			for (const milestone of PROGRESS_MILESTONES) {
+				if (!fired.has(milestone) && pct >= milestone) {
+					fired.add(milestone);
+					trackVideoProgress(data.id, milestone);
+				}
+			}
+		};
+
+		video.addEventListener("timeupdate", onTimeUpdate);
+		return () => video.removeEventListener("timeupdate", onTimeUpdate);
+	}, [data.id, data.owner.id, viewerId]);
 
 	const isDisabled = (setting: ViewerSettingKey) =>
 		videoSettings?.[setting] ?? data.orgSettings?.[setting] ?? false;

--- a/apps/web/app/s/[videoId]/Share.tsx
+++ b/apps/web/app/s/[videoId]/Share.tsx
@@ -420,12 +420,11 @@ export const Share = ({
 
 	useEffect(() => {
 		if (viewerId && viewerId === data.owner.id) return;
-		const video = playerRef.current;
-		if (!video) return;
 
 		const fired = new Set<number>();
 
-		const onTimeUpdate = () => {
+		const onTimeUpdate = (e: Event) => {
+			const video = e.currentTarget as HTMLVideoElement;
 			if (!video.duration || video.duration === 0) return;
 			const pct = (video.currentTime / video.duration) * 100;
 			for (const milestone of PROGRESS_MILESTONES) {
@@ -436,8 +435,18 @@ export const Share = ({
 			}
 		};
 
-		video.addEventListener("timeupdate", onTimeUpdate);
-		return () => video.removeEventListener("timeupdate", onTimeUpdate);
+		const attach = () => {
+			const video = playerRef.current;
+			if (!video) return null;
+			video.addEventListener("timeupdate", onTimeUpdate);
+			return () => video.removeEventListener("timeupdate", onTimeUpdate);
+		};
+
+		const detach = attach();
+		if (detach) return detach;
+
+		const raf = requestAnimationFrame(() => attach());
+		return () => cancelAnimationFrame(raf);
 	}, [data.id, data.owner.id, viewerId]);
 
 	const isDisabled = (setting: ViewerSettingKey) =>

--- a/apps/web/app/s/[videoId]/Share.tsx
+++ b/apps/web/app/s/[videoId]/Share.tsx
@@ -435,18 +435,23 @@ export const Share = ({
 			}
 		};
 
+		let cleanup: (() => void) | null = null;
+
 		const attach = () => {
 			const video = playerRef.current;
-			if (!video) return null;
+			if (!video) return false;
 			video.addEventListener("timeupdate", onTimeUpdate);
-			return () => video.removeEventListener("timeupdate", onTimeUpdate);
+			cleanup = () => video.removeEventListener("timeupdate", onTimeUpdate);
+			return true;
 		};
 
-		const detach = attach();
-		if (detach) return detach;
+		let raf = 0;
+		if (!attach()) raf = requestAnimationFrame(() => attach());
 
-		const raf = requestAnimationFrame(() => attach());
-		return () => cancelAnimationFrame(raf);
+		return () => {
+			cancelAnimationFrame(raf);
+			cleanup?.();
+		};
 	}, [data.id, data.owner.id, viewerId]);
 
 	const isDisabled = (setting: ViewerSettingKey) =>

--- a/apps/web/app/s/[videoId]/_components/tabs/Activity/Analytics.tsx
+++ b/apps/web/app/s/[videoId]/_components/tabs/Activity/Analytics.tsx
@@ -1,9 +1,40 @@
 "use client";
 
 import { use, useEffect, useMemo, useState } from "react";
-import { getVideoAnalytics } from "@/actions/videos/get-analytics";
+import {
+	getVideoAnalytics,
+	getVideoEngagement,
+} from "@/actions/videos/get-analytics";
 import { CapCardAnalytics } from "@/app/(org)/dashboard/caps/components/CapCard/CapCardAnalytics";
 import type { CommentType } from "../../../Share";
+
+type EngagementData = Awaited<ReturnType<typeof getVideoEngagement>>;
+
+const DropOffBar = ({
+	label,
+	count,
+	total,
+}: {
+	label: string;
+	count: number;
+	total: number;
+}) => {
+	const pct = total > 0 ? Math.round((count / total) * 100) : 0;
+	return (
+		<div className="flex flex-col gap-0.5 min-w-0">
+			<div className="flex justify-between items-center">
+				<span className="text-[10px] text-gray-500">{label}</span>
+				<span className="text-[10px] font-medium text-gray-700">{count}</span>
+			</div>
+			<div className="h-1 rounded-full bg-gray-100 overflow-hidden">
+				<div
+					className="h-full rounded-full bg-blue-500 transition-all"
+					style={{ width: `${pct}%` }}
+				/>
+			</div>
+		</div>
+	);
+};
 
 const Analytics = (props: {
 	videoId: string;
@@ -15,12 +46,12 @@ const Analytics = (props: {
 	const [views, setViews] = useState(
 		props.views instanceof Promise ? use(props.views) : props.views,
 	);
+	const [engagement, setEngagement] = useState<EngagementData | null>(null);
 
 	useEffect(() => {
 		const fetchAnalytics = async () => {
 			try {
 				const result = await getVideoAnalytics(props.videoId);
-
 				setViews(result.count);
 			} catch (error) {
 				console.error("Error fetching analytics:", error);
@@ -29,6 +60,13 @@ const Analytics = (props: {
 
 		fetchAnalytics();
 	}, [props.videoId]);
+
+	useEffect(() => {
+		if (!props.isOwner) return;
+		getVideoEngagement(props.videoId)
+			.then(setEngagement)
+			.catch(() => {});
+	}, [props.videoId, props.isOwner]);
 
 	const totalComments = useMemo(
 		() => props.comments.filter((c) => c.type === "text").length,
@@ -41,14 +79,48 @@ const Analytics = (props: {
 	);
 
 	return (
-		<CapCardAnalytics
-			isLoadingAnalytics={props.isLoadingAnalytics}
-			capId={props.videoId}
-			displayCount={views}
-			totalComments={totalComments}
-			totalReactions={totalReactions}
-			isOwner={props.isOwner}
-		/>
+		<div className="flex flex-col gap-3 w-full">
+			<CapCardAnalytics
+				isLoadingAnalytics={props.isLoadingAnalytics}
+				capId={props.videoId}
+				displayCount={views}
+				totalComments={totalComments}
+				totalReactions={totalReactions}
+				isOwner={props.isOwner}
+			/>
+			{props.isOwner && engagement && engagement.total > 0 && (
+				<div className="flex flex-col gap-2 pt-2 border-t border-gray-100">
+					<div className="flex items-center justify-between">
+						<span className="text-xs text-gray-500">Avg watched</span>
+						<span className="text-xs font-semibold text-gray-800">
+							{engagement.avgPercent}%
+						</span>
+					</div>
+					<div className="grid grid-cols-4 gap-2">
+						<DropOffBar
+							label="25%"
+							count={engagement.reached25}
+							total={engagement.total}
+						/>
+						<DropOffBar
+							label="50%"
+							count={engagement.reached50}
+							total={engagement.total}
+						/>
+						<DropOffBar
+							label="75%"
+							count={engagement.reached75}
+							total={engagement.total}
+						/>
+						<DropOffBar
+							label="95%"
+							count={engagement.reached95}
+							total={engagement.total}
+						/>
+					</div>
+				</div>
+			)}
+		</div>
 	);
 };
 

--- a/packages/web-backend/src/Tinybird/index.ts
+++ b/packages/web-backend/src/Tinybird/index.ts
@@ -23,6 +23,7 @@ export interface TinybirdEventRow {
 	browser?: string | null;
 	device?: string | null;
 	os?: string | null;
+	percent_watched?: number | null;
 }
 
 export class Tinybird extends Effect.Service<Tinybird>()("Tinybird", {
@@ -185,6 +186,7 @@ export class Tinybird extends Effect.Service<Tinybird>()("Tinybird", {
 						browser: row.browser ?? "unknown",
 						device: row.device ?? "desktop",
 						os: row.os ?? "unknown",
+						percent_watched: row.percent_watched ?? null,
 					}),
 				)
 				.join("\n");

--- a/packages/web-backend/src/Tinybird/index.ts
+++ b/packages/web-backend/src/Tinybird/index.ts
@@ -247,24 +247,30 @@ export class Tinybird extends Effect.Service<Tinybird>()("Tinybird", {
 						console.log("Tinybird empty response", { path });
 						return { data: [] } as TinybirdResponse<T>;
 					}
+					let parsed: unknown;
 					try {
-						const parsed = JSON.parse(textBody);
-						const normalizedRes: TinybirdResponse<T> = Array.isArray(parsed)
-							? ({ data: parsed } as TinybirdResponse<T>)
-							: parsed && typeof parsed === "object" && "data" in parsed
-								? (parsed as TinybirdResponse<T>)
-								: ({ data: [parsed as T] } as TinybirdResponse<T>);
-						if ((normalizedRes as TinybirdResponse<T>).error) {
-							throw new Error(
-								(normalizedRes as TinybirdResponse<T>).error as string,
-							);
-						}
-						return normalizedRes;
+						parsed = JSON.parse(textBody);
 					} catch {
 						const aliases = extractAliases(normalized);
 						const objects = parseTsvToObjects<T>(textBody, aliases);
 						return { data: objects } as TinybirdResponse<T>;
 					}
+
+					const normalizedRes: TinybirdResponse<T> = Array.isArray(parsed)
+						? ({ data: parsed } as TinybirdResponse<T>)
+						: parsed && typeof parsed === "object" && "data" in parsed
+							? (parsed as TinybirdResponse<T>)
+							: ({ data: [parsed as T] } as TinybirdResponse<T>);
+
+					if (normalizedRes.error) {
+						console.error("Tinybird query error", {
+							path,
+							error: normalizedRes.error,
+						});
+						throw new Error(normalizedRes.error);
+					}
+
+					return normalizedRes;
 				},
 				catch: (cause) => cause as Error,
 			});

--- a/scripts/analytics/tinybird/datasources/analytics_events.datasource
+++ b/scripts/analytics/tinybird/datasources/analytics_events.datasource
@@ -15,7 +15,8 @@ SCHEMA >
 	city LowCardinality(String) `json:$.city` DEFAULT '',
 	browser LowCardinality(String) `json:$.browser` DEFAULT 'unknown',
 	device LowCardinality(String) `json:$.device` DEFAULT 'desktop',
-	os LowCardinality(String) `json:$.os` DEFAULT 'unknown'
+	os LowCardinality(String) `json:$.os` DEFAULT 'unknown',
+	percent_watched UInt8 `json:$.percent_watched` DEFAULT 0
 
 ENGINE MergeTree
 ENGINE_PARTITION_KEY toYYYYMM(timestamp)
@@ -24,4 +25,4 @@ ENGINE_TTL timestamp + INTERVAL 90 DAY
 ENGINE_SETTINGS index_granularity = 8192
 
 FORWARD_QUERY >
-	SELECT timestamp, session_id, defaultValueOfTypeName('LowCardinality(String)') AS user_id, tenant_id, action, version, defaultValueOfTypeName('String') AS pathname, defaultValueOfTypeName('LowCardinality(String)') AS video_id, defaultValueOfTypeName('LowCardinality(String)') AS country, defaultValueOfTypeName('LowCardinality(String)') AS region, defaultValueOfTypeName('LowCardinality(String)') AS city, defaultValueOfTypeName('LowCardinality(String)') AS browser, defaultValueOfTypeName('LowCardinality(String)') AS device, defaultValueOfTypeName('LowCardinality(String)') AS os
+	SELECT timestamp, session_id, defaultValueOfTypeName('LowCardinality(String)') AS user_id, tenant_id, action, version, defaultValueOfTypeName('String') AS pathname, defaultValueOfTypeName('LowCardinality(String)') AS video_id, defaultValueOfTypeName('LowCardinality(String)') AS country, defaultValueOfTypeName('LowCardinality(String)') AS region, defaultValueOfTypeName('LowCardinality(String)') AS city, defaultValueOfTypeName('LowCardinality(String)') AS browser, defaultValueOfTypeName('LowCardinality(String)') AS device, defaultValueOfTypeName('LowCardinality(String)') AS os, defaultValueOfTypeName('UInt8') AS percent_watched


### PR DESCRIPTION
## Summary

Adds watch engagement analytics to the video share page, requested by the community.

- **Tracking**: fires video_progress events at 25%, 50%, 75%, 95% milestones per viewer session via sendBeacon, same pattern as existing page_hit tracking, zero extra latency
- **Backend**: /api/analytics/track handles video_progress separately (no email/notification overhead); skips recording if the viewer is the video owner; stores percent_watched in Tinybird analytics_events
- **Query**: getVideoEngagement() is auth-gated (owner only) and aggregates per-session max milestone via ClickHouse subquery — counts how many sessions reached each quartile and avg watch %
- **UI**: engagement section shown in the Analytics tab (owner-only) — avg watched % + 4-step drop-off bars, hidden until first real data arrives

## Security
- getVideoEngagement throws Unauthorized if the caller is not the video owner
- Owner self-views are excluded from engagement data

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds video watch-engagement analytics: the frontend fires `video_progress` beacon events at 25/50/75/95% milestones, the API route records them in Tinybird (skipping owner self-views), and a new `getVideoEngagement` server action queries per-session max progress to produce drop-off statistics shown in the owner-only Analytics tab.

- The `video_progress` ingestion path validates `percentWatched` range, guards against missing video records, and uses `randomUUID()` as a session fallback — all improvements over the `page_hit` baseline.
- The `querySql` refactor in Tinybird fixes a latent bug where API-level error responses were silently swallowed by falling into the TSV parsing fallback instead of propagating the error.
- The engagement query in `getVideoEngagement` has no time-range predicate and will scan the full event history; adding a bounded window (matching the 90-day default used by `getVideoAnalytics`) would prevent performance degradation on high-traffic videos.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with the understanding that the engagement query will grow slower over time on active videos as history accumulates without a date bound.
- The core ingestion and auth logic is sound, and the Tinybird query fix is a genuine improvement. The one thing worth addressing before this sees heavy production traffic is the unbounded full-history scan in `getVideoEngagement` — on a popular video it will keep getting slower with no natural cutoff.
- apps/web/actions/videos/get-analytics.ts — the `getVideoEngagement` SQL query needs a time-range filter to stay performant.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/actions/videos/get-analytics.ts | Adds `getVideoEngagement` — auth-gated, owner-only, uses `escapeLiteral` for safe SQL interpolation; the engagement ClickHouse subquery lacks a time-range predicate so it will become increasingly slow as data accumulates. |
| apps/web/app/api/analytics/track/route.ts | Adds `video_progress` branch: validates percent range, skips owner self-views, falls back to `randomUUID()` for session-less callers (addressed in previous review), and guards against missing video records (addressed in previous review). Clean separation from the page_hit path. |
| apps/web/app/s/[videoId]/Share.tsx | Adds `timeupdate` milestone tracker with RAF-based deferred attachment; listener cleanup is handled via a closure over the `cleanup` variable so the detachment function is correctly reachable by React's effect cleanup. The previous RAF/cleanup concern was flagged in an earlier review thread. |
| apps/web/app/s/[videoId]/_components/tabs/Activity/Analytics.tsx | Adds owner-only engagement UI: `DropOffBar` component, `useEffect` fetch of `getVideoEngagement`, and conditional render guarded by `engagement.total > 0`. Straightforward and correct. |
| packages/web-backend/src/Tinybird/index.ts | Adds `percent_watched` field to `TinybirdEventRow`; refactors `querySql` so Tinybird API-level errors (JSON `error` field) are no longer silently swallowed by falling into the TSV fallback — a genuine bug fix. |
| scripts/analytics/tinybird/datasources/analytics_events.datasource | Adds `percent_watched UInt8 DEFAULT 0` column and updates the FORWARD_QUERY accordingly. Schema change is consistent with how the field is used in the ingestion path. |

<sub>Reviews (7): Last reviewed commit: ["fix(analytics): guard page\_hit against m..."](https://github.com/capsoftware/cap/commit/afbcd3d675b42822a928f5ece4a95c2a68a66f20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36246803)</sub>

<!-- /greptile_comment -->