### PR TITLE
unintentional vibe coding stuff which I now regret

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3159,7 +3159,7 @@ async fn upload_exported_video(
     channel: Channel<UploadProgress>,
     organization_id: Option<String>,
 ) -> Result<UploadResult, String> {
-    let Ok(Some(auth)) = AuthStore::get(&app) else {
+    let Ok(Some(_auth)) = AuthStore::get(&app) else {
         AuthStore::set(&app, None).map_err(|e| e.to_string())?;
         return Ok(UploadResult::NotAuthenticated);
     };
@@ -3174,10 +3174,6 @@ async fn upload_exported_video(
 
     let metadata = build_video_meta(&file_path)
         .map_err(|err| format!("Error getting output video meta: {err}"))?;
-
-    if !auth.is_upgraded() && metadata.duration_in_secs > 300.0 {
-        return Ok(UploadResult::UpgradeRequired);
-    }
 
     channel.send(UploadProgress { progress: 0.0 }).ok();
 

--- a/apps/desktop/src/routes/editor/ExportPage.tsx
+++ b/apps/desktop/src/routes/editor/ExportPage.tsx
@@ -652,21 +652,6 @@ export function ExportPage() {
 					has_existing_auth: !!existingAuth,
 				});
 
-				const metadata = await commands.getVideoMetadata(projectPath);
-				const plan = await commands.checkUpgradedAndUpdate();
-				const canShare = {
-					allowed: plan || metadata.duration < 300,
-					reason: !plan && metadata.duration >= 300 ? "upgrade_required" : null,
-				};
-
-				if (!canShare.allowed) {
-					if (canShare.reason === "upgrade_required") {
-						await commands.showWindow("Upgrade");
-						await new Promise((resolve) => setTimeout(resolve, 1000));
-						throw new SilentError();
-					}
-				}
-
 				const uploadChannel = new Channel<UploadProgress>((progress) => {
 					console.log("Upload progress:", progress);
 					setExportState(

--- a/apps/desktop/src/routes/editor/ShareButton.tsx
+++ b/apps/desktop/src/routes/editor/ShareButton.tsx
@@ -37,22 +37,6 @@ function ShareButton() {
 				throw new Error("You need to sign in to share recordings");
 			}
 
-			const metadata = await commands.getVideoMetadata(projectPath);
-			const plan = await commands.checkUpgradedAndUpdate();
-			const canShare = {
-				allowed: plan || metadata.duration < 300,
-				reason: !plan && metadata.duration >= 300 ? "upgrade_required" : null,
-			};
-
-			if (!canShare.allowed) {
-				if (canShare.reason === "upgrade_required") {
-					await commands.showWindow("Upgrade");
-					throw new Error(
-						"Upgrade required to share recordings longer than 5 minutes",
-					);
-				}
-			}
-
 			const uploadChannel = new Channel<UploadProgress>((progress) => {
 				console.log("Upload progress:", progress);
 				setUploadState(

--- a/apps/desktop/src/routes/in-progress-recording.tsx
+++ b/apps/desktop/src/routes/in-progress-recording.tsx
@@ -23,7 +23,6 @@ import {
 } from "solid-js";
 import { createStore, produce } from "solid-js/store";
 import { TransitionGroup } from "solid-transition-group";
-import { authStore } from "~/store";
 import { getCameraWindow } from "~/utils/camera-window";
 import { createTauriEventListener } from "~/utils/createEventListener";
 import {
@@ -54,7 +53,6 @@ declare global {
 	}
 }
 
-const MAX_RECORDING_FOR_FREE = 5 * 60 * 1000;
 const NO_MICROPHONE = "No Microphone";
 const NO_WEBCAM = "No Webcam";
 const FAKE_WINDOW_BOUNDS_NAME = "recording-controls-interactive-area";
@@ -86,16 +84,6 @@ function InProgressRecordingInner() {
 	const optionsQuery = createOptionsQuery();
 	const startedWithMicrophone = optionsQuery.rawOptions.micName != null;
 	const startedWithCameraInput = optionsQuery.rawOptions.cameraID != null;
-
-	const [authData, setAuthData] = createSignal<{
-		plan?: { upgraded?: boolean };
-	} | null>(null);
-	onMount(() => {
-		authStore
-			.get()
-			.then(setAuthData)
-			.catch(() => setAuthData(null));
-	});
 
 	const audioLevel = createAudioInputLevel();
 	const [disconnectedInputs, setDisconnectedInputs] =
@@ -632,33 +620,6 @@ function InProgressRecordingInner() {
 		return Math.max(0, t);
 	};
 
-	const isMaxRecordingLimitEnabled = () => {
-		// Only enforce the limit on instant mode.
-		// We enforce it on studio mode when exporting.
-		return (
-			optionsQuery.rawOptions.mode === "instant" &&
-			// If the data is loaded and the user is not upgraded
-			authData()?.plan?.upgraded === false
-		);
-	};
-
-	let aborted = false;
-	createEffect(() => {
-		if (
-			isMaxRecordingLimitEnabled() &&
-			adjustedTime() > MAX_RECORDING_FOR_FREE &&
-			!aborted
-		) {
-			aborted = true;
-			stopRecording.mutate();
-		}
-	});
-
-	const remainingRecordingTime = () => {
-		if (MAX_RECORDING_FOR_FREE < adjustedTime()) return 0;
-		return MAX_RECORDING_FOR_FREE - adjustedTime();
-	};
-
 	const isInitializing = () => state().variant === "initializing";
 	const closeStartingBar = async () => {
 		setStartingDismissed(true);
@@ -776,12 +737,7 @@ function InProgressRecordingInner() {
 													</div>
 												}
 											>
-												<Show
-													when={isMaxRecordingLimitEnabled()}
-													fallback={formatTime(adjustedTime() / 1000)}
-												>
-													{formatTime(remainingRecordingTime() / 1000)}
-												</Show>
+												{formatTime(adjustedTime() / 1000)}
 											</Show>
 										</span>
 									</button>

--- a/apps/desktop/src/routes/recordings-overlay.tsx
+++ b/apps/desktop/src/routes/recordings-overlay.tsx
@@ -725,22 +725,6 @@ function createRecordingMutations(
 				throw new Error("You need to sign in to share recordings");
 			}
 
-			const metadata = await commands.getVideoMetadata(media.path);
-			const plan = await commands.checkUpgradedAndUpdate();
-			const canShare = {
-				allowed: plan || metadata.duration < 300,
-				reason: !plan && metadata.duration >= 300 ? "upgrade_required" : null,
-			};
-
-			if (!canShare.allowed) {
-				if (canShare.reason === "upgrade_required") {
-					await commands.showWindow("Upgrade");
-					throw new Error(
-						"Upgrade required to share recordings longer than 5 minutes",
-					);
-				}
-			}
-
 			const uploadChannel = new Channel<UploadProgress>((progress) => {
 				console.log("Upload progress:", progress);
 				setActionState(

--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -396,7 +396,6 @@ function Inner() {
 								commands.closeTargetSelectOverlays();
 							}}
 						/>
-						<ShowCapFreeWarning isInstantMode={options.mode === "instant"} />
 					</div>
 				)}
 			</Match>
@@ -679,9 +678,6 @@ function Inner() {
 										>
 											Adjust recording area
 										</Button>
-										<ShowCapFreeWarning
-											isInstantMode={options.mode === "instant"}
-										/>
 									</div>
 								</div>
 							)}
@@ -1137,11 +1133,6 @@ function Inner() {
 												is too small
 											</small>
 										</div>
-									</Show>
-									<Show when={isValid()}>
-										<ShowCapFreeWarning
-											isInstantMode={options.mode === "instant"}
-										/>
 									</Show>
 								</div>
 							</div>
@@ -1846,25 +1837,5 @@ function RecordingControls(props: {
 				</div>
 			</div>
 		</>
-	);
-}
-
-function ShowCapFreeWarning(props: { isInstantMode: boolean }) {
-	const auth = authStore.createQuery();
-
-	return (
-		<Suspense>
-			<Show when={props.isInstantMode && auth.data?.plan?.upgraded === false}>
-				<p class="text-sm text-center max-w-64 text-gray-3 mt-3">
-					Instant Mode recordings are limited to 5 mins,{" "}
-					<button
-						class="underline font-bold text-gray-3"
-						onClick={() => commands.showWindow("Upgrade")}
-					>
-						Upgrade to Pro
-					</button>
-				</p>
-			</Show>
-		</Suspense>
 	);
 }

--- a/apps/web/actions/video/create-for-processing.ts
+++ b/apps/web/actions/video/create-for-processing.ts
@@ -5,7 +5,7 @@ import { getCurrentUser } from "@cap/database/auth/session";
 import { nanoId } from "@cap/database/helpers";
 import { videos, videoUploads } from "@cap/database/schema";
 import { buildEnv, NODE_ENV, serverEnv } from "@cap/env";
-import { dub, userIsPro } from "@cap/utils";
+import { dub } from "@cap/utils";
 import { Storage as StorageService } from "@cap/web-backend";
 import {
 	type Folder,
@@ -44,10 +44,6 @@ export async function createVideoForServerProcessing({
 	const user = await getCurrentUser();
 
 	if (!user) throw new Error("Unauthorized");
-
-	if (!userIsPro(user) && duration && duration > 300) {
-		throw new Error("upgrade_required");
-	}
 
 	await requireOrganizationAccess(user.id, orgId);
 

--- a/apps/web/actions/video/upload.ts
+++ b/apps/web/actions/video/upload.ts
@@ -5,7 +5,7 @@ import { getCurrentUser } from "@cap/database/auth/session";
 import { nanoId } from "@cap/database/helpers";
 import { videos, videoUploads } from "@cap/database/schema";
 import { buildEnv, NODE_ENV, serverEnv } from "@cap/env";
-import { dub, userIsPro } from "@cap/utils";
+import { dub } from "@cap/utils";
 import { Storage as StorageService } from "@cap/web-backend";
 import {
 	type Folder,
@@ -134,9 +134,6 @@ export async function createVideoAndGetUploadUrl({
 	if (!user) throw new Error("Unauthorized");
 
 	try {
-		if (!userIsPro(user) && duration && duration > 300)
-			throw new Error("upgrade_required");
-
 		await requireOrganizationAccess(user.id, orgId);
 
 		const date = new Date();

--- a/apps/web/app/(org)/dashboard/caps/components/web-recorder-dialog/useWebRecorder.ts
+++ b/apps/web/app/(org)/dashboard/caps/components/web-recorder-dialog/useWebRecorder.ts
@@ -40,7 +40,6 @@ import {
 	DISPLAY_MODE_PREFERENCES,
 	type DisplaySurfacePreference,
 	type ExtendedDisplayMediaStreamOptions,
-	FREE_PLAN_MAX_RECORDING_MS,
 	RECORDING_MODE_TO_DISPLAY_SURFACE,
 } from "./web-recorder-constants";
 import type {
@@ -68,7 +67,6 @@ interface UseWebRecorderOptions {
 	systemAudioEnabled: boolean;
 	recordingMode: RecordingMode;
 	selectedCameraId: string | null;
-	isProUser: boolean;
 	onPhaseChange?: (phase: RecorderPhase) => void;
 	onRecordingSurfaceDetected?: (mode: RecordingMode) => void;
 	onRecordingStart?: () => void;
@@ -131,7 +129,6 @@ export const useWebRecorder = ({
 	systemAudioEnabled,
 	recordingMode,
 	selectedCameraId,
-	isProUser,
 	onPhaseChange,
 	onRecordingSurfaceDetected,
 	onRecordingStart,
@@ -244,7 +241,6 @@ export const useWebRecorder = ({
 	const instantChunkModeRef = useRef<InstantChunkingMode | null>(null);
 	const chunkStartGuardTimeoutRef = useRef<number | null>(null);
 	const lastInstantChunkAtRef = useRef<number | null>(null);
-	const freePlanAutoStopTriggeredRef = useRef(false);
 	const shareUrlOpenedRef = useRef(false);
 	const errorDownloadUrlRef = useRef<string | null>(null);
 	const stopInFlightRef = useRef(false);
@@ -506,8 +502,6 @@ export const useWebRecorder = ({
 		},
 		[deleteVideo],
 	);
-
-	const isFreePlan = !isProUser;
 
 	const stopInstantChunkInterval = useCallback(() => {
 		if (!dataRequestIntervalRef.current) return;
@@ -1421,32 +1415,6 @@ export const useWebRecorder = ({
 	useEffect(() => {
 		stopRecordingRef.current = stopRecording;
 	}, [stopRecording]);
-
-	useEffect(() => {
-		if (!isFreePlan) {
-			freePlanAutoStopTriggeredRef.current = false;
-			return;
-		}
-
-		const isRecordingPhase = phase === "recording" || phase === "paused";
-		if (!isRecordingPhase) {
-			freePlanAutoStopTriggeredRef.current = false;
-			return;
-		}
-
-		if (
-			durationMs >= FREE_PLAN_MAX_RECORDING_MS &&
-			!freePlanAutoStopTriggeredRef.current
-		) {
-			freePlanAutoStopTriggeredRef.current = true;
-			toast.info(
-				"Free plan recordings are limited to 5 minutes. Recording stopped automatically.",
-			);
-			stopRecording().catch((error) => {
-				console.error("Failed to stop recording at free plan limit", error);
-			});
-		}
-	}, [durationMs, isFreePlan, phase, stopRecording]);
 
 	const restartRecording = useCallback(async () => {
 		if (isRestarting) return;

--- a/apps/web/app/(org)/dashboard/caps/components/web-recorder-dialog/web-recorder-constants.ts
+++ b/apps/web/app/(org)/dashboard/caps/components/web-recorder-dialog/web-recorder-constants.ts
@@ -118,5 +118,3 @@ export const WEBM_MIME_TYPES = {
 } as const;
 
 export const DETECTION_RETRY_DELAYS = [120, 450, 1000];
-
-export const FREE_PLAN_MAX_RECORDING_MS = 5 * 60 * 1000;

--- a/apps/web/app/(org)/dashboard/caps/components/web-recorder-dialog/web-recorder-dialog.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/web-recorder-dialog/web-recorder-dialog.tsx
@@ -31,10 +31,7 @@ import { useDevicePreferences } from "./useDevicePreferences";
 import { useDialogInteractions } from "./useDialogInteractions";
 import { useMicrophoneDevices } from "./useMicrophoneDevices";
 import { useWebRecorder } from "./useWebRecorder";
-import {
-	dialogVariants,
-	FREE_PLAN_MAX_RECORDING_MS,
-} from "./web-recorder-constants";
+import { dialogVariants } from "./web-recorder-constants";
 import { WebRecorderDialogHeader } from "./web-recorder-dialog-header";
 
 const recoveredRecordingTimeFormatter = new Intl.DateTimeFormat(undefined, {
@@ -93,7 +90,7 @@ export const WebRecorderDialog = () => {
 		playAudio(stopSoundRef.current);
 	}, [playAudio]);
 
-	const { activeOrganization, user } = useDashboardContext();
+	const { activeOrganization } = useDashboardContext();
 	const organisationId = activeOrganization?.organization.id;
 	const { devices: availableMics, refresh: refreshMics } =
 		useMicrophoneDevices(open);
@@ -160,7 +157,6 @@ export const WebRecorderDialog = () => {
 		systemAudioEnabled,
 		recordingMode,
 		selectedCameraId,
-		isProUser: user.isPro,
 		onRecordingSurfaceDetected: (mode) => {
 			setRecordingMode(mode);
 		},
@@ -236,9 +232,7 @@ export const WebRecorderDialog = () => {
 	};
 
 	const showInProgressBar = isRecording || isBusy || phase === "error";
-	const recordingTimerDisplayMs = user.isPro
-		? durationMs
-		: Math.max(0, FREE_PLAN_MAX_RECORDING_MS - durationMs);
+	const recordingTimerDisplayMs = durationMs;
 
 	return (
 		<>

--- a/apps/web/app/(org)/dashboard/caps/record/RecordVideoPage.tsx
+++ b/apps/web/app/(org)/dashboard/caps/record/RecordVideoPage.tsx
@@ -6,7 +6,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ChevronDown } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useId, useRef, useState } from "react";
-import { FREE_PLAN_MAX_RECORDING_MS } from "../components/web-recorder-dialog/web-recorder-constants";
 import { WebRecorderDialog } from "../components/web-recorder-dialog/web-recorder-dialog";
 
 export const RecordVideoPage = () => {
@@ -71,7 +70,6 @@ export const RecordVideoPage = () => {
 };
 
 const FaqAccordion = () => {
-	const freeMinutes = Math.floor(FREE_PLAN_MAX_RECORDING_MS / 60000);
 	const items = [
 		{
 			id: "what-is-cap",
@@ -106,7 +104,7 @@ const FaqAccordion = () => {
 		{
 			id: "install",
 			q: "Do I need to install the app?",
-			a: `No. You can record in your browser. For longer recordings, system audio, and advanced editing, use Cap Desktop. The Free plan supports up to ${freeMinutes} minutes per recording in the browser.`,
+			a: "No. You can record in your browser. For system audio and advanced editing, use Cap Desktop.",
 		},
 	];
 

--- a/apps/web/app/api/desktop/[...route]/video.ts
+++ b/apps/web/app/api/desktop/[...route]/video.ts
@@ -12,7 +12,7 @@ import {
 } from "@cap/database/schema";
 import type { VideoMetadata } from "@cap/database/types";
 import { buildEnv, NODE_ENV, serverEnv } from "@cap/env";
-import { dub, userIsPro } from "@cap/utils";
+import { dub } from "@cap/utils";
 import { Storage } from "@cap/web-backend";
 import { Organisation, Video } from "@cap/web-domain";
 import { zValidator } from "@hono/zod-validator";
@@ -97,11 +97,6 @@ app.get(
 				orgId,
 			} = c.req.valid("query");
 			const user = c.get("user");
-
-			const isCapPro = userIsPro(user);
-
-			if (!isCapPro && durationInSecs && durationInSecs > /* 5 min */ 5 * 60)
-				return c.json({ error: "upgrade_required" }, { status: 403 });
 
 			console.log("Video create request:", {
 				recordingMode,

--- a/apps/web/lib/messenger/constants.ts
+++ b/apps/web/lib/messenger/constants.ts
@@ -93,7 +93,7 @@ PRICING (early adopter beta pricing, locked in for lifetime of subscription):
 - Student discount available at https://cap.so/student-discount
 
 RECORDING MODES (DESKTOP APP):
-1. Instant Mode: records and uploads in real-time simultaneously. When you stop recording, the shareable link is ready within seconds. AI auto-generates captions, title, summary, and chapters (Pro). Perfect for quick feedback, bug reports, and async communication. Free users limited to 5 minutes; Pro users have unlimited length.
+1. Instant Mode: records and uploads in real-time simultaneously. When you stop recording, the shareable link is ready within seconds. AI auto-generates captions, title, summary, and chapters (Pro). Perfect for quick feedback, bug reports, and async communication.
 2. Studio Mode: records locally to your machine with no time limits. After recording, opens in the full editor with timeline, backgrounds, effects, cursor styling, text overlays, zoom, and more. Export to MP4 or GIF. Can pause/resume during recording. Supports crash-recoverable recording (fragmented segments that can be recovered if the app crashes).
 3. Screenshot Mode: capture a screenshot of your entire screen, a specific window, or a custom area. Opens in the screenshot editor with cropping, annotations (text, shapes, arrows, drawing, masking), custom backgrounds, padding, rounding, shadows, and borders. Export to file or copy to clipboard.
 


### PR DESCRIPTION
Eliminate the free-plan 5-minute recording limit across all enforcement layers so free users get unlimited recording length:

- Web browser recorder: drop the auto-stop timer and show elapsed time
- Desktop Instant Mode: drop the auto-stop and remaining-time countdown
- Desktop studio share/export: remove the 300s upgrade gates
- Web server actions and desktop video API: remove duration upload gates
- Desktop Rust upload: remove the duration UpgradeRequired check
- Update related UI/FAQ/assistant copy that referenced the limit

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the 5-minute free-plan recording cap at every enforcement layer — desktop Rust client check, desktop TypeScript pre-upload gates, Instant Mode auto-stop timer, web server actions, and the desktop API `/create` endpoint — and updates all related UI copy (FAQ, assistant constants, warning components).

- **Desktop (Rust/TypeScript):** Local duration check removed from `upload_exported_video`; TypeScript pre-upload gates removed from `ShareButton`, `ExportPage`, and `recordings-overlay`; `ShowCapFreeWarning` component and Instant Mode auto-stop effect deleted from `in-progress-recording` and `target-select-overlay`.
- **Web server:** `userIsPro` duration guards removed from `actions/video/upload.ts`, `actions/video/create-for-processing.ts`, and the `api/desktop/.../video.ts` GET `/create` route.
- **UI/Copy:** Timer now shows elapsed time for all users; FAQ and AI-assistant copy updated to remove the 5-minute limit mention.

<h3>Confidence Score: 4/5</h3>

Safe to merge. All enforcement layers are consistently removed and the changes are internally coherent across Rust, TypeScript, and server actions.

The only residual concern is that the `UpgradeRequired` result branches in `ShareButton.tsx`, `ExportPage.tsx`, and `recordings-overlay.tsx` are now dead code for the video upload flow — the server no longer returns a 403 for any duration reason on the endpoint those calls reach. This is harmless but is a minor cleanup left undone in the same PR that removed the trigger.

apps/desktop/src/routes/editor/ShareButton.tsx and ExportPage.tsx — both retain an `UpgradeRequired` result handler that is now unreachable for video uploads.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/lib.rs | Removes local duration check before upload; `auth` renamed to `_auth` to suppress unused-variable warning cleanly. `UploadResult::UpgradeRequired` enum variant and its match arms survive for other callers (e.g., `upload_screenshot` still gate-keeps on `is_upgraded()`). |
| apps/desktop/src/routes/editor/ShareButton.tsx | Removes the pre-upload duration gate. The remaining `UpgradeRequired` result branch in the upload response handler is now unreachable for the video upload flow since the server no longer returns a 403 for duration reasons. |
| apps/desktop/src/routes/editor/ExportPage.tsx | Same as ShareButton: pre-upload duration gate removed; `UpgradeRequired` branch in the result handler is now dead for video uploads. |
| apps/desktop/src/routes/in-progress-recording.tsx | Removes Instant Mode 5-min auto-stop for free users and converts the timer display from countdown (remaining) to elapsed time for all users. |
| apps/desktop/src/routes/recordings-overlay.tsx | Removes pre-upload duration gate; residual `UpgradeRequired` result handler (not in diff) is now dead for video uploads but harmless. |
| apps/desktop/src/routes/target-select-overlay.tsx | Removes three call sites of `ShowCapFreeWarning` and deletes the component itself, which displayed the Instant Mode 5-min warning for free users. |
| apps/web/actions/video/create-for-processing.ts | Removes server-side duration gate (`userIsPro` check) from video-for-processing creation path; `userIsPro` import removed as no longer needed here. |
| apps/web/actions/video/upload.ts | Removes server-side duration gate from the web upload action; `userIsPro` import removed. |
| apps/web/app/(org)/dashboard/caps/components/web-recorder-dialog/useWebRecorder.ts | Removes `isProUser` option, `isFreePlan` derived flag, `freePlanAutoStopTriggeredRef`, and the `useEffect` that auto-stopped recording at the free-plan limit. |
| apps/web/app/(org)/dashboard/caps/components/web-recorder-dialog/web-recorder-dialog.tsx | Drops `user` from the `useDashboardContext()` destructure (it was only used for `isProUser` and the countdown display); timer now always shows elapsed time. |
| apps/web/app/(org)/dashboard/caps/components/web-recorder-dialog/web-recorder-constants.ts | Deletes the `FREE_PLAN_MAX_RECORDING_MS` constant (5 × 60 × 1000). |
| apps/web/app/(org)/dashboard/caps/record/RecordVideoPage.tsx | Updates FAQ copy to remove the 5-minute free-plan limit reference; drops unused `FREE_PLAN_MAX_RECORDING_MS` import. |
| apps/web/app/api/desktop/[...route]/video.ts | Removes the 403 `upgrade_required` gate on the `/create` endpoint for the desktop API; `userIsPro` import removed. |
| apps/web/lib/messenger/constants.ts | Updates AI-assistant copy for Instant Mode to remove 'Free users limited to 5 minutes' language. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/routes/editor/ShareButton.tsx`, line 103-104 ([link](https://github.com/capsoftware/cap/blob/d8b04e6f8ce350c99968fcdcf3f8eab4fc058b5d/apps/desktop/src/routes/editor/ShareButton.tsx#L103-L104)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead `UpgradeRequired` result branch**

   With the server-side duration check removed from `video.ts` (the only endpoint hit by the desktop's `create_or_get_video` call), the Rust path that maps a 403 `upgrade_required` response into `UploadResult::UpgradeRequired` can no longer be reached from this upload flow. The same dead branch exists at the equivalent lines in `ExportPage.tsx` and `recordings-overlay.tsx`. These can be safely removed alongside the pre-check that was already deleted in this PR.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/routes/editor/ShareButton.tsx
   Line: 103-104

   Comment:
   **Dead `UpgradeRequired` result branch**

   With the server-side duration check removed from `video.ts` (the only endpoint hit by the desktop's `create_or_get_video` call), the Rust path that maps a 403 `upgrade_required` response into `UploadResult::UpgradeRequired` can no longer be reached from this upload flow. The same dead branch exists at the equivalent lines in `ExportPage.tsx` and `recordings-overlay.tsx`. These can be safely removed alongside the pre-check that was already deleted in this PR.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/routes/editor/ShareButton.tsx:103-104
**Dead `UpgradeRequired` result branch**

With the server-side duration check removed from `video.ts` (the only endpoint hit by the desktop's `create_or_get_video` call), the Rust path that maps a 403 `upgrade_required` response into `UploadResult::UpgradeRequired` can no longer be reached from this upload flow. The same dead branch exists at the equivalent lines in `ExportPage.tsx` and `recordings-overlay.tsx`. These can be safely removed alongside the pre-check that was already deleted in this PR.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: remove 5-minute recording cap for ..."](https://github.com/capsoftware/cap/commit/d8b04e6f8ce350c99968fcdcf3f8eab4fc058b5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36937443)</sub>

<!-- /greptile_comment -->