### PR TITLE
Public links for spaces and folders

### DIFF
--- a/apps/web/__tests__/unit/public-collections-policy.test.ts
+++ b/apps/web/__tests__/unit/public-collections-policy.test.ts
@@ -76,7 +76,7 @@ describe("public collections policy", () => {
 				allowedEmailDomain: "company.com",
 				viewerEmail: null,
 				passwordHash: "hash",
-				verifiedPasswordHash: null,
+				verifiedPasswordHashes: [],
 			}),
 		).toEqual({ state: "email_restriction_login_required" });
 
@@ -85,7 +85,7 @@ describe("public collections policy", () => {
 				allowedEmailDomain: "company.com",
 				viewerEmail: "person@example.com",
 				passwordHash: "hash",
-				verifiedPasswordHash: null,
+				verifiedPasswordHashes: [],
 			}),
 		).toEqual({ state: "email_restriction_denied" });
 	});
@@ -95,7 +95,7 @@ describe("public collections policy", () => {
 			resolvePublicCollectionAccess({
 				viewerEmail: "person@company.com",
 				passwordHash: "space-hash",
-				verifiedPasswordHash: null,
+				verifiedPasswordHashes: [],
 			}),
 		).toEqual({ state: "password_required" });
 
@@ -103,8 +103,26 @@ describe("public collections policy", () => {
 			resolvePublicCollectionAccess({
 				viewerEmail: "person@company.com",
 				passwordHash: "space-hash",
-				verifiedPasswordHash: "space-hash",
+				verifiedPasswordHashes: ["space-hash"],
 			}),
 		).toEqual({ state: "allowed" });
+	});
+
+	it("matches the collection password against any verified hash", () => {
+		expect(
+			resolvePublicCollectionAccess({
+				viewerEmail: "person@company.com",
+				passwordHash: "space-hash",
+				verifiedPasswordHashes: ["video-hash", "space-hash"],
+			}),
+		).toEqual({ state: "allowed" });
+
+		expect(
+			resolvePublicCollectionAccess({
+				viewerEmail: "person@company.com",
+				passwordHash: "space-hash",
+				verifiedPasswordHashes: ["video-hash"],
+			}),
+		).toEqual({ state: "password_required" });
 	});
 });

--- a/apps/web/__tests__/unit/public-collections-policy.test.ts
+++ b/apps/web/__tests__/unit/public-collections-policy.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+	getPublicCollectionHref,
+	parsePublicCollectionPage,
+	resolvePublicCollectionAccess,
+	resolvePublicCollectionCandidate,
+} from "@/lib/public-collections-policy";
+
+describe("public collections policy", () => {
+	it("parses invalid collection pages as the first page", () => {
+		expect(parsePublicCollectionPage(undefined)).toBe(1);
+		expect(parsePublicCollectionPage("0")).toBe(1);
+		expect(parsePublicCollectionPage("-2")).toBe(1);
+		expect(parsePublicCollectionPage("1.5")).toBe(1);
+		expect(parsePublicCollectionPage(["3", "4"])).toBe(3);
+	});
+
+	it("builds canonical collection page hrefs", () => {
+		expect(getPublicCollectionHref("abc123", 1)).toBe("/c/abc123");
+		expect(getPublicCollectionHref("abc123", 2)).toBe("/c/abc123?page=2");
+	});
+
+	it("resolves public folder before public space on id collisions", () => {
+		const folder = {
+			kind: "folder" as const,
+			public: true,
+			organizationTombstoneAt: null,
+			name: "Folder",
+		};
+		const space = {
+			kind: "space" as const,
+			public: true,
+			organizationTombstoneAt: null,
+			name: "Space",
+		};
+
+		expect(resolvePublicCollectionCandidate(folder, space)).toBe(folder);
+	});
+
+	it("falls through private or tombstoned folders to public spaces", () => {
+		const privateFolder = {
+			kind: "folder" as const,
+			public: false,
+			organizationTombstoneAt: null,
+		};
+		const tombstonedFolder = {
+			kind: "folder" as const,
+			public: true,
+			organizationTombstoneAt: new Date("2026-01-01T00:00:00.000Z"),
+		};
+		const space = {
+			kind: "space" as const,
+			public: true,
+			organizationTombstoneAt: null,
+		};
+
+		expect(resolvePublicCollectionCandidate(privateFolder, space)).toBe(space);
+		expect(resolvePublicCollectionCandidate(tombstonedFolder, space)).toBe(
+			space,
+		);
+	});
+
+	it("blocks tombstoned spaces", () => {
+		const space = {
+			kind: "space" as const,
+			public: true,
+			organizationTombstoneAt: new Date("2026-01-01T00:00:00.000Z"),
+		};
+
+		expect(resolvePublicCollectionCandidate(null, space)).toBeNull();
+	});
+
+	it("applies email restrictions before password checks", () => {
+		expect(
+			resolvePublicCollectionAccess({
+				allowedEmailDomain: "company.com",
+				viewerEmail: null,
+				passwordHash: "hash",
+				verifiedPasswordHash: null,
+			}),
+		).toEqual({ state: "email_restriction_login_required" });
+
+		expect(
+			resolvePublicCollectionAccess({
+				allowedEmailDomain: "company.com",
+				viewerEmail: "person@example.com",
+				passwordHash: "hash",
+				verifiedPasswordHash: null,
+			}),
+		).toEqual({ state: "email_restriction_denied" });
+	});
+
+	it("requires the collection password when present", () => {
+		expect(
+			resolvePublicCollectionAccess({
+				viewerEmail: "person@company.com",
+				passwordHash: "space-hash",
+				verifiedPasswordHash: null,
+			}),
+		).toEqual({ state: "password_required" });
+
+		expect(
+			resolvePublicCollectionAccess({
+				viewerEmail: "person@company.com",
+				passwordHash: "space-hash",
+				verifiedPasswordHash: "space-hash",
+			}),
+		).toEqual({ state: "allowed" });
+	});
+});

--- a/apps/web/__tests__/unit/public-page-settings.test.ts
+++ b/apps/web/__tests__/unit/public-page-settings.test.ts
@@ -1,0 +1,64 @@
+import { PublicCollection } from "@cap/web-domain";
+import { Either, Schema } from "effect";
+import { describe, expect, it } from "vitest";
+
+const decode = Schema.decodeUnknownEither(
+	PublicCollection.PublicPageSettingsUpdate,
+);
+
+describe("PublicPageSettingsUpdate", () => {
+	it("accepts a valid partial patch", () => {
+		const result = decode({ title: "Launch videos", gridColumns: 3 });
+		expect(Either.isRight(result)).toBe(true);
+	});
+
+	it("strips logoUrl — only the upload action may write it", () => {
+		const result = decode({
+			logoUrl: "organizations/other-org/logo.svg",
+			title: "t",
+		});
+		expect(Either.isRight(result)).toBe(true);
+		if (Either.isRight(result)) {
+			expect("logoUrl" in result.right).toBe(false);
+		}
+	});
+
+	it("rejects oversized text fields", () => {
+		const over = (length: number) => "x".repeat(length + 1);
+		expect(
+			Either.isLeft(
+				decode({
+					title: over(PublicCollection.PUBLIC_PAGE_TITLE_MAX_LENGTH),
+				}),
+			),
+		).toBe(true);
+		expect(
+			Either.isLeft(
+				decode({
+					subtitle: over(PublicCollection.PUBLIC_PAGE_SUBTITLE_MAX_LENGTH),
+				}),
+			),
+		).toBe(true);
+		expect(
+			Either.isLeft(
+				decode({
+					ctaLabel: over(PublicCollection.PUBLIC_PAGE_CTA_LABEL_MAX_LENGTH),
+				}),
+			),
+		).toBe(true);
+		expect(
+			Either.isLeft(
+				decode({
+					ctaUrl: over(PublicCollection.PUBLIC_PAGE_CTA_URL_MAX_LENGTH),
+				}),
+			),
+		).toBe(true);
+	});
+
+	it("rejects values outside the literal unions", () => {
+		expect(Either.isLeft(decode({ gridColumns: 7 }))).toBe(true);
+		expect(Either.isLeft(decode({ layout: "carousel" }))).toBe(true);
+		expect(Either.isLeft(decode({ logoMode: "remote" }))).toBe(true);
+		expect(Either.isLeft(decode({ hideTitle: "yes" }))).toBe(true);
+	});
+});

--- a/apps/web/__tests__/unit/videos-policy.test.ts
+++ b/apps/web/__tests__/unit/videos-policy.test.ts
@@ -85,7 +85,7 @@ function makeDeps(config: {
 function runCanView(
 	deps: VideosPolicyDeps,
 	user: Option.Option<CurrentUser["Type"]>,
-	attachedPassword: Option.Option<string> = Option.none(),
+	attachedPasswords: ReadonlyArray<string> = [],
 ): Promise<"allowed" | "denied" | "password"> {
 	const policy = buildCanView(deps, TEST_VIDEO_ID);
 
@@ -99,13 +99,12 @@ function runCanView(
 		),
 	);
 
-	const withPassword = Option.match(attachedPassword, {
-		onNone: () => program,
-		onSome: (password) =>
-			Effect.provideService(program, Video.VideoPasswordAttachment, {
-				password: Option.some(password),
-			}),
-	});
+	const withPassword =
+		attachedPasswords.length === 0
+			? program
+			: Effect.provideService(program, Video.VideoPasswordAttachment, {
+					passwords: attachedPasswords,
+				});
 
 	const withUser = user.pipe(
 		Option.match({
@@ -272,9 +271,9 @@ describe("VideosPolicy.canView", () => {
 				spacePasswords: ["space-one-hash", "space-two-hash"],
 			});
 
-			expect(
-				await runCanView(deps, noUser, Option.some("space-two-hash")),
-			).toBe("allowed");
+			expect(await runCanView(deps, noUser, ["space-two-hash"])).toBe(
+				"allowed",
+			);
 		});
 
 		it("allows access with either video or space password hash", async () => {
@@ -284,11 +283,29 @@ describe("VideosPolicy.canView", () => {
 				spacePasswords: ["space-hash"],
 			});
 
-			expect(await runCanView(deps, noUser, Option.some("video-hash"))).toBe(
-				"allowed",
-			);
-			expect(await runCanView(deps, noUser, Option.some("space-hash"))).toBe(
-				"allowed",
+			expect(await runCanView(deps, noUser, ["video-hash"])).toBe("allowed");
+			expect(await runCanView(deps, noUser, ["space-hash"])).toBe("allowed");
+		});
+
+		it("allows access when the matching hash sits alongside other verified hashes", async () => {
+			const deps = makeDeps({
+				video: makeVideo({ public: true }),
+				password: Option.some("video-hash"),
+			});
+
+			expect(
+				await runCanView(deps, noUser, ["collection-hash", "video-hash"]),
+			).toBe("allowed");
+		});
+
+		it("requires a password when no verified hash matches", async () => {
+			const deps = makeDeps({
+				video: makeVideo({ public: true }),
+				password: Option.some("video-hash"),
+			});
+
+			expect(await runCanView(deps, noUser, ["collection-hash"])).toBe(
+				"password",
 			);
 		});
 	});

--- a/apps/web/actions/collections/logo.ts
+++ b/apps/web/actions/collections/logo.ts
@@ -1,0 +1,226 @@
+"use server";
+
+import { db } from "@cap/database";
+import { getCurrentUser } from "@cap/database/auth/session";
+import { folders, spaces } from "@cap/database/schema";
+import { ImageUploads } from "@cap/web-backend";
+import {
+	type Folder,
+	type ImageUpload,
+	Space,
+	type User,
+} from "@cap/web-domain";
+import { eq, sql } from "drizzle-orm";
+import { Effect, Option } from "effect";
+import { revalidatePath } from "next/cache";
+import { isOrganizationOwnerPro } from "@/lib/org-pro";
+import { canManageSpace } from "@/lib/permissions/roles";
+import { sanitizeFile } from "@/lib/sanitizeFile";
+import { runPromise } from "@/lib/server";
+import { getOrganizationAccess } from "../organization/authorization";
+import { getSpaceAccess } from "../organization/space-authorization";
+
+const MAX_LOGO_BYTES = 1024 * 1024;
+const ALLOWED_LOGO_TYPES = new Set([
+	"image/png",
+	"image/jpeg",
+	"image/svg+xml",
+	"image/webp",
+]);
+
+function logoKey(value: string | undefined) {
+	return value ? (value as ImageUpload.ImageUrlOrKey) : null;
+}
+
+async function readFilePayload(
+	formData: FormData,
+): Promise<ImageUpload.ImageUpdatePayload | { error: string }> {
+	if (formData.get("remove") === "true") return Option.none();
+
+	const file = formData.get("logo");
+	if (!(file instanceof File) || file.size === 0) {
+		return { error: "No file provided" };
+	}
+	if (!ALLOWED_LOGO_TYPES.has(file.type.toLowerCase())) {
+		return { error: "Please upload a PNG, JPEG, SVG or WebP image" };
+	}
+	if (file.size > MAX_LOGO_BYTES) {
+		return { error: "Logo must be 1MB or less" };
+	}
+
+	// Strips scripts/event handlers from SVGs (same treatment as space icons);
+	// other formats pass through untouched.
+	const sanitized = await sanitizeFile(file);
+	const data = new Uint8Array(await sanitized.arrayBuffer());
+	return Option.some({
+		contentType: file.type,
+		fileName: file.name,
+		data,
+	});
+}
+
+/**
+ * Uploads (or removes) the custom logo shown on a collection's public page.
+ * Publishing/customizing collections is a Pro entitlement, so this mirrors the
+ * Pro gate enforced on the rest of the public-page settings.
+ */
+export async function setCollectionLogo(formData: FormData) {
+	const user = await getCurrentUser();
+	if (!user) return { success: false, error: "Unauthorized" };
+
+	const collectionId = String(formData.get("collectionId") ?? "");
+	const kind = String(formData.get("kind") ?? "");
+	if (!collectionId || (kind !== "folder" && kind !== "space")) {
+		return { success: false, error: "Invalid request" };
+	}
+
+	const payloadResult = await readFilePayload(formData);
+	if ("error" in payloadResult) {
+		return { success: false, error: payloadResult.error };
+	}
+
+	if (kind === "space") {
+		return setSpaceLogo(collectionId, user.id, payloadResult);
+	}
+	return setFolderLogo(collectionId, user.id, payloadResult);
+}
+
+async function setSpaceLogo(
+	collectionId: string,
+	userId: User.UserId,
+	payload: ImageUpload.ImageUpdatePayload,
+) {
+	const id = Space.SpaceId.make(collectionId);
+	const [space] = await db()
+		.select({
+			organizationId: spaces.organizationId,
+			settings: spaces.settings,
+		})
+		.from(spaces)
+		.where(eq(spaces.id, id))
+		.limit(1);
+
+	if (!space) return { success: false, error: "Space not found" };
+
+	const access = await getSpaceAccess(userId, id).catch(() => null);
+	if (!access?.canManage) return { success: false, error: "Unauthorized" };
+
+	if (!(await isOrganizationOwnerPro(space.organizationId))) {
+		return {
+			success: false,
+			error: "Upgrade to Cap Pro to customize the collection logo",
+		};
+	}
+
+	const existing = space.settings ?? {};
+
+	await Effect.gen(function* () {
+		const imageUploads = yield* ImageUploads;
+		yield* imageUploads.applyUpdate({
+			payload,
+			existing: Option.fromNullable(logoKey(existing.publicPage?.logoUrl)),
+			keyPrefix: `organizations/${space.organizationId}/collections/${id}/logo`,
+			update: (database, key) =>
+				database
+					.update(spaces)
+					.set({
+						// Atomic merge (a JSON null deletes the key per RFC 7396) so
+						// concurrent settings patches can't overwrite the logo write.
+						settings: sql`JSON_MERGE_PATCH(COALESCE(${spaces.settings}, '{}'), CAST(${JSON.stringify(
+							{
+								publicPage: {
+									logoUrl: key ?? null,
+									logoMode: key ? "custom" : "cap",
+								},
+							},
+						)} AS JSON))`,
+					})
+					.where(eq(spaces.id, id)),
+		});
+	}).pipe(runPromise);
+
+	revalidateCollection(collectionId);
+	return { success: true };
+}
+
+async function setFolderLogo(
+	collectionId: string,
+	userId: User.UserId,
+	payload: ImageUpload.ImageUpdatePayload,
+) {
+	const id = collectionId as Folder.FolderId;
+	const [folder] = await db()
+		.select({
+			organizationId: folders.organizationId,
+			spaceId: folders.spaceId,
+			createdById: folders.createdById,
+			settings: folders.settings,
+		})
+		.from(folders)
+		.where(eq(folders.id, id))
+		.limit(1);
+
+	if (!folder) return { success: false, error: "Folder not found" };
+
+	// Mirrors FoldersPolicy.canEdit: folders in a real space require space/org
+	// management; folders in the org-wide area (spaceId === organizationId)
+	// require org management; personal folders are creator-only.
+	const canManage = !folder.spaceId
+		? folder.createdById === userId
+		: folder.spaceId === folder.organizationId
+			? canManageSpace({
+					organizationRole: (
+						await getOrganizationAccess(userId, folder.organizationId).catch(
+							() => null,
+						)
+					)?.role,
+					spaceRole: null,
+				})
+			: ((await getSpaceAccess(userId, folder.spaceId).catch(() => null))
+					?.canManage ?? false);
+	if (!canManage) return { success: false, error: "Unauthorized" };
+
+	if (!(await isOrganizationOwnerPro(folder.organizationId))) {
+		return {
+			success: false,
+			error: "Upgrade to Cap Pro to customize the collection logo",
+		};
+	}
+
+	const existing = folder.settings ?? {};
+
+	await Effect.gen(function* () {
+		const imageUploads = yield* ImageUploads;
+		yield* imageUploads.applyUpdate({
+			payload,
+			existing: Option.fromNullable(logoKey(existing.publicPage?.logoUrl)),
+			keyPrefix: `organizations/${folder.organizationId}/collections/${id}/logo`,
+			update: (database, key) =>
+				database
+					.update(folders)
+					.set({
+						// Atomic merge (a JSON null deletes the key per RFC 7396) so
+						// concurrent settings patches can't overwrite the logo write.
+						settings: sql`JSON_MERGE_PATCH(COALESCE(${folders.settings}, '{}'), CAST(${JSON.stringify(
+							{
+								publicPage: {
+									logoUrl: key ?? null,
+									logoMode: key ? "custom" : "cap",
+								},
+							},
+						)} AS JSON))`,
+					})
+					.where(eq(folders.id, id)),
+		});
+	}).pipe(runPromise);
+
+	revalidateCollection(collectionId);
+	return { success: true };
+}
+
+function revalidateCollection(collectionId: string) {
+	revalidatePath("/dashboard");
+	revalidatePath(`/dashboard/spaces/${collectionId}`);
+	revalidatePath(`/dashboard/folder/${collectionId}`);
+	revalidatePath(`/c/${collectionId}`);
+}

--- a/apps/web/actions/collections/logo.ts
+++ b/apps/web/actions/collections/logo.ts
@@ -102,7 +102,9 @@ async function setSpaceLogo(
 
 	if (!space) return { success: false, error: "Space not found" };
 
-	const access = await getSpaceAccess(userId, id).catch(() => null);
+	// getSpaceAccess returns null for expected denials; genuine failures must
+	// propagate instead of being misreported as "Unauthorized".
+	const access = await getSpaceAccess(userId, id);
 	if (!access?.canManage) return { success: false, error: "Unauthorized" };
 
 	if (!(await isOrganizationOwnerPro(space.organizationId))) {
@@ -170,14 +172,11 @@ async function setFolderLogo(
 		: folder.spaceId === folder.organizationId
 			? canManageSpace({
 					organizationRole: (
-						await getOrganizationAccess(userId, folder.organizationId).catch(
-							() => null,
-						)
+						await getOrganizationAccess(userId, folder.organizationId)
 					)?.role,
 					spaceRole: null,
 				})
-			: ((await getSpaceAccess(userId, folder.spaceId).catch(() => null))
-					?.canManage ?? false);
+			: ((await getSpaceAccess(userId, folder.spaceId))?.canManage ?? false);
 	if (!canManage) return { success: false, error: "Unauthorized" };
 
 	if (!(await isOrganizationOwnerPro(folder.organizationId))) {

--- a/apps/web/actions/collections/password.ts
+++ b/apps/web/actions/collections/password.ts
@@ -1,0 +1,68 @@
+"use server";
+
+import { verifyPassword as verifyPlainPassword } from "@cap/database/crypto";
+import { NODE_ENV } from "@cap/env";
+import { checkRateLimit } from "@vercel/firewall";
+import { revalidatePath } from "next/cache";
+import { headers } from "next/headers";
+import { setVerifiedPasswordCookie } from "@/lib/password-cookie";
+import { getPublicCollectionPasswordHash } from "@/lib/public-collections";
+
+const COLLECTION_PASSWORD_RATE_LIMIT_ID = "rl_collection_password";
+
+/** Per-IP throttle so the public action isn't an open brute-force oracle. */
+async function isRateLimited() {
+	if (NODE_ENV !== "production") return false;
+
+	try {
+		const headersList = await headers();
+		const request = new Request("https://cap.so/api/collection-password", {
+			method: "POST",
+			headers: headersList,
+		});
+
+		const { rateLimited } = await checkRateLimit(
+			COLLECTION_PASSWORD_RATE_LIMIT_ID,
+			{ request },
+		);
+		return rateLimited;
+	} catch (error) {
+		// Best-effort: self-hosted deploys without the Vercel firewall (or an
+		// x-real-ip header) must not lose password verification entirely; the
+		// PBKDF2 verification cost still slows brute force.
+		console.warn("Collection password rate limit check failed:", error);
+		return false;
+	}
+}
+
+export async function verifyCollectionPassword(
+	collectionId: string,
+	password: string,
+) {
+	try {
+		if (!collectionId || typeof password !== "string") {
+			throw new Error("Missing data");
+		}
+
+		if (await isRateLimited()) {
+			return {
+				success: false,
+				error: "Too many attempts. Please try again later.",
+			};
+		}
+
+		const passwordHash = await getPublicCollectionPasswordHash(collectionId);
+		if (!passwordHash) throw new Error("No password set");
+
+		const valid = await verifyPlainPassword(passwordHash, password);
+		if (!valid) throw new Error("Invalid password");
+
+		await setVerifiedPasswordCookie(passwordHash);
+		revalidatePath(`/c/${encodeURIComponent(collectionId)}`);
+
+		return { success: true, value: "Password verified" };
+	} catch (error) {
+		console.error("Error verifying collection password:", error);
+		return { success: false, error: "Failed to verify password" };
+	}
+}

--- a/apps/web/actions/collections/password.ts
+++ b/apps/web/actions/collections/password.ts
@@ -41,7 +41,7 @@ export async function verifyCollectionPassword(
 ) {
 	try {
 		if (!collectionId || typeof password !== "string") {
-			throw new Error("Missing data");
+			return { success: false, error: "Failed to verify password" };
 		}
 
 		if (await isRateLimited()) {
@@ -51,11 +51,16 @@ export async function verifyCollectionPassword(
 			};
 		}
 
+		// Missing hash and wrong password are expected outcomes (typos, links to
+		// collections whose password was since removed) — return without logging
+		// so console.error stays reserved for genuine failures.
 		const passwordHash = await getPublicCollectionPasswordHash(collectionId);
-		if (!passwordHash) throw new Error("No password set");
-
-		const valid = await verifyPlainPassword(passwordHash, password);
-		if (!valid) throw new Error("Invalid password");
+		const valid = passwordHash
+			? await verifyPlainPassword(passwordHash, password)
+			: false;
+		if (!passwordHash || !valid) {
+			return { success: false, error: "Failed to verify password" };
+		}
 
 		await setVerifiedPasswordCookie(passwordHash);
 		revalidatePath(`/c/${encodeURIComponent(collectionId)}`);

--- a/apps/web/actions/collections/visibility.ts
+++ b/apps/web/actions/collections/visibility.ts
@@ -8,7 +8,7 @@ import { eq, type SQL, sql } from "drizzle-orm";
 import { Either, Schema } from "effect";
 import { revalidatePath } from "next/cache";
 import { isOrganizationOwnerPro } from "@/lib/org-pro";
-import { requireSpaceManager } from "../organization/space-authorization";
+import { getSpaceAccess } from "../organization/space-authorization";
 
 const decodeSettingsPatch = Schema.decodeUnknownEither(
 	PublicCollection.PublicPageSettingsUpdate,
@@ -50,6 +50,9 @@ export async function setSpaceCollectionVisibility(input: {
 
 	const id = Space.SpaceId.make(input.spaceId);
 
+	// getSpaceAccess returns null for the expected denials (missing space, no
+	// membership) and only throws on genuine failures, which must propagate
+	// instead of being misreported as "Unauthorized".
 	const [[space], access] = await Promise.all([
 		db()
 			.select({
@@ -59,11 +62,11 @@ export async function setSpaceCollectionVisibility(input: {
 			.from(spaces)
 			.where(eq(spaces.id, id))
 			.limit(1),
-		requireSpaceManager(user.id, id).catch(() => null),
+		getSpaceAccess(user.id, id),
 	]);
 
 	if (!space) return { success: false, error: "Space not found" };
-	if (!access) return { success: false, error: "Unauthorized" };
+	if (!access?.canManage) return { success: false, error: "Unauthorized" };
 
 	const enablingPublic = input.public === true && !space.public;
 	const changingSettings = settingsPatch !== undefined;

--- a/apps/web/actions/collections/visibility.ts
+++ b/apps/web/actions/collections/visibility.ts
@@ -1,0 +1,98 @@
+"use server";
+
+import { db } from "@cap/database";
+import { getCurrentUser } from "@cap/database/auth/session";
+import { spaces } from "@cap/database/schema";
+import { PublicCollection, Space } from "@cap/web-domain";
+import { eq, type SQL, sql } from "drizzle-orm";
+import { Either, Schema } from "effect";
+import { revalidatePath } from "next/cache";
+import { isOrganizationOwnerPro } from "@/lib/org-pro";
+import { requireSpaceManager } from "../organization/space-authorization";
+
+const decodeSettingsPatch = Schema.decodeUnknownEither(
+	PublicCollection.PublicPageSettingsUpdate,
+);
+
+/**
+ * Toggles a space's public collection link and/or its public-page presentation
+ * settings from the dashboard space page. Enabling public (or customizing the
+ * page) requires the org owner to be on Pro; un-publishing is always allowed.
+ *
+ * `settings` is a partial patch merged into the stored `settings.publicPage`,
+ * mirroring the folder path (FolderUpdate RPC).
+ */
+export async function setSpaceCollectionVisibility(input: {
+	spaceId: string;
+	public?: boolean;
+	settings?: PublicCollection.PublicPageSettingsUpdate;
+}) {
+	const user = await getCurrentUser();
+	if (!user) return { success: false, error: "Unauthorized" };
+
+	// Server actions are publicly callable; the TS parameter types are
+	// compile-time only, so validate everything before it reaches the database.
+	if (typeof input.spaceId !== "string" || input.spaceId.length === 0) {
+		return { success: false, error: "Invalid request" };
+	}
+	if (input.public !== undefined && typeof input.public !== "boolean") {
+		return { success: false, error: "Invalid request" };
+	}
+
+	let settingsPatch: PublicCollection.PublicPageSettingsUpdate | undefined;
+	if (input.settings !== undefined) {
+		const decoded = decodeSettingsPatch(input.settings);
+		if (Either.isLeft(decoded)) {
+			return { success: false, error: "Invalid public page settings" };
+		}
+		settingsPatch = decoded.right;
+	}
+
+	const id = Space.SpaceId.make(input.spaceId);
+
+	const [[space], access] = await Promise.all([
+		db()
+			.select({
+				organizationId: spaces.organizationId,
+				public: spaces.public,
+			})
+			.from(spaces)
+			.where(eq(spaces.id, id))
+			.limit(1),
+		requireSpaceManager(user.id, id).catch(() => null),
+	]);
+
+	if (!space) return { success: false, error: "Space not found" };
+	if (!access) return { success: false, error: "Unauthorized" };
+
+	const enablingPublic = input.public === true && !space.public;
+	const changingSettings = settingsPatch !== undefined;
+
+	if (
+		(enablingPublic || changingSettings) &&
+		!(await isOrganizationOwnerPro(space.organizationId))
+	) {
+		return {
+			success: false,
+			error: "Upgrade to Cap Pro to create a public collection link",
+		};
+	}
+
+	const update: { public?: boolean; settings?: SQL } = {};
+	if (input.public !== undefined) update.public = input.public;
+	if (settingsPatch !== undefined) {
+		// Atomic merge so concurrent patches (and the logo upload action, which
+		// also writes settings.publicPage) can't overwrite each other's keys.
+		update.settings = sql`JSON_MERGE_PATCH(COALESCE(${spaces.settings}, '{}'), CAST(${JSON.stringify(
+			{ publicPage: settingsPatch },
+		)} AS JSON))`;
+	}
+
+	if (Object.keys(update).length > 0)
+		await db().update(spaces).set(update).where(eq(spaces.id, id));
+
+	revalidatePath("/dashboard");
+	revalidatePath(`/dashboard/spaces/${id}`);
+	revalidatePath(`/c/${id}`);
+	return { success: true };
+}

--- a/apps/web/actions/organization/create-space.ts
+++ b/apps/web/actions/organization/create-space.ts
@@ -8,6 +8,7 @@ import { spaceMembers, spaces } from "@cap/database/schema";
 import { userIsPro } from "@cap/utils";
 import {
 	type ImageUpload,
+	Organisation,
 	Space,
 	SpaceMemberId,
 	type SpaceMemberRole,
@@ -15,6 +16,7 @@ import {
 } from "@cap/web-domain";
 import { and, eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import { isOrganizationOwnerPro } from "@/lib/org-pro";
 import {
 	getSpaceSettingsFromFormData,
 	hasProSpaceSettingsEnabled,
@@ -45,6 +47,7 @@ export async function createSpace(
 		const name = formData.get("name") as string;
 		const passwordEnabled = formData.get("passwordEnabled") === "true";
 		const password = formData.get("password") as string | null;
+		const publicEnabled = formData.get("public") === "true";
 		const settings = getSpaceSettingsFromFormData(formData);
 		const canUseProFeatures = userIsPro(user);
 
@@ -73,6 +76,18 @@ export async function createSpace(
 			return {
 				success: false,
 				error: "Upgrade required to change these viewer rules",
+			};
+		}
+
+		if (
+			publicEnabled &&
+			!(await isOrganizationOwnerPro(
+				Organisation.OrganisationId.make(user.activeOrganizationId),
+			))
+		) {
+			return {
+				success: false,
+				error: "Upgrade to Cap Pro to create a public collection link",
 			};
 		}
 
@@ -110,6 +125,7 @@ export async function createSpace(
 				iconUrl: null,
 				settings,
 				password: hashedPassword,
+				public: publicEnabled,
 			});
 
 			const memberUserIds: string[] = [];

--- a/apps/web/actions/organization/update-space.ts
+++ b/apps/web/actions/organization/update-space.ts
@@ -19,7 +19,7 @@ import { revalidatePath } from "next/cache";
 import { isOrganizationOwnerPro } from "@/lib/org-pro";
 import { normalizeSpaceRole } from "@/lib/permissions/roles";
 import { runPromise } from "@/lib/server";
-import { requireSpaceManager } from "./space-authorization";
+import { getSpaceAccess } from "./space-authorization";
 import {
 	getSpaceSettingsFromFormData,
 	preserveProSpaceSettings,
@@ -60,8 +60,10 @@ export async function updateSpace(formData: FormData) {
 		return { success: false, error: "Space not found" };
 	}
 
-	const access = await requireSpaceManager(user.id, id).catch(() => null);
-	if (!access) {
+	// getSpaceAccess returns null for expected denials; genuine failures must
+	// propagate instead of being misreported as "Unauthorized".
+	const access = await getSpaceAccess(user.id, id);
+	if (!access?.canManage) {
 		return { success: false, error: "Unauthorized" };
 	}
 

--- a/apps/web/actions/organization/update-space.ts
+++ b/apps/web/actions/organization/update-space.ts
@@ -13,9 +13,10 @@ import {
 	type SpaceMemberRole,
 	type User,
 } from "@cap/web-domain";
-import { eq } from "drizzle-orm";
+import { eq, type SQL, sql } from "drizzle-orm";
 import { Effect, Option } from "effect";
 import { revalidatePath } from "next/cache";
+import { isOrganizationOwnerPro } from "@/lib/org-pro";
 import { normalizeSpaceRole } from "@/lib/permissions/roles";
 import { runPromise } from "@/lib/server";
 import { requireSpaceManager } from "./space-authorization";
@@ -39,12 +40,17 @@ export async function updateSpace(formData: FormData) {
 		| "remove"
 		| null;
 	const password = formData.get("password") as string | null;
+	// Only touch the public flag when the form actually submitted it — callers
+	// that omit the field must not silently un-publish the space.
+	const publicField = formData.get("public");
+	const publicEnabled = publicField === "true";
 
 	const [space] = await db()
 		.select({
 			createdById: spaces.createdById,
 			organizationId: spaces.organizationId,
 			settings: spaces.settings,
+			public: spaces.public,
 		})
 		.from(spaces)
 		.where(eq(spaces.id, id))
@@ -59,16 +65,40 @@ export async function updateSpace(formData: FormData) {
 		return { success: false, error: "Unauthorized" };
 	}
 
+	// Publishing is gated on the org owner's plan, but a downgraded org can
+	// always un-publish — so only the false→true transition requires Pro.
+	if (
+		publicEnabled &&
+		!space.public &&
+		!(await isOrganizationOwnerPro(space.organizationId))
+	) {
+		return {
+			success: false,
+			error: "Upgrade to Cap Pro to create a public collection link",
+		};
+	}
+
 	const submittedSettings = getSpaceSettingsFromFormData(formData);
 	const canUseProFeatures = userIsPro(user);
-	const settings = canUseProFeatures
+	const viewerSettings = canUseProFeatures
 		? submittedSettings
 		: preserveProSpaceSettings(submittedSettings, space.settings);
+	// Atomic per-key merge: the form submits every viewer-settings key
+	// explicitly, while settings.publicPage (managed by the visibility/logo
+	// actions, possibly concurrently) is left untouched instead of being
+	// rewritten from a stale snapshot.
 	const spaceUpdate: {
 		name: string;
-		settings: ReturnType<typeof getSpaceSettingsFromFormData>;
+		settings: SQL;
+		public?: boolean;
 		password?: string | null;
-	} = { name, settings };
+	} = {
+		name,
+		settings: sql`JSON_MERGE_PATCH(COALESCE(${spaces.settings}, '{}'), CAST(${JSON.stringify(
+			viewerSettings,
+		)} AS JSON))`,
+	};
+	if (publicField !== null) spaceUpdate.public = publicEnabled;
 
 	if (passwordAction === "set") {
 		if (!canUseProFeatures) {
@@ -144,5 +174,6 @@ export async function updateSpace(formData: FormData) {
 	revalidatePath("/dashboard");
 	revalidatePath("/dashboard/caps");
 	revalidatePath(`/dashboard/spaces/${id}`);
+	revalidatePath(`/c/${id}`);
 	return { success: true };
 }

--- a/apps/web/actions/videos/password.ts
+++ b/apps/web/actions/videos/password.ts
@@ -3,7 +3,6 @@
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import {
-	encrypt,
 	hashPassword,
 	verifyPassword as verifyPlainPassword,
 } from "@cap/database/crypto";
@@ -12,7 +11,7 @@ import { collectPasswordHashes } from "@cap/web-backend";
 import type { Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
+import { setVerifiedPasswordCookie } from "@/lib/password-cookie";
 
 export async function setVideoPassword(
 	videoId: Video.VideoId,
@@ -115,7 +114,7 @@ export async function verifyVideoPassword(
 		for (const passwordHash of passwordHashes) {
 			const valid = await verifyPlainPassword(passwordHash, password);
 			if (valid) {
-				(await cookies()).set("x-cap-password", await encrypt(passwordHash));
+				await setVerifiedPasswordCookie(passwordHash);
 				return { success: true, value: "Password verified" };
 			}
 		}

--- a/apps/web/actions/videos/password.ts
+++ b/apps/web/actions/videos/password.ts
@@ -89,14 +89,14 @@ export async function verifyVideoPassword(
 ) {
 	try {
 		if (!videoId || typeof password !== "string")
-			throw new Error("Missing data");
+			return { success: false, error: "Failed to verify password" };
 
 		const [video] = await db()
 			.select()
 			.from(videos)
 			.where(eq(videos.id, videoId));
 
-		if (!video) throw new Error("No password set");
+		if (!video) return { success: false, error: "Failed to verify password" };
 
 		const spacePasswords = await db()
 			.select({ password: spaces.password })
@@ -109,8 +109,6 @@ export async function verifyVideoPassword(
 			spacePasswords,
 		});
 
-		if (passwordHashes.length === 0) throw new Error("No password set");
-
 		for (const passwordHash of passwordHashes) {
 			const valid = await verifyPlainPassword(passwordHash, password);
 			if (valid) {
@@ -119,7 +117,9 @@ export async function verifyVideoPassword(
 			}
 		}
 
-		throw new Error("Invalid password");
+		// Wrong passwords and links whose password was since removed are expected
+		// outcomes — return without logging so console.error stays signal.
+		return { success: false, error: "Failed to verify password" };
 	} catch (error) {
 		console.error("Error verifying video password:", error);
 		return { success: false, error: "Failed to verify password" };

--- a/apps/web/app/(org)/dashboard/_components/CollectionShareControl.tsx
+++ b/apps/web/app/(org)/dashboard/_components/CollectionShareControl.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { Button } from "@cap/ui";
+import { type Folder, PublicCollection } from "@cap/web-domain";
+import {
+	faCheck,
+	faCopy,
+	faGlobe,
+	faSliders,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { setCollectionLogo } from "@/actions/collections/logo";
+import { setSpaceCollectionVisibility } from "@/actions/collections/visibility";
+import { Tooltip } from "@/components/Tooltip";
+import { useEffectMutation, useRpcClient } from "@/lib/EffectRuntime";
+import { useCopyCollectionLink } from "@/lib/public-collection-client";
+import { useDashboardContext } from "../Contexts";
+import { CollectionShareDialog } from "./CollectionShareDialog";
+
+type PublicPageSettings = PublicCollection.PublicPageSettings;
+type PublicPageSettingsUpdate = PublicCollection.PublicPageSettingsUpdate;
+
+interface CollectionShareControlProps {
+	kind: "folder" | "space";
+	collectionId: string;
+	isPublic: boolean;
+	canManage: boolean;
+	isPro: boolean;
+	settings: PublicPageSettings | null;
+}
+
+export const CollectionShareControl = ({
+	kind,
+	collectionId,
+	isPublic,
+	canManage,
+	isPro,
+	settings,
+}: CollectionShareControlProps) => {
+	const router = useRouter();
+	const rpc = useRpcClient();
+	const { setUpgradeModalOpen } = useDashboardContext();
+	const { url, copied, copy } = useCopyCollectionLink(collectionId);
+	const displayUrl = url.replace(/^https?:\/\//, "");
+
+	const [pub, setPub] = useState(isPublic);
+	const [draft, setDraft] = useState(() =>
+		PublicCollection.resolvePublicPageSettings(settings),
+	);
+	const [open, setOpen] = useState(false);
+
+	useEffect(() => setPub(isPublic), [isPublic]);
+	useEffect(
+		() => setDraft(PublicCollection.resolvePublicPageSettings(settings)),
+		[settings],
+	);
+
+	const onError = (error: unknown) => {
+		setPub(isPublic);
+		setDraft(PublicCollection.resolvePublicPageSettings(settings));
+		toast.error(
+			error instanceof Error ? error.message : "Something went wrong",
+		);
+	};
+	const onSuccess = () => router.refresh();
+
+	const folderMutation = useEffectMutation({
+		mutationFn: (data: {
+			public?: boolean;
+			settings?: PublicPageSettingsUpdate;
+		}) =>
+			rpc.FolderUpdate({
+				id: collectionId as Folder.FolderId,
+				public: data.public,
+				publicPage: data.settings,
+			}),
+		onSuccess,
+		onError,
+	});
+
+	const spaceMutation = useMutation({
+		mutationFn: async (data: {
+			public?: boolean;
+			settings?: PublicPageSettingsUpdate;
+		}) => {
+			const result = await setSpaceCollectionVisibility({
+				spaceId: collectionId,
+				public: data.public,
+				settings: data.settings,
+			});
+			if (!result.success) throw new Error(result.error);
+		},
+		onSuccess,
+		onError,
+	});
+
+	const persist = (data: {
+		public?: boolean;
+		settings?: PublicPageSettingsUpdate;
+	}) =>
+		kind === "folder"
+			? folderMutation.mutate(data)
+			: spaceMutation.mutate(data);
+
+	const logoMutation = useMutation({
+		mutationFn: async (file: File | null) => {
+			const formData = new FormData();
+			formData.append("collectionId", collectionId);
+			formData.append("kind", kind);
+			if (file) formData.append("logo", file);
+			else formData.append("remove", "true");
+
+			const result = await setCollectionLogo(formData);
+			if (!result.success) throw new Error(result.error);
+		},
+		onSuccess: (_data, file) => {
+			router.refresh();
+			toast.success(file ? "Logo updated" : "Logo removed");
+		},
+		onError: (error) =>
+			toast.error(
+				error instanceof Error ? error.message : "Failed to update logo",
+			),
+	});
+
+	const isPending =
+		folderMutation.isPending ||
+		spaceMutation.isPending ||
+		logoMutation.isPending;
+
+	const handleTogglePublic = (next: boolean) => {
+		if (next) {
+			if (!isPro) {
+				setOpen(false);
+				setUpgradeModalOpen(true);
+				return;
+			}
+			setPub(true);
+			persist({ public: true });
+			return;
+		}
+		setPub(false);
+		persist({ public: false });
+	};
+
+	// Optimistically merge into the local draft but persist only the patch —
+	// the server merges it into the stored settings, so a concurrent logo
+	// upload (or another in-flight patch) is never overwritten.
+	const updateSettings = (patch: PublicPageSettingsUpdate) => {
+		setDraft((prev) => ({ ...prev, ...patch }));
+		persist({ settings: patch });
+	};
+
+	if (!pub && !canManage) return null;
+
+	const dialog = canManage ? (
+		<CollectionShareDialog
+			open={open}
+			onOpenChange={setOpen}
+			kind={kind}
+			collectionId={collectionId}
+			isPublic={pub}
+			isPro={isPro}
+			isPending={isPending}
+			settings={draft}
+			onTogglePublic={handleTogglePublic}
+			onUpdateSettings={updateSettings}
+			onUploadLogo={(file) => logoMutation.mutate(file)}
+			onRemoveLogo={() => logoMutation.mutate(null)}
+			isUploadingLogo={logoMutation.isPending}
+		/>
+	) : null;
+
+	if (pub) {
+		return (
+			<div className="flex gap-2 items-center">
+				<Tooltip content="Copy public link">
+					<button
+						type="button"
+						onClick={copy}
+						className="group flex gap-2.5 items-center pr-2.5 pl-3 h-10 text-sm rounded-xl border transition-colors border-gray-4 bg-gray-2 hover:bg-gray-3 hover:border-gray-5"
+					>
+						<FontAwesomeIcon icon={faGlobe} className="text-blue-9 size-3" />
+						<span className="max-w-[140px] truncate text-gray-11 sm:max-w-[220px]">
+							{displayUrl}
+						</span>
+						<span className="flex justify-center items-center rounded-md transition-colors size-6 text-gray-10 group-hover:text-gray-12">
+							<FontAwesomeIcon
+								icon={copied ? faCheck : faCopy}
+								className={copied ? "size-3 text-blue-11" : "size-3"}
+							/>
+						</span>
+					</button>
+				</Tooltip>
+				{canManage && (
+					<Button
+						type="button"
+						variant="gray"
+						size="sm"
+						disabled={isPending}
+						onClick={() => setOpen(true)}
+					>
+						<FontAwesomeIcon icon={faSliders} className="size-3" />
+						Customize
+					</Button>
+				)}
+				{dialog}
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<Button
+				type="button"
+				variant="gray"
+				size="sm"
+				disabled={isPending}
+				onClick={() => setOpen(true)}
+			>
+				<FontAwesomeIcon icon={faGlobe} className="size-3" />
+				Share
+			</Button>
+			{dialog}
+		</>
+	);
+};

--- a/apps/web/app/(org)/dashboard/_components/CollectionShareDialog.tsx
+++ b/apps/web/app/(org)/dashboard/_components/CollectionShareDialog.tsx
@@ -1,0 +1,470 @@
+"use client";
+
+import {
+	Button,
+	buttonVariants,
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Input,
+	Select,
+	Switch,
+} from "@cap/ui";
+import { PublicCollection } from "@cap/web-domain";
+import {
+	faArrowUpRightFromSquare,
+	faCheck,
+	faCopy,
+	faGlobe,
+	faLock,
+	faUpload,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import clsx from "clsx";
+import { useEffect, useId, useRef, useState } from "react";
+import { useCopyCollectionLink } from "@/lib/public-collection-client";
+import {
+	PUBLIC_GRID_COLUMN_OPTIONS,
+	PUBLIC_LAYOUT_OPTIONS,
+	PUBLIC_LOGO_OPTIONS,
+} from "@/lib/public-collection-settings";
+
+type PublicPageSettings = PublicCollection.PublicPageSettings;
+type PublicPageSettingsUpdate = PublicCollection.PublicPageSettingsUpdate;
+
+const {
+	PUBLIC_PAGE_TITLE_MAX_LENGTH,
+	PUBLIC_PAGE_SUBTITLE_MAX_LENGTH,
+	PUBLIC_PAGE_CTA_LABEL_MAX_LENGTH,
+	PUBLIC_PAGE_CTA_URL_MAX_LENGTH,
+} = PublicCollection;
+
+const gridColumnSelectOptions = PUBLIC_GRID_COLUMN_OPTIONS.map((option) => ({
+	value: String(option.value),
+	label: option.label,
+}));
+
+interface CollectionShareDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	kind: "folder" | "space";
+	collectionId: string;
+	isPublic: boolean;
+	isPro: boolean;
+	isPending: boolean;
+	settings: Required<PublicPageSettings>;
+	onTogglePublic: (next: boolean) => void;
+	onUpdateSettings: (patch: PublicPageSettingsUpdate) => void;
+	onUploadLogo: (file: File) => void;
+	onRemoveLogo: () => void;
+	isUploadingLogo: boolean;
+}
+
+export const CollectionShareDialog = ({
+	open,
+	onOpenChange,
+	kind,
+	collectionId,
+	isPublic,
+	isPro,
+	isPending,
+	settings,
+	onTogglePublic,
+	onUpdateSettings,
+	onUploadLogo,
+	onRemoveLogo,
+	isUploadingLogo,
+}: CollectionShareDialogProps) => {
+	const { url, copied, copy } = useCopyCollectionLink(collectionId);
+	const displayUrl = url.replace(/^https?:\/\//, "");
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="flex flex-col p-0 w-[calc(100%-20px)] max-w-lg rounded-xl border bg-gray-2 border-gray-4 max-h-[90vh]">
+				<DialogHeader
+					icon={<FontAwesomeIcon icon={faGlobe} className="size-3.5" />}
+					description={
+						isPublic
+							? `Anyone with the link can browse the public caps in this ${kind}.`
+							: `Publish this ${kind} as a clean, browsable page you can share with anyone.`
+					}
+				>
+					<DialogTitle>Share this {kind}</DialogTitle>
+				</DialogHeader>
+
+				<div className="overflow-y-auto flex-1 p-5 space-y-4 min-h-0">
+					<div
+						className={clsx(
+							"flex gap-3 justify-between items-center p-3.5 rounded-xl border transition-colors",
+							isPublic ? "border-blue-9 bg-gray-1" : "border-gray-4 bg-gray-1",
+						)}
+					>
+						<div className="flex gap-3 items-center min-w-0">
+							<div
+								className={clsx(
+									"flex justify-center items-center rounded-full transition-colors size-9 shrink-0",
+									isPublic ? "text-blue-9 bg-blue-3" : "text-gray-11 bg-gray-3",
+								)}
+							>
+								<FontAwesomeIcon
+									icon={isPublic ? faGlobe : faLock}
+									className="size-3.5"
+								/>
+							</div>
+							<div className="min-w-0">
+								<div className="flex gap-1.5 items-center">
+									<p className="text-sm font-medium text-gray-12">
+										Anyone with the link
+									</p>
+									{!isPro && (
+										<span className="rounded-full bg-blue-11 px-1.5 py-0.5 text-[10px] font-medium leading-none text-white">
+											Pro
+										</span>
+									)}
+								</div>
+								<p className="text-xs text-gray-10">
+									{isPublic
+										? "Public — anyone with the link can view"
+										: "Private — only members can view"}
+								</p>
+							</div>
+						</div>
+						<Switch
+							checked={isPublic}
+							disabled={isPending}
+							onCheckedChange={onTogglePublic}
+						/>
+					</div>
+
+					{isPublic && (
+						<>
+							<div className="relative">
+								<Input
+									type="text"
+									readOnly
+									value={url}
+									onFocus={(e) => e.currentTarget.select()}
+									className="pr-11 font-mono text-xs"
+								/>
+								<button
+									type="button"
+									onClick={copy}
+									aria-label="Copy public link"
+									className="flex absolute right-1.5 top-1/2 justify-center items-center rounded-lg transition-colors -translate-y-1/2 size-8 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
+								>
+									<FontAwesomeIcon
+										icon={copied ? faCheck : faCopy}
+										className={clsx("size-3.5", copied && "text-blue-11")}
+									/>
+								</button>
+							</div>
+
+							<FieldGroup title="Page header">
+								<TextField
+									label="Title"
+									value={settings.title}
+									placeholder="Defaults to the collection name"
+									maxLength={PUBLIC_PAGE_TITLE_MAX_LENGTH}
+									disabled={isPending}
+									onCommit={(value) => onUpdateSettings({ title: value })}
+								/>
+								<TextField
+									label="Subtitle"
+									value={settings.subtitle}
+									placeholder="Add a short description"
+									maxLength={PUBLIC_PAGE_SUBTITLE_MAX_LENGTH}
+									disabled={isPending}
+									onCommit={(value) => onUpdateSettings({ subtitle: value })}
+								/>
+								<div className="space-y-1.5">
+									<span className="text-sm text-gray-12">Logo</span>
+									<Select
+										size="default"
+										className="w-full"
+										value={settings.logoMode}
+										placeholder="Logo"
+										options={PUBLIC_LOGO_OPTIONS}
+										onValueChange={(value) =>
+											onUpdateSettings({
+												logoMode: value as PublicPageSettings["logoMode"],
+											})
+										}
+									/>
+									{settings.logoMode === "custom" && (
+										<LogoUploader
+											hasLogo={Boolean(settings.logoUrl)}
+											isUploading={isUploadingLogo}
+											onUpload={onUploadLogo}
+											onRemove={onRemoveLogo}
+										/>
+									)}
+								</div>
+
+								<div className="divide-y divide-gray-4">
+									<SettingRow label="Show title">
+										<Switch
+											checked={!settings.hideTitle}
+											disabled={isPending}
+											onCheckedChange={(checked) =>
+												onUpdateSettings({ hideTitle: !checked })
+											}
+										/>
+									</SettingRow>
+									<SettingRow label="Show copy link button">
+										<Switch
+											checked={!settings.hideCopyLink}
+											disabled={isPending}
+											onCheckedChange={(checked) =>
+												onUpdateSettings({ hideCopyLink: !checked })
+											}
+										/>
+									</SettingRow>
+								</div>
+							</FieldGroup>
+
+							<FieldGroup
+								title="Call to action"
+								description="Add a button to the page header."
+							>
+								<TextField
+									label="Button label"
+									value={settings.ctaLabel}
+									placeholder="e.g. Visit our website"
+									maxLength={PUBLIC_PAGE_CTA_LABEL_MAX_LENGTH}
+									disabled={isPending}
+									onCommit={(value) => onUpdateSettings({ ctaLabel: value })}
+								/>
+								<TextField
+									label="Button link"
+									value={settings.ctaUrl}
+									placeholder="https://example.com"
+									maxLength={PUBLIC_PAGE_CTA_URL_MAX_LENGTH}
+									disabled={isPending}
+									onCommit={(value) => onUpdateSettings({ ctaUrl: value })}
+								/>
+							</FieldGroup>
+
+							<FieldGroup title="Layout">
+								<div className="divide-y divide-gray-4">
+									<SettingRow label="Style" description="How caps are arranged">
+										<Select
+											size="sm"
+											value={settings.layout}
+											placeholder="Layout"
+											options={PUBLIC_LAYOUT_OPTIONS}
+											onValueChange={(value) =>
+												onUpdateSettings({
+													layout: value as PublicPageSettings["layout"],
+												})
+											}
+										/>
+									</SettingRow>
+
+									{settings.layout === "grid" && (
+										<SettingRow
+											label="Columns"
+											description="Caps shown per row"
+										>
+											<Select
+												size="sm"
+												value={String(settings.gridColumns)}
+												placeholder="Columns"
+												options={gridColumnSelectOptions}
+												onValueChange={(value) =>
+													onUpdateSettings({
+														gridColumns: Number(
+															value,
+														) as PublicPageSettings["gridColumns"],
+													})
+												}
+											/>
+										</SettingRow>
+									)}
+								</div>
+							</FieldGroup>
+						</>
+					)}
+				</div>
+
+				<DialogFooter className="sm:justify-between">
+					{isPublic ? (
+						<a
+							href={url}
+							target="_blank"
+							rel="noreferrer"
+							className={buttonVariants({ variant: "gray", size: "sm" })}
+						>
+							<FontAwesomeIcon
+								icon={faArrowUpRightFromSquare}
+								className="size-3"
+							/>
+							Open page
+						</a>
+					) : (
+						<span className="hidden text-xs truncate text-gray-9 sm:block">
+							{displayUrl}
+						</span>
+					)}
+					<Button
+						type="button"
+						variant="dark"
+						size="sm"
+						onClick={() => onOpenChange(false)}
+					>
+						Done
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};
+
+function LogoUploader({
+	hasLogo,
+	isUploading,
+	onUpload,
+	onRemove,
+}: {
+	hasLogo: boolean;
+	isUploading: boolean;
+	onUpload: (file: File) => void;
+	onRemove: () => void;
+}) {
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	return (
+		<div className="pt-1 space-y-1.5">
+			<div className="flex gap-2 items-center">
+				<input
+					ref={inputRef}
+					type="file"
+					accept="image/png,image/jpeg,image/svg+xml,image/webp"
+					className="hidden"
+					onChange={(e) => {
+						const file = e.target.files?.[0];
+						if (file) onUpload(file);
+						e.currentTarget.value = "";
+					}}
+				/>
+				<Button
+					type="button"
+					variant="gray"
+					size="sm"
+					disabled={isUploading}
+					spinner={isUploading}
+					onClick={() => inputRef.current?.click()}
+				>
+					{!isUploading && (
+						<FontAwesomeIcon icon={faUpload} className="size-3" />
+					)}
+					{hasLogo ? "Replace logo" : "Upload logo"}
+				</Button>
+				{hasLogo && (
+					<Button
+						type="button"
+						variant="gray"
+						size="sm"
+						disabled={isUploading}
+						onClick={onRemove}
+					>
+						Remove
+					</Button>
+				)}
+			</div>
+			<p className="text-xs text-gray-10">PNG, JPEG, SVG or WebP, up to 1MB.</p>
+		</div>
+	);
+}
+
+function FieldGroup({
+	title,
+	description,
+	children,
+}: {
+	title: string;
+	description?: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="rounded-xl border border-gray-4 bg-gray-1 p-3.5">
+			<p className="text-[11px] font-medium tracking-wide uppercase text-gray-9">
+				{title}
+			</p>
+			{description && (
+				<p className="mt-0.5 text-xs text-gray-10">{description}</p>
+			)}
+			<div className="mt-3 space-y-3">{children}</div>
+		</div>
+	);
+}
+
+function TextField({
+	label,
+	value,
+	placeholder,
+	maxLength,
+	disabled,
+	onCommit,
+}: {
+	label: string;
+	value: string;
+	placeholder?: string;
+	maxLength?: number;
+	disabled?: boolean;
+	onCommit: (value: string) => void;
+}) {
+	const id = useId();
+	const [draft, setDraft] = useState(value);
+
+	useEffect(() => setDraft(value), [value]);
+
+	const commit = () => {
+		const next = draft.trim();
+		setDraft(next);
+		if (next === value) return;
+		onCommit(next);
+	};
+
+	return (
+		<div className="space-y-1.5">
+			<label htmlFor={id} className="text-sm text-gray-12">
+				{label}
+			</label>
+			<Input
+				id={id}
+				type="text"
+				value={draft}
+				placeholder={placeholder}
+				maxLength={maxLength}
+				disabled={disabled}
+				onChange={(e) => setDraft(e.target.value)}
+				onBlur={commit}
+				onKeyDown={(e) => {
+					if (e.key === "Enter") e.currentTarget.blur();
+				}}
+			/>
+		</div>
+	);
+}
+
+function SettingRow({
+	label,
+	description,
+	children,
+}: {
+	label: string;
+	description?: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="flex gap-3 justify-between items-center py-3 first:pt-0 last:pb-0">
+			<div className="min-w-0">
+				<p className="text-sm text-gray-12">{label}</p>
+				{description && <p className="text-xs text-gray-10">{description}</p>}
+			</div>
+			{children}
+		</div>
+	);
+}

--- a/apps/web/app/(org)/dashboard/_components/Navbar/SpaceDialog.tsx
+++ b/apps/web/app/(org)/dashboard/_components/Navbar/SpaceDialog.tsx
@@ -16,11 +16,7 @@ import {
 	Switch,
 } from "@cap/ui";
 import type { ImageUpload } from "@cap/web-domain";
-import {
-	faGear,
-	faLayerGroup,
-	faLock,
-} from "@fortawesome/free-solid-svg-icons";
+import { faLayerGroup, faLock } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
@@ -34,6 +30,7 @@ import { FileInput } from "@/components/FileInput";
 import { useDashboardContext } from "../../Contexts";
 import type { OrganizationSettings } from "../../dashboard-data";
 import { MemberSelect } from "../../spaces/[spaceId]/components/MemberSelect";
+import { PublicCollectionField } from "../PublicCollectionField";
 import { createSpace } from "./server";
 
 interface SpaceDialogProps {
@@ -47,6 +44,7 @@ interface SpaceDialogProps {
 		iconUrl?: ImageUpload.ImageUrl;
 		settings?: OrganizationSettings | null;
 		hasPassword?: boolean;
+		public?: boolean;
 	} | null;
 	onSpaceUpdated?: () => void;
 }
@@ -68,20 +66,20 @@ const SpaceDialog = ({
 
 	return (
 		<Dialog open={open} onOpenChange={(open) => !open && onClose()}>
-			<DialogContent className="p-0 w-[calc(100%-20px)] max-w-md rounded-xl border bg-gray-2 border-gray-4">
+			<DialogContent className="p-0 w-[calc(100%-20px)] max-w-2xl rounded-xl border bg-gray-2 border-gray-4">
 				<DialogHeader
 					icon={<FontAwesomeIcon icon={faLayerGroup} />}
 					description={
 						edit
-							? "Edit your space details"
-							: "A new space for your team to collaborate"
+							? "Manage details, sharing and viewer permissions."
+							: "Set up a space for your team to collaborate."
 					}
 				>
 					<DialogTitle className="text-lg text-gray-12">
 						{edit ? "Edit Space" : "Create New Space"}
 					</DialogTitle>
 				</DialogHeader>
-				<div className="p-5 max-h-[70vh] overflow-y-auto">
+				<div className="px-6 py-5 max-h-[70vh] overflow-y-auto">
 					<NewSpaceForm
 						formRef={formRef}
 						setCreateLoading={setIsSubmitting}
@@ -129,6 +127,7 @@ export interface NewSpaceFormProps {
 		iconUrl?: ImageUpload.ImageUrl;
 		settings?: OrganizationSettings | null;
 		hasPassword?: boolean;
+		public?: boolean;
 	} | null;
 }
 
@@ -225,12 +224,14 @@ export const NewSpaceForm: React.FC<NewSpaceFormProps> = (props) => {
 	const [passwordEnabled, setPasswordEnabled] = useState(
 		Boolean(space?.hasPassword),
 	);
+	const [publicEnabled, setPublicEnabled] = useState(Boolean(space?.public));
 	const [passwordValue, setPasswordValue] = useState("");
 	const iconInputId = useId();
 
 	useEffect(() => {
 		setSettings({ ...defaultSettings, ...space?.settings });
 		setPasswordEnabled(Boolean(space?.hasPassword));
+		setPublicEnabled(Boolean(space?.public));
 		setPasswordValue("");
 	}, [space]);
 
@@ -308,6 +309,7 @@ export const NewSpaceForm: React.FC<NewSpaceFormProps> = (props) => {
 						}
 
 						formData.append("passwordEnabled", String(passwordEnabled));
+						formData.append("public", String(publicEnabled));
 
 						if (passwordEnabled && passwordValue.trim()) {
 							formData.append("password", passwordValue.trim());
@@ -376,117 +378,158 @@ export const NewSpaceForm: React.FC<NewSpaceFormProps> = (props) => {
 					}
 				})}
 			>
-				<div className="space-y-4">
-					<FormField
-						control={form.control}
-						name="name"
-						render={({ field }) => (
-							<FormControl>
-								<Input
-									placeholder="Space name"
-									maxLength={25}
-									{...field}
-									onChange={(e) => {
-										field.onChange(e);
-										props.onNameChange?.(e.target.value);
-									}}
+				<div className="space-y-7">
+					{/* Details */}
+					<section className="space-y-3">
+						<SectionLabel
+							title="Details"
+							description="Name your space and choose who belongs in it."
+						/>
+						<div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:items-start">
+							<div className="space-y-4">
+								<FormField
+									control={form.control}
+									name="name"
+									render={({ field }) => (
+										<FormControl>
+											<Input
+												placeholder="Space name"
+												maxLength={25}
+												{...field}
+												onChange={(e) => {
+													field.onChange(e);
+													props.onNameChange?.(e.target.value);
+												}}
+											/>
+										</FormControl>
+									)}
 								/>
-							</FormControl>
-						)}
-					/>
 
-					{/* Space Members Input */}
-					<div className="space-y-1">
-						<Label htmlFor="members">Members</Label>
-						<CardDescription className="w-full max-w-[400px]">
-							Add team members to this space.
-						</CardDescription>
-					</div>
-					<FormField
-						control={form.control}
-						name="members"
-						render={({ field }) => {
-							return (
-								<FormControl>
-									<MemberSelect
-										placeholder="Add member..."
-										showEmptyIfNoMembers={false}
+								<div className="space-y-2">
+									<div className="space-y-1">
+										<Label htmlFor={iconInputId}>Space icon</Label>
+										<CardDescription>
+											Custom logo or icon (max 1MB).
+										</CardDescription>
+									</div>
+									<FileInput
+										id={iconInputId}
+										name="icon"
+										initialPreviewUrl={space?.iconUrl || null}
+										notDraggingClassName="hover:bg-gray-3"
+										onChange={handleFileChange}
 										disabled={isUploading}
-										canManageMembers={true}
-										selected={(activeOrganization?.members ?? [])
-											.filter((m) => (field.value ?? []).includes(m.user.id))
-											.map((m) => ({
-												value: m.user.id,
-												label: m.user.name || m.user.email,
-												image: m.user.image ?? undefined,
-											}))}
-										onSelect={(selected) =>
-											field.onChange(selected.map((opt) => opt.value))
-										}
+										isLoading={isUploading}
 									/>
-								</FormControl>
-							);
-						}}
-					/>
-
-					<div className="space-y-3 rounded-xl border border-gray-4 bg-gray-1 p-3">
-						<div className="flex items-start justify-between gap-4">
-							<div className="flex gap-3">
-								<div className="flex size-8 items-center justify-center rounded-full bg-gray-3">
-									<FontAwesomeIcon
-										icon={faLock}
-										className="size-3 text-gray-11"
-									/>
-								</div>
-								<div>
-									<p className="text-sm font-medium text-gray-12">
-										Require password
-									</p>
-									<p className="text-xs text-gray-10">
-										All caps in this space require this password
-									</p>
 								</div>
 							</div>
-							<Switch
-								checked={passwordEnabled}
-								onCheckedChange={handlePasswordToggle}
-							/>
-						</div>
-						{passwordEnabled && (
-							<div className="space-y-1">
-								<Input
-									type="password"
-									value={passwordValue}
-									onChange={(e) => setPasswordValue(e.target.value)}
-									placeholder={
-										space?.hasPassword ? "Enter new password" : "Set a password"
-									}
+
+							<div className="space-y-2">
+								<div className="space-y-1">
+									<Label htmlFor="members">Members</Label>
+									<CardDescription>
+										Add team members to this space.
+									</CardDescription>
+								</div>
+								<FormField
+									control={form.control}
+									name="members"
+									render={({ field }) => (
+										<FormControl>
+											<MemberSelect
+												placeholder="Add member..."
+												showEmptyIfNoMembers={false}
+												disabled={isUploading}
+												canManageMembers={true}
+												selected={(activeOrganization?.members ?? [])
+													.filter((m) =>
+														(field.value ?? []).includes(m.user.id),
+													)
+													.map((m) => ({
+														value: m.user.id,
+														label: m.user.name || m.user.email,
+														image: m.user.image ?? undefined,
+													}))}
+												onSelect={(selected) =>
+													field.onChange(selected.map((opt) => opt.value))
+												}
+											/>
+										</FormControl>
+									)}
 								/>
-								{space?.hasPassword && !passwordValue && (
-									<p className="text-xs text-gray-9">
-										Leave blank to keep existing password
-									</p>
+							</div>
+						</div>
+					</section>
+
+					{/* Sharing */}
+					<section className="space-y-3">
+						<SectionLabel
+							title="Sharing"
+							description="Control how this space can be reached."
+						/>
+						<div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:items-start">
+							<PublicCollectionField
+								kind="space"
+								enabled={publicEnabled}
+								onChange={setPublicEnabled}
+								isPro={Boolean(activeOrganization?.ownerIsPro)}
+								onUpgrade={() => setUpgradeModalOpen(true)}
+								collectionId={edit && space?.id ? space.id : undefined}
+							/>
+
+							<div className="rounded-xl border border-gray-4 bg-gray-1">
+								<div className="flex gap-3 justify-between items-center p-3.5">
+									<div className="flex gap-3 items-center min-w-0">
+										<div className="flex justify-center items-center rounded-full size-9 bg-gray-3 shrink-0">
+											<FontAwesomeIcon
+												icon={faLock}
+												className="size-3.5 text-gray-11"
+											/>
+										</div>
+										<div className="min-w-0">
+											<p className="text-sm font-medium text-gray-12">
+												Require password
+											</p>
+											<p className="text-xs text-gray-10">
+												Protect every cap in this space
+											</p>
+										</div>
+									</div>
+									<Switch
+										checked={passwordEnabled}
+										onCheckedChange={handlePasswordToggle}
+									/>
+								</div>
+								{passwordEnabled && (
+									<div className="px-3.5 pb-3.5 space-y-1">
+										<Input
+											type="password"
+											value={passwordValue}
+											onChange={(e) => setPasswordValue(e.target.value)}
+											placeholder={
+												space?.hasPassword
+													? "Enter new password"
+													: "Set a password"
+											}
+										/>
+										{space?.hasPassword && !passwordValue && (
+											<p className="text-xs text-gray-9">
+												Leave blank to keep existing password
+											</p>
+										)}
+									</div>
 								)}
 							</div>
-						)}
-					</div>
-
-					<div className="space-y-3 rounded-xl border border-gray-4 bg-gray-1 p-3">
-						<div className="flex gap-3">
-							<div className="flex size-8 items-center justify-center rounded-full bg-gray-3">
-								<FontAwesomeIcon
-									icon={faGear}
-									className="size-3 text-gray-11"
-								/>
-							</div>
-							<div>
-								<p className="text-sm font-medium text-gray-12">Viewer rules</p>
-								<p className="text-xs text-gray-10">
-									These apply to every cap in this space
-								</p>
-							</div>
 						</div>
-						<div className="grid grid-cols-1 gap-2">
+					</section>
+
+					{/* Viewer permissions */}
+					<section className="space-y-3">
+						<SectionLabel
+							title="Viewer permissions"
+							description="These apply to every cap shared in this space."
+						/>
+						<div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
 							{settingOptions.map((option) => {
 								const disabled =
 									(option.pro && !user?.isPro) ||
@@ -497,15 +540,15 @@ export const NewSpaceForm: React.FC<NewSpaceFormProps> = (props) => {
 								return (
 									<div
 										key={option.value}
-										className="flex items-center justify-between gap-4 rounded-lg border border-gray-3 bg-gray-2 p-3"
+										className="flex gap-3 justify-between items-center p-3 rounded-lg border border-gray-4 bg-gray-1"
 									>
 										<div>
-											<div className="flex items-center gap-1.5">
+											<div className="flex gap-1.5 items-center">
 												<p className="text-sm text-gray-12">{option.label}</p>
 												{option.pro && (
-													<p className="rounded-full bg-blue-11 px-1.5 py-1 text-[10px] font-medium leading-none text-white">
+													<span className="rounded-full bg-blue-11 px-1.5 py-0.5 text-[10px] font-medium leading-none text-white">
 														Pro
-													</p>
+													</span>
 												)}
 											</div>
 											<p className="text-xs text-gray-10">
@@ -521,30 +564,30 @@ export const NewSpaceForm: React.FC<NewSpaceFormProps> = (props) => {
 								);
 							})}
 						</div>
-					</div>
-
-					<div className="space-y-1">
-						<Label htmlFor={iconInputId}>Space Icon</Label>
-						<CardDescription className="w-full max-w-[400px]">
-							Upload a custom logo or icon for your space (max 1MB).
-						</CardDescription>
-					</div>
-
-					<div className="relative mt-2">
-						<FileInput
-							id={iconInputId}
-							name="icon"
-							initialPreviewUrl={space?.iconUrl || null}
-							notDraggingClassName="hover:bg-gray-3"
-							onChange={handleFileChange}
-							disabled={isUploading}
-							isLoading={isUploading}
-						/>
-					</div>
+					</section>
 				</div>
 			</form>
 		</Form>
 	);
 };
+
+function SectionLabel({
+	title,
+	description,
+}: {
+	title: string;
+	description?: string;
+}) {
+	return (
+		<div>
+			<p className="text-[11px] font-medium tracking-wide uppercase text-gray-9">
+				{title}
+			</p>
+			{description && (
+				<p className="mt-0.5 text-xs text-gray-10">{description}</p>
+			)}
+		</div>
+	);
+}
 
 export default SpaceDialog;

--- a/apps/web/app/(org)/dashboard/_components/PublicCollectionField.tsx
+++ b/apps/web/app/(org)/dashboard/_components/PublicCollectionField.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { Button, Switch } from "@cap/ui";
+import {
+	faCheck,
+	faCopy,
+	faGlobe,
+	faLock,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import clsx from "clsx";
+import { useCopyCollectionLink } from "@/lib/public-collection-client";
+
+interface PublicCollectionFieldProps {
+	kind: "folder" | "space";
+	enabled: boolean;
+	onChange: (enabled: boolean) => void;
+	isPro: boolean;
+	onUpgrade: () => void;
+	collectionId?: string;
+	disabled?: boolean;
+}
+
+export const PublicCollectionField = ({
+	kind,
+	enabled,
+	onChange,
+	isPro,
+	onUpgrade,
+	collectionId,
+	disabled,
+}: PublicCollectionFieldProps) => {
+	const { copied, copy } = useCopyCollectionLink(collectionId);
+
+	return (
+		<div
+			className={clsx(
+				"rounded-xl border transition-colors",
+				enabled ? "border-blue-9 bg-gray-1" : "border-gray-4 bg-gray-1",
+			)}
+		>
+			<div className="flex gap-3 justify-between items-center p-3.5">
+				<div className="flex gap-3 items-center min-w-0">
+					<div
+						className={clsx(
+							"flex justify-center items-center rounded-full transition-colors size-9 shrink-0",
+							enabled ? "text-blue-9 bg-blue-3" : "text-gray-11 bg-gray-3",
+						)}
+					>
+						<FontAwesomeIcon
+							icon={enabled ? faGlobe : faLock}
+							className="size-3.5"
+						/>
+					</div>
+					<div className="min-w-0">
+						<div className="flex gap-1.5 items-center">
+							<p className="text-sm font-medium text-gray-12">
+								Public collection link
+							</p>
+							{!isPro && (
+								<span className="rounded-full bg-blue-11 px-1.5 py-0.5 text-[10px] font-medium leading-none text-white">
+									Pro
+								</span>
+							)}
+						</div>
+						<p className="text-xs text-gray-10">
+							Anyone with the link can browse public caps in this {kind}.
+						</p>
+					</div>
+				</div>
+				<Switch
+					checked={enabled}
+					disabled={disabled}
+					onCheckedChange={(checked) => {
+						if (checked && !isPro) {
+							onUpgrade();
+							return;
+						}
+						onChange(checked);
+					}}
+				/>
+			</div>
+			{enabled && collectionId && (
+				<div className="px-3.5 pb-3.5">
+					<Button
+						type="button"
+						size="sm"
+						variant="gray"
+						className="w-full"
+						onClick={copy}
+					>
+						<FontAwesomeIcon
+							icon={copied ? faCheck : faCopy}
+							className={copied ? "size-3 text-blue-11" : "size-3"}
+						/>
+						{copied ? "Copied" : "Copy public link"}
+					</Button>
+				</div>
+			)}
+		</div>
+	);
+};

--- a/apps/web/app/(org)/dashboard/caps/components/CapPagination.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/CapPagination.tsx
@@ -11,11 +11,13 @@ import {
 interface CapPaginationProps {
 	currentPage: number;
 	totalPages: number;
+	hrefForPage?: (page: number) => string;
 }
 
 export const CapPagination: React.FC<CapPaginationProps> = ({
 	currentPage,
 	totalPages,
+	hrefForPage = (page) => `/dashboard/caps?page=${page}`,
 }) => {
 	return (
 		<Pagination>
@@ -24,14 +26,14 @@ export const CapPagination: React.FC<CapPaginationProps> = ({
 					<PaginationItem>
 						<PaginationPrevious
 							className="h-10 bg-transparent hover:bg-gray-4"
-							href={`/dashboard/caps?page=${currentPage - 1}`}
+							href={hrefForPage(currentPage - 1)}
 						/>
 					</PaginationItem>
 				)}
 				<PaginationItem>
 					<PaginationLink
 						className="h-10 min-w-10"
-						href={`/dashboard/caps?page=1`}
+						href={hrefForPage(1)}
 						isActive={currentPage === 1}
 					>
 						1
@@ -41,7 +43,7 @@ export const CapPagination: React.FC<CapPaginationProps> = ({
 					<PaginationItem>
 						<PaginationLink
 							className="h-10 min-w-10"
-							href={`/dashboard/caps?page=${currentPage}`}
+							href={hrefForPage(currentPage)}
 							isActive={true}
 						>
 							{currentPage}
@@ -52,7 +54,7 @@ export const CapPagination: React.FC<CapPaginationProps> = ({
 					<PaginationItem>
 						<PaginationLink
 							className="h-10 min-w-10 hover:bg-gray-3"
-							href={`/dashboard/caps?page=${currentPage + 1}`}
+							href={hrefForPage(currentPage + 1)}
 							isActive={false}
 						>
 							{currentPage + 1}
@@ -63,9 +65,9 @@ export const CapPagination: React.FC<CapPaginationProps> = ({
 				<PaginationItem>
 					<PaginationNext
 						className="h-10 bg-transparent hover:bg-gray-4"
-						href={`/dashboard/caps?page=${
-							currentPage === totalPages ? currentPage : currentPage + 1
-						}`}
+						href={hrefForPage(
+							currentPage === totalPages ? currentPage : currentPage + 1,
+						)}
 					/>
 				</PaginationItem>
 			</PaginationContent>

--- a/apps/web/app/(org)/dashboard/caps/components/Folder.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/Folder.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type { Folder, Space } from "@cap/web-domain";
-import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faGlobe, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Fit, Layout, useRive } from "@rive-app/react-canvas";
 import clsx from "clsx";
@@ -10,6 +10,7 @@ import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { moveVideoToFolder } from "@/actions/folders/moveVideoToFolder";
 import { useEffectMutation, useRpcClient } from "@/lib/EffectRuntime";
+import { useCopyCollectionLink } from "@/lib/public-collection-client";
 import { ConfirmationDialog } from "../../_components/ConfirmationDialog";
 import { useDashboardContext, useTheme } from "../../Contexts";
 import { registerDropTarget } from "../../folder/[id]/components/ClientCapCard";
@@ -19,6 +20,7 @@ export type FolderDataType = {
 	name: string;
 	id: Folder.FolderId;
 	color: "normal" | "blue" | "red" | "yellow";
+	public: boolean;
 	videoCount: number;
 	spaceId?: Space.SpaceIdOrOrganisationId | null;
 	parentId: Folder.FolderId | null;
@@ -27,6 +29,7 @@ export type FolderDataType = {
 const FolderCard = ({
 	name,
 	color,
+	public: isPublic,
 	id,
 	parentId,
 	videoCount,
@@ -37,19 +40,22 @@ const FolderCard = ({
 	const [confirmDeleteFolderOpen, setConfirmDeleteFolderOpen] = useState(false);
 	const [isRenaming, setIsRenaming] = useState(false);
 	const [updateName, setUpdateName] = useState(name);
+	const [publicEnabled, setPublicEnabled] = useState(isPublic);
 	const nameRef = useRef<HTMLTextAreaElement>(null);
-	const folderRef = useRef<HTMLDivElement>(null);
+	const folderRef = useRef<HTMLFieldSetElement>(null);
 	const [isDragOver, setIsDragOver] = useState(false);
 	const [isMovingVideo, setIsMovingVideo] = useState(false);
-	const { activeOrganization } = useDashboardContext();
+	const { activeOrganization, setUpgradeModalOpen } = useDashboardContext();
+	const ownerIsPro = Boolean(activeOrganization?.ownerIsPro);
+	const folderHref = spaceId
+		? `/dashboard/spaces/${spaceId}/folder/${id}`
+		: `/dashboard/folder/${id}`;
 
-	// Use a ref to track drag state to avoid re-renders during animation
 	const dragStateRef = useRef({
 		isDragging: false,
 		isAnimating: false,
 	});
 
-	// Add a debounce timer ref to prevent animation stuttering
 	const animationTimerRef = useRef<NodeJS.Timeout | null>(null);
 
 	const artboard =
@@ -70,6 +76,7 @@ const FolderCard = ({
 	});
 
 	const rpc = useRpcClient();
+	const { copy: copyPublicLink } = useCopyCollectionLink(id);
 
 	const deleteFolder = useEffectMutation({
 		mutationFn: (id: Folder.FolderId) => rpc.FolderDelete(id),
@@ -86,10 +93,13 @@ const FolderCard = ({
 	const updateFolder = useEffectMutation({
 		mutationFn: (data: Folder.FolderUpdate) => rpc.FolderUpdate(data),
 		onSuccess: () => {
-			toast.success("Folder name updated successfully");
+			toast.success("Folder updated successfully");
 			router.refresh();
 		},
-		onError: () => toast.error("Failed to update folder name"),
+		onError: () => {
+			setPublicEnabled(isPublic);
+			toast.error("Failed to update folder");
+		},
 		onSettled: () => setIsRenaming(false),
 	});
 
@@ -100,13 +110,15 @@ const FolderCard = ({
 		}
 	}, [isRenaming]);
 
-	// Register this folder as a drop target for mobile drag and drop
+	useEffect(() => {
+		setPublicEnabled(isPublic);
+	}, [isPublic]);
+
 	useEffect(() => {
 		if (!folderRef.current) return;
 
 		const unregister = registerDropTarget(
 			folderRef.current,
-			// onDrop handler
 			async (data) => {
 				if (!data || !data.id) return;
 
@@ -193,7 +205,7 @@ const FolderCard = ({
 		spaceId,
 	]);
 
-	const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+	const handleDragOver = (e: React.DragEvent<HTMLFieldSetElement>) => {
 		e.preventDefault();
 		e.stopPropagation();
 
@@ -218,7 +230,7 @@ const FolderCard = ({
 		}
 	};
 
-	const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+	const handleDragLeave = (e: React.DragEvent<HTMLFieldSetElement>) => {
 		e.preventDefault();
 		e.stopPropagation();
 
@@ -240,7 +252,7 @@ const FolderCard = ({
 		}
 	};
 
-	const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
+	const handleDrop = async (e: React.DragEvent<HTMLFieldSetElement>) => {
 		e.preventDefault();
 		e.stopPropagation();
 		setIsDragOver(false);
@@ -277,135 +289,142 @@ const FolderCard = ({
 	};
 
 	return (
-		<Link
-			prefetch={false}
-			href={
-				spaceId
-					? `/dashboard/spaces/${spaceId}/folder/${id}`
-					: `/dashboard/folder/${id}`
-			}
+		<fieldset
+			ref={folderRef}
+			onMouseEnter={() => {
+				if (dragStateRef.current.isDragging) return;
+				if (!rive) return;
+
+				if (animationTimerRef.current) {
+					clearTimeout(animationTimerRef.current);
+					animationTimerRef.current = null;
+				}
+
+				animationTimerRef.current = setTimeout(() => {
+					rive.stop();
+					rive.play("folder-open");
+				}, 50);
+			}}
+			onMouseLeave={() => {
+				if (dragStateRef.current.isDragging) return;
+				if (!rive) return;
+
+				if (animationTimerRef.current) {
+					clearTimeout(animationTimerRef.current);
+					animationTimerRef.current = null;
+				}
+
+				animationTimerRef.current = setTimeout(() => {
+					rive.stop();
+					rive.play("folder-close");
+				}, 50);
+			}}
+			onDragOver={handleDragOver}
+			onDragLeave={handleDragLeave}
+			onDrop={handleDrop}
+			className={clsx(
+				"flex justify-between items-center px-4 py-4 w-full h-auto min-w-0 rounded-lg border transition-all duration-200 bg-gray-3 hover:bg-gray-4 hover:border-gray-6",
+				isDragOver ? "border-blue-10 bg-gray-4" : "border-gray-5",
+				isMovingVideo && "opacity-70",
+			)}
 		>
-			<div
-				ref={folderRef}
-				onMouseEnter={() => {
-					// Don't play mouse animations during drag operations
-					if (dragStateRef.current.isDragging) return;
-					if (!rive) return;
-
-					// Clear any pending animation timer
-					if (animationTimerRef.current) {
-						clearTimeout(animationTimerRef.current);
-						animationTimerRef.current = null;
-					}
-
-					// Use a small delay to prevent stuttering when moving the mouse quickly
-					animationTimerRef.current = setTimeout(() => {
-						rive.stop();
-						rive.play("folder-open");
-					}, 50);
-				}}
-				onMouseLeave={() => {
-					// Don't play mouse animations during drag operations
-					if (dragStateRef.current.isDragging) return;
-					if (!rive) return;
-
-					// Clear any pending animation timer
-					if (animationTimerRef.current) {
-						clearTimeout(animationTimerRef.current);
-						animationTimerRef.current = null;
-					}
-
-					// Use a small delay to prevent stuttering when moving the mouse quickly
-					animationTimerRef.current = setTimeout(() => {
-						rive.stop();
-						rive.play("folder-close");
-					}, 50);
-				}}
-				onDragOver={handleDragOver}
-				onDragLeave={handleDragLeave}
-				onDrop={handleDrop}
-				className={clsx(
-					"flex justify-between items-center px-4 py-4 w-full h-auto rounded-lg border transition-all duration-200 cursor-pointer bg-gray-3 hover:bg-gray-4 hover:border-gray-6",
-					isDragOver ? "border-blue-10 bg-gray-4" : "border-gray-5",
-					isMovingVideo && "opacity-70",
-				)}
-			>
-				<div className="flex flex-1 gap-3 items-center">
+			<div className="flex flex-1 gap-3 items-center">
+				<Link href={folderHref} prefetch={false} className="shrink-0">
 					<FolderRive
 						key={`${theme}folder${id}`}
 						className="w-[50px] h-[50px]"
 					/>
-					<div
-						onClick={(e) => {
-							e.preventDefault();
-							e.stopPropagation();
-						}}
-						className="flex flex-col justify-center h-10"
-					>
-						{isRenaming ? (
-							<textarea
-								ref={nameRef}
-								rows={1}
-								value={updateName}
-								onChange={(e) => setUpdateName(e.target.value)}
-								onBlur={() => {
+				</Link>
+				<div className="flex flex-col justify-center h-10">
+					{isRenaming ? (
+						<textarea
+							ref={nameRef}
+							rows={1}
+							value={updateName}
+							onClick={(e) => {
+								e.preventDefault();
+								e.stopPropagation();
+							}}
+							onChange={(e) => setUpdateName(e.target.value)}
+							onBlur={() => {
+								setIsRenaming(false);
+								if (updateName.trim() !== name)
+									updateFolder.mutate({
+										id,
+										name: updateName.trim(),
+									});
+							}}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
 									setIsRenaming(false);
 									if (updateName.trim() !== name)
 										updateFolder.mutate({
 											id,
 											name: updateName.trim(),
 										});
-								}}
-								onKeyDown={(e) => {
-									if (e.key === "Enter") {
-										setIsRenaming(false);
-										if (updateName.trim() !== name)
-											updateFolder.mutate({
-												id,
-												name: updateName.trim(),
-											});
-									}
-								}}
-								className="w-full resize-none bg-transparent border-none focus:outline-none
+								}
+							}}
+							className="w-full resize-none bg-transparent border-none focus:outline-none
                  focus:ring-0 focus:border-none text-gray-12 text-[15px] max-w-[116px] truncate p-0 m-0 h-[22px] leading-[22px] overflow-hidden font-normal tracking-normal"
-							/>
-						) : (
-							<div
-								onClick={(e) => {
-									e.preventDefault();
-									e.stopPropagation();
-									setIsRenaming(true);
-								}}
-							>
-								<p className="text-[15px] truncate text-gray-12 w-full max-w-[116px] m-0 p-0 h-[22px] leading-[22px] font-normal tracking-normal">
-									{updateName}
-								</p>
-							</div>
-						)}
+						/>
+					) : (
+						<Link
+							href={folderHref}
+							prefetch={false}
+							className="block text-left"
+						>
+							<span className="block text-[15px] truncate text-gray-12 w-full max-w-[116px] m-0 p-0 h-[22px] leading-[22px] font-normal tracking-normal">
+								{updateName}
+							</span>
+						</Link>
+					)}
+					<div className="flex gap-2 items-center">
 						<p className="text-sm truncate text-gray-10 w-fit">{`${videoCount} ${
 							videoCount === 1 ? "video" : "videos"
 						}`}</p>
+						{publicEnabled && (
+							<span className="inline-flex gap-1 items-center text-[11px] font-medium text-blue-9">
+								<FontAwesomeIcon icon={faGlobe} className="size-2.5" />
+								Public
+							</span>
+						)}
 					</div>
 				</div>
-				<ConfirmationDialog
-					loading={deleteFolder.isPending}
-					open={confirmDeleteFolderOpen}
-					icon={<FontAwesomeIcon icon={faTrash} />}
-					onConfirm={() => deleteFolder.mutate(id)}
-					onCancel={() => setConfirmDeleteFolderOpen(false)}
-					confirmLabel={deleteFolder.isPending ? "Deleting..." : "Delete"}
-					title="Delete Folder"
-					description={`Are you sure you want to delete the folder "${name}"? This action cannot be undone.`}
-				/>
-				<FoldersDropdown
-					id={id}
-					parentId={parentId}
-					setIsRenaming={setIsRenaming}
-					setConfirmDeleteFolderOpen={setConfirmDeleteFolderOpen}
-					nameRef={nameRef}
-				/>
 			</div>
-		</Link>
+			<ConfirmationDialog
+				loading={deleteFolder.isPending}
+				open={confirmDeleteFolderOpen}
+				icon={<FontAwesomeIcon icon={faTrash} />}
+				onConfirm={() => deleteFolder.mutate(id)}
+				onCancel={() => setConfirmDeleteFolderOpen(false)}
+				confirmLabel={deleteFolder.isPending ? "Deleting..." : "Delete"}
+				title="Delete Folder"
+				description={`Are you sure you want to delete the folder "${name}"? This action cannot be undone.`}
+			/>
+			<FoldersDropdown
+				id={id}
+				parentId={parentId}
+				public={publicEnabled}
+				setIsRenaming={setIsRenaming}
+				setConfirmDeleteFolderOpen={setConfirmDeleteFolderOpen}
+				nameRef={nameRef}
+				onPublicToggle={() => {
+					const nextPublic = !publicEnabled;
+					if (nextPublic && !ownerIsPro) {
+						setUpgradeModalOpen(true);
+						return;
+					}
+					setPublicEnabled(nextPublic);
+					updateFolder.mutate({
+						id,
+						public: nextPublic,
+					});
+				}}
+				onCopyPublicLink={async () => {
+					await copyPublicLink();
+				}}
+			/>
+		</fieldset>
 	);
 };
 

--- a/apps/web/app/(org)/dashboard/caps/components/FoldersDropdown.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/FoldersDropdown.tsx
@@ -5,7 +5,9 @@ import {
 	DropdownMenuTrigger,
 } from "@cap/ui";
 import {
+	faCopy,
 	faEllipsis,
+	faGlobe,
 	faPencil,
 	faTrash,
 } from "@fortawesome/free-solid-svg-icons";
@@ -18,89 +20,90 @@ interface FoldersDropdownProps {
 	setConfirmDeleteFolderOpen: (open: boolean) => void;
 	nameRef: RefObject<HTMLTextAreaElement | null>;
 	parentId?: string | null;
+	public: boolean;
+	onPublicToggle: () => void;
+	onCopyPublicLink: () => void;
 }
 
 export const FoldersDropdown = ({
 	setIsRenaming,
 	setConfirmDeleteFolderOpen,
 	nameRef,
+	public: isPublic,
+	onPublicToggle,
+	onCopyPublicLink,
 }: FoldersDropdownProps) => {
 	return (
-		<div
-			onClick={(e) => e.stopPropagation()}
-			onMouseEnter={(e) => e.stopPropagation()}
-			onMouseLeave={(e) => e.stopPropagation()}
-		>
-			<DropdownMenu>
-				<DropdownMenuTrigger asChild>
-					<div
-						className="flex justify-center items-center rounded-full border transition-colors duration-200
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					onClick={(e) => {
+						e.preventDefault();
+						e.stopPropagation();
+					}}
+					onMouseEnter={(e) => e.stopPropagation()}
+					onMouseLeave={(e) => e.stopPropagation()}
+					className="flex justify-center items-center rounded-full border transition-colors duration-200
             size-8 bg-gray-5 border-gray-7 hover:bg-gray-7 hover:border-gray-9 data-[state=open]:bg-gray-7 data-[state=open]:border-gray-9"
-					>
-						<FontAwesomeIcon
-							className="text-gray-12 size-4"
-							icon={faEllipsis}
-						/>
-					</div>
-				</DropdownMenuTrigger>
-				<DropdownMenuContent>
-					{(() => {
-						type FolderDropdownItem = {
-							label: string;
-							icon: any;
-							onClick: () => void | Promise<void>;
-						};
-						const items: FolderDropdownItem[] = [
-							{
-								label: "Rename",
-								icon: faPencil,
-								onClick: () => {
-									setIsRenaming(true);
-									setTimeout(() => {
-										nameRef.current?.focus();
-										nameRef.current?.select();
-									}, 0);
-								},
+				>
+					<FontAwesomeIcon className="text-gray-12 size-4" icon={faEllipsis} />
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent>
+				{(() => {
+					type FolderDropdownItem = {
+						label: string;
+						icon: typeof faPencil;
+						onClick: () => void | Promise<void>;
+					};
+					const items: FolderDropdownItem[] = [
+						{
+							label: "Rename",
+							icon: faPencil,
+							onClick: () => {
+								setIsRenaming(true);
+								setTimeout(() => {
+									nameRef.current?.focus();
+									nameRef.current?.select();
+								}, 0);
 							},
-							// Only show Duplicate if there is NO active space
-							// ...(!activeSpace
-							//   ? [
-							//       {
-							//         label: "Duplicate",
-							//         icon: faCopy,
-							//         onClick: async () => {
-							//           try {
-							//             await duplicateFolder(id, parentId);
-							//             toast.success("Folder duplicated successfully");
-							//           } catch (error) {
-							//             toast.error("Failed to duplicate folder");
-							//           }
-							//         },
-							//       },
-							//     ]
-							//   : []),
-							{
-								label: "Delete",
-								icon: faTrash,
-								onClick: () => setConfirmDeleteFolderOpen(true),
-							},
-						];
-						return items.map((item) => (
-							<DropdownMenuItem
-								key={item.label}
-								onClick={item.onClick}
-								className="rounded-lg"
-							>
-								<FontAwesomeIcon
-									className="mr-1.5 text-gray-10 size-3"
-									icon={item.icon}
-								/>
-								{item.label}
-							</DropdownMenuItem>
-						));
-					})()}
-				</DropdownMenuContent>
-			</DropdownMenu>
-		</div>
+						},
+						{
+							label: isPublic ? "Make private" : "Make public",
+							icon: faGlobe,
+							onClick: onPublicToggle,
+						},
+						...(isPublic
+							? [
+									{
+										label: "Copy public link",
+										icon: faCopy,
+										onClick: onCopyPublicLink,
+									},
+								]
+							: []),
+						{
+							label: "Delete",
+							icon: faTrash,
+							onClick: () => setConfirmDeleteFolderOpen(true),
+						},
+					];
+					return items.map((item) => (
+						<DropdownMenuItem
+							key={item.label}
+							onClick={item.onClick}
+							className="rounded-lg"
+						>
+							<FontAwesomeIcon
+								className="mr-1.5 text-gray-10 size-3"
+								icon={item.icon}
+							/>
+							{item.label}
+						</DropdownMenuItem>
+					));
+				})()}
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 };

--- a/apps/web/app/(org)/dashboard/caps/components/NewFolderDialog.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/NewFolderDialog.tsx
@@ -19,6 +19,8 @@ import { useRouter } from "next/navigation";
 import React, { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useEffectMutation, useRpcClient } from "@/lib/EffectRuntime";
+import { PublicCollectionField } from "../../_components/PublicCollectionField";
+import { useDashboardContext } from "../../Contexts";
 import {
 	BlueFolder,
 	type FolderHandle,
@@ -77,6 +79,8 @@ export const NewFolderDialog: React.FC<Props> = ({
 		(typeof FolderOptions)[number]["value"] | null
 	>(null);
 	const [folderName, setFolderName] = useState<string>("");
+	const [publicEnabled, setPublicEnabled] = useState(false);
+	const { activeOrganization, setUpgradeModalOpen } = useDashboardContext();
 	const router = useRouter();
 
 	const { riveFile } = useRiveFile({
@@ -84,7 +88,10 @@ export const NewFolderDialog: React.FC<Props> = ({
 	});
 
 	useEffect(() => {
-		if (!open) setSelectedColor(null);
+		if (!open) {
+			setSelectedColor(null);
+			setPublicEnabled(false);
+		}
 	}, [open]);
 
 	const folderRefs = useRef(
@@ -103,10 +110,15 @@ export const NewFolderDialog: React.FC<Props> = ({
 	const rpc = useRpcClient();
 
 	const createFolder = useEffectMutation({
-		mutationFn: (data: { name: string; color: Folder.FolderColor }) =>
+		mutationFn: (data: {
+			name: string;
+			color: Folder.FolderColor;
+			public: boolean;
+		}) =>
 			rpc.FolderCreate({
 				name: data.name,
 				color: data.color,
+				public: data.public,
 				spaceId: Option.fromNullable(spaceId),
 				parentId: Option.none(),
 			}),
@@ -140,7 +152,8 @@ export const NewFolderDialog: React.FC<Props> = ({
 					<div className="flex flex-wrap gap-2 mt-3">
 						{FolderOptions.map((option) => {
 							return (
-								<div
+								<button
+									type="button"
 									className={clsx(
 										"flex flex-col flex-1 gap-1 items-center p-2 rounded-xl border transition-colors duration-200 cursor-pointer",
 										selectedColor === option.value
@@ -172,10 +185,19 @@ export const NewFolderDialog: React.FC<Props> = ({
 										riveFile as RiveFile,
 										folderRefs.current[option.value],
 									)}
-									<p className="text-xs text-gray-10">{option.label}</p>
-								</div>
+									<span className="text-xs text-gray-10">{option.label}</span>
+								</button>
 							);
 						})}
+					</div>
+					<div className="mt-4">
+						<PublicCollectionField
+							kind="folder"
+							enabled={publicEnabled}
+							onChange={setPublicEnabled}
+							isPro={Boolean(activeOrganization?.ownerIsPro)}
+							onUpgrade={() => setUpgradeModalOpen(true)}
+						/>
 					</div>
 				</div>
 				<DialogFooter>
@@ -185,7 +207,11 @@ export const NewFolderDialog: React.FC<Props> = ({
 					<Button
 						onClick={() => {
 							if (selectedColor === null) return;
-							createFolder.mutate({ name: folderName, color: selectedColor });
+							createFolder.mutate({
+								name: folderName,
+								color: selectedColor,
+								public: publicEnabled,
+							});
 						}}
 						size="sm"
 						spinner={createFolder.isPending}

--- a/apps/web/app/(org)/dashboard/caps/page.tsx
+++ b/apps/web/app/(org)/dashboard/caps/page.tsx
@@ -226,6 +226,7 @@ export default async function CapsPage(props: PageProps<"/dashboard/caps">) {
 			id: folders.id,
 			name: folders.name,
 			color: folders.color,
+			public: folders.public,
 			parentId: folders.parentId,
 			videoCount: sql<number>`(
         SELECT COUNT(*) FROM videos WHERE videos.folderId = folders.id

--- a/apps/web/app/(org)/dashboard/dashboard-data.ts
+++ b/apps/web/app/(org)/dashboard/dashboard-data.ts
@@ -10,6 +10,7 @@ import {
 	users,
 	videos,
 } from "@cap/database/schema";
+import { userIsPro } from "@cap/utils";
 import { Database, ImageUploads } from "@cap/web-backend";
 import type { ImageUpload } from "@cap/web-domain";
 import { and, count, eq, inArray, isNull, or, sql } from "drizzle-orm";
@@ -43,6 +44,8 @@ export type Organization = {
 	invites: (typeof organizationInvites.$inferSelect)[];
 	inviteQuota: number;
 	totalInvites: number;
+	/** Whether the organization OWNER is on Pro — gates org-wide Pro features. */
+	ownerIsPro: boolean;
 };
 
 export type OrganizationSettings = NonNullable<
@@ -191,6 +194,7 @@ export async function getDashboardData(user: typeof userSelectProps) {
 								id: spaces.id,
 								primary: spaces.primary,
 								privacy: spaces.privacy,
+								public: spaces.public,
 								name: spaces.name,
 								description: spaces.description,
 								organizationId: spaces.organizationId,
@@ -306,6 +310,7 @@ export async function getDashboardData(user: typeof userSelectProps) {
 						videoCount: orgVideoCount,
 						settings: null,
 						hasPassword: false,
+						public: false,
 						currentUserRole: currentOrganizationRole,
 						currentUserCanManage: canManageOrganizationMembers(
 							currentOrganizationRole,
@@ -358,6 +363,8 @@ export async function getDashboardData(user: typeof userSelectProps) {
 								inviteQuota: users.inviteQuota,
 								stripeSubscriptionId: users.stripeSubscriptionId,
 								stripeSubscriptionStatus: users.stripeSubscriptionStatus,
+								thirdPartyStripeSubscriptionId:
+									users.thirdPartyStripeSubscriptionId,
 							})
 							.from(users)
 							.where(inArray(users.id, managerIds)),
@@ -455,6 +462,7 @@ export async function getDashboardData(user: typeof userSelectProps) {
 						),
 						inviteQuota: proSeatProvider?.inviteQuota || 1,
 						totalInvites,
+						ownerIsPro: userIsPro(owner ?? null),
 					};
 				}),
 			),

--- a/apps/web/app/(org)/dashboard/folder/[id]/components/SubfolderDialog.tsx
+++ b/apps/web/app/(org)/dashboard/folder/[id]/components/SubfolderDialog.tsx
@@ -20,6 +20,7 @@ import { useRouter } from "next/navigation";
 import React, { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useEffectMutation, useRpcClient } from "@/lib/EffectRuntime";
+import { PublicCollectionField } from "../../../_components/PublicCollectionField";
 import { useDashboardContext } from "../../../Contexts";
 import {
 	BlueFolder,
@@ -79,7 +80,9 @@ export const SubfolderDialog: React.FC<Props> = ({
 		(typeof FolderOptions)[number]["value"] | null
 	>(null);
 	const [folderName, setFolderName] = useState<string>("");
-	const { activeSpace } = useDashboardContext();
+	const [publicEnabled, setPublicEnabled] = useState(false);
+	const { activeSpace, activeOrganization, setUpgradeModalOpen } =
+		useDashboardContext();
 	const router = useRouter();
 
 	const { riveFile } = useRiveFile({
@@ -90,6 +93,7 @@ export const SubfolderDialog: React.FC<Props> = ({
 		if (!open) {
 			setSelectedColor(null);
 			setFolderName("");
+			setPublicEnabled(false);
 		}
 	}, [open]);
 
@@ -109,10 +113,15 @@ export const SubfolderDialog: React.FC<Props> = ({
 	const rpc = useRpcClient();
 
 	const createSubfolder = useEffectMutation({
-		mutationFn: (data: { name: string; color: Folder.FolderColor }) =>
+		mutationFn: (data: {
+			name: string;
+			color: Folder.FolderColor;
+			public: boolean;
+		}) =>
 			rpc.FolderCreate({
 				name: data.name,
 				color: data.color,
+				public: data.public,
 				spaceId: Option.fromNullable(activeSpace?.id),
 				parentId: Option.some(parentFolderId),
 			}),
@@ -146,7 +155,8 @@ export const SubfolderDialog: React.FC<Props> = ({
 					<div className="flex flex-wrap gap-2 mt-3">
 						{FolderOptions.map((option) => {
 							return (
-								<div
+								<button
+									type="button"
 									className={clsx(
 										"flex flex-col flex-1 gap-1 items-center p-2 rounded-xl border transition-colors duration-200 cursor-pointer",
 										selectedColor === option.value
@@ -178,10 +188,19 @@ export const SubfolderDialog: React.FC<Props> = ({
 										riveFile as RiveFile,
 										folderRefs.current[option.value],
 									)}
-									<p className="text-xs text-gray-10">{option.label}</p>
-								</div>
+									<span className="text-xs text-gray-10">{option.label}</span>
+								</button>
 							);
 						})}
+					</div>
+					<div className="mt-4">
+						<PublicCollectionField
+							kind="folder"
+							enabled={publicEnabled}
+							onChange={setPublicEnabled}
+							isPro={Boolean(activeOrganization?.ownerIsPro)}
+							onUpgrade={() => setUpgradeModalOpen(true)}
+						/>
 					</div>
 				</div>
 				<DialogFooter>
@@ -194,6 +213,7 @@ export const SubfolderDialog: React.FC<Props> = ({
 							createSubfolder.mutate({
 								name: folderName,
 								color: selectedColor,
+								public: publicEnabled,
 							});
 						}}
 						size="sm"

--- a/apps/web/app/(org)/dashboard/folder/[id]/page.tsx
+++ b/apps/web/app/(org)/dashboard/folder/[id]/page.tsx
@@ -7,10 +7,13 @@ import { notFound } from "next/navigation";
 import {
 	getChildFolders,
 	getFolderBreadcrumb,
+	getFolderById,
 	getVideosByFolderId,
 } from "@/lib/folder";
+import { isOrganizationOwnerPro } from "@/lib/org-pro";
 import { runPromise } from "@/lib/server";
 
+import { CollectionShareControl } from "../../_components/CollectionShareControl";
 import { UploadCapButton } from "../../caps/components";
 import FolderCard from "../../caps/components/Folder";
 import { WebRecorderDialog } from "../../caps/components/web-recorder-dialog/web-recorder-dialog";
@@ -29,13 +32,30 @@ const FolderPage = async (props: PageProps<"/dashboard/folder/[id]">) => {
 	if (!user || !user.activeOrganizationId) return notFound();
 
 	return Effect.gen(function* () {
-		const [childFolders, breadcrumb, videosData] = yield* Effect.all([
-			getChildFolders(folderId, { variant: "user" }),
-			getFolderBreadcrumb(folderId),
-			getVideosByFolderId(folderId, {
-				variant: "user",
-			}),
-		]);
+		const [childFolders, breadcrumb, videosData, share] = yield* Effect.all(
+			[
+				getChildFolders(folderId, { variant: "user" }),
+				getFolderBreadcrumb(folderId),
+				getVideosByFolderId(folderId, {
+					variant: "user",
+				}),
+				Effect.gen(function* () {
+					const folder = yield* getFolderById(folderId);
+					// Mirrors FoldersPolicy.canEdit for personal folders: only the
+					// creator may manage sharing; the Pro gate uses the folder's own
+					// organization, which is what the server enforces on writes.
+					const canManage =
+						folder.spaceId === null && folder.createdById === user.id;
+					const ownerIsPro = canManage
+						? yield* Effect.promise(() =>
+								isOrganizationOwnerPro(folder.organizationId),
+							)
+						: false;
+					return { folder, canManage, ownerIsPro };
+				}),
+			],
+			{ concurrency: "unbounded" },
+		);
 
 		return (
 			<div>
@@ -43,8 +63,20 @@ const FolderPage = async (props: PageProps<"/dashboard/folder/[id]">) => {
 					<NewSubfolderButton parentFolderId={folderId} />
 					<UploadCapButton size="sm" />
 					<WebRecorderDialog />
+					<CollectionShareControl
+						kind="folder"
+						collectionId={folderId}
+						isPublic={share.folder.public}
+						canManage={share.canManage}
+						isPro={share.ownerIsPro}
+						settings={
+							share.canManage
+								? (share.folder.settings?.publicPage ?? null)
+								: null
+						}
+					/>
 				</div>
-				<div className="flex justify-between items-center mb-6 w-full">
+				<div className="flex flex-wrap gap-3 items-center mb-6 w-full">
 					<div className="flex overflow-x-auto items-center font-medium">
 						<ClientMyCapsLink />
 
@@ -74,6 +106,7 @@ const FolderPage = async (props: PageProps<"/dashboard/folder/[id]">) => {
 									key={folder.id}
 									name={folder.name}
 									color={folder.color}
+									public={folder.public}
 									id={folder.id}
 									parentId={folder.parentId}
 									videoCount={folder.videoCount}

--- a/apps/web/app/(org)/dashboard/spaces/[spaceId]/SharedCaps.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/[spaceId]/SharedCaps.tsx
@@ -6,6 +6,7 @@ import type { SpaceRuleSource, ViewerSettingKey } from "@cap/web-backend";
 import type {
 	ImageUpload,
 	Organisation,
+	PublicCollection,
 	Space,
 	User,
 	Video,
@@ -16,7 +17,7 @@ import {
 	faInfoCircle,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import {
 	canManageOrganizationMembers,
@@ -25,6 +26,7 @@ import {
 	getEffectiveSpaceRole,
 } from "@/lib/permissions/roles";
 import { useVideosAnalyticsQuery } from "@/lib/Queries/Analytics";
+import { CollectionShareControl } from "../../_components/CollectionShareControl";
 import SpaceDialog from "../../_components/Navbar/SpaceDialog";
 import { useDashboardContext } from "../../Contexts";
 import { CapPagination } from "../../caps/components/CapPagination";
@@ -74,8 +76,13 @@ type SpaceData = {
 	organizationId: Organisation.OrganisationId;
 	createdById: User.UserId;
 	iconUrl?: ImageUpload.ImageUrl | null;
-	settings?: Partial<Record<ViewerSettingKey, boolean>> | null;
+	settings?:
+		| (Partial<Record<ViewerSettingKey, boolean>> & {
+				publicPage?: PublicCollection.PublicPageSettings;
+		  })
+		| null;
 	hasPassword?: boolean;
+	public?: boolean;
 };
 
 export const SharedCaps = ({
@@ -107,6 +114,7 @@ export const SharedCaps = ({
 	};
 }) => {
 	const params = useSearchParams();
+	const pathname = usePathname();
 	const router = useRouter();
 	const page = Number(params.get("page")) || 1;
 	const { activeOrganization } = useDashboardContext();
@@ -183,7 +191,21 @@ export const SharedCaps = ({
 				iconUrl: spaceData.iconUrl ?? undefined,
 				settings: spaceData.settings ?? null,
 				hasPassword: spaceData.hasPassword,
+				public: spaceData.public,
 			}}
+		/>
+	) : null;
+
+	const collectionShareControl = spaceData ? (
+		<CollectionShareControl
+			kind="space"
+			collectionId={spaceData.id}
+			isPublic={Boolean(spaceData.public)}
+			canManage={canManageCurrentSpace}
+			isPro={Boolean(activeOrganization?.ownerIsPro)}
+			settings={
+				canManageCurrentSpace ? (spaceData.settings?.publicPage ?? null) : null
+			}
 		/>
 	) : null;
 
@@ -211,6 +233,7 @@ export const SharedCaps = ({
 									Space settings
 								</Button>
 							)}
+							{collectionShareControl}
 							<MembersIndicator
 								memberCount={spaceMemberCount}
 								members={spaceMembers}
@@ -325,6 +348,7 @@ export const SharedCaps = ({
 								Space settings
 							</Button>
 						)}
+						{collectionShareControl}
 						<MembersIndicator
 							memberCount={spaceMemberCount}
 							members={spaceMembers}
@@ -422,7 +446,13 @@ export const SharedCaps = ({
 					</div>
 					{(data.length > limit || data.length === limit || page !== 1) && (
 						<div className="mt-4">
-							<CapPagination currentPage={page} totalPages={totalPages} />
+							<CapPagination
+								currentPage={page}
+								totalPages={totalPages}
+								hrefForPage={(targetPage) =>
+									targetPage <= 1 ? pathname : `${pathname}?page=${targetPage}`
+								}
+							/>
 						</div>
 					)}
 				</>

--- a/apps/web/app/(org)/dashboard/spaces/[spaceId]/folder/[folderId]/page.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/[spaceId]/folder/[folderId]/page.tsx
@@ -1,15 +1,21 @@
 import { getCurrentUser } from "@cap/database/auth/session";
 import { serverEnv } from "@cap/env";
 import { makeCurrentUserLayer, Spaces } from "@cap/web-backend";
-import { type Folder, Space } from "@cap/web-domain";
+import { type Folder, type Organisation, Space } from "@cap/web-domain";
 import { Effect } from "effect";
 import { notFound } from "next/navigation";
+import { getOrganizationAccess } from "@/actions/organization/authorization";
+import { getSpaceAccess } from "@/actions/organization/space-authorization";
+import { CollectionShareControl } from "@/app/(org)/dashboard/_components/CollectionShareControl";
 import FolderCard from "@/app/(org)/dashboard/caps/components/Folder";
 import {
 	getChildFolders,
 	getFolderBreadcrumb,
+	getFolderById,
 	getVideosByFolderId,
 } from "@/lib/folder";
+import { isOrganizationOwnerPro } from "@/lib/org-pro";
+import { canManageSpace } from "@/lib/permissions/roles";
 import { runPromise } from "@/lib/server";
 import {
 	BreadcrumbItem,
@@ -36,21 +42,66 @@ const FolderPage = async (props: {
 		);
 		if (!spaceOrOrg) notFound();
 
-		const [childFolders, breadcrumb, videosData] = yield* Effect.all([
-			getChildFolders(
-				params.folderId,
-				spaceOrOrg.variant === "space"
-					? { variant: "space", spaceId: spaceOrOrg.space.id }
-					: { variant: "org", organizationId: spaceOrOrg.organization.id },
-			),
-			getFolderBreadcrumb(params.folderId),
-			getVideosByFolderId(
-				params.folderId,
-				spaceOrOrg.variant === "space"
-					? { variant: "space", spaceId: spaceOrOrg.space.id }
-					: { variant: "org", organizationId: spaceOrOrg.organization.id },
-			),
-		]);
+		const orgId: Organisation.OrganisationId =
+			spaceOrOrg.variant === "space"
+				? spaceOrOrg.space.organizationId
+				: spaceOrOrg.organization.id;
+
+		const spaceManagementAccess =
+			spaceOrOrg.variant === "space"
+				? Effect.promise(() => getSpaceAccess(user.id, spaceOrOrg.space.id))
+				: Effect.succeed(null);
+		const orgManagementAccess =
+			spaceOrOrg.variant === "space"
+				? Effect.succeed(null)
+				: Effect.promise(() => getOrganizationAccess(user.id, orgId));
+
+		const [
+			childFolders,
+			breadcrumb,
+			videosData,
+			currentFolder,
+			ownerIsPro,
+			managementAccess,
+			orgAccess,
+		] = yield* Effect.all(
+			[
+				getChildFolders(
+					params.folderId,
+					spaceOrOrg.variant === "space"
+						? { variant: "space", spaceId: spaceOrOrg.space.id }
+						: { variant: "org", organizationId: spaceOrOrg.organization.id },
+				),
+				getFolderBreadcrumb(params.folderId),
+				getVideosByFolderId(
+					params.folderId,
+					spaceOrOrg.variant === "space"
+						? { variant: "space", spaceId: spaceOrOrg.space.id }
+						: { variant: "org", organizationId: spaceOrOrg.organization.id },
+				),
+				getFolderById(params.folderId),
+				Effect.promise(() => isOrganizationOwnerPro(orgId)),
+				spaceManagementAccess,
+				orgManagementAccess,
+			],
+			// Independent reads — without this, Effect.all runs them sequentially
+			// and every page view pays the roundtrips back to back.
+			{ concurrency: "unbounded" },
+		);
+		// Mirrors FoldersPolicy.canEdit so the share control is only shown to
+		// users the server would actually allow: space folders need space/org
+		// management; org-wide folders need org management. The folder must also
+		// actually belong to the routed space/org — getFolderById is unscoped,
+		// so a foreign folderId must not surface another collection's settings.
+		const folderBelongsToContext = currentFolder.spaceId === params.spaceId;
+		const canManageCollection =
+			folderBelongsToContext &&
+			(spaceOrOrg.variant === "space"
+				? Boolean(managementAccess?.canManage)
+				: canManageSpace({
+						organizationRole: orgAccess?.role,
+						spaceRole: null,
+					}));
 
 		return (
 			<div>
@@ -61,8 +112,20 @@ const FolderPage = async (props: {
 						spaceId={params.spaceId}
 						folderName={breadcrumb[breadcrumb.length - 1]?.name ?? "Folder"}
 					/>
+					<CollectionShareControl
+						kind="folder"
+						collectionId={params.folderId}
+						isPublic={currentFolder.public}
+						canManage={canManageCollection}
+						isPro={ownerIsPro}
+						settings={
+							canManageCollection
+								? (currentFolder.settings?.publicPage ?? null)
+								: null
+						}
+					/>
 				</div>
-				<div className="flex justify-between items-center mb-6 w-full">
+				<div className="flex flex-wrap gap-3 items-center mb-6 w-full">
 					<div className="flex overflow-x-auto items-center font-medium">
 						<ClientMyCapsLink spaceId={params.spaceId} />
 						{breadcrumb.map((folder, index) => (
@@ -79,7 +142,6 @@ const FolderPage = async (props: {
 						))}
 					</div>
 				</div>
-				{/* Display Child Folders */}
 				{childFolders.length > 0 && (
 					<>
 						<h1 className="mb-6 text-xl font-medium text-gray-12">
@@ -91,6 +153,7 @@ const FolderPage = async (props: {
 									key={folder.id}
 									name={folder.name}
 									color={folder.color}
+									public={folder.public}
 									spaceId={params.spaceId}
 									id={folder.id}
 									parentId={folder.parentId}
@@ -100,7 +163,6 @@ const FolderPage = async (props: {
 						</div>
 					</>
 				)}
-				{/* Display Videos */}
 				<FolderVideosSection
 					initialVideos={videosData}
 					analyticsEnabled={Boolean(

--- a/apps/web/app/(org)/dashboard/spaces/[spaceId]/page.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/[spaceId]/page.tsx
@@ -58,6 +58,7 @@ async function fetchFolders(
 			id: folders.id,
 			name: folders.name,
 			color: folders.color,
+			public: folders.public,
 			parentId: folders.parentId,
 			spaceId: folders.spaceId,
 			videoCount: sql<number>`(

--- a/apps/web/app/(org)/dashboard/spaces/browse/page.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/browse/page.tsx
@@ -183,6 +183,9 @@ export default function BrowseSpacesPage() {
 																(m: { user: { id: string } }) => m.user.id,
 															),
 															iconUrl: space.iconUrl ?? undefined,
+															settings: space.settings,
+															hasPassword: space.hasPassword,
+															public: space.public,
 														});
 														setShowSpaceDialog(true);
 													}}

--- a/apps/web/app/c/[id]/CollectionCopyLinkButton.tsx
+++ b/apps/web/app/c/[id]/CollectionCopyLinkButton.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Button } from "@cap/ui";
+import { faLink } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { toast } from "sonner";
+
+export function CollectionCopyLinkButton() {
+	return (
+		<Button
+			type="button"
+			variant="gray"
+			size="sm"
+			onClick={async () => {
+				try {
+					await navigator.clipboard.writeText(
+						window.location.origin + window.location.pathname,
+					);
+					toast.success("Link copied");
+				} catch {
+					toast.error("Failed to copy link");
+				}
+			}}
+		>
+			<FontAwesomeIcon icon={faLink} className="size-3" />
+			Copy link
+		</Button>
+	);
+}

--- a/apps/web/app/c/[id]/CollectionPasswordOverlay.tsx
+++ b/apps/web/app/c/[id]/CollectionPasswordOverlay.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Button, Dialog, DialogContent, Input, Logo } from "@cap/ui";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { useId, useState } from "react";
+import { toast } from "sonner";
+import { verifyCollectionPassword } from "@/actions/collections/password";
+import type { SharePageBranding } from "@/lib/share-branding";
+
+export function CollectionPasswordOverlay({
+	collectionId,
+	collectionName,
+	organizationName,
+	branding,
+	isOpen,
+}: {
+	collectionId: string;
+	collectionName: string;
+	organizationName: string;
+	branding: SharePageBranding | null;
+	isOpen: boolean;
+}) {
+	const [password, setPassword] = useState("");
+	const passwordInputId = useId();
+	const router = useRouter();
+
+	const verifyPassword = useMutation({
+		mutationFn: () =>
+			verifyCollectionPassword(collectionId, password).then((value) => {
+				if (value.success) return value.value;
+				throw new Error(value.error);
+			}),
+		onSuccess: (result) => {
+			toast.success(result);
+			router.refresh();
+		},
+		onError: (error) => {
+			toast.error(error.message);
+		},
+	});
+
+	return (
+		<Dialog open={isOpen}>
+			<DialogContent className="w-[95vw] max-w-sm p-4 sm:max-w-md sm:p-6 md:p-8">
+				<div className="flex flex-col items-center space-y-4 sm:space-y-6">
+					<div className="flex flex-col items-center space-y-3 text-center sm:space-y-4">
+						{branding?.type === "custom" ? (
+							// biome-ignore lint/performance/noImgElement: arbitrary org-uploaded icon
+							<img
+								src={branding.imageUrl}
+								alt={branding.name}
+								className="h-auto max-h-14 w-auto max-w-[160px] object-contain"
+							/>
+						) : branding?.type === "cap" ? (
+							<Logo className="w-16 h-auto sm:w-20 md:w-24" />
+						) : null}
+						<div className="space-y-2">
+							<h2 className="text-lg font-semibold text-gray-12 sm:text-xl">
+								{collectionName}
+							</h2>
+							<p className="max-w-xs px-2 text-xs text-gray-10 sm:max-w-sm sm:px-0 sm:text-sm">
+								This collection from {organizationName} is password protected.
+								Enter the password to continue.
+							</p>
+						</div>
+					</div>
+
+					<div className="space-y-3 w-full sm:space-y-4">
+						<div className="space-y-2">
+							<label
+								htmlFor={passwordInputId}
+								className="text-sm font-medium text-gray-12"
+							>
+								Password
+							</label>
+							<Input
+								id={passwordInputId}
+								type="password"
+								value={password}
+								onChange={(event) => setPassword(event.target.value)}
+								placeholder="Enter password"
+								className="w-full"
+								autoFocus
+								onKeyDown={(event) => {
+									if (
+										event.key === "Enter" &&
+										password.trim() &&
+										!verifyPassword.isPending
+									)
+										verifyPassword.mutate();
+								}}
+							/>
+						</div>
+						<Button
+							type="button"
+							variant="dark"
+							size="lg"
+							className="w-full"
+							spinner={verifyPassword.isPending}
+							disabled={verifyPassword.isPending || !password.trim()}
+							onClick={() => verifyPassword.mutate()}
+						>
+							{verifyPassword.isPending ? "Verifying..." : "Access collection"}
+						</Button>
+					</div>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/app/c/[id]/page.tsx
+++ b/apps/web/app/c/[id]/page.tsx
@@ -1,0 +1,463 @@
+import { buttonVariants, Logo } from "@cap/ui";
+import {
+	faArrowLeft,
+	faArrowUpRightFromSquare,
+	faFolder,
+	faLock,
+	faVideo,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { ReactNode } from "react";
+import { PublicCapCard } from "@/components/PublicCapCard";
+import {
+	GRID_COLUMN_CLASS,
+	sanitizeCtaUrl,
+} from "@/lib/public-collection-settings";
+import {
+	getPublicCollectionMetadata,
+	getPublicCollectionPageData,
+	type PublicCollection,
+	type PublicCollectionFolder,
+} from "@/lib/public-collections";
+import {
+	getPublicCollectionHref,
+	parsePublicCollectionPage,
+} from "@/lib/public-collections-policy";
+import type { SharePageBranding } from "@/lib/share-branding";
+import { CapPagination } from "../../(org)/dashboard/caps/components/CapPagination";
+import { CollectionCopyLinkButton } from "./CollectionCopyLinkButton";
+import { CollectionPasswordOverlay } from "./CollectionPasswordOverlay";
+
+export async function generateMetadata(
+	props: PageProps<"/c/[id]">,
+): Promise<Metadata> {
+	const params = await props.params;
+	const collection = await getPublicCollectionMetadata(params.id);
+
+	if (!collection) notFound();
+
+	const title = collection.publicPage.title.trim() || collection.name;
+	const description =
+		collection.publicPage.subtitle.trim() ||
+		collection.description?.trim() ||
+		`View public videos in ${title} on Cap.`;
+
+	return {
+		title: `${title} | Cap Collection`,
+		description,
+		robots: "noindex, nofollow",
+	};
+}
+
+function resolveBranding(
+	collection: PublicCollection,
+): SharePageBranding | null {
+	const { logoMode } = collection.publicPage;
+
+	if (logoMode === "none") return null;
+
+	if (logoMode === "custom" && collection.collectionLogoUrl) {
+		return {
+			type: "custom",
+			imageUrl: collection.collectionLogoUrl,
+			name: collection.organizationName,
+		};
+	}
+
+	if (logoMode === "organization" && collection.organizationIconUrl) {
+		return {
+			type: "custom",
+			imageUrl: collection.organizationIconUrl,
+			name: collection.organizationName,
+		};
+	}
+
+	return { type: "cap" };
+}
+
+function BrandingMark({
+	branding,
+	className,
+}: {
+	branding: SharePageBranding;
+	className?: string;
+}) {
+	if (branding.type === "custom") {
+		return (
+			// biome-ignore lint/performance/noImgElement: arbitrary org-uploaded icon
+			<img
+				src={branding.imageUrl}
+				alt={branding.name}
+				className={className ?? "h-7 w-auto max-w-[160px] object-contain"}
+			/>
+		);
+	}
+	return <Logo className={className ?? "h-7 w-auto"} />;
+}
+
+export default async function PublicCollectionPage(
+	props: PageProps<"/c/[id]">,
+) {
+	const params = await props.params;
+	const searchParams = await props.searchParams;
+	const page = parsePublicCollectionPage(searchParams.page);
+	const data = await getPublicCollectionPageData(params.id, page);
+
+	if (!data) notFound();
+
+	const branding = resolveBranding(data.collection);
+
+	if (data.access.state === "email_restriction_login_required") {
+		return (
+			<CollectionAccessView
+				branding={branding}
+				title="This collection requires sign-in"
+				description={
+					<>
+						The owner has restricted access. Please{" "}
+						<Link href="/login" className="text-gray-12 underline">
+							sign in
+						</Link>{" "}
+						with an authorized email address to view.
+					</>
+				}
+			/>
+		);
+	}
+
+	if (data.access.state === "email_restriction_denied") {
+		return (
+			<CollectionAccessView
+				branding={branding}
+				title="Access restricted"
+				description="Your email address does not meet the requirements set by this collection owner."
+			/>
+		);
+	}
+
+	const isPasswordRequired = data.access.state === "password_required";
+	const showCopyLink =
+		!isPasswordRequired && !data.collection.publicPage.hideCopyLink;
+	const showHeader = Boolean(branding) || showCopyLink;
+
+	return (
+		<div className="flex flex-col min-h-screen bg-gray-2 text-gray-12">
+			<CollectionPasswordOverlay
+				collectionId={data.collection.id}
+				collectionName={data.collection.name}
+				organizationName={data.collection.organizationName}
+				branding={branding}
+				isOpen={isPasswordRequired}
+			/>
+			{data.viewerIsSignedIn && (
+				<div className="border-b border-gray-4 bg-gray-1">
+					<div className="flex items-center px-4 mx-auto max-w-7xl h-11 sm:px-6 lg:px-8">
+						<Link
+							href="/dashboard/caps"
+							className="inline-flex gap-1.5 items-center text-[13px] transition-colors text-gray-10 hover:text-gray-12"
+						>
+							<FontAwesomeIcon icon={faArrowLeft} className="size-3" />
+							Back to dashboard
+						</Link>
+					</div>
+				</div>
+			)}
+			{showHeader && (
+				<header className="sticky top-0 z-30 border-b backdrop-blur-md border-gray-4 bg-gray-1/85">
+					<div className="flex justify-between items-center px-4 mx-auto max-w-7xl h-16 sm:px-6 lg:px-8">
+						{branding ? (
+							branding.type === "cap" ? (
+								<Link href="/?ref=collection" aria-label="Cap home">
+									<BrandingMark branding={branding} />
+								</Link>
+							) : (
+								<BrandingMark branding={branding} />
+							)
+						) : (
+							<span />
+						)}
+						{showCopyLink && <CollectionCopyLinkButton />}
+					</div>
+				</header>
+			)}
+
+			<main className="flex-1 px-4 py-10 mx-auto w-full max-w-7xl sm:px-6 lg:px-8 sm:py-12">
+				<CollectionHero
+					collection={data.collection}
+					videoCount={data.totalCount}
+					folderCount={data.folders.length}
+				/>
+
+				{isPasswordRequired ? (
+					<CollectionStateCard
+						icon={faLock}
+						title="Password required"
+						description="Enter the collection password to view its public videos."
+					/>
+				) : (
+					<CollectionContent data={data} />
+				)}
+			</main>
+
+			<CollectionFooter
+				showPoweredBy={data.collection.publicPage.logoMode !== "none"}
+			/>
+		</div>
+	);
+}
+
+function CollectionHero({
+	collection,
+	videoCount,
+	folderCount,
+}: {
+	collection: PublicCollection;
+	videoCount: number;
+	folderCount: number;
+}) {
+	const { publicPage } = collection;
+
+	const title = publicPage.title.trim() || collection.name;
+	const subtitle =
+		publicPage.subtitle.trim() || collection.description?.trim() || "";
+	const ctaLabel = publicPage.ctaLabel.trim();
+	const ctaUrl = sanitizeCtaUrl(publicPage.ctaUrl);
+
+	const metaParts = [collection.organizationName];
+	if (videoCount > 0)
+		metaParts.push(`${videoCount} ${videoCount === 1 ? "video" : "videos"}`);
+	if (folderCount > 0)
+		metaParts.push(
+			`${folderCount} ${folderCount === 1 ? "folder" : "folders"}`,
+		);
+
+	return (
+		<section className="pb-8 mb-10 border-b border-gray-4">
+			<div className="max-w-2xl">
+				{!publicPage.hideTitle && (
+					<h1 className="text-3xl font-semibold tracking-tight text-gray-12 sm:text-4xl">
+						{title}
+					</h1>
+				)}
+				{subtitle && (
+					<p className="mt-3 text-base leading-7 text-gray-11">{subtitle}</p>
+				)}
+				<p className="mt-3 text-sm text-gray-10">{metaParts.join(" · ")}</p>
+				{ctaLabel && ctaUrl && (
+					<a
+						href={ctaUrl}
+						target="_blank"
+						rel="noreferrer"
+						className={buttonVariants({
+							variant: "blue",
+							size: "sm",
+							className: "mt-6 w-fit",
+						})}
+					>
+						{ctaLabel}
+						<FontAwesomeIcon
+							icon={faArrowUpRightFromSquare}
+							className="size-3"
+						/>
+					</a>
+				)}
+			</div>
+		</section>
+	);
+}
+
+function CollectionContent({
+	data,
+}: {
+	data: NonNullable<Awaited<ReturnType<typeof getPublicCollectionPageData>>>;
+}) {
+	const renderedAt = Date.now();
+	const hasContent = data.folders.length > 0 || data.videos.length > 0;
+	const { layout, gridColumns } = data.collection.publicPage;
+	const containerClass =
+		layout === "list"
+			? "flex flex-col gap-2"
+			: `grid grid-cols-1 gap-4 sm:grid-cols-2 ${GRID_COLUMN_CLASS[gridColumns]}`;
+
+	return (
+		<div className="space-y-10">
+			{data.folders.length > 0 && (
+				<section>
+					<SectionHeading title="Folders" count={data.folders.length} />
+					<div className={containerClass}>
+						{data.folders.map((folder) => (
+							<PublicFolderCard
+								key={folder.id}
+								folder={folder}
+								layout={layout}
+							/>
+						))}
+					</div>
+				</section>
+			)}
+
+			{data.videos.length > 0 && (
+				<section>
+					<SectionHeading title="Videos" count={data.totalCount} />
+					<div className={containerClass}>
+						{data.videos.map((video) => (
+							<PublicCapCard
+								key={video.id}
+								cap={video}
+								now={renderedAt}
+								layout={layout}
+							/>
+						))}
+					</div>
+				</section>
+			)}
+
+			{!hasContent && (
+				<CollectionStateCard
+					icon={faVideo}
+					title="No public videos yet"
+					description="This collection does not have any public videos available."
+				/>
+			)}
+
+			{data.totalPages > 1 && (
+				<div className="flex justify-center pt-2">
+					<CapPagination
+						currentPage={data.currentPage}
+						totalPages={data.totalPages}
+						hrefForPage={(targetPage) =>
+							getPublicCollectionHref(data.collection.id, targetPage)
+						}
+					/>
+				</div>
+			)}
+		</div>
+	);
+}
+
+function SectionHeading({ title, count }: { title: string; count: number }) {
+	return (
+		<div className="flex gap-2.5 items-baseline mb-4">
+			<h2 className="text-lg font-medium text-gray-12">{title}</h2>
+			<span className="text-sm tabular-nums text-gray-9">{count}</span>
+		</div>
+	);
+}
+
+function CollectionStateCard({
+	icon,
+	title,
+	description,
+}: {
+	icon: typeof faVideo;
+	title: string;
+	description: string;
+}) {
+	return (
+		<section className="flex justify-center items-center p-8 min-h-[340px] text-center rounded-2xl border border-dashed border-gray-4 bg-gray-1">
+			<div className="max-w-sm">
+				<div className="flex justify-center items-center mx-auto mb-4 rounded-full size-12 bg-gray-3 text-gray-10">
+					<FontAwesomeIcon icon={icon} className="size-5" />
+				</div>
+				<h2 className="text-lg font-medium text-gray-12">{title}</h2>
+				<p className="mt-2 text-sm leading-6 text-gray-10">{description}</p>
+			</div>
+		</section>
+	);
+}
+
+function PublicFolderCard({
+	folder,
+	layout,
+}: {
+	folder: PublicCollectionFolder;
+	layout: "grid" | "list";
+}) {
+	const meta = `${folder.videoCount} ${
+		folder.videoCount === 1 ? "video" : "videos"
+	}`;
+
+	if (layout === "list") {
+		return (
+			<Link
+				href={`/c/${folder.id}`}
+				className="flex gap-3 items-center p-3 rounded-xl border transition-colors border-gray-4 bg-gray-1 hover:border-gray-6"
+			>
+				<div className="flex shrink-0 justify-center items-center rounded-lg size-9 bg-gray-3 text-gray-10">
+					<FontAwesomeIcon icon={faFolder} className="size-4" />
+				</div>
+				<div className="min-w-0">
+					<h3 className="text-sm font-medium truncate text-gray-12">
+						{folder.name}
+					</h3>
+					<p className="text-xs text-gray-10">{meta}</p>
+				</div>
+			</Link>
+		);
+	}
+
+	return (
+		<Link
+			href={`/c/${folder.id}`}
+			className="flex gap-3 items-start p-4 rounded-xl border transition-colors min-h-28 border-gray-4 bg-gray-1 hover:border-gray-6"
+		>
+			<div className="flex shrink-0 justify-center items-center rounded-lg size-10 bg-gray-3 text-gray-10">
+				<FontAwesomeIcon icon={faFolder} className="size-4" />
+			</div>
+			<div className="min-w-0">
+				<h3 className="text-base font-medium leading-6 truncate text-gray-12">
+					{folder.name}
+				</h3>
+				<p className="mt-1 text-sm text-gray-10">{meta}</p>
+			</div>
+		</Link>
+	);
+}
+
+function CollectionFooter({ showPoweredBy }: { showPoweredBy: boolean }) {
+	if (!showPoweredBy) return null;
+
+	return (
+		<footer className="mt-16 border-t border-gray-4">
+			<div className="flex justify-center items-center px-4 mx-auto max-w-7xl h-16 sm:px-6 lg:px-8">
+				<a
+					href="https://cap.so/?ref=collection"
+					target="_blank"
+					rel="noreferrer"
+					className="inline-flex gap-1.5 items-center text-xs transition-colors text-gray-9 hover:text-gray-11"
+				>
+					Powered by
+					<Logo className="w-auto h-3.5" />
+				</a>
+			</div>
+		</footer>
+	);
+}
+
+function CollectionAccessView({
+	branding,
+	title,
+	description,
+}: {
+	branding: SharePageBranding | null;
+	title: string;
+	description: ReactNode;
+}) {
+	return (
+		<div className="flex flex-col justify-center items-center p-4 min-h-screen text-center bg-gray-2 text-gray-12">
+			{branding ? (
+				<BrandingMark
+					branding={branding}
+					className="mb-6 h-12 w-auto max-w-[200px] object-contain"
+				/>
+			) : (
+				<Logo className="mb-6 size-24" />
+			)}
+			<h1 className="mb-2 text-2xl font-semibold">{title}</h1>
+			<p className="max-w-md text-gray-10">{description}</p>
+		</div>
+	);
+}

--- a/apps/web/app/c/error.tsx
+++ b/apps/web/app/c/error.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Button } from "@cap/ui";
+import { useEffect } from "react";
+
+export default function CollectionError({
+	error,
+	reset,
+}: {
+	error: Error & { digest?: string };
+	reset: () => void;
+}) {
+	useEffect(() => {
+		console.error("Public collection page error:", error);
+	}, [error]);
+
+	return (
+		<div className="wrapper flex flex-col items-center justify-center h-screen text-center">
+			<h1 className="text-5xl md:text-6xl font-medium">Something went wrong</h1>
+			<p className="text-xl md:text-2xl mt-2 mb-6 text-gray-400">
+				This collection could not be loaded right now.
+			</p>
+			<Button type="button" variant="gray" size="sm" onClick={reset}>
+				Try again
+			</Button>
+		</div>
+	);
+}

--- a/apps/web/app/c/layout.tsx
+++ b/apps/web/app/c/layout.tsx
@@ -1,0 +1,8 @@
+import type { PropsWithChildren } from "react";
+import { AppProviders } from "../Layout/AppProviders";
+
+export const dynamic = "force-dynamic";
+
+export default function CollectionsLayout({ children }: PropsWithChildren) {
+	return <AppProviders>{children}</AppProviders>;
+}

--- a/apps/web/app/c/page.tsx
+++ b/apps/web/app/c/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default async function CollectionsPage() {
+	redirect("/");
+}

--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -51,6 +51,7 @@ import {
 import { resolveDefaultPlaybackSpeed } from "@/lib/playback-speed";
 import * as EffectRuntime from "@/lib/server";
 import { runPromise } from "@/lib/server";
+import { getSharePageBranding } from "@/lib/share-branding";
 import {
 	isSocialCrawlerUserAgent,
 	SOCIAL_REFERRER_DOMAINS,
@@ -66,7 +67,6 @@ import { PasswordOverlay } from "./_components/PasswordOverlay";
 import { PendingRecordingShare } from "./_components/PendingRecordingShare";
 import { ShareHeader } from "./_components/ShareHeader";
 import { Share } from "./Share";
-import type { SharePageBranding } from "./types";
 
 const VIEW_NOTIFICATION_DELAY_MS = 2 * 60 * 1000;
 const VIDEO_ID_PATTERN = /^[0-9abcdefghjkmnpqrstvwxyz]+$/;
@@ -191,36 +191,6 @@ const renderNoSuchElement = (awaitRecording: boolean) =>
 	awaitRecording
 		? Effect.succeed(<PendingRecordingShare />)
 		: Effect.sync(() => notFound());
-
-function getSharePageBranding(data: {
-	owner: { isPro: boolean };
-	orgSettings?: OrganizationSettings | null;
-	organizationName?: string | null;
-	organizationIconUrl?: ImageUpload.ImageUrl | null;
-	shareableLinkIconUrl?: ImageUpload.ImageUrl | null;
-}): SharePageBranding | null {
-	if (!data.owner.isPro) {
-		return { type: "cap" };
-	}
-
-	const brandedIcon = data.orgSettings?.shareableLinkUseOrganizationIcon
-		? data.organizationIconUrl
-		: data.shareableLinkIconUrl;
-
-	if (brandedIcon) {
-		return {
-			type: "custom",
-			imageUrl: brandedIcon,
-			name: data.organizationName ?? "Organization",
-		};
-	}
-
-	if (data.orgSettings?.hideShareableLinkCapLogo) {
-		return null;
-	}
-
-	return { type: "cap" };
-}
 
 const getShareVideoPageCatchers = (
 	videoId: Video.VideoId,

--- a/apps/web/app/s/[videoId]/types.ts
+++ b/apps/web/app/s/[videoId]/types.ts
@@ -27,12 +27,4 @@ export type VideoOwner = {
 	image?: ImageUpload.ImageUrl | null;
 };
 
-export type SharePageBranding =
-	| {
-			type: "custom";
-			imageUrl: ImageUpload.ImageUrl;
-			name: string;
-	  }
-	| {
-			type: "cap";
-	  };
+export type { SharePageBranding } from "@/lib/share-branding";

--- a/apps/web/components/PublicCapCard.tsx
+++ b/apps/web/components/PublicCapCard.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import type { VideoMetadata } from "@cap/database/types";
+import type { Video } from "@cap/web-domain";
+import { faComment, faLock, faSmile } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import clsx from "clsx";
+import Link from "next/link";
+import { useState } from "react";
+import {
+	type ImageLoadingStatus,
+	VideoThumbnail,
+} from "@/components/VideoThumbnail";
+
+type PublicCapCardVideo = {
+	id: string;
+	name: string;
+	createdAt: Date | string;
+	metadata: Pick<VideoMetadata, "customCreatedAt"> | undefined;
+	duration: number | null;
+	totalComments: number;
+	totalReactions: number;
+	ownerName: string;
+	hasPassword: boolean;
+	hasActiveUpload: boolean;
+};
+
+const relativeTimeFormatter = new Intl.RelativeTimeFormat("en", {
+	numeric: "auto",
+});
+const relativeTimeUnits: {
+	unit: Intl.RelativeTimeFormatUnit;
+	seconds: number;
+}[] = [
+	{ unit: "year", seconds: 31536000 },
+	{ unit: "month", seconds: 2592000 },
+	{ unit: "week", seconds: 604800 },
+	{ unit: "day", seconds: 86400 },
+	{ unit: "hour", seconds: 3600 },
+	{ unit: "minute", seconds: 60 },
+	{ unit: "second", seconds: 1 },
+];
+
+function formatRelativeDate(date: Date, now: number) {
+	const secondsFromNow = Math.round((date.getTime() - now) / 1000);
+	const absoluteSeconds = Math.abs(secondsFromNow);
+	const unit = relativeTimeUnits.find(
+		({ seconds }) => absoluteSeconds >= seconds,
+	) ?? { unit: "second", seconds: 1 };
+
+	return relativeTimeFormatter.format(
+		Math.round(secondsFromNow / unit.seconds),
+		unit.unit,
+	);
+}
+
+export function PublicCapCard({
+	cap,
+	now,
+	layout = "grid",
+}: {
+	cap: PublicCapCardVideo;
+	/**
+	 * Server render timestamp, passed as a prop so the hydrated client render
+	 * produces the same relative-date string as the server HTML.
+	 */
+	now: number;
+	layout?: "grid" | "list";
+}) {
+	const [imageStatus, setImageStatus] = useState<ImageLoadingStatus>("loading");
+	const effectiveDate = cap.metadata?.customCreatedAt
+		? new Date(cap.metadata.customCreatedAt)
+		: new Date(cap.createdAt);
+	const subtitle = `${cap.ownerName || "Cap"} · ${formatRelativeDate(effectiveDate, now)}`;
+
+	const lockBadge = cap.hasPassword && (
+		<div className="flex absolute top-2 right-2 z-10 justify-center items-center rounded-full size-7 bg-black/70 text-white">
+			<FontAwesomeIcon icon={faLock} className="size-3" />
+		</div>
+	);
+
+	const stats = (
+		<div className="flex gap-4 items-center text-sm text-gray-10">
+			<span className="inline-flex gap-1.5 items-center">
+				<FontAwesomeIcon icon={faComment} className="size-3.5" />
+				{cap.totalComments}
+			</span>
+			<span className="inline-flex gap-1.5 items-center">
+				<FontAwesomeIcon icon={faSmile} className="size-3.5" />
+				{cap.totalReactions}
+			</span>
+		</div>
+	);
+
+	if (layout === "list") {
+		return (
+			<Link
+				href={`/s/${cap.id}`}
+				className="group flex gap-4 items-center p-3 rounded-xl border transition-colors border-gray-4 bg-gray-1 hover:border-gray-6"
+			>
+				<div className="overflow-hidden relative w-40 rounded-lg shrink-0 aspect-video bg-gray-3">
+					<VideoThumbnail
+						videoDuration={cap.duration ?? undefined}
+						imageClass="transition-opacity duration-200 group-hover:opacity-80"
+						containerClass="absolute inset-0 rounded-lg"
+						videoId={cap.id as Video.VideoId}
+						alt={`${cap.name} Thumbnail`}
+						imageStatus={imageStatus}
+						setImageStatus={setImageStatus}
+						hasActiveUpload={cap.hasActiveUpload}
+					/>
+					{lockBadge}
+				</div>
+				<div className="flex flex-1 justify-between items-center min-w-0">
+					<div className="min-w-0">
+						<h3 className="text-base font-medium leading-6 truncate text-gray-12">
+							{cap.name}
+						</h3>
+						<p className="text-sm leading-5 truncate text-gray-10">
+							{subtitle}
+						</p>
+					</div>
+					<div className="hidden shrink-0 sm:block">{stats}</div>
+				</div>
+			</Link>
+		);
+	}
+
+	return (
+		<Link
+			href={`/s/${cap.id}`}
+			className={clsx(
+				"group flex flex-col h-full rounded-xl border transition-colors",
+				"overflow-hidden border-gray-4 bg-gray-1 hover:border-gray-6",
+			)}
+		>
+			<div className="overflow-hidden relative w-full aspect-video bg-gray-3">
+				<VideoThumbnail
+					videoDuration={cap.duration ?? undefined}
+					imageClass="transition-opacity duration-200 group-hover:opacity-80"
+					containerClass="absolute inset-0 rounded-t-xl"
+					videoId={cap.id as Video.VideoId}
+					alt={`${cap.name} Thumbnail`}
+					imageStatus={imageStatus}
+					setImageStatus={setImageStatus}
+					hasActiveUpload={cap.hasActiveUpload}
+				/>
+				{lockBadge}
+			</div>
+			<div className="flex flex-col flex-1 gap-3 p-4">
+				<div className="min-w-0">
+					<h3 className="text-base font-medium leading-6 truncate text-gray-12">
+						{cap.name}
+					</h3>
+					<p className="text-sm leading-5 truncate text-gray-10">{subtitle}</p>
+				</div>
+				<div className="mt-auto">{stats}</div>
+			</div>
+		</Link>
+	);
+}

--- a/apps/web/lib/folder.ts
+++ b/apps/web/lib/folder.ts
@@ -371,6 +371,7 @@ export const getChildFolders = Effect.fn(function* (
 				id: folders.id,
 				name: folders.name,
 				color: folders.color,
+				public: folders.public,
 				parentId: folders.parentId,
 				organizationId: folders.organizationId,
 				videoCount: sql<number>`(

--- a/apps/web/lib/org-pro.ts
+++ b/apps/web/lib/org-pro.ts
@@ -1,0 +1,27 @@
+import "server-only";
+
+import { db } from "@cap/database";
+import { organizations, users } from "@cap/database/schema";
+import { userIsPro } from "@cap/utils";
+import type { Organisation } from "@cap/web-domain";
+import { eq } from "drizzle-orm";
+
+/**
+ * Whether an organization's OWNER is on a Pro plan. Public collection links are
+ * an org-wide Pro entitlement: any manager can publish while the owner is Pro.
+ */
+export async function isOrganizationOwnerPro(
+	organizationId: Organisation.OrganisationId,
+): Promise<boolean> {
+	const [owner] = await db()
+		.select({
+			stripeSubscriptionStatus: users.stripeSubscriptionStatus,
+			thirdPartyStripeSubscriptionId: users.thirdPartyStripeSubscriptionId,
+		})
+		.from(organizations)
+		.innerJoin(users, eq(organizations.ownerId, users.id))
+		.where(eq(organizations.id, organizationId))
+		.limit(1);
+
+	return userIsPro(owner ?? null);
+}

--- a/apps/web/lib/password-cookie.ts
+++ b/apps/web/lib/password-cookie.ts
@@ -1,0 +1,18 @@
+import "server-only";
+
+import { encrypt } from "@cap/database/crypto";
+import { cookies } from "next/headers";
+
+/**
+ * Marks a share password (video or collection) as verified for this browser
+ * session. The cookie is shared by the `/s/` and `/c/` flows, holds only the
+ * encrypted hash, and is never read client-side — so it can be locked down.
+ */
+export async function setVerifiedPasswordCookie(passwordHash: string) {
+	(await cookies()).set("x-cap-password", await encrypt(passwordHash), {
+		httpOnly: true,
+		secure: process.env.NODE_ENV === "production",
+		sameSite: "lax",
+		path: "/",
+	});
+}

--- a/apps/web/lib/password-cookie.ts
+++ b/apps/web/lib/password-cookie.ts
@@ -1,18 +1,68 @@
 import "server-only";
 
-import { encrypt } from "@cap/database/crypto";
+import { decrypt, encrypt } from "@cap/database/crypto";
 import { cookies } from "next/headers";
+
+const COOKIE_NAME = "x-cap-password";
+
+// A verified hash is ~64 base64 chars, so 10 entries encrypt to well under
+// the 4KB cookie limit while covering any realistic number of concurrently
+// open password-protected shares.
+const MAX_VERIFIED_HASHES = 10;
+
+/**
+ * Every share password (video or collection) this browser has verified. The
+ * cookie holds an encrypted JSON array of password hashes so unlocking one
+ * resource never evicts another; pre-array cookies that hold a single bare
+ * hash are still accepted.
+ */
+export async function getVerifiedPasswordHashes(): Promise<string[]> {
+	const cookieValue = (await cookies()).get(COOKIE_NAME)?.value;
+	if (!cookieValue) return [];
+
+	let decrypted: string;
+	try {
+		// decrypt is async — without the await its rejection (corrupt or stale
+		// cookie, rotated encryption key) would escape this catch and crash the
+		// page instead of falling back to the password prompt.
+		decrypted = await decrypt(cookieValue);
+	} catch {
+		return [];
+	}
+
+	try {
+		const parsed: unknown = JSON.parse(decrypted);
+		if (
+			Array.isArray(parsed) &&
+			parsed.every((hash) => typeof hash === "string")
+		) {
+			return parsed;
+		}
+	} catch {
+		// Legacy cookie: the decrypted value is the hash itself.
+	}
+	return [decrypted];
+}
 
 /**
  * Marks a share password (video or collection) as verified for this browser
- * session. The cookie is shared by the `/s/` and `/c/` flows, holds only the
- * encrypted hash, and is never read client-side — so it can be locked down.
+ * session. The cookie is shared by the `/s/` and `/c/` flows and is never
+ * read client-side — so it can be locked down.
  */
 export async function setVerifiedPasswordCookie(passwordHash: string) {
-	(await cookies()).set("x-cap-password", await encrypt(passwordHash), {
-		httpOnly: true,
-		secure: process.env.NODE_ENV === "production",
-		sameSite: "lax",
-		path: "/",
-	});
+	const hashes = (await getVerifiedPasswordHashes()).filter(
+		(hash) => hash !== passwordHash,
+	);
+	hashes.push(passwordHash);
+
+	(await cookies()).set(
+		COOKIE_NAME,
+		await encrypt(JSON.stringify(hashes.slice(-MAX_VERIFIED_HASHES))),
+		{
+			httpOnly: true,
+			secure: process.env.NODE_ENV === "production",
+			sameSite: "lax",
+			path: "/",
+		},
+	);
 }

--- a/apps/web/lib/public-collection-client.ts
+++ b/apps/web/lib/public-collection-client.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { usePublicEnv } from "@/utils/public-env";
+
+/**
+ * Canonical public collection link + copy-to-clipboard with the shared
+ * 2s "copied" feedback state. Builds the URL from the configured web URL so
+ * every dashboard surface produces the same link regardless of the origin the
+ * dashboard happens to be served from.
+ */
+export function useCopyCollectionLink(collectionId: string | undefined) {
+	const { webUrl } = usePublicEnv();
+	const [copied, setCopied] = useState(false);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(
+		() => () => {
+			if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		},
+		[],
+	);
+
+	const url = `${webUrl}/c/${collectionId ?? ""}`;
+
+	const copy = async () => {
+		if (!collectionId) return false;
+		try {
+			await navigator.clipboard.writeText(url);
+		} catch {
+			toast.error("Failed to copy public collection link");
+			return false;
+		}
+		toast.success("Public collection link copied");
+		if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		setCopied(true);
+		timeoutRef.current = setTimeout(() => setCopied(false), 2000);
+		return true;
+	};
+
+	return { url, copied, copy };
+}

--- a/apps/web/lib/public-collection-settings.ts
+++ b/apps/web/lib/public-collection-settings.ts
@@ -1,0 +1,62 @@
+import type { PublicCollection } from "@cap/web-domain";
+
+/**
+ * Resolves a user-provided CTA link into a safe, absolute http(s) URL. Bare
+ * hosts (e.g. `example.com`) are upgraded to `https://`, and anything that
+ * isn't http/https (e.g. `javascript:`) is rejected so the public page can't be
+ * turned into an injection vector.
+ */
+export function sanitizeCtaUrl(raw: string | null | undefined): string | null {
+	const value = raw?.trim();
+	if (!value) return null;
+
+	const withProtocol = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+
+	try {
+		const url = new URL(withProtocol);
+		if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+		return url.toString();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Static Tailwind class per grid density (kept as literal strings so the JIT
+ * compiler keeps them). Applied at the `lg` breakpoint; smaller screens always
+ * collapse to 1–2 columns.
+ */
+export const GRID_COLUMN_CLASS: Record<
+	PublicCollection.PublicCollectionGridColumns,
+	string
+> = {
+	2: "lg:grid-cols-2",
+	3: "lg:grid-cols-3",
+	4: "lg:grid-cols-4",
+	5: "lg:grid-cols-5",
+};
+
+export const PUBLIC_LAYOUT_OPTIONS = [
+	{ value: "grid" as const, label: "Grid" },
+	{ value: "list" as const, label: "List" },
+];
+
+export const PUBLIC_LOGO_OPTIONS: {
+	value: PublicCollection.PublicCollectionLogoMode;
+	label: string;
+}[] = [
+	{ value: "cap", label: "Cap logo" },
+	{ value: "organization", label: "Organization logo" },
+	{ value: "custom", label: "Custom logo" },
+	{ value: "none", label: "No logo" },
+];
+
+export const PUBLIC_GRID_COLUMN_OPTIONS: {
+	value: PublicCollection.PublicCollectionGridColumns;
+	label: string;
+}[] = [
+	{ value: 2, label: "2 per row" },
+	{ value: 3, label: "3 per row" },
+	{ value: 4, label: "4 per row" },
+	{ value: 5, label: "5 per row" },
+];

--- a/apps/web/lib/public-collections-policy.ts
+++ b/apps/web/lib/public-collections-policy.ts
@@ -1,0 +1,80 @@
+import { isEmailAllowedByRestriction } from "@cap/utils";
+
+export const PUBLIC_COLLECTION_PAGE_SIZE = 15;
+
+export type PublicCollectionKind = "folder" | "space";
+
+export type PublicCollectionCandidate = {
+	kind: PublicCollectionKind;
+	public: boolean;
+	organizationTombstoneAt: Date | null;
+};
+
+export type PublicCollectionAccess =
+	| { state: "allowed" }
+	| { state: "email_restriction_login_required" }
+	| { state: "email_restriction_denied" }
+	| { state: "password_required" };
+
+export function parsePublicCollectionPage(
+	page: string | string[] | undefined,
+): number {
+	const value = Array.isArray(page) ? page[0] : page;
+	const parsed = Number(value);
+
+	if (!Number.isInteger(parsed) || parsed < 1) return 1;
+
+	return parsed;
+}
+
+export function getPublicCollectionHref(id: string, page: number): string {
+	return page <= 1 ? `/c/${id}` : `/c/${id}?page=${page}`;
+}
+
+export function resolvePublicCollectionCandidate<
+	TFolder extends PublicCollectionCandidate,
+>(folder: TFolder | null, space: null): TFolder | null;
+export function resolvePublicCollectionCandidate<
+	TSpace extends PublicCollectionCandidate,
+>(folder: null, space: TSpace | null): TSpace | null;
+export function resolvePublicCollectionCandidate<
+	TFolder extends PublicCollectionCandidate,
+	TSpace extends PublicCollectionCandidate,
+>(folder: TFolder | null, space: TSpace | null): TFolder | TSpace | null;
+export function resolvePublicCollectionCandidate(
+	folder: PublicCollectionCandidate | null,
+	space: PublicCollectionCandidate | null,
+): PublicCollectionCandidate | null {
+	if (folder?.public && !folder.organizationTombstoneAt) return folder;
+	if (space?.public && !space.organizationTombstoneAt) return space;
+
+	return null;
+}
+
+export function resolvePublicCollectionAccess({
+	allowedEmailDomain,
+	viewerEmail,
+	passwordHash,
+	verifiedPasswordHash,
+}: {
+	allowedEmailDomain?: string | null;
+	viewerEmail?: string | null;
+	passwordHash?: string | null;
+	verifiedPasswordHash?: string | null;
+}): PublicCollectionAccess {
+	const restriction = allowedEmailDomain?.trim() ?? "";
+
+	if (restriction.length > 0) {
+		if (!viewerEmail) return { state: "email_restriction_login_required" };
+
+		if (!isEmailAllowedByRestriction(viewerEmail, restriction)) {
+			return { state: "email_restriction_denied" };
+		}
+	}
+
+	if (passwordHash && passwordHash !== verifiedPasswordHash) {
+		return { state: "password_required" };
+	}
+
+	return { state: "allowed" };
+}

--- a/apps/web/lib/public-collections-policy.ts
+++ b/apps/web/lib/public-collections-policy.ts
@@ -55,12 +55,12 @@ export function resolvePublicCollectionAccess({
 	allowedEmailDomain,
 	viewerEmail,
 	passwordHash,
-	verifiedPasswordHash,
+	verifiedPasswordHashes,
 }: {
 	allowedEmailDomain?: string | null;
 	viewerEmail?: string | null;
 	passwordHash?: string | null;
-	verifiedPasswordHash?: string | null;
+	verifiedPasswordHashes?: readonly string[];
 }): PublicCollectionAccess {
 	const restriction = allowedEmailDomain?.trim() ?? "";
 
@@ -72,7 +72,7 @@ export function resolvePublicCollectionAccess({
 		}
 	}
 
-	if (passwordHash && passwordHash !== verifiedPasswordHash) {
+	if (passwordHash && !verifiedPasswordHashes?.includes(passwordHash)) {
 		return { state: "password_required" };
 	}
 

--- a/apps/web/lib/public-collections.ts
+++ b/apps/web/lib/public-collections.ts
@@ -2,7 +2,6 @@ import "server-only";
 
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
-import { decrypt } from "@cap/database/crypto";
 import {
 	comments,
 	folders,
@@ -27,8 +26,8 @@ import {
 } from "@cap/web-domain";
 import { and, desc, eq, inArray, isNull, type SQL, sql } from "drizzle-orm";
 import { Effect } from "effect";
-import { cookies } from "next/headers";
 import { cache } from "react";
+import { getVerifiedPasswordHashes } from "@/lib/password-cookie";
 import {
 	PUBLIC_COLLECTION_PAGE_SIZE,
 	type PublicCollectionAccess,
@@ -109,7 +108,7 @@ export type PublicCollectionPageData = {
 function videoPasswordPredicate(
 	videoId: SQL,
 	videoPassword: SQL,
-	verifiedPasswordHash: string | null,
+	verifiedPasswordHashes: readonly string[],
 ) {
 	const noPassword = sql`(${videoPassword} IS NULL AND NOT EXISTS (
 		SELECT 1 FROM space_videos sv_password
@@ -118,15 +117,20 @@ function videoPasswordPredicate(
 			AND s_password.password IS NOT NULL
 	))`;
 
-	if (!verifiedPasswordHash) return noPassword;
+	if (verifiedPasswordHashes.length === 0) return noPassword;
+
+	const verifiedHashes = sql.join(
+		verifiedPasswordHashes.map((hash) => sql`${hash}`),
+		sql`, `,
+	);
 
 	return sql`(${noPassword}
-		OR ${videoPassword} = ${verifiedPasswordHash}
+		OR ${videoPassword} IN (${verifiedHashes})
 		OR EXISTS (
 			SELECT 1 FROM space_videos sv_password
 			INNER JOIN spaces s_password ON sv_password.spaceId = s_password.id
 			WHERE sv_password.videoId = ${videoId}
-				AND s_password.password = ${verifiedPasswordHash}
+				AND s_password.password IN (${verifiedHashes})
 		)
 	)`;
 }
@@ -140,20 +144,6 @@ function hasPasswordExpression(videoId: SQL, videoPassword: SQL) {
 	)`;
 }
 
-async function getVerifiedPasswordHash() {
-	const cookieValue = (await cookies()).get("x-cap-password")?.value;
-	if (!cookieValue) return null;
-
-	try {
-		// decrypt is async — without the await its rejection (corrupt or stale
-		// cookie, rotated encryption key) would escape this catch and crash the
-		// page instead of falling back to the password prompt.
-		return await decrypt(cookieValue);
-	} catch {
-		return null;
-	}
-}
-
 export async function getPublicCollectionMetadata(collectionId: string) {
 	return resolvePublicCollection(collectionId);
 }
@@ -162,10 +152,10 @@ export async function getPublicCollectionPageData(
 	collectionId: string,
 	page: number,
 ): Promise<PublicCollectionPageData | null> {
-	const [collection, user, verifiedPasswordHash] = await Promise.all([
+	const [collection, user, verifiedPasswordHashes] = await Promise.all([
 		resolvePublicCollection(collectionId),
 		getCurrentUser(),
-		getVerifiedPasswordHash(),
+		getVerifiedPasswordHashes(),
 	]);
 
 	if (!collection) return null;
@@ -174,7 +164,7 @@ export async function getPublicCollectionPageData(
 		allowedEmailDomain: collection.allowedEmailDomain,
 		viewerEmail: user?.email,
 		passwordHash: collection.passwordHash,
-		verifiedPasswordHash,
+		verifiedPasswordHashes,
 	});
 
 	if (access.state !== "allowed") {
@@ -191,8 +181,8 @@ export async function getPublicCollectionPageData(
 	}
 
 	const [childFolders, videoPage] = await Promise.all([
-		getPublicChildFolders(collection, verifiedPasswordHash),
-		getPublicCollectionVideos(collection, page, verifiedPasswordHash),
+		getPublicChildFolders(collection, verifiedPasswordHashes),
+		getPublicCollectionVideos(collection, page, verifiedPasswordHashes),
 	]);
 
 	return {
@@ -274,126 +264,107 @@ function resolveEffectivePublicPage(
 
 const resolvePublicCollection = cache(
 	async (collectionId: string): Promise<PublicCollection | null> => {
-		// Fetched by primary key, then gated in `resolvePublicCollectionCandidate`
+		// Fetched by primary key — both lookups in parallel since the id's kind
+		// isn't known up front — then gated in `resolvePublicCollectionCandidate`
 		// so the public/tombstone policy lives in one tested place.
-		const [folderRow] = await db()
-			.select({
-				id: folders.id,
-				name: folders.name,
-				color: folders.color,
-				public: folders.public,
-				settings: folders.settings,
-				spaceId: folders.spaceId,
-				organizationId: folders.organizationId,
-				organizationName: organizations.name,
-				organizationTombstoneAt: organizations.tombstoneAt,
-				allowedEmailDomain: organizations.allowedEmailDomain,
-				organizationIconUrl: organizations.iconUrl,
-				ownerStripeSubscriptionStatus: users.stripeSubscriptionStatus,
-				ownerThirdPartyStripeSubscriptionId:
-					users.thirdPartyStripeSubscriptionId,
-				passwordHash: spaces.password,
-			})
-			.from(folders)
-			.innerJoin(organizations, eq(folders.organizationId, organizations.id))
-			.innerJoin(users, eq(organizations.ownerId, users.id))
-			.leftJoin(spaces, eq(folders.spaceId, spaces.id))
-			.where(eq(folders.id, collectionId as Folder.FolderId))
-			.limit(1);
+		const [[folderRow], [spaceRow]] = await Promise.all([
+			db()
+				.select({
+					id: folders.id,
+					name: folders.name,
+					color: folders.color,
+					public: folders.public,
+					settings: folders.settings,
+					spaceId: folders.spaceId,
+					organizationId: folders.organizationId,
+					organizationName: organizations.name,
+					organizationTombstoneAt: organizations.tombstoneAt,
+					allowedEmailDomain: organizations.allowedEmailDomain,
+					organizationIconUrl: organizations.iconUrl,
+					ownerStripeSubscriptionStatus: users.stripeSubscriptionStatus,
+					ownerThirdPartyStripeSubscriptionId:
+						users.thirdPartyStripeSubscriptionId,
+					passwordHash: spaces.password,
+				})
+				.from(folders)
+				.innerJoin(organizations, eq(folders.organizationId, organizations.id))
+				.innerJoin(users, eq(organizations.ownerId, users.id))
+				.leftJoin(spaces, eq(folders.spaceId, spaces.id))
+				.where(eq(folders.id, collectionId as Folder.FolderId))
+				.limit(1),
+			db()
+				.select({
+					id: spaces.id,
+					name: spaces.name,
+					description: spaces.description,
+					public: spaces.public,
+					settings: spaces.settings,
+					organizationId: spaces.organizationId,
+					organizationName: organizations.name,
+					organizationTombstoneAt: organizations.tombstoneAt,
+					allowedEmailDomain: organizations.allowedEmailDomain,
+					organizationIconUrl: organizations.iconUrl,
+					ownerStripeSubscriptionStatus: users.stripeSubscriptionStatus,
+					ownerThirdPartyStripeSubscriptionId:
+						users.thirdPartyStripeSubscriptionId,
+					passwordHash: spaces.password,
+				})
+				.from(spaces)
+				.innerJoin(organizations, eq(spaces.organizationId, organizations.id))
+				.innerJoin(users, eq(organizations.ownerId, users.id))
+				.where(eq(spaces.id, collectionId as Space.SpaceIdOrOrganisationId))
+				.limit(1),
+		]);
 
-		const folder = resolvePublicCollectionCandidate(
+		const candidate = resolvePublicCollectionCandidate(
 			folderRow ? { kind: "folder" as const, ...folderRow } : null,
-			null,
-		);
-
-		if (folder) {
-			const publicPage = resolveEffectivePublicPage(
-				userIsPro({
-					stripeSubscriptionStatus: folder.ownerStripeSubscriptionStatus,
-					thirdPartyStripeSubscriptionId:
-						folder.ownerThirdPartyStripeSubscriptionId,
-				}),
-				folder.settings?.publicPage,
-			);
-			const icons = await resolveIconUrls({
-				...publicPageIconKeys(publicPage, {
-					organizationIconUrl: folder.organizationIconUrl,
-				}),
-			});
-
-			return {
-				id: folder.id,
-				kind: "folder",
-				name: folder.name,
-				color: folder.color,
-				description: null,
-				spaceId: folder.spaceId,
-				organizationId: folder.organizationId,
-				organizationName: folder.organizationName,
-				allowedEmailDomain: folder.allowedEmailDomain,
-				passwordHash: folder.passwordHash,
-				publicPage,
-				...icons,
-			};
-		}
-
-		const [spaceRow] = await db()
-			.select({
-				id: spaces.id,
-				name: spaces.name,
-				description: spaces.description,
-				public: spaces.public,
-				settings: spaces.settings,
-				organizationId: spaces.organizationId,
-				organizationName: organizations.name,
-				organizationTombstoneAt: organizations.tombstoneAt,
-				allowedEmailDomain: organizations.allowedEmailDomain,
-				organizationIconUrl: organizations.iconUrl,
-				ownerStripeSubscriptionStatus: users.stripeSubscriptionStatus,
-				ownerThirdPartyStripeSubscriptionId:
-					users.thirdPartyStripeSubscriptionId,
-				passwordHash: spaces.password,
-			})
-			.from(spaces)
-			.innerJoin(organizations, eq(spaces.organizationId, organizations.id))
-			.innerJoin(users, eq(organizations.ownerId, users.id))
-			.where(eq(spaces.id, collectionId as Space.SpaceIdOrOrganisationId))
-			.limit(1);
-
-		const space = resolvePublicCollectionCandidate(
-			null,
 			spaceRow ? { kind: "space" as const, ...spaceRow } : null,
 		);
 
-		if (!space) return null;
+		if (!candidate) return null;
 
 		const publicPage = resolveEffectivePublicPage(
 			userIsPro({
-				stripeSubscriptionStatus: space.ownerStripeSubscriptionStatus,
+				stripeSubscriptionStatus: candidate.ownerStripeSubscriptionStatus,
 				thirdPartyStripeSubscriptionId:
-					space.ownerThirdPartyStripeSubscriptionId,
+					candidate.ownerThirdPartyStripeSubscriptionId,
 			}),
-			space.settings?.publicPage,
+			candidate.settings?.publicPage,
 		);
-		const icons = await resolveIconUrls({
-			...publicPageIconKeys(publicPage, {
-				organizationIconUrl: space.organizationIconUrl,
+		const icons = await resolveIconUrls(
+			publicPageIconKeys(publicPage, {
+				organizationIconUrl: candidate.organizationIconUrl,
 			}),
-		});
+		);
 
-		return {
-			id: space.id,
-			kind: "space",
-			name: space.name,
-			color: null,
-			description: space.description,
-			spaceId: space.id,
-			organizationId: space.organizationId,
-			organizationName: space.organizationName,
-			allowedEmailDomain: space.allowedEmailDomain,
-			passwordHash: space.passwordHash,
+		const shared = {
+			name: candidate.name,
+			organizationId: candidate.organizationId,
+			organizationName: candidate.organizationName,
+			allowedEmailDomain: candidate.allowedEmailDomain,
+			passwordHash: candidate.passwordHash,
 			publicPage,
 			...icons,
+		};
+
+		if (candidate.kind === "folder") {
+			return {
+				...shared,
+				id: candidate.id,
+				kind: "folder",
+				color: candidate.color,
+				description: null,
+				spaceId: candidate.spaceId,
+			};
+		}
+
+		return {
+			...shared,
+			id: candidate.id,
+			kind: "space",
+			color: null,
+			description: candidate.description,
+			spaceId: candidate.id,
 		};
 	},
 );
@@ -425,21 +396,21 @@ function isOrgLevelFolder(collection: PublicCollection) {
 async function getPublicCollectionVideos(
 	collection: PublicCollection,
 	page: number,
-	verifiedPasswordHash: string | null,
+	verifiedPasswordHashes: readonly string[],
 ) {
 	if (collection.kind === "space") {
-		return getPublicSpaceVideos(collection, page, verifiedPasswordHash);
+		return getPublicSpaceVideos(collection, page, verifiedPasswordHashes);
 	}
 
 	if (isOrgLevelFolder(collection)) {
-		return getPublicOrgFolderVideos(collection, page, verifiedPasswordHash);
+		return getPublicOrgFolderVideos(collection, page, verifiedPasswordHashes);
 	}
 
 	if (collection.spaceId) {
-		return getPublicSpaceFolderVideos(collection, page, verifiedPasswordHash);
+		return getPublicSpaceFolderVideos(collection, page, verifiedPasswordHashes);
 	}
 
-	return getPublicUserFolderVideos(collection, page, verifiedPasswordHash);
+	return getPublicUserFolderVideos(collection, page, verifiedPasswordHashes);
 }
 
 const videoSelect = {
@@ -498,7 +469,7 @@ function toPublicCollectionVideos(
 async function getPublicSpaceVideos(
 	collection: PublicCollection,
 	page: number,
-	verifiedPasswordHash: string | null,
+	verifiedPasswordHashes: readonly string[],
 ) {
 	const offset = (page - 1) * PUBLIC_COLLECTION_PAGE_SIZE;
 	const where = and(
@@ -508,7 +479,7 @@ async function getPublicSpaceVideos(
 		videoPasswordPredicate(
 			sql`${videos.id}`,
 			sql`${videos.password}`,
-			verifiedPasswordHash,
+			verifiedPasswordHashes,
 		),
 	);
 
@@ -543,7 +514,7 @@ async function getPublicSpaceVideos(
 async function getPublicSpaceFolderVideos(
 	collection: PublicCollection,
 	page: number,
-	verifiedPasswordHash: string | null,
+	verifiedPasswordHashes: readonly string[],
 ) {
 	const offset = (page - 1) * PUBLIC_COLLECTION_PAGE_SIZE;
 	const where = and(
@@ -553,7 +524,7 @@ async function getPublicSpaceFolderVideos(
 		videoPasswordPredicate(
 			sql`${videos.id}`,
 			sql`${videos.password}`,
-			verifiedPasswordHash,
+			verifiedPasswordHashes,
 		),
 	);
 
@@ -588,7 +559,7 @@ async function getPublicSpaceFolderVideos(
 async function getPublicOrgFolderVideos(
 	collection: PublicCollection,
 	page: number,
-	verifiedPasswordHash: string | null,
+	verifiedPasswordHashes: readonly string[],
 ) {
 	const offset = (page - 1) * PUBLIC_COLLECTION_PAGE_SIZE;
 	const where = and(
@@ -598,7 +569,7 @@ async function getPublicOrgFolderVideos(
 		videoPasswordPredicate(
 			sql`${videos.id}`,
 			sql`${videos.password}`,
-			verifiedPasswordHash,
+			verifiedPasswordHashes,
 		),
 	);
 
@@ -633,7 +604,7 @@ async function getPublicOrgFolderVideos(
 async function getPublicUserFolderVideos(
 	collection: PublicCollection,
 	page: number,
-	verifiedPasswordHash: string | null,
+	verifiedPasswordHashes: readonly string[],
 ) {
 	const offset = (page - 1) * PUBLIC_COLLECTION_PAGE_SIZE;
 	const where = and(
@@ -643,7 +614,7 @@ async function getPublicUserFolderVideos(
 		videoPasswordPredicate(
 			sql`${videos.id}`,
 			sql`${videos.password}`,
-			verifiedPasswordHash,
+			verifiedPasswordHashes,
 		),
 	);
 
@@ -675,7 +646,7 @@ async function getPublicUserFolderVideos(
 
 async function getPublicChildFolders(
 	collection: PublicCollection,
-	verifiedPasswordHash: string | null,
+	verifiedPasswordHashes: readonly string[],
 ): Promise<PublicCollectionFolder[]> {
 	const where =
 		collection.kind === "space"
@@ -707,10 +678,10 @@ async function getPublicChildFolders(
 
 	const folderIds = childFolders.map((folder) => folder.id);
 	const counts = isOrgLevelFolder(collection)
-		? await getPublicOrgFolderVideoCounts(folderIds, verifiedPasswordHash)
+		? await getPublicOrgFolderVideoCounts(folderIds, verifiedPasswordHashes)
 		: collection.kind === "space" || Boolean(collection.spaceId)
-			? await getPublicSpaceFolderVideoCounts(folderIds, verifiedPasswordHash)
-			: await getPublicUserFolderVideoCounts(folderIds, verifiedPasswordHash);
+			? await getPublicSpaceFolderVideoCounts(folderIds, verifiedPasswordHashes)
+			: await getPublicUserFolderVideoCounts(folderIds, verifiedPasswordHashes);
 	const countByFolderId = new Map(
 		counts.map((row) => [row.folderId, row.videoCount]),
 	);
@@ -723,7 +694,7 @@ async function getPublicChildFolders(
 
 async function getPublicSpaceFolderVideoCounts(
 	folderIds: Folder.FolderId[],
-	verifiedPasswordHash: string | null,
+	verifiedPasswordHashes: readonly string[],
 ) {
 	return db()
 		.select({
@@ -741,7 +712,7 @@ async function getPublicSpaceFolderVideoCounts(
 				videoPasswordPredicate(
 					sql`${videos.id}`,
 					sql`${videos.password}`,
-					verifiedPasswordHash,
+					verifiedPasswordHashes,
 				),
 			),
 		)
@@ -750,7 +721,7 @@ async function getPublicSpaceFolderVideoCounts(
 
 async function getPublicOrgFolderVideoCounts(
 	folderIds: Folder.FolderId[],
-	verifiedPasswordHash: string | null,
+	verifiedPasswordHashes: readonly string[],
 ) {
 	return db()
 		.select({
@@ -768,7 +739,7 @@ async function getPublicOrgFolderVideoCounts(
 				videoPasswordPredicate(
 					sql`${videos.id}`,
 					sql`${videos.password}`,
-					verifiedPasswordHash,
+					verifiedPasswordHashes,
 				),
 			),
 		)
@@ -777,7 +748,7 @@ async function getPublicOrgFolderVideoCounts(
 
 async function getPublicUserFolderVideoCounts(
 	folderIds: Folder.FolderId[],
-	verifiedPasswordHash: string | null,
+	verifiedPasswordHashes: readonly string[],
 ) {
 	return db()
 		.select({
@@ -794,7 +765,7 @@ async function getPublicUserFolderVideoCounts(
 				videoPasswordPredicate(
 					sql`${videos.id}`,
 					sql`${videos.password}`,
-					verifiedPasswordHash,
+					verifiedPasswordHashes,
 				),
 			),
 		)

--- a/apps/web/lib/public-collections.ts
+++ b/apps/web/lib/public-collections.ts
@@ -1,0 +1,802 @@
+import "server-only";
+
+import { db } from "@cap/database";
+import { getCurrentUser } from "@cap/database/auth/session";
+import { decrypt } from "@cap/database/crypto";
+import {
+	comments,
+	folders,
+	organizations,
+	sharedVideos,
+	spaces,
+	spaceVideos,
+	users,
+	videos,
+	videoUploads,
+} from "@cap/database/schema";
+import type { VideoMetadata } from "@cap/database/types";
+import { userIsPro } from "@cap/utils";
+import { ImageUploads } from "@cap/web-backend";
+import {
+	type Folder,
+	type ImageUpload,
+	type Organisation,
+	PublicCollection as PublicCollectionDomain,
+	type Space,
+	Video,
+} from "@cap/web-domain";
+import { and, desc, eq, inArray, isNull, type SQL, sql } from "drizzle-orm";
+import { Effect } from "effect";
+import { cookies } from "next/headers";
+import { cache } from "react";
+import {
+	PUBLIC_COLLECTION_PAGE_SIZE,
+	type PublicCollectionAccess,
+	type PublicCollectionKind,
+	resolvePublicCollectionAccess,
+	resolvePublicCollectionCandidate,
+} from "@/lib/public-collections-policy";
+import { runPromise } from "@/lib/server";
+
+export type PublicCollection = {
+	id: string;
+	kind: PublicCollectionKind;
+	name: string;
+	color: "normal" | "blue" | "red" | "yellow" | null;
+	description: string | null;
+	spaceId: Space.SpaceIdOrOrganisationId | null;
+	organizationId: Organisation.OrganisationId;
+	organizationName: string;
+	allowedEmailDomain: string | null;
+	passwordHash: string | null;
+	publicPage: Required<PublicCollectionDomain.PublicPageSettings>;
+	organizationIconUrl: ImageUpload.ImageUrl | null;
+	collectionLogoUrl: ImageUpload.ImageUrl | null;
+};
+
+export type PublicCollectionFolder = {
+	id: Folder.FolderId;
+	name: string;
+	color: "normal" | "blue" | "red" | "yellow";
+	parentId: Folder.FolderId | null;
+	videoCount: number;
+};
+
+/**
+ * Exactly the fields the public cap card renders — this object is serialized
+ * into the RSC payload of an anonymous page, so internal video settings,
+ * sources, and owner/org ids deliberately stay out of it.
+ */
+export type PublicCollectionVideo = {
+	id: Video.VideoId;
+	name: string;
+	createdAt: Date;
+	// Only the owner-set display date — never the full metadata JSON, which
+	// holds internal fields (sourceName, AI summary, processing state).
+	metadata: Pick<VideoMetadata, "customCreatedAt"> | undefined;
+	duration: number | null;
+	totalComments: number;
+	totalReactions: number;
+	ownerName: string;
+	hasPassword: boolean;
+	hasActiveUpload: boolean;
+};
+
+type PublicCollectionVideoRow = {
+	id: string;
+	name: string;
+	createdAt: Date;
+	metadata: (typeof videos.$inferSelect)["metadata"];
+	duration: number | null;
+	totalComments: number;
+	totalReactions: number;
+	ownerName: string | null;
+	hasPassword: boolean;
+	hasActiveUpload: boolean;
+};
+
+export type PublicCollectionPageData = {
+	collection: PublicCollection;
+	access: PublicCollectionAccess;
+	folders: PublicCollectionFolder[];
+	videos: PublicCollectionVideo[];
+	currentPage: number;
+	totalCount: number;
+	totalPages: number;
+	viewerIsSignedIn: boolean;
+};
+
+function videoPasswordPredicate(
+	videoId: SQL,
+	videoPassword: SQL,
+	verifiedPasswordHash: string | null,
+) {
+	const noPassword = sql`(${videoPassword} IS NULL AND NOT EXISTS (
+		SELECT 1 FROM space_videos sv_password
+		INNER JOIN spaces s_password ON sv_password.spaceId = s_password.id
+		WHERE sv_password.videoId = ${videoId}
+			AND s_password.password IS NOT NULL
+	))`;
+
+	if (!verifiedPasswordHash) return noPassword;
+
+	return sql`(${noPassword}
+		OR ${videoPassword} = ${verifiedPasswordHash}
+		OR EXISTS (
+			SELECT 1 FROM space_videos sv_password
+			INNER JOIN spaces s_password ON sv_password.spaceId = s_password.id
+			WHERE sv_password.videoId = ${videoId}
+				AND s_password.password = ${verifiedPasswordHash}
+		)
+	)`;
+}
+
+function hasPasswordExpression(videoId: SQL, videoPassword: SQL) {
+	return sql`${videoPassword} IS NOT NULL OR EXISTS (
+		SELECT 1 FROM space_videos sv_password
+		INNER JOIN spaces s_password ON sv_password.spaceId = s_password.id
+		WHERE sv_password.videoId = ${videoId}
+			AND s_password.password IS NOT NULL
+	)`;
+}
+
+async function getVerifiedPasswordHash() {
+	const cookieValue = (await cookies()).get("x-cap-password")?.value;
+	if (!cookieValue) return null;
+
+	try {
+		// decrypt is async — without the await its rejection (corrupt or stale
+		// cookie, rotated encryption key) would escape this catch and crash the
+		// page instead of falling back to the password prompt.
+		return await decrypt(cookieValue);
+	} catch {
+		return null;
+	}
+}
+
+export async function getPublicCollectionMetadata(collectionId: string) {
+	return resolvePublicCollection(collectionId);
+}
+
+export async function getPublicCollectionPageData(
+	collectionId: string,
+	page: number,
+): Promise<PublicCollectionPageData | null> {
+	const [collection, user, verifiedPasswordHash] = await Promise.all([
+		resolvePublicCollection(collectionId),
+		getCurrentUser(),
+		getVerifiedPasswordHash(),
+	]);
+
+	if (!collection) return null;
+
+	const access = resolvePublicCollectionAccess({
+		allowedEmailDomain: collection.allowedEmailDomain,
+		viewerEmail: user?.email,
+		passwordHash: collection.passwordHash,
+		verifiedPasswordHash,
+	});
+
+	if (access.state !== "allowed") {
+		return {
+			collection,
+			access,
+			folders: [],
+			videos: [],
+			currentPage: page,
+			totalCount: 0,
+			totalPages: 0,
+			viewerIsSignedIn: Boolean(user),
+		};
+	}
+
+	const [childFolders, videoPage] = await Promise.all([
+		getPublicChildFolders(collection, verifiedPasswordHash),
+		getPublicCollectionVideos(collection, page, verifiedPasswordHash),
+	]);
+
+	return {
+		collection,
+		access,
+		folders: childFolders,
+		videos: videoPage.videos,
+		currentPage: page,
+		totalCount: videoPage.totalCount,
+		totalPages: Math.ceil(videoPage.totalCount / PUBLIC_COLLECTION_PAGE_SIZE),
+		viewerIsSignedIn: Boolean(user),
+	};
+}
+
+async function resolveIconUrls(keys: {
+	organizationIconUrl: ImageUpload.ImageUrlOrKey | null;
+	collectionLogoUrl: ImageUpload.ImageUrlOrKey | null;
+}): Promise<{
+	organizationIconUrl: ImageUpload.ImageUrl | null;
+	collectionLogoUrl: ImageUpload.ImageUrl | null;
+}> {
+	const empty = {
+		organizationIconUrl: null,
+		collectionLogoUrl: null,
+	};
+
+	if (!keys.organizationIconUrl && !keys.collectionLogoUrl) {
+		return empty;
+	}
+
+	return Effect.gen(function* () {
+		const imageUploads = yield* ImageUploads;
+		const resolve = (key: ImageUpload.ImageUrlOrKey | null) =>
+			key ? imageUploads.resolveImageUrl(key) : Effect.succeed(null);
+
+		return {
+			organizationIconUrl: yield* resolve(keys.organizationIconUrl),
+			collectionLogoUrl: yield* resolve(keys.collectionLogoUrl),
+		};
+	}).pipe(runPromise);
+}
+
+function collectionLogoKey(
+	publicPage: Required<PublicCollectionDomain.PublicPageSettings>,
+): ImageUpload.ImageUrlOrKey | null {
+	return publicPage.logoUrl
+		? (publicPage.logoUrl as ImageUpload.ImageUrlOrKey)
+		: null;
+}
+
+function publicPageIconKeys(
+	publicPage: Required<PublicCollectionDomain.PublicPageSettings>,
+	keys: {
+		organizationIconUrl: ImageUpload.ImageUrlOrKey | null;
+	},
+) {
+	return {
+		organizationIconUrl:
+			publicPage.logoMode === "organization" ? keys.organizationIconUrl : null,
+		collectionLogoUrl:
+			publicPage.logoMode === "custom" ? collectionLogoKey(publicPage) : null,
+	};
+}
+
+/**
+ * Custom presentation (branding, CTA, hidden Cap logo) is a Pro entitlement
+ * gated on the org OWNER's plan at render time, mirroring `/s/`
+ * (`getSharePageBranding`): when the owner downgrades, already-public
+ * collections stay reachable but fall back to the default presentation.
+ */
+function resolveEffectivePublicPage(
+	ownerIsPro: boolean,
+	stored: PublicCollectionDomain.PublicPageSettings | null | undefined,
+) {
+	return PublicCollectionDomain.resolvePublicPageSettings(
+		ownerIsPro ? stored : null,
+	);
+}
+
+const resolvePublicCollection = cache(
+	async (collectionId: string): Promise<PublicCollection | null> => {
+		// Fetched by primary key, then gated in `resolvePublicCollectionCandidate`
+		// so the public/tombstone policy lives in one tested place.
+		const [folderRow] = await db()
+			.select({
+				id: folders.id,
+				name: folders.name,
+				color: folders.color,
+				public: folders.public,
+				settings: folders.settings,
+				spaceId: folders.spaceId,
+				organizationId: folders.organizationId,
+				organizationName: organizations.name,
+				organizationTombstoneAt: organizations.tombstoneAt,
+				allowedEmailDomain: organizations.allowedEmailDomain,
+				organizationIconUrl: organizations.iconUrl,
+				ownerStripeSubscriptionStatus: users.stripeSubscriptionStatus,
+				ownerThirdPartyStripeSubscriptionId:
+					users.thirdPartyStripeSubscriptionId,
+				passwordHash: spaces.password,
+			})
+			.from(folders)
+			.innerJoin(organizations, eq(folders.organizationId, organizations.id))
+			.innerJoin(users, eq(organizations.ownerId, users.id))
+			.leftJoin(spaces, eq(folders.spaceId, spaces.id))
+			.where(eq(folders.id, collectionId as Folder.FolderId))
+			.limit(1);
+
+		const folder = resolvePublicCollectionCandidate(
+			folderRow ? { kind: "folder" as const, ...folderRow } : null,
+			null,
+		);
+
+		if (folder) {
+			const publicPage = resolveEffectivePublicPage(
+				userIsPro({
+					stripeSubscriptionStatus: folder.ownerStripeSubscriptionStatus,
+					thirdPartyStripeSubscriptionId:
+						folder.ownerThirdPartyStripeSubscriptionId,
+				}),
+				folder.settings?.publicPage,
+			);
+			const icons = await resolveIconUrls({
+				...publicPageIconKeys(publicPage, {
+					organizationIconUrl: folder.organizationIconUrl,
+				}),
+			});
+
+			return {
+				id: folder.id,
+				kind: "folder",
+				name: folder.name,
+				color: folder.color,
+				description: null,
+				spaceId: folder.spaceId,
+				organizationId: folder.organizationId,
+				organizationName: folder.organizationName,
+				allowedEmailDomain: folder.allowedEmailDomain,
+				passwordHash: folder.passwordHash,
+				publicPage,
+				...icons,
+			};
+		}
+
+		const [spaceRow] = await db()
+			.select({
+				id: spaces.id,
+				name: spaces.name,
+				description: spaces.description,
+				public: spaces.public,
+				settings: spaces.settings,
+				organizationId: spaces.organizationId,
+				organizationName: organizations.name,
+				organizationTombstoneAt: organizations.tombstoneAt,
+				allowedEmailDomain: organizations.allowedEmailDomain,
+				organizationIconUrl: organizations.iconUrl,
+				ownerStripeSubscriptionStatus: users.stripeSubscriptionStatus,
+				ownerThirdPartyStripeSubscriptionId:
+					users.thirdPartyStripeSubscriptionId,
+				passwordHash: spaces.password,
+			})
+			.from(spaces)
+			.innerJoin(organizations, eq(spaces.organizationId, organizations.id))
+			.innerJoin(users, eq(organizations.ownerId, users.id))
+			.where(eq(spaces.id, collectionId as Space.SpaceIdOrOrganisationId))
+			.limit(1);
+
+		const space = resolvePublicCollectionCandidate(
+			null,
+			spaceRow ? { kind: "space" as const, ...spaceRow } : null,
+		);
+
+		if (!space) return null;
+
+		const publicPage = resolveEffectivePublicPage(
+			userIsPro({
+				stripeSubscriptionStatus: space.ownerStripeSubscriptionStatus,
+				thirdPartyStripeSubscriptionId:
+					space.ownerThirdPartyStripeSubscriptionId,
+			}),
+			space.settings?.publicPage,
+		);
+		const icons = await resolveIconUrls({
+			...publicPageIconKeys(publicPage, {
+				organizationIconUrl: space.organizationIconUrl,
+			}),
+		});
+
+		return {
+			id: space.id,
+			kind: "space",
+			name: space.name,
+			color: null,
+			description: space.description,
+			spaceId: space.id,
+			organizationId: space.organizationId,
+			organizationName: space.organizationName,
+			allowedEmailDomain: space.allowedEmailDomain,
+			passwordHash: space.passwordHash,
+			publicPage,
+			...icons,
+		};
+	},
+);
+
+/**
+ * Single source of truth for which password protects a public collection
+ * (a folder inherits its parent space's password). Reused by the password
+ * verification action so it can never drift from what the page checks.
+ */
+export async function getPublicCollectionPasswordHash(
+	collectionId: string,
+): Promise<string | null> {
+	const collection = await resolvePublicCollection(collectionId);
+	return collection?.passwordHash ?? null;
+}
+
+/**
+ * Folders in the org-wide shared area carry the ORGANIZATION id as their
+ * spaceId (the "all spaces" entry) and track membership in `shared_videos`,
+ * not `space_videos`.
+ */
+function isOrgLevelFolder(collection: PublicCollection) {
+	return (
+		collection.kind === "folder" &&
+		collection.spaceId === collection.organizationId
+	);
+}
+
+async function getPublicCollectionVideos(
+	collection: PublicCollection,
+	page: number,
+	verifiedPasswordHash: string | null,
+) {
+	if (collection.kind === "space") {
+		return getPublicSpaceVideos(collection, page, verifiedPasswordHash);
+	}
+
+	if (isOrgLevelFolder(collection)) {
+		return getPublicOrgFolderVideos(collection, page, verifiedPasswordHash);
+	}
+
+	if (collection.spaceId) {
+		return getPublicSpaceFolderVideos(collection, page, verifiedPasswordHash);
+	}
+
+	return getPublicUserFolderVideos(collection, page, verifiedPasswordHash);
+}
+
+const videoSelect = {
+	id: videos.id,
+	name: videos.name,
+	createdAt: videos.createdAt,
+	metadata: videos.metadata,
+	duration: videos.duration,
+	totalComments: sql<number>`COUNT(DISTINCT CASE WHEN ${comments.type} = 'text' THEN ${comments.id} END)`,
+	totalReactions: sql<number>`COUNT(DISTINCT CASE WHEN ${comments.type} = 'emoji' THEN ${comments.id} END)`,
+	ownerName: users.name,
+	hasPassword: hasPasswordExpression(
+		sql`${videos.id}`,
+		sql`${videos.password}`,
+	).mapWith(Boolean),
+	hasActiveUpload: sql`MAX(${videoUploads.videoId} IS NOT NULL)`.mapWith(
+		Boolean,
+	),
+};
+
+const videoGroupBy = [
+	videos.id,
+	videos.ownerId,
+	videos.orgId,
+	videos.name,
+	videos.createdAt,
+	videos.metadata,
+	videos.source,
+	videos.isScreenshot,
+	videos.duration,
+	videos.public,
+	videos.settings,
+	videos.password,
+	users.name,
+];
+
+function toPublicCollectionVideos(
+	videoRows: PublicCollectionVideoRow[],
+): PublicCollectionVideo[] {
+	return videoRows.map((video) => ({
+		id: Video.VideoId.make(video.id),
+		name: video.name,
+		createdAt: video.createdAt,
+		metadata: video.metadata?.customCreatedAt
+			? { customCreatedAt: video.metadata.customCreatedAt }
+			: undefined,
+		duration: video.duration,
+		totalComments: video.totalComments,
+		totalReactions: video.totalReactions,
+		ownerName: video.ownerName ?? "",
+		hasPassword: video.hasPassword,
+		hasActiveUpload: video.hasActiveUpload,
+	}));
+}
+
+async function getPublicSpaceVideos(
+	collection: PublicCollection,
+	page: number,
+	verifiedPasswordHash: string | null,
+) {
+	const offset = (page - 1) * PUBLIC_COLLECTION_PAGE_SIZE;
+	const where = and(
+		eq(spaceVideos.spaceId, collection.id as Space.SpaceIdOrOrganisationId),
+		eq(videos.public, true),
+		isNull(organizations.tombstoneAt),
+		videoPasswordPredicate(
+			sql`${videos.id}`,
+			sql`${videos.password}`,
+			verifiedPasswordHash,
+		),
+	);
+
+	const [videoRows, totalCountResult] = await Promise.all([
+		db()
+			.select(videoSelect)
+			.from(spaceVideos)
+			.innerJoin(videos, eq(spaceVideos.videoId, videos.id))
+			.innerJoin(organizations, eq(videos.orgId, organizations.id))
+			.leftJoin(comments, eq(videos.id, comments.videoId))
+			.leftJoin(users, eq(videos.ownerId, users.id))
+			.leftJoin(videoUploads, eq(videos.id, videoUploads.videoId))
+			.where(where)
+			.groupBy(...videoGroupBy)
+			.orderBy(desc(videos.effectiveCreatedAt))
+			.limit(PUBLIC_COLLECTION_PAGE_SIZE)
+			.offset(offset),
+		db()
+			.select({ count: sql<number>`COUNT(DISTINCT ${videos.id})` })
+			.from(spaceVideos)
+			.innerJoin(videos, eq(spaceVideos.videoId, videos.id))
+			.innerJoin(organizations, eq(videos.orgId, organizations.id))
+			.where(where),
+	]);
+
+	return {
+		videos: toPublicCollectionVideos(videoRows),
+		totalCount: totalCountResult[0]?.count ?? 0,
+	};
+}
+
+async function getPublicSpaceFolderVideos(
+	collection: PublicCollection,
+	page: number,
+	verifiedPasswordHash: string | null,
+) {
+	const offset = (page - 1) * PUBLIC_COLLECTION_PAGE_SIZE;
+	const where = and(
+		eq(spaceVideos.folderId, collection.id as Folder.FolderId),
+		eq(videos.public, true),
+		isNull(organizations.tombstoneAt),
+		videoPasswordPredicate(
+			sql`${videos.id}`,
+			sql`${videos.password}`,
+			verifiedPasswordHash,
+		),
+	);
+
+	const [videoRows, totalCountResult] = await Promise.all([
+		db()
+			.select(videoSelect)
+			.from(spaceVideos)
+			.innerJoin(videos, eq(spaceVideos.videoId, videos.id))
+			.innerJoin(organizations, eq(videos.orgId, organizations.id))
+			.leftJoin(comments, eq(videos.id, comments.videoId))
+			.leftJoin(users, eq(videos.ownerId, users.id))
+			.leftJoin(videoUploads, eq(videos.id, videoUploads.videoId))
+			.where(where)
+			.groupBy(...videoGroupBy)
+			.orderBy(desc(videos.effectiveCreatedAt))
+			.limit(PUBLIC_COLLECTION_PAGE_SIZE)
+			.offset(offset),
+		db()
+			.select({ count: sql<number>`COUNT(DISTINCT ${videos.id})` })
+			.from(spaceVideos)
+			.innerJoin(videos, eq(spaceVideos.videoId, videos.id))
+			.innerJoin(organizations, eq(videos.orgId, organizations.id))
+			.where(where),
+	]);
+
+	return {
+		videos: toPublicCollectionVideos(videoRows),
+		totalCount: totalCountResult[0]?.count ?? 0,
+	};
+}
+
+async function getPublicOrgFolderVideos(
+	collection: PublicCollection,
+	page: number,
+	verifiedPasswordHash: string | null,
+) {
+	const offset = (page - 1) * PUBLIC_COLLECTION_PAGE_SIZE;
+	const where = and(
+		eq(sharedVideos.folderId, collection.id as Folder.FolderId),
+		eq(videos.public, true),
+		isNull(organizations.tombstoneAt),
+		videoPasswordPredicate(
+			sql`${videos.id}`,
+			sql`${videos.password}`,
+			verifiedPasswordHash,
+		),
+	);
+
+	const [videoRows, totalCountResult] = await Promise.all([
+		db()
+			.select(videoSelect)
+			.from(sharedVideos)
+			.innerJoin(videos, eq(sharedVideos.videoId, videos.id))
+			.innerJoin(organizations, eq(videos.orgId, organizations.id))
+			.leftJoin(comments, eq(videos.id, comments.videoId))
+			.leftJoin(users, eq(videos.ownerId, users.id))
+			.leftJoin(videoUploads, eq(videos.id, videoUploads.videoId))
+			.where(where)
+			.groupBy(...videoGroupBy)
+			.orderBy(desc(videos.effectiveCreatedAt))
+			.limit(PUBLIC_COLLECTION_PAGE_SIZE)
+			.offset(offset),
+		db()
+			.select({ count: sql<number>`COUNT(DISTINCT ${videos.id})` })
+			.from(sharedVideos)
+			.innerJoin(videos, eq(sharedVideos.videoId, videos.id))
+			.innerJoin(organizations, eq(videos.orgId, organizations.id))
+			.where(where),
+	]);
+
+	return {
+		videos: toPublicCollectionVideos(videoRows),
+		totalCount: totalCountResult[0]?.count ?? 0,
+	};
+}
+
+async function getPublicUserFolderVideos(
+	collection: PublicCollection,
+	page: number,
+	verifiedPasswordHash: string | null,
+) {
+	const offset = (page - 1) * PUBLIC_COLLECTION_PAGE_SIZE;
+	const where = and(
+		eq(videos.folderId, collection.id as Folder.FolderId),
+		eq(videos.public, true),
+		isNull(organizations.tombstoneAt),
+		videoPasswordPredicate(
+			sql`${videos.id}`,
+			sql`${videos.password}`,
+			verifiedPasswordHash,
+		),
+	);
+
+	const [videoRows, totalCountResult] = await Promise.all([
+		db()
+			.select(videoSelect)
+			.from(videos)
+			.innerJoin(organizations, eq(videos.orgId, organizations.id))
+			.leftJoin(comments, eq(videos.id, comments.videoId))
+			.leftJoin(users, eq(videos.ownerId, users.id))
+			.leftJoin(videoUploads, eq(videos.id, videoUploads.videoId))
+			.where(where)
+			.groupBy(...videoGroupBy)
+			.orderBy(desc(videos.effectiveCreatedAt))
+			.limit(PUBLIC_COLLECTION_PAGE_SIZE)
+			.offset(offset),
+		db()
+			.select({ count: sql<number>`COUNT(DISTINCT ${videos.id})` })
+			.from(videos)
+			.innerJoin(organizations, eq(videos.orgId, organizations.id))
+			.where(where),
+	]);
+
+	return {
+		videos: toPublicCollectionVideos(videoRows),
+		totalCount: totalCountResult[0]?.count ?? 0,
+	};
+}
+
+async function getPublicChildFolders(
+	collection: PublicCollection,
+	verifiedPasswordHash: string | null,
+): Promise<PublicCollectionFolder[]> {
+	const where =
+		collection.kind === "space"
+			? and(
+					eq(folders.spaceId, collection.id as Space.SpaceIdOrOrganisationId),
+					isNull(folders.parentId),
+					eq(folders.public, true),
+					isNull(organizations.tombstoneAt),
+				)
+			: and(
+					eq(folders.parentId, collection.id as Folder.FolderId),
+					eq(folders.public, true),
+					isNull(organizations.tombstoneAt),
+				);
+
+	const childFolders = await db()
+		.select({
+			id: folders.id,
+			name: folders.name,
+			color: folders.color,
+			parentId: folders.parentId,
+		})
+		.from(folders)
+		.innerJoin(organizations, eq(folders.organizationId, organizations.id))
+		.where(where)
+		.orderBy(folders.name);
+
+	if (childFolders.length === 0) return [];
+
+	const folderIds = childFolders.map((folder) => folder.id);
+	const counts = isOrgLevelFolder(collection)
+		? await getPublicOrgFolderVideoCounts(folderIds, verifiedPasswordHash)
+		: collection.kind === "space" || Boolean(collection.spaceId)
+			? await getPublicSpaceFolderVideoCounts(folderIds, verifiedPasswordHash)
+			: await getPublicUserFolderVideoCounts(folderIds, verifiedPasswordHash);
+	const countByFolderId = new Map(
+		counts.map((row) => [row.folderId, row.videoCount]),
+	);
+
+	return childFolders.map((folder) => ({
+		...folder,
+		videoCount: countByFolderId.get(folder.id) ?? 0,
+	}));
+}
+
+async function getPublicSpaceFolderVideoCounts(
+	folderIds: Folder.FolderId[],
+	verifiedPasswordHash: string | null,
+) {
+	return db()
+		.select({
+			folderId: spaceVideos.folderId,
+			videoCount: sql<number>`COUNT(DISTINCT ${videos.id})`,
+		})
+		.from(spaceVideos)
+		.innerJoin(videos, eq(spaceVideos.videoId, videos.id))
+		.innerJoin(organizations, eq(videos.orgId, organizations.id))
+		.where(
+			and(
+				inArray(spaceVideos.folderId, folderIds),
+				eq(videos.public, true),
+				isNull(organizations.tombstoneAt),
+				videoPasswordPredicate(
+					sql`${videos.id}`,
+					sql`${videos.password}`,
+					verifiedPasswordHash,
+				),
+			),
+		)
+		.groupBy(spaceVideos.folderId);
+}
+
+async function getPublicOrgFolderVideoCounts(
+	folderIds: Folder.FolderId[],
+	verifiedPasswordHash: string | null,
+) {
+	return db()
+		.select({
+			folderId: sharedVideos.folderId,
+			videoCount: sql<number>`COUNT(DISTINCT ${videos.id})`,
+		})
+		.from(sharedVideos)
+		.innerJoin(videos, eq(sharedVideos.videoId, videos.id))
+		.innerJoin(organizations, eq(videos.orgId, organizations.id))
+		.where(
+			and(
+				inArray(sharedVideos.folderId, folderIds),
+				eq(videos.public, true),
+				isNull(organizations.tombstoneAt),
+				videoPasswordPredicate(
+					sql`${videos.id}`,
+					sql`${videos.password}`,
+					verifiedPasswordHash,
+				),
+			),
+		)
+		.groupBy(sharedVideos.folderId);
+}
+
+async function getPublicUserFolderVideoCounts(
+	folderIds: Folder.FolderId[],
+	verifiedPasswordHash: string | null,
+) {
+	return db()
+		.select({
+			folderId: videos.folderId,
+			videoCount: sql<number>`COUNT(DISTINCT ${videos.id})`,
+		})
+		.from(videos)
+		.innerJoin(organizations, eq(videos.orgId, organizations.id))
+		.where(
+			and(
+				inArray(videos.folderId, folderIds),
+				eq(videos.public, true),
+				isNull(organizations.tombstoneAt),
+				videoPasswordPredicate(
+					sql`${videos.id}`,
+					sql`${videos.password}`,
+					verifiedPasswordHash,
+				),
+			),
+		)
+		.groupBy(videos.folderId);
+}

--- a/apps/web/lib/server.ts
+++ b/apps/web/lib/server.ts
@@ -51,7 +51,14 @@ const CookiePasswordAttachmentLive = Layer.effect(
 		const password = Option.fromNullable(
 			yield* Effect.promise(async () => {
 				const pw = (await cookies()).get("x-cap-password")?.value;
-				if (pw) return decrypt(pw);
+				if (!pw) return undefined;
+				try {
+					return await decrypt(pw);
+				} catch {
+					// Corrupt or stale cookie (e.g. rotated encryption key) — treat
+					// as absent rather than crashing the page with a defect.
+					return undefined;
+				}
 			}),
 		);
 		return { password };

--- a/apps/web/lib/server.ts
+++ b/apps/web/lib/server.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import { decrypt } from "@cap/database/crypto";
 import { serverEnv } from "@cap/env";
 import {
 	AwsCredentials,
@@ -41,27 +40,15 @@ import {
 	Option,
 	Redacted,
 } from "effect";
-import { cookies } from "next/headers";
 import { allowedOrigins } from "@/utils/cors";
+import { getVerifiedPasswordHashes } from "./password-cookie";
 import { layerTracer } from "./tracing";
 
 const CookiePasswordAttachmentLive = Layer.effect(
 	Video.VideoPasswordAttachment,
 	Effect.gen(function* () {
-		const password = Option.fromNullable(
-			yield* Effect.promise(async () => {
-				const pw = (await cookies()).get("x-cap-password")?.value;
-				if (!pw) return undefined;
-				try {
-					return await decrypt(pw);
-				} catch {
-					// Corrupt or stale cookie (e.g. rotated encryption key) — treat
-					// as absent rather than crashing the page with a defect.
-					return undefined;
-				}
-			}),
-		);
-		return { password };
+		const passwords = yield* Effect.promise(getVerifiedPasswordHashes);
+		return { passwords };
 	}),
 );
 

--- a/apps/web/lib/share-branding.ts
+++ b/apps/web/lib/share-branding.ts
@@ -1,0 +1,57 @@
+import type { ImageUpload } from "@cap/web-domain";
+
+/**
+ * Branding shown on public-facing pages (`/s/[videoId]` and `/c/[id]`).
+ * Pro organizations can show a custom icon or hide the Cap logo entirely;
+ * free organizations always fall back to the Cap logo.
+ */
+export type SharePageBranding =
+	| {
+			type: "custom";
+			imageUrl: ImageUpload.ImageUrl;
+			name: string;
+	  }
+	| {
+			type: "cap";
+	  };
+
+export type SharePageBrandingInput = {
+	owner: { isPro: boolean };
+	orgSettings?: {
+		shareableLinkUseOrganizationIcon?: boolean;
+		hideShareableLinkCapLogo?: boolean;
+	} | null;
+	organizationName?: string | null;
+	organizationIconUrl?: ImageUpload.ImageUrl | null;
+	shareableLinkIconUrl?: ImageUpload.ImageUrl | null;
+};
+
+/**
+ * Resolves how a shared page should be branded. Returns `null` when a Pro
+ * organization has opted to hide the Cap logo and has no custom icon set.
+ */
+export function getSharePageBranding(
+	data: SharePageBrandingInput,
+): SharePageBranding | null {
+	if (!data.owner.isPro) {
+		return { type: "cap" };
+	}
+
+	const brandedIcon = data.orgSettings?.shareableLinkUseOrganizationIcon
+		? data.organizationIconUrl
+		: data.shareableLinkIconUrl;
+
+	if (brandedIcon) {
+		return {
+			type: "custom",
+			imageUrl: brandedIcon,
+			name: data.organizationName ?? "Organization",
+		};
+	}
+
+	if (data.orgSettings?.hideShareableLinkCapLogo) {
+		return null;
+	}
+
+	return { type: "cap" };
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -98,6 +98,16 @@ const nextConfig = {
 					},
 				],
 			},
+			{
+				source: "/c/:collectionId",
+				destination: "/c/:collectionId",
+				has: [
+					{
+						type: "host",
+						value: "(?!cap.so|cap.link).*",
+					},
+				],
+			},
 		];
 	},
 	async redirects() {

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -44,6 +44,7 @@ export async function proxy(request: NextRequest) {
 		if (
 			!(
 				path.startsWith("/s/") ||
+				path.startsWith("/c/") ||
 				path.startsWith("/middleware") ||
 				path.startsWith("/dashboard") ||
 				path.startsWith("/onboarding") ||
@@ -69,7 +70,7 @@ export async function proxy(request: NextRequest) {
 	const webUrl = new URL(serverEnv().WEB_URL).hostname;
 
 	try {
-		if (!path.startsWith("/s/")) {
+		if (!(path.startsWith("/s/") || path.startsWith("/c/"))) {
 			const url = new URL(request.url);
 			url.hostname = webUrl;
 			return NextResponse.redirect(url);

--- a/packages/database/migrations/0028_nebulous_madame_masque.sql
+++ b/packages/database/migrations/0028_nebulous_madame_masque.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `folders` ADD `public` boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `spaces` ADD `public` boolean DEFAULT false NOT NULL;--> statement-breakpoint
+CREATE INDEX `public_parent_id_idx` ON `folders` (`public`,`parentId`);--> statement-breakpoint
+CREATE INDEX `public_idx` ON `spaces` (`public`);

--- a/packages/database/migrations/0029_blushing_pretty_boy.sql
+++ b/packages/database/migrations/0029_blushing_pretty_boy.sql
@@ -1,0 +1,3 @@
+DROP INDEX `public_idx` ON `spaces`;--> statement-breakpoint
+CREATE INDEX `public_space_parent_id_idx` ON `folders` (`public`,`spaceId`,`parentId`);--> statement-breakpoint
+CREATE INDEX `public_organization_id_idx` ON `spaces` (`public`,`organizationId`);

--- a/packages/database/migrations/0030_add_folder_settings.sql
+++ b/packages/database/migrations/0030_add_folder_settings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `folders` ADD `settings` json;

--- a/packages/database/migrations/meta/0028_snapshot.json
+++ b/packages/database/migrations/meta/0028_snapshot.json
@@ -1,0 +1,3298 @@
+{
+	"version": "5",
+	"dialect": "mysql",
+	"id": "a7eae021-91eb-40ee-abf5-25c72ac44e74",
+	"prevId": "64acdb33-8e7f-46a4-b84d-7641ac12e93d",
+	"tables": {
+		"accounts": {
+			"name": "accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerAccountId": {
+					"name": "providerAccountId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_in": {
+					"name": "expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_in": {
+					"name": "refresh_token_expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"tempColumn": {
+					"name": "tempColumn",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				},
+				"provider_account_id_idx": {
+					"name": "provider_account_id_idx",
+					"columns": ["providerAccountId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"accounts_id": {
+					"name": "accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"auth_api_keys": {
+			"name": "auth_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(36)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"auth_api_keys_id": {
+					"name": "auth_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"comments": {
+			"name": "comments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(6)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"authorId": {
+					"name": "authorId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"parentCommentId": {
+					"name": "parentCommentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"video_type_created_idx": {
+					"name": "video_type_created_idx",
+					"columns": ["videoId", "type", "createdAt", "id"],
+					"isUnique": false
+				},
+				"author_id_idx": {
+					"name": "author_id_idx",
+					"columns": ["authorId"],
+					"isUnique": false
+				},
+				"parent_comment_id_idx": {
+					"name": "parent_comment_id_idx",
+					"columns": ["parentCommentId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"comments_id": {
+					"name": "comments_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_api_keys": {
+			"name": "developer_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyType": {
+					"name": "keyType",
+					"type": "varchar(8)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyPrefix": {
+					"name": "keyPrefix",
+					"type": "varchar(12)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyHash": {
+					"name": "keyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"encryptedKey": {
+					"name": "encryptedKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"lastUsedAt": {
+					"name": "lastUsedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"revokedAt": {
+					"name": "revokedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"key_hash_idx": {
+					"name": "key_hash_idx",
+					"columns": ["keyHash"],
+					"isUnique": true
+				},
+				"app_key_type_idx": {
+					"name": "app_key_type_idx",
+					"columns": ["appId", "keyType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_api_keys_appId_developer_apps_id_fk": {
+					"name": "developer_api_keys_appId_developer_apps_id_fk",
+					"tableFrom": "developer_api_keys",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_api_keys_id": {
+					"name": "developer_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_app_domains": {
+			"name": "developer_app_domains",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"domain": {
+					"name": "domain",
+					"type": "varchar(253)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_app_domains_appId_developer_apps_id_fk": {
+					"name": "developer_app_domains_appId_developer_apps_id_fk",
+					"tableFrom": "developer_app_domains",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_app_domains_id": {
+					"name": "developer_app_domains_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_domain_unique": {
+					"name": "app_domain_unique",
+					"columns": ["appId", "domain"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_apps": {
+			"name": "developer_apps",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"environment": {
+					"name": "environment",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"logoUrl": {
+					"name": "logoUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_deleted_idx": {
+					"name": "owner_deleted_idx",
+					"columns": ["ownerId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"developer_apps_id": {
+					"name": "developer_apps_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_accounts": {
+			"name": "developer_credit_accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceMicroCredits": {
+					"name": "balanceMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripePaymentMethodId": {
+					"name": "stripePaymentMethodId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"autoTopUpEnabled": {
+					"name": "autoTopUpEnabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"autoTopUpThresholdMicroCredits": {
+					"name": "autoTopUpThresholdMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"autoTopUpAmountCents": {
+					"name": "autoTopUpAmountCents",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_id_unique": {
+					"name": "app_id_unique",
+					"columns": ["appId"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"developer_credit_accounts_appId_developer_apps_id_fk": {
+					"name": "developer_credit_accounts_appId_developer_apps_id_fk",
+					"tableFrom": "developer_credit_accounts",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_accounts_id": {
+					"name": "developer_credit_accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_transactions": {
+			"name": "developer_credit_transactions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amountMicroCredits": {
+					"name": "amountMicroCredits",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceAfterMicroCredits": {
+					"name": "balanceAfterMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"referenceId": {
+					"name": "referenceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"referenceType": {
+					"name": "referenceType",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"account_type_created_idx": {
+					"name": "account_type_created_idx",
+					"columns": ["accountId", "type", "createdAt"],
+					"isUnique": false
+				},
+				"account_ref_dedup_idx": {
+					"name": "account_ref_dedup_idx",
+					"columns": ["accountId", "referenceId", "referenceType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"dev_credit_txn_account_fk": {
+					"name": "dev_credit_txn_account_fk",
+					"tableFrom": "developer_credit_transactions",
+					"tableTo": "developer_credit_accounts",
+					"columnsFrom": ["accountId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_transactions_id": {
+					"name": "developer_credit_transactions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_daily_storage_snapshots": {
+			"name": "developer_daily_storage_snapshots",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"snapshotDate": {
+					"name": "snapshotDate",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"totalDurationMinutes": {
+					"name": "totalDurationMinutes",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"videoCount": {
+					"name": "videoCount",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"microCreditsCharged": {
+					"name": "microCreditsCharged",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processedAt": {
+					"name": "processedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_daily_storage_snapshots_appId_developer_apps_id_fk": {
+					"name": "developer_daily_storage_snapshots_appId_developer_apps_id_fk",
+					"tableFrom": "developer_daily_storage_snapshots",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_daily_storage_snapshots_id": {
+					"name": "developer_daily_storage_snapshots_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_date_unique": {
+					"name": "app_date_unique",
+					"columns": ["appId", "snapshotDate"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_videos": {
+			"name": "developer_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"externalUserId": {
+					"name": "externalUserId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Untitled'"
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"s3Key": {
+					"name": "s3Key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_created_idx": {
+					"name": "app_created_idx",
+					"columns": ["appId", "createdAt"],
+					"isUnique": false
+				},
+				"app_user_idx": {
+					"name": "app_user_idx",
+					"columns": ["appId", "externalUserId"],
+					"isUnique": false
+				},
+				"app_deleted_idx": {
+					"name": "app_deleted_idx",
+					"columns": ["appId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_videos_appId_developer_apps_id_fk": {
+					"name": "developer_videos_appId_developer_apps_id_fk",
+					"tableFrom": "developer_videos",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_videos_id": {
+					"name": "developer_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"folders": {
+			"name": "folders",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"color": {
+					"name": "color",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'normal'"
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parentId": {
+					"name": "parentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				},
+				"parent_id_idx": {
+					"name": "parent_id_idx",
+					"columns": ["parentId"],
+					"isUnique": false
+				},
+				"space_id_idx": {
+					"name": "space_id_idx",
+					"columns": ["spaceId"],
+					"isUnique": false
+				},
+				"public_parent_id_idx": {
+					"name": "public_parent_id_idx",
+					"columns": ["public", "parentId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"folders_id": {
+					"name": "folders_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"imported_videos": {
+			"name": "imported_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"imported_videos_orgId_source_source_id_pk": {
+					"name": "imported_videos_orgId_source_source_id_pk",
+					"columns": ["orgId", "source", "source_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_conversations": {
+			"name": "messenger_conversations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent": {
+					"name": "agent",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'agent'"
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverByUserId": {
+					"name": "takeoverByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverAt": {
+					"name": "takeoverAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"lastMessageAt": {
+					"name": "lastMessageAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_last_message_idx": {
+					"name": "user_last_message_idx",
+					"columns": ["userId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"anonymous_last_message_idx": {
+					"name": "anonymous_last_message_idx",
+					"columns": ["anonymousId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"mode_last_message_idx": {
+					"name": "mode_last_message_idx",
+					"columns": ["mode", "lastMessageAt"],
+					"isUnique": false
+				},
+				"updated_at_idx": {
+					"name": "updated_at_idx",
+					"columns": ["updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"messenger_conversations_id": {
+					"name": "messenger_conversations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_messages": {
+			"name": "messenger_messages",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"conversationId": {
+					"name": "conversationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"conversation_created_at_idx": {
+					"name": "conversation_created_at_idx",
+					"columns": ["conversationId", "createdAt"],
+					"isUnique": false
+				},
+				"role_created_at_idx": {
+					"name": "role_created_at_idx",
+					"columns": ["role", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"messenger_messages_conversationId_messenger_conversations_id_fk": {
+					"name": "messenger_messages_conversationId_messenger_conversations_id_fk",
+					"tableFrom": "messenger_messages",
+					"tableTo": "messenger_conversations",
+					"columnsFrom": ["conversationId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"messenger_messages_id": {
+					"name": "messenger_messages_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"notifications": {
+			"name": "notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recipientId": {
+					"name": "recipientId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"data": {
+					"name": "data",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dedupKey": {
+					"name": "dedupKey",
+					"type": "varchar(128)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"readAt": {
+					"name": "readAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"org_id_idx": {
+					"name": "org_id_idx",
+					"columns": ["orgId"],
+					"isUnique": false
+				},
+				"type_idx": {
+					"name": "type_idx",
+					"columns": ["type"],
+					"isUnique": false
+				},
+				"read_at_idx": {
+					"name": "read_at_idx",
+					"columns": ["readAt"],
+					"isUnique": false
+				},
+				"created_at_idx": {
+					"name": "created_at_idx",
+					"columns": ["createdAt"],
+					"isUnique": false
+				},
+				"recipient_read_idx": {
+					"name": "recipient_read_idx",
+					"columns": ["recipientId", "readAt"],
+					"isUnique": false
+				},
+				"recipient_created_idx": {
+					"name": "recipient_created_idx",
+					"columns": ["recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"dedup_key_idx": {
+					"name": "dedup_key_idx",
+					"columns": ["dedupKey"],
+					"isUnique": true
+				},
+				"type_recipient_created_idx": {
+					"name": "type_recipient_created_idx",
+					"columns": ["type", "recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"type_recipient_video_created_idx": {
+					"name": "type_recipient_video_created_idx",
+					"columns": ["type", "recipientId", "videoId", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"notifications_id": {
+					"name": "notifications_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_invites": {
+			"name": "organization_invites",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedEmail": {
+					"name": "invitedEmail",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedByUserId": {
+					"name": "invitedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"invited_email_idx": {
+					"name": "invited_email_idx",
+					"columns": ["invitedEmail"],
+					"isUnique": false
+				},
+				"invited_by_user_id_idx": {
+					"name": "invited_by_user_id_idx",
+					"columns": ["invitedByUserId"],
+					"isUnique": false
+				},
+				"status_idx": {
+					"name": "status_idx",
+					"columns": ["status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_invites_id": {
+					"name": "organization_invites_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_members": {
+			"name": "organization_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"hasProSeat": {
+					"name": "hasProSeat",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"user_id_organization_id_idx": {
+					"name": "user_id_organization_id_idx",
+					"columns": ["userId", "organizationId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_members_id": {
+					"name": "organization_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organizations": {
+			"name": "organizations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tombstoneAt": {
+					"name": "tombstoneAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"allowedEmailDomain": {
+					"name": "allowedEmailDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customDomain": {
+					"name": "customDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"domainVerified": {
+					"name": "domainVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"shareableLinkIconUrl": {
+					"name": "shareableLinkIconUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"workosOrganizationId": {
+					"name": "workosOrganizationId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"workosConnectionId": {
+					"name": "workosConnectionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"owner_id_tombstone_idx": {
+					"name": "owner_id_tombstone_idx",
+					"columns": ["ownerId", "tombstoneAt"],
+					"isUnique": false
+				},
+				"custom_domain_idx": {
+					"name": "custom_domain_idx",
+					"columns": ["customDomain"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organizations_id": {
+					"name": "organizations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"s3_buckets": {
+			"name": "s3_buckets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"region": {
+					"name": "region",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"endpoint": {
+					"name": "endpoint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"bucketName": {
+					"name": "bucketName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accessKeyId": {
+					"name": "accessKeyId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"secretAccessKey": {
+					"name": "secretAccessKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('aws')"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_organization_idx": {
+					"name": "owner_organization_idx",
+					"columns": ["ownerId", "organizationId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"s3_buckets_id": {
+					"name": "s3_buckets_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"sessions": {
+			"name": "sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sessionToken": {
+					"name": "sessionToken",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"session_token_idx": {
+					"name": "session_token_idx",
+					"columns": ["sessionToken"],
+					"isUnique": true
+				},
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"sessions_id": {
+					"name": "sessions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"shared_videos": {
+			"name": "shared_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedByUserId": {
+					"name": "sharedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedAt": {
+					"name": "sharedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"shared_by_user_id_idx": {
+					"name": "shared_by_user_id_idx",
+					"columns": ["sharedByUserId"],
+					"isUnique": false
+				},
+				"video_id_organization_id_idx": {
+					"name": "video_id_organization_id_idx",
+					"columns": ["videoId", "organizationId"],
+					"isUnique": false
+				},
+				"video_id_folder_id_idx": {
+					"name": "video_id_folder_id_idx",
+					"columns": ["videoId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"shared_videos_id": {
+					"name": "shared_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"space_members": {
+			"name": "space_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'member'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_members_id": {
+					"name": "space_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"space_id_user_id_unique": {
+					"name": "space_id_user_id_unique",
+					"columns": ["spaceId", "userId"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"space_videos": {
+			"name": "space_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedById": {
+					"name": "addedById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedAt": {
+					"name": "addedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"added_by_id_idx": {
+					"name": "added_by_id_idx",
+					"columns": ["addedById"],
+					"isUnique": false
+				},
+				"space_id_video_id_idx": {
+					"name": "space_id_video_id_idx",
+					"columns": ["spaceId", "videoId"],
+					"isUnique": false
+				},
+				"space_id_folder_id_idx": {
+					"name": "space_id_folder_id_idx",
+					"columns": ["spaceId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_videos_id": {
+					"name": "space_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"spaces": {
+			"name": "spaces",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"primary": {
+					"name": "primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "varchar(1000)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"privacy": {
+					"name": "privacy",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Private'"
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				},
+				"public_idx": {
+					"name": "public_idx",
+					"columns": ["public"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"spaces_id": {
+					"name": "spaces_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_integrations": {
+			"name": "storage_integrations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"displayName": {
+					"name": "displayName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"encryptedConfig": {
+					"name": "encryptedConfig",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"googleDriveAccessToken": {
+					"name": "googleDriveAccessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveAccessTokenExpiresAt": {
+					"name": "googleDriveAccessTokenExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseId": {
+					"name": "googleDriveTokenRefreshLeaseId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseExpiresAt": {
+					"name": "googleDriveTokenRefreshLeaseExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveStorageQuotaCache": {
+					"name": "googleDriveStorageQuotaCache",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_provider_idx": {
+					"name": "owner_provider_idx",
+					"columns": ["ownerId", "provider"],
+					"isUnique": false
+				},
+				"owner_active_idx": {
+					"name": "owner_active_idx",
+					"columns": ["ownerId", "active"],
+					"isUnique": false
+				},
+				"organization_provider_idx": {
+					"name": "organization_provider_idx",
+					"columns": ["organizationId", "provider"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"storage_integrations_id": {
+					"name": "storage_integrations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_objects": {
+			"name": "storage_objects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"integrationId": {
+					"name": "integrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"objectKey": {
+					"name": "objectKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"objectKeyHash": {
+					"name": "objectKeyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerObjectId": {
+					"name": "providerObjectId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploadSessionUrl": {
+					"name": "uploadSessionUrl",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"uploadStatus": {
+					"name": "uploadStatus",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"contentType": {
+					"name": "contentType",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"contentLength": {
+					"name": "contentLength",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"integration_key_hash_idx": {
+					"name": "integration_key_hash_idx",
+					"columns": ["integrationId", "objectKeyHash"],
+					"isUnique": true
+				},
+				"integration_status_idx": {
+					"name": "integration_status_idx",
+					"columns": ["integrationId", "uploadStatus"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"storage_objects_integrationId_storage_integrations_id_fk": {
+					"name": "storage_objects_integrationId_storage_integrations_id_fk",
+					"tableFrom": "storage_objects",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["integrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"storage_objects_id": {
+					"name": "storage_objects_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"lastName": {
+					"name": "lastName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionId": {
+					"name": "stripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"thirdPartyStripeSubscriptionId": {
+					"name": "thirdPartyStripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionStatus": {
+					"name": "stripeSubscriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionPriceId": {
+					"name": "stripeSubscriptionPriceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preferences": {
+					"name": "preferences",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "('null')"
+				},
+				"activeOrganizationId": {
+					"name": "activeOrganizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"onboardingSteps": {
+					"name": "onboardingSteps",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"onboarding_completed_at": {
+					"name": "onboarding_completed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customBucket": {
+					"name": "customBucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"inviteQuota": {
+					"name": "inviteQuota",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"defaultOrgId": {
+					"name": "defaultOrgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"authSessionVersion": {
+					"name": "authSessionVersion",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {
+				"email_idx": {
+					"name": "email_idx",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"users_id": {
+					"name": "users_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"verification_tokens": {
+			"name": "verification_tokens",
+			"columns": {
+				"identifier": {
+					"name": "identifier",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"verification_tokens_identifier": {
+					"name": "verification_tokens_identifier",
+					"columns": ["identifier"]
+				}
+			},
+			"uniqueConstraints": {
+				"verification_tokens_token_unique": {
+					"name": "verification_tokens_token_unique",
+					"columns": ["token"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"video_edits": {
+			"name": "video_edits",
+			"columns": {
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sourceKey": {
+					"name": "sourceKey",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"editSpec": {
+					"name": "editSpec",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"video_edits_videoId_videos_id_fk": {
+					"name": "video_edits_videoId_videos_id_fk",
+					"tableFrom": "video_edits",
+					"tableTo": "videos",
+					"columnsFrom": ["videoId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"video_edits_videoId": {
+					"name": "video_edits_videoId",
+					"columns": ["videoId"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"video_uploads": {
+			"name": "video_uploads",
+			"columns": {
+				"video_id": {
+					"name": "video_id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploaded": {
+					"name": "uploaded",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"total": {
+					"name": "total",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phase": {
+					"name": "phase",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'uploading'"
+				},
+				"processing_progress": {
+					"name": "processing_progress",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processing_message": {
+					"name": "processing_message",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"processing_error": {
+					"name": "processing_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"raw_file_key": {
+					"name": "raw_file_key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"phase_updated_at_video_id_idx": {
+					"name": "phase_updated_at_video_id_idx",
+					"columns": ["phase", "updated_at", "video_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"video_uploads_video_id": {
+					"name": "video_uploads_video_id",
+					"columns": ["video_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"videos": {
+			"name": "videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'My Video'"
+				},
+				"bucket": {
+					"name": "bucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"storageIntegrationId": {
+					"name": "storageIntegrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('{\"type\":\"MediaConvert\"}')"
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"effectiveCreatedAt": {
+					"name": "effectiveCreatedAt",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"generated": {
+						"as": "COALESCE(\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%s.%fZ'),\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%sZ'),\n          `createdAt`\n        )",
+						"type": "stored"
+					}
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"xStreamInfo": {
+					"name": "xStreamInfo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"firstViewEmailSentAt": {
+					"name": "firstViewEmailSentAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"isScreenshot": {
+					"name": "isScreenshot",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"awsRegion": {
+					"name": "awsRegion",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"awsBucket": {
+					"name": "awsBucket",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoStartTime": {
+					"name": "videoStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"audioStartTime": {
+					"name": "audioStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobId": {
+					"name": "jobId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobStatus": {
+					"name": "jobStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"skipProcessing": {
+					"name": "skipProcessing",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				},
+				"is_public_idx": {
+					"name": "is_public_idx",
+					"columns": ["public"],
+					"isUnique": false
+				},
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"storage_integration_id_idx": {
+					"name": "storage_integration_id_idx",
+					"columns": ["storageIntegrationId"],
+					"isUnique": false
+				},
+				"org_owner_folder_idx": {
+					"name": "org_owner_folder_idx",
+					"columns": ["orgId", "ownerId", "folderId"],
+					"isUnique": false
+				},
+				"org_effective_created_idx": {
+					"name": "org_effective_created_idx",
+					"columns": ["orgId", "effectiveCreatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"videos_storageIntegrationId_storage_integrations_id_fk": {
+					"name": "videos_storageIntegrationId_storage_integrations_id_fk",
+					"tableFrom": "videos",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["storageIntegrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"videos_id": {
+					"name": "videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		}
+	},
+	"views": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"tables": {},
+		"indexes": {}
+	}
+}

--- a/packages/database/migrations/meta/0029_snapshot.json
+++ b/packages/database/migrations/meta/0029_snapshot.json
@@ -1,0 +1,3303 @@
+{
+	"version": "5",
+	"dialect": "mysql",
+	"id": "dbb85015-6143-46d2-933a-e77e36f6a4cb",
+	"prevId": "a7eae021-91eb-40ee-abf5-25c72ac44e74",
+	"tables": {
+		"accounts": {
+			"name": "accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerAccountId": {
+					"name": "providerAccountId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_in": {
+					"name": "expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_in": {
+					"name": "refresh_token_expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"tempColumn": {
+					"name": "tempColumn",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				},
+				"provider_account_id_idx": {
+					"name": "provider_account_id_idx",
+					"columns": ["providerAccountId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"accounts_id": {
+					"name": "accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"auth_api_keys": {
+			"name": "auth_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(36)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"auth_api_keys_id": {
+					"name": "auth_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"comments": {
+			"name": "comments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(6)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"authorId": {
+					"name": "authorId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"parentCommentId": {
+					"name": "parentCommentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"video_type_created_idx": {
+					"name": "video_type_created_idx",
+					"columns": ["videoId", "type", "createdAt", "id"],
+					"isUnique": false
+				},
+				"author_id_idx": {
+					"name": "author_id_idx",
+					"columns": ["authorId"],
+					"isUnique": false
+				},
+				"parent_comment_id_idx": {
+					"name": "parent_comment_id_idx",
+					"columns": ["parentCommentId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"comments_id": {
+					"name": "comments_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_api_keys": {
+			"name": "developer_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyType": {
+					"name": "keyType",
+					"type": "varchar(8)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyPrefix": {
+					"name": "keyPrefix",
+					"type": "varchar(12)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyHash": {
+					"name": "keyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"encryptedKey": {
+					"name": "encryptedKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"lastUsedAt": {
+					"name": "lastUsedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"revokedAt": {
+					"name": "revokedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"key_hash_idx": {
+					"name": "key_hash_idx",
+					"columns": ["keyHash"],
+					"isUnique": true
+				},
+				"app_key_type_idx": {
+					"name": "app_key_type_idx",
+					"columns": ["appId", "keyType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_api_keys_appId_developer_apps_id_fk": {
+					"name": "developer_api_keys_appId_developer_apps_id_fk",
+					"tableFrom": "developer_api_keys",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_api_keys_id": {
+					"name": "developer_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_app_domains": {
+			"name": "developer_app_domains",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"domain": {
+					"name": "domain",
+					"type": "varchar(253)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_app_domains_appId_developer_apps_id_fk": {
+					"name": "developer_app_domains_appId_developer_apps_id_fk",
+					"tableFrom": "developer_app_domains",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_app_domains_id": {
+					"name": "developer_app_domains_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_domain_unique": {
+					"name": "app_domain_unique",
+					"columns": ["appId", "domain"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_apps": {
+			"name": "developer_apps",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"environment": {
+					"name": "environment",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"logoUrl": {
+					"name": "logoUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_deleted_idx": {
+					"name": "owner_deleted_idx",
+					"columns": ["ownerId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"developer_apps_id": {
+					"name": "developer_apps_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_accounts": {
+			"name": "developer_credit_accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceMicroCredits": {
+					"name": "balanceMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripePaymentMethodId": {
+					"name": "stripePaymentMethodId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"autoTopUpEnabled": {
+					"name": "autoTopUpEnabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"autoTopUpThresholdMicroCredits": {
+					"name": "autoTopUpThresholdMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"autoTopUpAmountCents": {
+					"name": "autoTopUpAmountCents",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_id_unique": {
+					"name": "app_id_unique",
+					"columns": ["appId"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"developer_credit_accounts_appId_developer_apps_id_fk": {
+					"name": "developer_credit_accounts_appId_developer_apps_id_fk",
+					"tableFrom": "developer_credit_accounts",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_accounts_id": {
+					"name": "developer_credit_accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_transactions": {
+			"name": "developer_credit_transactions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amountMicroCredits": {
+					"name": "amountMicroCredits",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceAfterMicroCredits": {
+					"name": "balanceAfterMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"referenceId": {
+					"name": "referenceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"referenceType": {
+					"name": "referenceType",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"account_type_created_idx": {
+					"name": "account_type_created_idx",
+					"columns": ["accountId", "type", "createdAt"],
+					"isUnique": false
+				},
+				"account_ref_dedup_idx": {
+					"name": "account_ref_dedup_idx",
+					"columns": ["accountId", "referenceId", "referenceType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"dev_credit_txn_account_fk": {
+					"name": "dev_credit_txn_account_fk",
+					"tableFrom": "developer_credit_transactions",
+					"tableTo": "developer_credit_accounts",
+					"columnsFrom": ["accountId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_transactions_id": {
+					"name": "developer_credit_transactions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_daily_storage_snapshots": {
+			"name": "developer_daily_storage_snapshots",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"snapshotDate": {
+					"name": "snapshotDate",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"totalDurationMinutes": {
+					"name": "totalDurationMinutes",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"videoCount": {
+					"name": "videoCount",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"microCreditsCharged": {
+					"name": "microCreditsCharged",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processedAt": {
+					"name": "processedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_daily_storage_snapshots_appId_developer_apps_id_fk": {
+					"name": "developer_daily_storage_snapshots_appId_developer_apps_id_fk",
+					"tableFrom": "developer_daily_storage_snapshots",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_daily_storage_snapshots_id": {
+					"name": "developer_daily_storage_snapshots_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_date_unique": {
+					"name": "app_date_unique",
+					"columns": ["appId", "snapshotDate"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_videos": {
+			"name": "developer_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"externalUserId": {
+					"name": "externalUserId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Untitled'"
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"s3Key": {
+					"name": "s3Key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_created_idx": {
+					"name": "app_created_idx",
+					"columns": ["appId", "createdAt"],
+					"isUnique": false
+				},
+				"app_user_idx": {
+					"name": "app_user_idx",
+					"columns": ["appId", "externalUserId"],
+					"isUnique": false
+				},
+				"app_deleted_idx": {
+					"name": "app_deleted_idx",
+					"columns": ["appId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_videos_appId_developer_apps_id_fk": {
+					"name": "developer_videos_appId_developer_apps_id_fk",
+					"tableFrom": "developer_videos",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_videos_id": {
+					"name": "developer_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"folders": {
+			"name": "folders",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"color": {
+					"name": "color",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'normal'"
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parentId": {
+					"name": "parentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				},
+				"parent_id_idx": {
+					"name": "parent_id_idx",
+					"columns": ["parentId"],
+					"isUnique": false
+				},
+				"space_id_idx": {
+					"name": "space_id_idx",
+					"columns": ["spaceId"],
+					"isUnique": false
+				},
+				"public_parent_id_idx": {
+					"name": "public_parent_id_idx",
+					"columns": ["public", "parentId"],
+					"isUnique": false
+				},
+				"public_space_parent_id_idx": {
+					"name": "public_space_parent_id_idx",
+					"columns": ["public", "spaceId", "parentId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"folders_id": {
+					"name": "folders_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"imported_videos": {
+			"name": "imported_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"imported_videos_orgId_source_source_id_pk": {
+					"name": "imported_videos_orgId_source_source_id_pk",
+					"columns": ["orgId", "source", "source_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_conversations": {
+			"name": "messenger_conversations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent": {
+					"name": "agent",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'agent'"
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverByUserId": {
+					"name": "takeoverByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverAt": {
+					"name": "takeoverAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"lastMessageAt": {
+					"name": "lastMessageAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_last_message_idx": {
+					"name": "user_last_message_idx",
+					"columns": ["userId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"anonymous_last_message_idx": {
+					"name": "anonymous_last_message_idx",
+					"columns": ["anonymousId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"mode_last_message_idx": {
+					"name": "mode_last_message_idx",
+					"columns": ["mode", "lastMessageAt"],
+					"isUnique": false
+				},
+				"updated_at_idx": {
+					"name": "updated_at_idx",
+					"columns": ["updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"messenger_conversations_id": {
+					"name": "messenger_conversations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_messages": {
+			"name": "messenger_messages",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"conversationId": {
+					"name": "conversationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"conversation_created_at_idx": {
+					"name": "conversation_created_at_idx",
+					"columns": ["conversationId", "createdAt"],
+					"isUnique": false
+				},
+				"role_created_at_idx": {
+					"name": "role_created_at_idx",
+					"columns": ["role", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"messenger_messages_conversationId_messenger_conversations_id_fk": {
+					"name": "messenger_messages_conversationId_messenger_conversations_id_fk",
+					"tableFrom": "messenger_messages",
+					"tableTo": "messenger_conversations",
+					"columnsFrom": ["conversationId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"messenger_messages_id": {
+					"name": "messenger_messages_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"notifications": {
+			"name": "notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recipientId": {
+					"name": "recipientId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"data": {
+					"name": "data",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dedupKey": {
+					"name": "dedupKey",
+					"type": "varchar(128)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"readAt": {
+					"name": "readAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"org_id_idx": {
+					"name": "org_id_idx",
+					"columns": ["orgId"],
+					"isUnique": false
+				},
+				"type_idx": {
+					"name": "type_idx",
+					"columns": ["type"],
+					"isUnique": false
+				},
+				"read_at_idx": {
+					"name": "read_at_idx",
+					"columns": ["readAt"],
+					"isUnique": false
+				},
+				"created_at_idx": {
+					"name": "created_at_idx",
+					"columns": ["createdAt"],
+					"isUnique": false
+				},
+				"recipient_read_idx": {
+					"name": "recipient_read_idx",
+					"columns": ["recipientId", "readAt"],
+					"isUnique": false
+				},
+				"recipient_created_idx": {
+					"name": "recipient_created_idx",
+					"columns": ["recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"dedup_key_idx": {
+					"name": "dedup_key_idx",
+					"columns": ["dedupKey"],
+					"isUnique": true
+				},
+				"type_recipient_created_idx": {
+					"name": "type_recipient_created_idx",
+					"columns": ["type", "recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"type_recipient_video_created_idx": {
+					"name": "type_recipient_video_created_idx",
+					"columns": ["type", "recipientId", "videoId", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"notifications_id": {
+					"name": "notifications_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_invites": {
+			"name": "organization_invites",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedEmail": {
+					"name": "invitedEmail",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedByUserId": {
+					"name": "invitedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"invited_email_idx": {
+					"name": "invited_email_idx",
+					"columns": ["invitedEmail"],
+					"isUnique": false
+				},
+				"invited_by_user_id_idx": {
+					"name": "invited_by_user_id_idx",
+					"columns": ["invitedByUserId"],
+					"isUnique": false
+				},
+				"status_idx": {
+					"name": "status_idx",
+					"columns": ["status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_invites_id": {
+					"name": "organization_invites_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_members": {
+			"name": "organization_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"hasProSeat": {
+					"name": "hasProSeat",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"user_id_organization_id_idx": {
+					"name": "user_id_organization_id_idx",
+					"columns": ["userId", "organizationId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_members_id": {
+					"name": "organization_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organizations": {
+			"name": "organizations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tombstoneAt": {
+					"name": "tombstoneAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"allowedEmailDomain": {
+					"name": "allowedEmailDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customDomain": {
+					"name": "customDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"domainVerified": {
+					"name": "domainVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"shareableLinkIconUrl": {
+					"name": "shareableLinkIconUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"workosOrganizationId": {
+					"name": "workosOrganizationId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"workosConnectionId": {
+					"name": "workosConnectionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"owner_id_tombstone_idx": {
+					"name": "owner_id_tombstone_idx",
+					"columns": ["ownerId", "tombstoneAt"],
+					"isUnique": false
+				},
+				"custom_domain_idx": {
+					"name": "custom_domain_idx",
+					"columns": ["customDomain"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organizations_id": {
+					"name": "organizations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"s3_buckets": {
+			"name": "s3_buckets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"region": {
+					"name": "region",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"endpoint": {
+					"name": "endpoint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"bucketName": {
+					"name": "bucketName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accessKeyId": {
+					"name": "accessKeyId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"secretAccessKey": {
+					"name": "secretAccessKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('aws')"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_organization_idx": {
+					"name": "owner_organization_idx",
+					"columns": ["ownerId", "organizationId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"s3_buckets_id": {
+					"name": "s3_buckets_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"sessions": {
+			"name": "sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sessionToken": {
+					"name": "sessionToken",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"session_token_idx": {
+					"name": "session_token_idx",
+					"columns": ["sessionToken"],
+					"isUnique": true
+				},
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"sessions_id": {
+					"name": "sessions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"shared_videos": {
+			"name": "shared_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedByUserId": {
+					"name": "sharedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedAt": {
+					"name": "sharedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"shared_by_user_id_idx": {
+					"name": "shared_by_user_id_idx",
+					"columns": ["sharedByUserId"],
+					"isUnique": false
+				},
+				"video_id_organization_id_idx": {
+					"name": "video_id_organization_id_idx",
+					"columns": ["videoId", "organizationId"],
+					"isUnique": false
+				},
+				"video_id_folder_id_idx": {
+					"name": "video_id_folder_id_idx",
+					"columns": ["videoId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"shared_videos_id": {
+					"name": "shared_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"space_members": {
+			"name": "space_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'member'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_members_id": {
+					"name": "space_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"space_id_user_id_unique": {
+					"name": "space_id_user_id_unique",
+					"columns": ["spaceId", "userId"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"space_videos": {
+			"name": "space_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedById": {
+					"name": "addedById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedAt": {
+					"name": "addedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"added_by_id_idx": {
+					"name": "added_by_id_idx",
+					"columns": ["addedById"],
+					"isUnique": false
+				},
+				"space_id_video_id_idx": {
+					"name": "space_id_video_id_idx",
+					"columns": ["spaceId", "videoId"],
+					"isUnique": false
+				},
+				"space_id_folder_id_idx": {
+					"name": "space_id_folder_id_idx",
+					"columns": ["spaceId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_videos_id": {
+					"name": "space_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"spaces": {
+			"name": "spaces",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"primary": {
+					"name": "primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "varchar(1000)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"privacy": {
+					"name": "privacy",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Private'"
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				},
+				"public_organization_id_idx": {
+					"name": "public_organization_id_idx",
+					"columns": ["public", "organizationId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"spaces_id": {
+					"name": "spaces_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_integrations": {
+			"name": "storage_integrations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"displayName": {
+					"name": "displayName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"encryptedConfig": {
+					"name": "encryptedConfig",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"googleDriveAccessToken": {
+					"name": "googleDriveAccessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveAccessTokenExpiresAt": {
+					"name": "googleDriveAccessTokenExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseId": {
+					"name": "googleDriveTokenRefreshLeaseId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseExpiresAt": {
+					"name": "googleDriveTokenRefreshLeaseExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveStorageQuotaCache": {
+					"name": "googleDriveStorageQuotaCache",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_provider_idx": {
+					"name": "owner_provider_idx",
+					"columns": ["ownerId", "provider"],
+					"isUnique": false
+				},
+				"owner_active_idx": {
+					"name": "owner_active_idx",
+					"columns": ["ownerId", "active"],
+					"isUnique": false
+				},
+				"organization_provider_idx": {
+					"name": "organization_provider_idx",
+					"columns": ["organizationId", "provider"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"storage_integrations_id": {
+					"name": "storage_integrations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_objects": {
+			"name": "storage_objects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"integrationId": {
+					"name": "integrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"objectKey": {
+					"name": "objectKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"objectKeyHash": {
+					"name": "objectKeyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerObjectId": {
+					"name": "providerObjectId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploadSessionUrl": {
+					"name": "uploadSessionUrl",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"uploadStatus": {
+					"name": "uploadStatus",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"contentType": {
+					"name": "contentType",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"contentLength": {
+					"name": "contentLength",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"integration_key_hash_idx": {
+					"name": "integration_key_hash_idx",
+					"columns": ["integrationId", "objectKeyHash"],
+					"isUnique": true
+				},
+				"integration_status_idx": {
+					"name": "integration_status_idx",
+					"columns": ["integrationId", "uploadStatus"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"storage_objects_integrationId_storage_integrations_id_fk": {
+					"name": "storage_objects_integrationId_storage_integrations_id_fk",
+					"tableFrom": "storage_objects",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["integrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"storage_objects_id": {
+					"name": "storage_objects_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"lastName": {
+					"name": "lastName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionId": {
+					"name": "stripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"thirdPartyStripeSubscriptionId": {
+					"name": "thirdPartyStripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionStatus": {
+					"name": "stripeSubscriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionPriceId": {
+					"name": "stripeSubscriptionPriceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preferences": {
+					"name": "preferences",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "('null')"
+				},
+				"activeOrganizationId": {
+					"name": "activeOrganizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"onboardingSteps": {
+					"name": "onboardingSteps",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"onboarding_completed_at": {
+					"name": "onboarding_completed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customBucket": {
+					"name": "customBucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"inviteQuota": {
+					"name": "inviteQuota",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"defaultOrgId": {
+					"name": "defaultOrgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"authSessionVersion": {
+					"name": "authSessionVersion",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {
+				"email_idx": {
+					"name": "email_idx",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"users_id": {
+					"name": "users_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"verification_tokens": {
+			"name": "verification_tokens",
+			"columns": {
+				"identifier": {
+					"name": "identifier",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"verification_tokens_identifier": {
+					"name": "verification_tokens_identifier",
+					"columns": ["identifier"]
+				}
+			},
+			"uniqueConstraints": {
+				"verification_tokens_token_unique": {
+					"name": "verification_tokens_token_unique",
+					"columns": ["token"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"video_edits": {
+			"name": "video_edits",
+			"columns": {
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sourceKey": {
+					"name": "sourceKey",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"editSpec": {
+					"name": "editSpec",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"video_edits_videoId_videos_id_fk": {
+					"name": "video_edits_videoId_videos_id_fk",
+					"tableFrom": "video_edits",
+					"tableTo": "videos",
+					"columnsFrom": ["videoId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"video_edits_videoId": {
+					"name": "video_edits_videoId",
+					"columns": ["videoId"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"video_uploads": {
+			"name": "video_uploads",
+			"columns": {
+				"video_id": {
+					"name": "video_id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploaded": {
+					"name": "uploaded",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"total": {
+					"name": "total",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phase": {
+					"name": "phase",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'uploading'"
+				},
+				"processing_progress": {
+					"name": "processing_progress",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processing_message": {
+					"name": "processing_message",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"processing_error": {
+					"name": "processing_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"raw_file_key": {
+					"name": "raw_file_key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"phase_updated_at_video_id_idx": {
+					"name": "phase_updated_at_video_id_idx",
+					"columns": ["phase", "updated_at", "video_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"video_uploads_video_id": {
+					"name": "video_uploads_video_id",
+					"columns": ["video_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"videos": {
+			"name": "videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'My Video'"
+				},
+				"bucket": {
+					"name": "bucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"storageIntegrationId": {
+					"name": "storageIntegrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('{\"type\":\"MediaConvert\"}')"
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"effectiveCreatedAt": {
+					"name": "effectiveCreatedAt",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"generated": {
+						"as": "COALESCE(\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%s.%fZ'),\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%sZ'),\n          `createdAt`\n        )",
+						"type": "stored"
+					}
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"xStreamInfo": {
+					"name": "xStreamInfo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"firstViewEmailSentAt": {
+					"name": "firstViewEmailSentAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"isScreenshot": {
+					"name": "isScreenshot",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"awsRegion": {
+					"name": "awsRegion",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"awsBucket": {
+					"name": "awsBucket",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoStartTime": {
+					"name": "videoStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"audioStartTime": {
+					"name": "audioStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobId": {
+					"name": "jobId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobStatus": {
+					"name": "jobStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"skipProcessing": {
+					"name": "skipProcessing",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				},
+				"is_public_idx": {
+					"name": "is_public_idx",
+					"columns": ["public"],
+					"isUnique": false
+				},
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"storage_integration_id_idx": {
+					"name": "storage_integration_id_idx",
+					"columns": ["storageIntegrationId"],
+					"isUnique": false
+				},
+				"org_owner_folder_idx": {
+					"name": "org_owner_folder_idx",
+					"columns": ["orgId", "ownerId", "folderId"],
+					"isUnique": false
+				},
+				"org_effective_created_idx": {
+					"name": "org_effective_created_idx",
+					"columns": ["orgId", "effectiveCreatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"videos_storageIntegrationId_storage_integrations_id_fk": {
+					"name": "videos_storageIntegrationId_storage_integrations_id_fk",
+					"tableFrom": "videos",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["storageIntegrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"videos_id": {
+					"name": "videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		}
+	},
+	"views": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"tables": {},
+		"indexes": {}
+	}
+}

--- a/packages/database/migrations/meta/0030_snapshot.json
+++ b/packages/database/migrations/meta/0030_snapshot.json
@@ -1,0 +1,3310 @@
+{
+	"version": "5",
+	"dialect": "mysql",
+	"id": "cb7983a6-9260-4bbe-a1c8-d19c68305ee8",
+	"prevId": "dbb85015-6143-46d2-933a-e77e36f6a4cb",
+	"tables": {
+		"accounts": {
+			"name": "accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerAccountId": {
+					"name": "providerAccountId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_in": {
+					"name": "expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_in": {
+					"name": "refresh_token_expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"tempColumn": {
+					"name": "tempColumn",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				},
+				"provider_account_id_idx": {
+					"name": "provider_account_id_idx",
+					"columns": ["providerAccountId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"accounts_id": {
+					"name": "accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"auth_api_keys": {
+			"name": "auth_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(36)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"auth_api_keys_id": {
+					"name": "auth_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"comments": {
+			"name": "comments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(6)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"authorId": {
+					"name": "authorId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"parentCommentId": {
+					"name": "parentCommentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"video_type_created_idx": {
+					"name": "video_type_created_idx",
+					"columns": ["videoId", "type", "createdAt", "id"],
+					"isUnique": false
+				},
+				"author_id_idx": {
+					"name": "author_id_idx",
+					"columns": ["authorId"],
+					"isUnique": false
+				},
+				"parent_comment_id_idx": {
+					"name": "parent_comment_id_idx",
+					"columns": ["parentCommentId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"comments_id": {
+					"name": "comments_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_api_keys": {
+			"name": "developer_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyType": {
+					"name": "keyType",
+					"type": "varchar(8)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyPrefix": {
+					"name": "keyPrefix",
+					"type": "varchar(12)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyHash": {
+					"name": "keyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"encryptedKey": {
+					"name": "encryptedKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"lastUsedAt": {
+					"name": "lastUsedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"revokedAt": {
+					"name": "revokedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"key_hash_idx": {
+					"name": "key_hash_idx",
+					"columns": ["keyHash"],
+					"isUnique": true
+				},
+				"app_key_type_idx": {
+					"name": "app_key_type_idx",
+					"columns": ["appId", "keyType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_api_keys_appId_developer_apps_id_fk": {
+					"name": "developer_api_keys_appId_developer_apps_id_fk",
+					"tableFrom": "developer_api_keys",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_api_keys_id": {
+					"name": "developer_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_app_domains": {
+			"name": "developer_app_domains",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"domain": {
+					"name": "domain",
+					"type": "varchar(253)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_app_domains_appId_developer_apps_id_fk": {
+					"name": "developer_app_domains_appId_developer_apps_id_fk",
+					"tableFrom": "developer_app_domains",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_app_domains_id": {
+					"name": "developer_app_domains_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_domain_unique": {
+					"name": "app_domain_unique",
+					"columns": ["appId", "domain"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_apps": {
+			"name": "developer_apps",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"environment": {
+					"name": "environment",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"logoUrl": {
+					"name": "logoUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_deleted_idx": {
+					"name": "owner_deleted_idx",
+					"columns": ["ownerId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"developer_apps_id": {
+					"name": "developer_apps_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_accounts": {
+			"name": "developer_credit_accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceMicroCredits": {
+					"name": "balanceMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripePaymentMethodId": {
+					"name": "stripePaymentMethodId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"autoTopUpEnabled": {
+					"name": "autoTopUpEnabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"autoTopUpThresholdMicroCredits": {
+					"name": "autoTopUpThresholdMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"autoTopUpAmountCents": {
+					"name": "autoTopUpAmountCents",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_id_unique": {
+					"name": "app_id_unique",
+					"columns": ["appId"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"developer_credit_accounts_appId_developer_apps_id_fk": {
+					"name": "developer_credit_accounts_appId_developer_apps_id_fk",
+					"tableFrom": "developer_credit_accounts",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_accounts_id": {
+					"name": "developer_credit_accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_transactions": {
+			"name": "developer_credit_transactions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amountMicroCredits": {
+					"name": "amountMicroCredits",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceAfterMicroCredits": {
+					"name": "balanceAfterMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"referenceId": {
+					"name": "referenceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"referenceType": {
+					"name": "referenceType",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"account_type_created_idx": {
+					"name": "account_type_created_idx",
+					"columns": ["accountId", "type", "createdAt"],
+					"isUnique": false
+				},
+				"account_ref_dedup_idx": {
+					"name": "account_ref_dedup_idx",
+					"columns": ["accountId", "referenceId", "referenceType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"dev_credit_txn_account_fk": {
+					"name": "dev_credit_txn_account_fk",
+					"tableFrom": "developer_credit_transactions",
+					"tableTo": "developer_credit_accounts",
+					"columnsFrom": ["accountId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_transactions_id": {
+					"name": "developer_credit_transactions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_daily_storage_snapshots": {
+			"name": "developer_daily_storage_snapshots",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"snapshotDate": {
+					"name": "snapshotDate",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"totalDurationMinutes": {
+					"name": "totalDurationMinutes",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"videoCount": {
+					"name": "videoCount",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"microCreditsCharged": {
+					"name": "microCreditsCharged",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processedAt": {
+					"name": "processedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_daily_storage_snapshots_appId_developer_apps_id_fk": {
+					"name": "developer_daily_storage_snapshots_appId_developer_apps_id_fk",
+					"tableFrom": "developer_daily_storage_snapshots",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_daily_storage_snapshots_id": {
+					"name": "developer_daily_storage_snapshots_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_date_unique": {
+					"name": "app_date_unique",
+					"columns": ["appId", "snapshotDate"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_videos": {
+			"name": "developer_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"externalUserId": {
+					"name": "externalUserId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Untitled'"
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"s3Key": {
+					"name": "s3Key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_created_idx": {
+					"name": "app_created_idx",
+					"columns": ["appId", "createdAt"],
+					"isUnique": false
+				},
+				"app_user_idx": {
+					"name": "app_user_idx",
+					"columns": ["appId", "externalUserId"],
+					"isUnique": false
+				},
+				"app_deleted_idx": {
+					"name": "app_deleted_idx",
+					"columns": ["appId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_videos_appId_developer_apps_id_fk": {
+					"name": "developer_videos_appId_developer_apps_id_fk",
+					"tableFrom": "developer_videos",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_videos_id": {
+					"name": "developer_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"folders": {
+			"name": "folders",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"color": {
+					"name": "color",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'normal'"
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parentId": {
+					"name": "parentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				},
+				"parent_id_idx": {
+					"name": "parent_id_idx",
+					"columns": ["parentId"],
+					"isUnique": false
+				},
+				"space_id_idx": {
+					"name": "space_id_idx",
+					"columns": ["spaceId"],
+					"isUnique": false
+				},
+				"public_parent_id_idx": {
+					"name": "public_parent_id_idx",
+					"columns": ["public", "parentId"],
+					"isUnique": false
+				},
+				"public_space_parent_id_idx": {
+					"name": "public_space_parent_id_idx",
+					"columns": ["public", "spaceId", "parentId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"folders_id": {
+					"name": "folders_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"imported_videos": {
+			"name": "imported_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"imported_videos_orgId_source_source_id_pk": {
+					"name": "imported_videos_orgId_source_source_id_pk",
+					"columns": ["orgId", "source", "source_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_conversations": {
+			"name": "messenger_conversations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent": {
+					"name": "agent",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'agent'"
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverByUserId": {
+					"name": "takeoverByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverAt": {
+					"name": "takeoverAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"lastMessageAt": {
+					"name": "lastMessageAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_last_message_idx": {
+					"name": "user_last_message_idx",
+					"columns": ["userId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"anonymous_last_message_idx": {
+					"name": "anonymous_last_message_idx",
+					"columns": ["anonymousId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"mode_last_message_idx": {
+					"name": "mode_last_message_idx",
+					"columns": ["mode", "lastMessageAt"],
+					"isUnique": false
+				},
+				"updated_at_idx": {
+					"name": "updated_at_idx",
+					"columns": ["updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"messenger_conversations_id": {
+					"name": "messenger_conversations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_messages": {
+			"name": "messenger_messages",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"conversationId": {
+					"name": "conversationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"conversation_created_at_idx": {
+					"name": "conversation_created_at_idx",
+					"columns": ["conversationId", "createdAt"],
+					"isUnique": false
+				},
+				"role_created_at_idx": {
+					"name": "role_created_at_idx",
+					"columns": ["role", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"messenger_messages_conversationId_messenger_conversations_id_fk": {
+					"name": "messenger_messages_conversationId_messenger_conversations_id_fk",
+					"tableFrom": "messenger_messages",
+					"tableTo": "messenger_conversations",
+					"columnsFrom": ["conversationId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"messenger_messages_id": {
+					"name": "messenger_messages_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"notifications": {
+			"name": "notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recipientId": {
+					"name": "recipientId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"data": {
+					"name": "data",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dedupKey": {
+					"name": "dedupKey",
+					"type": "varchar(128)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"readAt": {
+					"name": "readAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"org_id_idx": {
+					"name": "org_id_idx",
+					"columns": ["orgId"],
+					"isUnique": false
+				},
+				"type_idx": {
+					"name": "type_idx",
+					"columns": ["type"],
+					"isUnique": false
+				},
+				"read_at_idx": {
+					"name": "read_at_idx",
+					"columns": ["readAt"],
+					"isUnique": false
+				},
+				"created_at_idx": {
+					"name": "created_at_idx",
+					"columns": ["createdAt"],
+					"isUnique": false
+				},
+				"recipient_read_idx": {
+					"name": "recipient_read_idx",
+					"columns": ["recipientId", "readAt"],
+					"isUnique": false
+				},
+				"recipient_created_idx": {
+					"name": "recipient_created_idx",
+					"columns": ["recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"dedup_key_idx": {
+					"name": "dedup_key_idx",
+					"columns": ["dedupKey"],
+					"isUnique": true
+				},
+				"type_recipient_created_idx": {
+					"name": "type_recipient_created_idx",
+					"columns": ["type", "recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"type_recipient_video_created_idx": {
+					"name": "type_recipient_video_created_idx",
+					"columns": ["type", "recipientId", "videoId", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"notifications_id": {
+					"name": "notifications_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_invites": {
+			"name": "organization_invites",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedEmail": {
+					"name": "invitedEmail",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedByUserId": {
+					"name": "invitedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"invited_email_idx": {
+					"name": "invited_email_idx",
+					"columns": ["invitedEmail"],
+					"isUnique": false
+				},
+				"invited_by_user_id_idx": {
+					"name": "invited_by_user_id_idx",
+					"columns": ["invitedByUserId"],
+					"isUnique": false
+				},
+				"status_idx": {
+					"name": "status_idx",
+					"columns": ["status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_invites_id": {
+					"name": "organization_invites_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_members": {
+			"name": "organization_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"hasProSeat": {
+					"name": "hasProSeat",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"user_id_organization_id_idx": {
+					"name": "user_id_organization_id_idx",
+					"columns": ["userId", "organizationId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_members_id": {
+					"name": "organization_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organizations": {
+			"name": "organizations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tombstoneAt": {
+					"name": "tombstoneAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"allowedEmailDomain": {
+					"name": "allowedEmailDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customDomain": {
+					"name": "customDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"domainVerified": {
+					"name": "domainVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"shareableLinkIconUrl": {
+					"name": "shareableLinkIconUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"workosOrganizationId": {
+					"name": "workosOrganizationId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"workosConnectionId": {
+					"name": "workosConnectionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"owner_id_tombstone_idx": {
+					"name": "owner_id_tombstone_idx",
+					"columns": ["ownerId", "tombstoneAt"],
+					"isUnique": false
+				},
+				"custom_domain_idx": {
+					"name": "custom_domain_idx",
+					"columns": ["customDomain"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organizations_id": {
+					"name": "organizations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"s3_buckets": {
+			"name": "s3_buckets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"region": {
+					"name": "region",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"endpoint": {
+					"name": "endpoint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"bucketName": {
+					"name": "bucketName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accessKeyId": {
+					"name": "accessKeyId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"secretAccessKey": {
+					"name": "secretAccessKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('aws')"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_organization_idx": {
+					"name": "owner_organization_idx",
+					"columns": ["ownerId", "organizationId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"s3_buckets_id": {
+					"name": "s3_buckets_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"sessions": {
+			"name": "sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sessionToken": {
+					"name": "sessionToken",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"session_token_idx": {
+					"name": "session_token_idx",
+					"columns": ["sessionToken"],
+					"isUnique": true
+				},
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"sessions_id": {
+					"name": "sessions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"shared_videos": {
+			"name": "shared_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedByUserId": {
+					"name": "sharedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedAt": {
+					"name": "sharedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"shared_by_user_id_idx": {
+					"name": "shared_by_user_id_idx",
+					"columns": ["sharedByUserId"],
+					"isUnique": false
+				},
+				"video_id_organization_id_idx": {
+					"name": "video_id_organization_id_idx",
+					"columns": ["videoId", "organizationId"],
+					"isUnique": false
+				},
+				"video_id_folder_id_idx": {
+					"name": "video_id_folder_id_idx",
+					"columns": ["videoId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"shared_videos_id": {
+					"name": "shared_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"space_members": {
+			"name": "space_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'member'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_members_id": {
+					"name": "space_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"space_id_user_id_unique": {
+					"name": "space_id_user_id_unique",
+					"columns": ["spaceId", "userId"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"space_videos": {
+			"name": "space_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedById": {
+					"name": "addedById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedAt": {
+					"name": "addedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"added_by_id_idx": {
+					"name": "added_by_id_idx",
+					"columns": ["addedById"],
+					"isUnique": false
+				},
+				"space_id_video_id_idx": {
+					"name": "space_id_video_id_idx",
+					"columns": ["spaceId", "videoId"],
+					"isUnique": false
+				},
+				"space_id_folder_id_idx": {
+					"name": "space_id_folder_id_idx",
+					"columns": ["spaceId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_videos_id": {
+					"name": "space_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"spaces": {
+			"name": "spaces",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"primary": {
+					"name": "primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "varchar(1000)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"privacy": {
+					"name": "privacy",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Private'"
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				},
+				"public_organization_id_idx": {
+					"name": "public_organization_id_idx",
+					"columns": ["public", "organizationId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"spaces_id": {
+					"name": "spaces_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_integrations": {
+			"name": "storage_integrations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"displayName": {
+					"name": "displayName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"encryptedConfig": {
+					"name": "encryptedConfig",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"googleDriveAccessToken": {
+					"name": "googleDriveAccessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveAccessTokenExpiresAt": {
+					"name": "googleDriveAccessTokenExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseId": {
+					"name": "googleDriveTokenRefreshLeaseId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseExpiresAt": {
+					"name": "googleDriveTokenRefreshLeaseExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveStorageQuotaCache": {
+					"name": "googleDriveStorageQuotaCache",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_provider_idx": {
+					"name": "owner_provider_idx",
+					"columns": ["ownerId", "provider"],
+					"isUnique": false
+				},
+				"owner_active_idx": {
+					"name": "owner_active_idx",
+					"columns": ["ownerId", "active"],
+					"isUnique": false
+				},
+				"organization_provider_idx": {
+					"name": "organization_provider_idx",
+					"columns": ["organizationId", "provider"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"storage_integrations_id": {
+					"name": "storage_integrations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_objects": {
+			"name": "storage_objects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"integrationId": {
+					"name": "integrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"objectKey": {
+					"name": "objectKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"objectKeyHash": {
+					"name": "objectKeyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerObjectId": {
+					"name": "providerObjectId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploadSessionUrl": {
+					"name": "uploadSessionUrl",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"uploadStatus": {
+					"name": "uploadStatus",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"contentType": {
+					"name": "contentType",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"contentLength": {
+					"name": "contentLength",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"integration_key_hash_idx": {
+					"name": "integration_key_hash_idx",
+					"columns": ["integrationId", "objectKeyHash"],
+					"isUnique": true
+				},
+				"integration_status_idx": {
+					"name": "integration_status_idx",
+					"columns": ["integrationId", "uploadStatus"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"storage_objects_integrationId_storage_integrations_id_fk": {
+					"name": "storage_objects_integrationId_storage_integrations_id_fk",
+					"tableFrom": "storage_objects",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["integrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"storage_objects_id": {
+					"name": "storage_objects_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"lastName": {
+					"name": "lastName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionId": {
+					"name": "stripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"thirdPartyStripeSubscriptionId": {
+					"name": "thirdPartyStripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionStatus": {
+					"name": "stripeSubscriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionPriceId": {
+					"name": "stripeSubscriptionPriceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preferences": {
+					"name": "preferences",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "('null')"
+				},
+				"activeOrganizationId": {
+					"name": "activeOrganizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"onboardingSteps": {
+					"name": "onboardingSteps",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"onboarding_completed_at": {
+					"name": "onboarding_completed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customBucket": {
+					"name": "customBucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"inviteQuota": {
+					"name": "inviteQuota",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"defaultOrgId": {
+					"name": "defaultOrgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"authSessionVersion": {
+					"name": "authSessionVersion",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {
+				"email_idx": {
+					"name": "email_idx",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"users_id": {
+					"name": "users_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"verification_tokens": {
+			"name": "verification_tokens",
+			"columns": {
+				"identifier": {
+					"name": "identifier",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"verification_tokens_identifier": {
+					"name": "verification_tokens_identifier",
+					"columns": ["identifier"]
+				}
+			},
+			"uniqueConstraints": {
+				"verification_tokens_token_unique": {
+					"name": "verification_tokens_token_unique",
+					"columns": ["token"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"video_edits": {
+			"name": "video_edits",
+			"columns": {
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sourceKey": {
+					"name": "sourceKey",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"editSpec": {
+					"name": "editSpec",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"video_edits_videoId_videos_id_fk": {
+					"name": "video_edits_videoId_videos_id_fk",
+					"tableFrom": "video_edits",
+					"tableTo": "videos",
+					"columnsFrom": ["videoId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"video_edits_videoId": {
+					"name": "video_edits_videoId",
+					"columns": ["videoId"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"video_uploads": {
+			"name": "video_uploads",
+			"columns": {
+				"video_id": {
+					"name": "video_id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploaded": {
+					"name": "uploaded",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"total": {
+					"name": "total",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phase": {
+					"name": "phase",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'uploading'"
+				},
+				"processing_progress": {
+					"name": "processing_progress",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processing_message": {
+					"name": "processing_message",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"processing_error": {
+					"name": "processing_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"raw_file_key": {
+					"name": "raw_file_key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"phase_updated_at_video_id_idx": {
+					"name": "phase_updated_at_video_id_idx",
+					"columns": ["phase", "updated_at", "video_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"video_uploads_video_id": {
+					"name": "video_uploads_video_id",
+					"columns": ["video_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"videos": {
+			"name": "videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'My Video'"
+				},
+				"bucket": {
+					"name": "bucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"storageIntegrationId": {
+					"name": "storageIntegrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('{\"type\":\"MediaConvert\"}')"
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"effectiveCreatedAt": {
+					"name": "effectiveCreatedAt",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"generated": {
+						"as": "COALESCE(\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%s.%fZ'),\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%sZ'),\n          `createdAt`\n        )",
+						"type": "stored"
+					}
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"xStreamInfo": {
+					"name": "xStreamInfo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"firstViewEmailSentAt": {
+					"name": "firstViewEmailSentAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"isScreenshot": {
+					"name": "isScreenshot",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"awsRegion": {
+					"name": "awsRegion",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"awsBucket": {
+					"name": "awsBucket",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoStartTime": {
+					"name": "videoStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"audioStartTime": {
+					"name": "audioStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobId": {
+					"name": "jobId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobStatus": {
+					"name": "jobStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"skipProcessing": {
+					"name": "skipProcessing",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				},
+				"is_public_idx": {
+					"name": "is_public_idx",
+					"columns": ["public"],
+					"isUnique": false
+				},
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"storage_integration_id_idx": {
+					"name": "storage_integration_id_idx",
+					"columns": ["storageIntegrationId"],
+					"isUnique": false
+				},
+				"org_owner_folder_idx": {
+					"name": "org_owner_folder_idx",
+					"columns": ["orgId", "ownerId", "folderId"],
+					"isUnique": false
+				},
+				"org_effective_created_idx": {
+					"name": "org_effective_created_idx",
+					"columns": ["orgId", "effectiveCreatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"videos_storageIntegrationId_storage_integrations_id_fk": {
+					"name": "videos_storageIntegrationId_storage_integrations_id_fk",
+					"tableFrom": "videos",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["storageIntegrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"videos_id": {
+					"name": "videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		}
+	},
+	"views": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"tables": {},
+		"indexes": {}
+	}
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -197,6 +197,27 @@
 			"when": 1780932760351,
 			"tag": "0027_giant_shinko_yamashiro",
 			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "5",
+			"when": 1780937790068,
+			"tag": "0028_nebulous_madame_masque",
+			"breakpoints": true
+		},
+		{
+			"idx": 29,
+			"version": "5",
+			"when": 1780937848351,
+			"tag": "0029_blushing_pretty_boy",
+			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "5",
+			"when": 1780940100362,
+			"tag": "0030_add_folder_settings",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -4,6 +4,7 @@ import type {
 	Folder,
 	ImageUpload,
 	Organisation,
+	PublicCollection,
 	S3Bucket,
 	Space,
 	Storage,
@@ -290,6 +291,11 @@ export const folders = mysqlTable(
 		})
 			.notNull()
 			.default("normal"),
+		// Internet-facing public collection link (/c/[id]).
+		public: boolean("public").notNull().default(false),
+		settings: json("settings").$type<{
+			publicPage?: PublicCollection.PublicPageSettings;
+		}>(),
 		organizationId: nanoId("organizationId")
 			.notNull()
 			.$type<Organisation.OrganisationId>(),
@@ -304,6 +310,15 @@ export const folders = mysqlTable(
 		createdByIdIndex: index("created_by_id_idx").on(table.createdById),
 		parentIdIndex: index("parent_id_idx").on(table.parentId),
 		spaceIdIndex: index("space_id_idx").on(table.spaceId),
+		publicParentIdIndex: index("public_parent_id_idx").on(
+			table.public,
+			table.parentId,
+		),
+		publicSpaceParentIdIndex: index("public_space_parent_id_idx").on(
+			table.public,
+			table.spaceId,
+			table.parentId,
+		),
 	}),
 );
 
@@ -950,17 +965,26 @@ export const spaces = mysqlTable(
 			disableReactions?: boolean;
 			disableTranscript?: boolean;
 			disableComments?: boolean;
+			publicPage?: PublicCollection.PublicPageSettings;
 		}>(),
 		password: encryptedTextNullable("password"),
 		createdAt: timestamp("createdAt").notNull().defaultNow(),
 		updatedAt: timestamp("updatedAt").notNull().defaultNow().onUpdateNow(),
+		// Org-internal browsability: "Public" spaces are visible to all org
+		// members. Unrelated to the internet-facing `public` flag below.
 		privacy: varchar("privacy", { length: 255, enum: ["Public", "Private"] })
 			.notNull()
 			.default("Private"),
+		// Internet-facing public collection link (/c/[id]).
+		public: boolean("public").notNull().default(false),
 	},
 	(table) => ({
 		organizationIdIndex: index("organization_id_idx").on(table.organizationId),
 		createdByIdIndex: index("created_by_id_idx").on(table.createdById),
+		publicOrganizationIdIndex: index("public_organization_id_idx").on(
+			table.public,
+			table.organizationId,
+		),
 	}),
 );
 

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -50,7 +50,7 @@ const selectTriggerVariants = cva(
 
 const selectContentVariants = cva(
 	cx(
-		"rounded-xl border overflow-hidden",
+		"z-[1000] rounded-xl border overflow-hidden",
 		"[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 		"data-[state=open]:animate-in data-[state=closed]:animate-out",
 		"data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",

--- a/packages/web-backend/src/Folders/index.ts
+++ b/packages/web-backend/src/Folders/index.ts
@@ -1,4 +1,5 @@
 import * as Db from "@cap/database/schema";
+import { userIsPro } from "@cap/utils";
 import {
 	CurrentUser,
 	type DatabaseError,
@@ -21,6 +22,32 @@ export class Folders extends Effect.Service<Folders>()("Folders", {
 		const db = yield* Database;
 		const policy = yield* FoldersPolicy;
 		const repo = yield* FoldersRepo;
+
+		/**
+		 * Making a collection public is a Pro feature, gated on the organization
+		 * OWNER's plan (any manager can publish while the owner is Pro). Disabling
+		 * public never requires Pro, so a downgraded org can always un-publish.
+		 */
+		const requireOwnerPro = (organizationId: Organisation.OrganisationId) =>
+			Effect.gen(function* () {
+				const [owner] = yield* db.use((db) =>
+					db
+						.select({
+							stripeSubscriptionStatus: Db.users.stripeSubscriptionStatus,
+							thirdPartyStripeSubscriptionId:
+								Db.users.thirdPartyStripeSubscriptionId,
+						})
+						.from(Db.organizations)
+						.innerJoin(Db.users, Dz.eq(Db.organizations.ownerId, Db.users.id))
+						.where(Dz.eq(Db.organizations.id, organizationId))
+						.limit(1),
+				);
+
+				if (!userIsPro(owner ?? null))
+					return yield* new Policy.PolicyDeniedError({
+						reason: "Upgrade to Cap Pro to create a public collection link",
+					});
+			});
 
 		const deleteFolder = (folder: {
 			id: Folder.FolderId;
@@ -75,10 +102,16 @@ export class Folders extends Effect.Service<Folders>()("Folders", {
 			create: Effect.fn("Folders.create")(function* (data: {
 				name: string;
 				color: Folder.FolderColor;
+				public?: boolean;
 				spaceId: Option.Option<Space.SpaceIdOrOrganisationId>;
 				parentId: Option.Option<Folder.FolderId>;
 			}) {
 				const user = yield* CurrentUser;
+
+				if (data.public === true)
+					yield* requireOwnerPro(
+						Organisation.OrganisationId.make(user.activeOrganizationId),
+					);
 
 				if (Option.isSome(data.spaceId)) {
 					yield* policy.canCreateIn(data.spaceId.value);
@@ -111,6 +144,7 @@ export class Folders extends Effect.Service<Folders>()("Folders", {
 						user.activeOrganizationId,
 					),
 					createdById: User.UserId.make(user.id),
+					public: data.public ?? false,
 					spaceId: data.spaceId,
 					parentId: data.parentId,
 				});
@@ -143,6 +177,24 @@ export class Folders extends Effect.Service<Folders>()("Folders", {
 						() => new Folder.NotFoundError(),
 					),
 				);
+
+				// Drizzle throws on an all-undefined .set(); a payload with only an
+				// id is a no-op, not an error.
+				if (
+					data.name === undefined &&
+					data.color === undefined &&
+					data.public === undefined &&
+					data.publicPage === undefined &&
+					data.parentId === undefined
+				)
+					return;
+
+				// Publishing, or customizing the public page, is Pro-gated on the
+				// org owner. Un-publishing (public: false) is always allowed.
+				if (data.public === true || data.publicPage !== undefined)
+					yield* requireOwnerPro(
+						Organisation.OrganisationId.make(folder.organizationId),
+					);
 
 				// If parentId is provided and not null, verify it exists and belongs to the same organization
 				if (data.parentId && Option.isSome(data.parentId)) {
@@ -191,6 +243,16 @@ export class Folders extends Effect.Service<Folders>()("Folders", {
 						.set({
 							name: data.name,
 							color: data.color,
+							public: data.public,
+							// Atomic merge so concurrent patches (and the logo upload
+							// action, which also writes settings.publicPage) can't
+							// overwrite each other's keys.
+							settings:
+								data.publicPage !== undefined
+									? Dz.sql`JSON_MERGE_PATCH(COALESCE(${Db.folders.settings}, '{}'), CAST(${JSON.stringify(
+											{ publicPage: data.publicPage },
+										)} AS JSON))`
+									: undefined,
 							parentId: data.parentId
 								? Option.getOrNull(data.parentId)
 								: undefined,

--- a/packages/web-backend/src/Spaces/index.ts
+++ b/packages/web-backend/src/Spaces/index.ts
@@ -28,6 +28,7 @@ export class Spaces extends Effect.Service<Spaces>()("Spaces", {
 							createdById: Db.spaces.createdById,
 							iconUrl: Db.spaces.iconUrl,
 							settings: Db.spaces.settings,
+							public: Db.spaces.public,
 							hasPassword: Dz.sql`${Db.spaces.password} IS NOT NULL`.mapWith(
 								Boolean,
 							),

--- a/packages/web-domain/src/Folder.ts
+++ b/packages/web-domain/src/Folder.ts
@@ -5,6 +5,7 @@ import { RpcAuthMiddleware } from "./Authentication.ts";
 import { InternalError } from "./Errors.ts";
 import { OrganisationId } from "./Organisation.ts";
 import { PolicyDeniedError } from "./Policy.ts";
+import { PublicPageSettingsUpdate } from "./PublicCollection.ts";
 import { SpaceIdOrOrganisationId } from "./Space.ts";
 import { UserId } from "./User.ts";
 
@@ -38,6 +39,7 @@ export class Folder extends Schema.Class<Folder>("Folder")({
 	id: FolderId,
 	name: Schema.String,
 	color: FolderColor,
+	public: Schema.Boolean,
 	organizationId: OrganisationId,
 	createdById: UserId,
 	spaceId: Schema.OptionFromNullOr(SpaceIdOrOrganisationId),
@@ -48,6 +50,9 @@ export const FolderUpdate = Schema.Struct({
 	id: FolderId,
 	name: Schema.optional(Schema.String),
 	color: Schema.optional(FolderColor),
+	public: Schema.optional(Schema.Boolean),
+	/** Partial patch merged into the stored `settings.publicPage`. */
+	publicPage: Schema.optional(PublicPageSettingsUpdate),
 	parentId: Schema.optional(Schema.Option(FolderId)),
 });
 export type FolderUpdate = Schema.Schema.Type<typeof FolderUpdate>;
@@ -61,6 +66,7 @@ export class FolderRpcs extends RpcGroup.make(
 		payload: Schema.Struct({
 			name: Schema.String,
 			color: FolderColor,
+			public: Schema.optional(Schema.Boolean),
 			spaceId: Schema.OptionFromUndefinedOr(SpaceIdOrOrganisationId),
 			parentId: Schema.OptionFromUndefinedOr(FolderId),
 		}),

--- a/packages/web-domain/src/PublicCollection.ts
+++ b/packages/web-domain/src/PublicCollection.ts
@@ -1,0 +1,112 @@
+import { Schema } from "effect";
+
+/**
+ * Presentation settings for a public collection page (`/c/[id]`), shared by
+ * public folders and public spaces. Stored as `{ publicPage: PublicPageSettings }`
+ * inside the `settings` JSON column of both `folders` and `spaces`.
+ */
+
+export const PublicCollectionLayout = Schema.Literal("grid", "list");
+export type PublicCollectionLayout = Schema.Schema.Type<
+	typeof PublicCollectionLayout
+>;
+
+export const PublicCollectionGridColumns = Schema.Literal(2, 3, 4, 5);
+export type PublicCollectionGridColumns = Schema.Schema.Type<
+	typeof PublicCollectionGridColumns
+>;
+
+/**
+ * Which logo (if any) is shown in the public collection header.
+ * - `cap`: the Cap logo
+ * - `organization`: the organization's own icon
+ * - `custom`: a logo uploaded specifically for this collection (`logoUrl`)
+ * - `none`: no logo (and no "Powered by Cap" footer)
+ */
+export const PublicCollectionLogoMode = Schema.Literal(
+	"cap",
+	"organization",
+	"custom",
+	"none",
+);
+export type PublicCollectionLogoMode = Schema.Schema.Type<
+	typeof PublicCollectionLogoMode
+>;
+
+/** Upper bounds keep stored JSON small and the public page readable. */
+export const PUBLIC_PAGE_TITLE_MAX_LENGTH = 80;
+export const PUBLIC_PAGE_SUBTITLE_MAX_LENGTH = 160;
+export const PUBLIC_PAGE_CTA_LABEL_MAX_LENGTH = 40;
+export const PUBLIC_PAGE_CTA_URL_MAX_LENGTH = 512;
+/** S3 object keys are capped at 1024 bytes. */
+export const PUBLIC_PAGE_LOGO_URL_MAX_LENGTH = 1024;
+
+export const PublicPageSettings = Schema.Struct({
+	hideTitle: Schema.optional(Schema.Boolean),
+	hideCopyLink: Schema.optional(Schema.Boolean),
+	logoMode: Schema.optional(PublicCollectionLogoMode),
+	logoUrl: Schema.optional(
+		Schema.String.pipe(Schema.maxLength(PUBLIC_PAGE_LOGO_URL_MAX_LENGTH)),
+	),
+	title: Schema.optional(
+		Schema.String.pipe(Schema.maxLength(PUBLIC_PAGE_TITLE_MAX_LENGTH)),
+	),
+	subtitle: Schema.optional(
+		Schema.String.pipe(Schema.maxLength(PUBLIC_PAGE_SUBTITLE_MAX_LENGTH)),
+	),
+	ctaLabel: Schema.optional(
+		Schema.String.pipe(Schema.maxLength(PUBLIC_PAGE_CTA_LABEL_MAX_LENGTH)),
+	),
+	ctaUrl: Schema.optional(
+		Schema.String.pipe(Schema.maxLength(PUBLIC_PAGE_CTA_URL_MAX_LENGTH)),
+	),
+	layout: Schema.optional(PublicCollectionLayout),
+	gridColumns: Schema.optional(PublicCollectionGridColumns),
+});
+export type PublicPageSettings = Schema.Schema.Type<typeof PublicPageSettings>;
+
+/**
+ * The client-writable subset of `PublicPageSettings`, applied as a partial
+ * patch merged into the stored value. `logoUrl` is excluded: it is owned by
+ * the logo upload action, which is the only writer of collection logo keys.
+ */
+export const PublicPageSettingsUpdate = PublicPageSettings.omit("logoUrl");
+export type PublicPageSettingsUpdate = Schema.Schema.Type<
+	typeof PublicPageSettingsUpdate
+>;
+
+export const DEFAULT_PUBLIC_PAGE_SETTINGS = {
+	hideTitle: false,
+	hideCopyLink: false,
+	logoMode: "cap",
+	logoUrl: "",
+	title: "",
+	subtitle: "",
+	ctaLabel: "",
+	ctaUrl: "",
+	layout: "grid",
+	gridColumns: 4,
+} as const satisfies Required<PublicPageSettings>;
+
+/**
+ * Merge a stored (possibly partial / null) `PublicPageSettings` onto the
+ * defaults so callers always have a fully-resolved presentation config.
+ */
+export function resolvePublicPageSettings(
+	settings: PublicPageSettings | null | undefined,
+): Required<PublicPageSettings> {
+	return {
+		hideTitle: settings?.hideTitle ?? DEFAULT_PUBLIC_PAGE_SETTINGS.hideTitle,
+		hideCopyLink:
+			settings?.hideCopyLink ?? DEFAULT_PUBLIC_PAGE_SETTINGS.hideCopyLink,
+		logoMode: settings?.logoMode ?? DEFAULT_PUBLIC_PAGE_SETTINGS.logoMode,
+		logoUrl: settings?.logoUrl ?? DEFAULT_PUBLIC_PAGE_SETTINGS.logoUrl,
+		title: settings?.title ?? DEFAULT_PUBLIC_PAGE_SETTINGS.title,
+		subtitle: settings?.subtitle ?? DEFAULT_PUBLIC_PAGE_SETTINGS.subtitle,
+		ctaLabel: settings?.ctaLabel ?? DEFAULT_PUBLIC_PAGE_SETTINGS.ctaLabel,
+		ctaUrl: settings?.ctaUrl ?? DEFAULT_PUBLIC_PAGE_SETTINGS.ctaUrl,
+		layout: settings?.layout ?? DEFAULT_PUBLIC_PAGE_SETTINGS.layout,
+		gridColumns:
+			settings?.gridColumns ?? DEFAULT_PUBLIC_PAGE_SETTINGS.gridColumns,
+	};
+}

--- a/packages/web-domain/src/Video.ts
+++ b/packages/web-domain/src/Video.ts
@@ -200,13 +200,15 @@ export function normalizeSegmentEntry(
 }
 
 /*
- * Used to specify a video password provided by a user,
+ * Used to specify video passwords provided by a user,
  * whether via cookies in the case of the website,
- * or via query params for the API.
+ * or via query params for the API. Holds every hash the user has verified
+ * (the cookie remembers one per unlocked resource), so unlocking one share
+ * never invalidates another.
  */
 export class VideoPasswordAttachment extends Context.Tag(
 	"VideoPasswordAttachment",
-)<VideoPasswordAttachment, { password: Option.Option<string> }>() {}
+)<VideoPasswordAttachment, { passwords: ReadonlyArray<string> }>() {}
 
 export class VerifyVideoPasswordError extends Schema.TaggedError<VerifyVideoPasswordError>()(
 	"VerifyVideoPasswordError",
@@ -236,16 +238,17 @@ export const verifyPasswordCandidates = (
 
 		if (passwords.length === 0) return;
 
-		if (
-			Option.isNone(passwordAttachment) ||
-			Option.isNone(passwordAttachment.value.password)
-		)
+		const verified = Option.isSome(passwordAttachment)
+			? passwordAttachment.value.passwords
+			: [];
+
+		if (verified.length === 0)
 			return yield* new VerifyVideoPasswordError({
 				id: video.id,
 				cause: "not-provided",
 			});
 
-		if (!passwords.includes(passwordAttachment.value.password.value))
+		if (!verified.some((hash) => passwords.includes(hash)))
 			return yield* new VerifyVideoPasswordError({
 				id: video.id,
 				cause: "wrong-password",

--- a/packages/web-domain/src/index.ts
+++ b/packages/web-domain/src/index.ts
@@ -12,6 +12,7 @@ export * as Loom from "./Loom.ts";
 export * as Organisation from "./Organisation.ts";
 export * from "./Organisation.ts";
 export * as Policy from "./Policy.ts";
+export * as PublicCollection from "./PublicCollection.ts";
 export { Rpcs } from "./Rpcs.ts";
 export * as S3Bucket from "./S3Bucket.ts";
 export { S3Error } from "./S3Bucket.ts";


### PR DESCRIPTION
Adds public collection pages at /c/[id] for spaces and folders. Org members can publish a space or folder, share a link, and visitors get a branded grid of caps with optional password protection and page customization.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds public collection pages at `/c/[id]` for spaces and folders, allowing org members to publish a space or folder with an optional password, email-domain restriction, custom branding, and a configurable grid/list layout. The feature is gated on the org owner's Pro plan.

- **New public page (`/c/[id]`)**: Parallel DB lookups for folder and space candidates, server-side access control (password / email restriction), paginated video grid, and branded header; previously flagged sequential DB queries are now resolved with `Promise.all`.
- **Password cookie refactored**: `password-cookie.ts` now stores an encrypted JSON array of hashes (up to 10) instead of a single hash, eliminating the cross-resource collision issue raised in the prior review.
- **Authorization and Pro-gating**: Three new server actions (`visibility`, `password`, `logo`) and backend `Folders.update` extension all enforce manager-level access and Pro checks before writing; un-publishing is always allowed without a Pro check.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge; authorization is enforced server-side on all write paths and the previously flagged issues have been addressed.

All three issues from the prior review (password cookie collision, sequential DB queries, console.error on bad passwords) are resolved. Server-side Pro and permission gates cover every write path, settings patches are schema-validated, updates are atomic via JSON_MERGE_PATCH, and password verification is rate-limited. The only new findings are style-level concerns.

Folder.tsx and FoldersDropdown.tsx — the Make public dropdown item is shown to all users who can see a folder card, not just those who can manage it.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/lib/public-collections.ts | New server module: parallel DB lookups for folder/space, correct password inheritance, public-video-only queries, and proper tombstone gating. Previous sequential-query concern is resolved with Promise.all. |
| apps/web/lib/public-collections-policy.ts | Access-control logic for public collections; email restriction and password gating are correctly ordered. parsePublicCollectionPage has no upper-bound check on the page number (flagged). |
| apps/web/lib/password-cookie.ts | Refactored from a single-hash cookie to an encrypted JSON array (up to 10 hashes), resolving the prior cross-resource collision. Legacy single-hash cookies are handled gracefully. |
| apps/web/actions/collections/password.ts | New action for collection password verification with per-IP rate limiting, PBKDF2 verification, and correct separation of expected vs. unexpected failure paths. |
| apps/web/actions/collections/visibility.ts | New server action for toggling space public status; schema-validates the settings patch, Pro-gates enabling/customizing, and uses atomic JSON_MERGE_PATCH to avoid concurrent-write races. |
| apps/web/actions/collections/logo.ts | New server action for collection logo upload/removal; validates file type, size, SVG sanitization, and applies proper authorization for both space and folder contexts with Pro gate. |
| apps/web/app/c/[id]/page.tsx | New public collection page; correctly gates content behind password/email-restriction states and renders metadata, branding, hero, folders, and paginated videos. |
| packages/database/schema.ts | Adds public boolean and settings JSON to both folders and spaces; adds composite indexes that support the new public-collection queries. |
| apps/web/app/(org)/dashboard/caps/components/Folder.tsx | Reworked to a fieldset container to allow interactive children without anchor nesting; adds public indicator and Make public dropdown toggle, but the toggle is shown to all users regardless of manage permission (flagged). |
| packages/web-backend/src/Folders/index.ts | Adds public and publicPage fields to FolderCreate and FolderUpdate; Pro-gates enabling or customizing the public page; uses JSON_MERGE_PATCH for atomic settings updates. |
| packages/web-domain/src/PublicCollection.ts | New domain types and Effect schemas for public collection page settings; PublicPageSettingsUpdate correctly omits logoUrl so only the logo action owns that field. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/app/(org)/dashboard/caps/components/Folder.tsx:289-430
**"Make public" shown to non-managers**

`FolderCard` receives no `canManage` prop, so every user who sees a folder card — including read-only space members — sees "Make public" (or "Make private") in the `FoldersDropdown`. Clicking it calls `updateFolder.mutate({ id, public: nextPublic })`, which the server correctly rejects, but the error that surfaces is a generic `"Failed to update folder"` rather than something actionable. The client-side Pro check (`ownerIsPro`) only guards the upgrade modal path, not the permission path.

Consider adding a `canManage` boolean to `FolderDataType` and threading it down to `FoldersDropdown` so the public-toggle items are only shown (or enabled) when the viewer actually has permission to make the change.

### Issue 2 of 2
apps/web/lib/public-collections-policy.ts:25-27
No upper bound is enforced on the page number. Passing a very large value (e.g. `page=9999999`) results in a huge SQL `OFFSET`, which MySQL must still evaluate and skip before returning zero rows. Capping at a reasonable ceiling costs nothing for normal usage and avoids wasted work on adversarial requests.

```suggestion
	if (!Number.isInteger(parsed) || parsed < 1 || parsed > 10_000) return 1;

	return parsed;
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): address review feedback on pub..."](https://github.com/capsoftware/cap/commit/6ed2a6ea399a12bea19395f6c1ed81f3f5739fae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36551729)</sub>

<!-- /greptile_comment -->