### PR TITLE
feat(share): configurable call-to-action button on shared videos

### DIFF
--- a/apps/web/actions/videos/edit-cta.ts
+++ b/apps/web/actions/videos/edit-cta.ts
@@ -1,0 +1,73 @@
+"use server";
+
+import { db } from "@cap/database";
+import { getCurrentUser } from "@cap/database/auth/session";
+import { videos } from "@cap/database/schema";
+import type { VideoCta, VideoMetadata } from "@cap/database/types";
+import type { Video } from "@cap/web-domain";
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+const MAX_LABEL_LENGTH = 40;
+
+export async function editCta(videoId: Video.VideoId, cta: VideoCta | null) {
+	const user = await getCurrentUser();
+
+	if (!user || !videoId) {
+		throw new Error("Missing required data for updating video CTA");
+	}
+
+	const userId = user.id;
+	const query = await db().select().from(videos).where(eq(videos.id, videoId));
+
+	const video = query[0];
+	if (!video) {
+		throw new Error("Video not found");
+	}
+
+	if (video.ownerId !== userId) {
+		throw new Error("You don't have permission to update this video");
+	}
+
+	const currentMetadata = (video.metadata as VideoMetadata) || {};
+	let nextCta: VideoCta | undefined;
+
+	if (cta?.enabled) {
+		const label = cta.label.trim().slice(0, MAX_LABEL_LENGTH);
+		const url = cta.url.trim();
+
+		if (!label) {
+			throw new Error("CTA label is required");
+		}
+
+		let parsed: URL;
+		try {
+			parsed = new URL(url);
+		} catch {
+			throw new Error("CTA URL is invalid");
+		}
+
+		if (parsed.protocol !== "https:") {
+			throw new Error("CTA URL must start with https://");
+		}
+
+		nextCta = { enabled: true, label, url: parsed.toString() };
+	}
+
+	const updatedMetadata: VideoMetadata = { ...currentMetadata };
+	if (nextCta) {
+		updatedMetadata.cta = nextCta;
+	} else {
+		delete updatedMetadata.cta;
+	}
+
+	await db()
+		.update(videos)
+		.set({ metadata: updatedMetadata })
+		.where(eq(videos.id, videoId));
+
+	revalidatePath(`/s/${videoId}`);
+	revalidatePath("/dashboard/caps");
+
+	return { success: true };
+}

--- a/apps/web/actions/videos/edit-cta.ts
+++ b/apps/web/actions/videos/edit-cta.ts
@@ -3,12 +3,14 @@
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { videos } from "@cap/database/schema";
-import type { VideoCta, VideoMetadata } from "@cap/database/types";
+import {
+	MAX_CTA_LABEL_LENGTH,
+	type VideoCta,
+	type VideoMetadata,
+} from "@cap/database/types";
 import type { Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
-
-const MAX_LABEL_LENGTH = 40;
 
 export async function editCta(videoId: Video.VideoId, cta: VideoCta | null) {
 	const user = await getCurrentUser();
@@ -33,7 +35,7 @@ export async function editCta(videoId: Video.VideoId, cta: VideoCta | null) {
 	let nextCta: VideoCta | undefined;
 
 	if (cta?.enabled) {
-		const label = cta.label.trim().slice(0, MAX_LABEL_LENGTH);
+		const label = cta.label.trim().slice(0, MAX_CTA_LABEL_LENGTH);
 		const url = cta.url.trim();
 
 		if (!label) {

--- a/apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx
+++ b/apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { VideoCta } from "@cap/database/types";
 import { LogoSpinner } from "@cap/ui";
 import { calculateStrokeDashoffset, getProgressCircleConfig } from "@cap/utils";
 import type { Video } from "@cap/web-domain";
@@ -13,6 +14,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { retryVideoProcessing } from "@/actions/video/retry-processing";
 import CommentStamp from "./CommentStamp";
+import { CtaButton } from "./CtaButton";
 import { getActiveCaptionText } from "./caption-cues";
 import {
 	AVC_LEVEL_IOS_HARDWARE_CEILING,
@@ -115,6 +117,7 @@ interface Props {
 	showPlaybackStatusBadge?: boolean;
 	showFloatingVolumeControl?: boolean;
 	onUploadComplete?: () => void;
+	cta?: VideoCta | null;
 }
 
 export function CapVideoPlayer({
@@ -148,6 +151,7 @@ export function CapVideoPlayer({
 	showPlaybackStatusBadge = false,
 	showFloatingVolumeControl = false,
 	onUploadComplete,
+	cta,
 }: Props) {
 	const [currentCue, setCurrentCue] = useState<string>("");
 	const [controlsVisible, setControlsVisible] = useState(false);
@@ -622,6 +626,7 @@ export function CapVideoPlayer({
 			)}
 			autoHide
 		>
+			<CtaButton cta={cta} />
 			{showUploadFailureOverlay && (
 				<div className="flex absolute inset-0 flex-col px-3 gap-3 z-[20] justify-center items-center bg-black transition-opacity duration-300">
 					<AlertTriangleIcon className="text-red-500 size-12" />

--- a/apps/web/app/s/[videoId]/_components/CtaButton.tsx
+++ b/apps/web/app/s/[videoId]/_components/CtaButton.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import type { VideoCta } from "@cap/database/types";
+import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+export function CtaButton({ cta }: { cta?: VideoCta | null }) {
+	if (!cta?.enabled || !cta.url || !cta.label) return null;
+
+	return (
+		<a
+			href={cta.url}
+			target="_blank"
+			rel="noopener noreferrer"
+			className="absolute top-3 right-3 z-30 inline-flex items-center gap-2 rounded-full bg-blue-500 px-4 py-2 text-sm font-medium text-white shadow-lg transition-colors hover:bg-blue-600"
+		>
+			<span className="truncate max-w-[200px]">{cta.label}</span>
+			<FontAwesomeIcon className="size-3" icon={faArrowUpRightFromSquare} />
+		</a>
+	);
+}

--- a/apps/web/app/s/[videoId]/_components/CtaDialog.tsx
+++ b/apps/web/app/s/[videoId]/_components/CtaDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { VideoCta } from "@cap/database/types";
+import { MAX_CTA_LABEL_LENGTH, type VideoCta } from "@cap/database/types";
 import {
 	Button,
 	Dialog,
@@ -19,8 +19,6 @@ import { useRouter } from "next/navigation";
 import { useEffect, useId, useState } from "react";
 import { toast } from "sonner";
 import { editCta } from "@/actions/videos/edit-cta";
-
-const MAX_LABEL_LENGTH = 40;
 
 export const CtaDialog = ({
 	isOpen,
@@ -97,7 +95,7 @@ export const CtaDialog = ({
 							id={labelId}
 							placeholder="Book a meeting"
 							value={label}
-							maxLength={MAX_LABEL_LENGTH}
+							maxLength={MAX_CTA_LABEL_LENGTH}
 							disabled={!enabled}
 							onChange={(e) => setLabel(e.target.value)}
 						/>
@@ -127,7 +125,10 @@ export const CtaDialog = ({
 						size="sm"
 						variant="dark"
 						onClick={handleSave}
-						disabled={isSaving || (enabled && (!label.trim() || !url.trim()))}
+						disabled={
+							isSaving ||
+							(enabled && (!label.trim() || !url.trim().startsWith("https://")))
+						}
 					>
 						{isSaving ? "Saving..." : "Save"}
 					</Button>

--- a/apps/web/app/s/[videoId]/_components/CtaDialog.tsx
+++ b/apps/web/app/s/[videoId]/_components/CtaDialog.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import type { VideoCta } from "@cap/database/types";
+import {
+	Button,
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Input,
+	Label,
+	Switch,
+} from "@cap/ui";
+import type { Video } from "@cap/web-domain";
+import { faUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useRouter } from "next/navigation";
+import { useEffect, useId, useState } from "react";
+import { toast } from "sonner";
+import { editCta } from "@/actions/videos/edit-cta";
+
+const MAX_LABEL_LENGTH = 40;
+
+export const CtaDialog = ({
+	isOpen,
+	onClose,
+	videoId,
+	cta,
+}: {
+	isOpen: boolean;
+	onClose: () => void;
+	videoId: Video.VideoId;
+	cta?: VideoCta | null;
+}) => {
+	const { refresh } = useRouter();
+	const enabledId = useId();
+	const labelId = useId();
+	const urlId = useId();
+	const [enabled, setEnabled] = useState(cta?.enabled ?? false);
+	const [label, setLabel] = useState(cta?.label ?? "");
+	const [url, setUrl] = useState(cta?.url ?? "");
+	const [isSaving, setIsSaving] = useState(false);
+
+	useEffect(() => {
+		if (isOpen) {
+			setEnabled(cta?.enabled ?? false);
+			setLabel(cta?.label ?? "");
+			setUrl(cta?.url ?? "");
+		}
+	}, [isOpen, cta]);
+
+	const handleSave = async () => {
+		setIsSaving(true);
+		try {
+			const next: VideoCta | null = enabled
+				? { enabled: true, label: label.trim(), url: url.trim() }
+				: null;
+			await editCta(videoId, next);
+			toast.success(
+				enabled ? "Call to action saved" : "Call to action removed",
+			);
+			refresh();
+			onClose();
+		} catch (error) {
+			toast.error(
+				error instanceof Error
+					? error.message
+					: "Failed to save call to action",
+			);
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	return (
+		<Dialog open={isOpen} onOpenChange={onClose}>
+			<DialogContent className="p-0 w-full max-w-md rounded-xl border bg-gray-2 border-gray-4">
+				<DialogHeader
+					icon={<FontAwesomeIcon icon={faUpRightFromSquare} />}
+					description="Show a button in the top-right of your video that links anywhere you like."
+				>
+					<DialogTitle>Call to action</DialogTitle>
+				</DialogHeader>
+				<div className="flex flex-col gap-4 p-5">
+					<div className="flex justify-between items-center">
+						<Label htmlFor={enabledId}>Show call to action</Label>
+						<Switch
+							id={enabledId}
+							checked={enabled}
+							onCheckedChange={setEnabled}
+						/>
+					</div>
+					<div className="flex flex-col gap-2">
+						<Label htmlFor={labelId}>Button label</Label>
+						<Input
+							id={labelId}
+							placeholder="Book a meeting"
+							value={label}
+							maxLength={MAX_LABEL_LENGTH}
+							disabled={!enabled}
+							onChange={(e) => setLabel(e.target.value)}
+						/>
+					</div>
+					<div className="flex flex-col gap-2">
+						<Label htmlFor={urlId}>Link (https)</Label>
+						<Input
+							id={urlId}
+							type="url"
+							placeholder="https://cal.com/your-handle"
+							value={url}
+							disabled={!enabled}
+							onChange={(e) => setUrl(e.target.value)}
+						/>
+					</div>
+				</div>
+				<DialogFooter className="p-5 border-t border-gray-4">
+					<Button
+						size="sm"
+						variant="gray"
+						onClick={onClose}
+						disabled={isSaving}
+					>
+						Cancel
+					</Button>
+					<Button
+						size="sm"
+						variant="dark"
+						onClick={handleSave}
+						disabled={isSaving || (enabled && (!label.trim() || !url.trim()))}
+					>
+						{isSaving ? "Saving..." : "Save"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/apps/web/app/s/[videoId]/_components/HLSVideoPlayer.tsx
+++ b/apps/web/app/s/[videoId]/_components/HLSVideoPlayer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { VideoCta } from "@cap/database/types";
 import { LogoSpinner } from "@cap/ui";
 import { calculateStrokeDashoffset, getProgressCircleConfig } from "@cap/utils";
 import type { Video } from "@cap/web-domain";
@@ -14,6 +15,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { retryVideoProcessing } from "@/actions/video/retry-processing";
+import { CtaButton } from "./CtaButton";
 import { getActiveCaptionText } from "./caption-cues";
 import {
 	canRetryFailedProcessing,
@@ -103,6 +105,7 @@ interface Props {
 	duration?: number | null;
 	defaultPlaybackSpeed?: number;
 	previewMode?: "background";
+	cta?: VideoCta | null;
 }
 
 export function HLSVideoPlayer({
@@ -128,6 +131,7 @@ export function HLSVideoPlayer({
 	duration: fallbackDuration,
 	defaultPlaybackSpeed,
 	previewMode,
+	cta,
 }: Props) {
 	const hlsInstance = useRef<Hls | null>(null);
 	const [currentCue, setCurrentCue] = useState<string>("");
@@ -620,6 +624,7 @@ export function HLSVideoPlayer({
 			)}
 			autoHide
 		>
+			{!isBackgroundPreview && <CtaButton cta={cta} />}
 			{hasFailedOrError && (
 				<div className="flex absolute inset-0 flex-col px-3 gap-3 z-[20] justify-center items-center bg-black transition-opacity duration-300">
 					<AlertTriangleIcon className="text-red-500 size-12" />

--- a/apps/web/app/s/[videoId]/_components/ShareHeader.tsx
+++ b/apps/web/app/s/[videoId]/_components/ShareHeader.tsx
@@ -7,6 +7,7 @@ import {
 	faChartSimple,
 	faChevronDown,
 	faLock,
+	faUpRightFromSquare,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { skipToken, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -31,6 +32,7 @@ import { UpgradeModal } from "@/components/UpgradeModal";
 import { usePublicEnv } from "@/utils/public-env";
 import { navigateWithTransition } from "@/utils/view-transition";
 import type { SharePageBranding, VideoData } from "../types";
+import { CtaDialog } from "./CtaDialog";
 
 export const ShareHeader = ({
 	data,
@@ -80,6 +82,7 @@ export const ShareHeader = ({
 	const [isTitleRevealing, setIsTitleRevealing] = useState(false);
 	const [upgradeModalOpen, setUpgradeModalOpen] = useState(false);
 	const [isSharingDialogOpen, setIsSharingDialogOpen] = useState(false);
+	const [isCtaDialogOpen, setIsCtaDialogOpen] = useState(false);
 	const [linkCopied, setLinkCopied] = useState(false);
 	const [showCopyOptions, setShowCopyOptions] = useState(false);
 	const [capturedTime, setCapturedTime] = useState(0);
@@ -443,6 +446,12 @@ export const ShareHeader = ({
 					</Button>
 				</div>
 			)}
+			<CtaDialog
+				isOpen={isCtaDialogOpen}
+				onClose={() => setIsCtaDialogOpen(false)}
+				videoId={data.id}
+				cta={data.metadata?.cta}
+			/>
 			<SharingDialog
 				isOpen={isSharingDialogOpen}
 				onClose={() => setIsSharingDialogOpen(false)}
@@ -610,6 +619,18 @@ export const ShareHeader = ({
 												icon={faChartSimple}
 											/>
 											View analytics
+										</Button>
+										<Button
+											variant="gray"
+											size="xs"
+											className="h-8 gap-1.5 rounded-full px-2.5 text-xs"
+											onClick={() => setIsCtaDialogOpen(true)}
+										>
+											<FontAwesomeIcon
+												className="size-3.5 text-gray-12"
+												icon={faUpRightFromSquare}
+											/>
+											Call to action
 										</Button>
 									</>
 								)}

--- a/apps/web/app/s/[videoId]/_components/ShareVideo.tsx
+++ b/apps/web/app/s/[videoId]/_components/ShareVideo.tsx
@@ -420,6 +420,7 @@ export const ShareVideo = forwardRef<
 							isCaptionLoading={captionContext.isTranslating}
 							hasCaptions={data.transcriptionStatus === "COMPLETE"}
 							canRetryProcessing={canRetryProcessing}
+							cta={data.metadata?.cta}
 						/>
 					) : (
 						<HLSVideoPlayer
@@ -443,6 +444,7 @@ export const ShareVideo = forwardRef<
 							isCaptionLoading={captionContext.isTranslating}
 							hasCaptions={data.transcriptionStatus === "COMPLETE"}
 							canRetryProcessing={canRetryProcessing}
+							cta={data.metadata?.cta}
 						/>
 					)}
 					{showFinalizeRecordingControl && (

--- a/packages/database/types/metadata.ts
+++ b/packages/database/types/metadata.ts
@@ -35,6 +35,13 @@ export interface VideoMetadata {
 		| "ERROR"
 		| "SKIPPED";
 	enhancedAudioStatus?: "PROCESSING" | "COMPLETE" | "ERROR" | "SKIPPED";
+	cta?: VideoCta;
+}
+
+export interface VideoCta {
+	enabled: boolean;
+	label: string;
+	url: string;
 }
 
 export type VideoEditRange = {

--- a/packages/database/types/metadata.ts
+++ b/packages/database/types/metadata.ts
@@ -44,6 +44,8 @@ export interface VideoCta {
 	url: string;
 }
 
+export const MAX_CTA_LABEL_LENGTH = 40;
+
 export type VideoEditRange = {
 	start: number;
 	end: number;


### PR DESCRIPTION
## What

Adds an optional **call-to-action button** in the top-right of the video player on the public share page (`/s/[videoId]`), similar to Loom's CTA. The video owner sets a label and an `https` link; viewers see the button and clicking it opens the link in a new tab.

Typical use: a "Book a meeting" / "Talk to sales" button linking to Cal.com, Calendly, etc.

## Demo

The owner sets a label + `https` link; viewers see the button in the top-right of the player (here linking to a booking page). Shown on the public share page:

![Call-to-action button on the video share page](https://raw.githubusercontent.com/alexis-morain/Cap/pr1907-cta-demo/demo/cta-button.png)

## How it works

- **Storage**: a `cta` object on the existing `videos.metadata` JSON column. No schema migration.

  ```ts
  cta?: { enabled: boolean; label: string; url: string }
  ```
- **Config UI**: a "Call to action" button in `ShareHeader` (owner-only) opens a dialog to toggle, set the label, and set the URL.
- **Server action** `editCta`: owner-only (`ownerId` check), trims the label (max 40 chars), and validates the URL with `new URL()` requiring `https:`. Disabling removes the key.
- **Display**: a small `CtaButton` overlay anchor (`target="_blank" rel="noopener noreferrer"`) rendered inside both `CapVideoPlayer` (MP4) and `HLSVideoPlayer` (HLS), so it stays visible in fullscreen. Hidden in the background-preview variant.

## Notes

- Purely additive (+272 lines, 8 files), no new routes, no migration.
- No code comments, Biome-clean, `tsc -b` passes.
- Per-video scope for this first version. An org-wide default could be a follow-up.

## Test plan

- [x] Owner adds a CTA (label + https URL) → button appears top-right.
- [x] Anonymous viewer sees the button; click opens the URL in a new tab.
- [x] Non-https URL rejected (client disables save + server throws).
- [x] Toggle off / save → button removed.
- [x] Visible in fullscreen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

