### PR TITLE
fix: start processing after buffered MP4 recordings finish uploading

### DIFF
--- a/apps/web/actions/video/trigger-instant-recording-processing.ts
+++ b/apps/web/actions/video/trigger-instant-recording-processing.ts
@@ -1,0 +1,39 @@
+"use server";
+
+import { db } from "@cap/database";
+import { getCurrentUser } from "@cap/database/auth/session";
+import { videos } from "@cap/database/schema";
+import type { Video } from "@cap/web-domain";
+import { eq } from "drizzle-orm";
+import { startVideoProcessingWorkflow } from "@/lib/video-processing";
+
+export async function triggerInstantRecordingProcessing({
+	videoId,
+}: {
+	videoId: Video.VideoId;
+}): Promise<{ success: boolean }> {
+	const user = await getCurrentUser();
+	if (!user) throw new Error("Unauthorized");
+
+	const [video] = await db()
+		.select()
+		.from(videos)
+		.where(eq(videos.id, videoId));
+
+	if (!video) throw new Error("Video not found");
+	if (video.ownerId !== user.id) throw new Error("Unauthorized");
+
+	const rawFileKey = `${video.ownerId}/${videoId}/result.mp4`;
+
+	await startVideoProcessingWorkflow({
+		videoId,
+		userId: user.id,
+		rawFileKey,
+		bucketId: video.bucket ?? null,
+		processingMessage: "Starting video processing...",
+		startFailureMessage: "Video uploaded, but processing could not start.",
+		mode: "singlepart",
+	});
+
+	return { success: true };
+}

--- a/apps/web/actions/video/trigger-instant-recording-processing.ts
+++ b/apps/web/actions/video/trigger-instant-recording-processing.ts
@@ -23,7 +23,7 @@ export async function triggerInstantRecordingProcessing({
 	if (!video) throw new Error("Video not found");
 	if (video.ownerId !== user.id) throw new Error("Unauthorized");
 
-	const rawFileKey = `${video.ownerId}/${videoId}/result.mp4`;
+	const rawFileKey = `${user.id}/${videoId}/result.mp4`;
 
 	await startVideoProcessingWorkflow({
 		videoId,

--- a/apps/web/app/(org)/dashboard/caps/components/web-recorder-dialog/useWebRecorder.ts
+++ b/apps/web/app/(org)/dashboard/caps/components/web-recorder-dialog/useWebRecorder.ts
@@ -6,6 +6,7 @@ import { Cause, Exit, Option } from "effect";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { triggerInstantRecordingProcessing } from "@/actions/video/trigger-instant-recording-processing";
 import { createVideoAndGetUploadUrl } from "@/actions/video/upload";
 import { useEffectMutation, useRpcClient } from "@/lib/EffectRuntime";
 import { ThumbnailRequest } from "@/lib/Requests/ThumbnailRequest";
@@ -1297,6 +1298,17 @@ export const useWebRecorder = ({
 						thumbnailPreviewUrl,
 						setUploadStatus,
 					);
+
+					try {
+						await triggerInstantRecordingProcessing({
+							videoId: creationResult.id,
+						});
+					} catch (processingError) {
+						console.error("Failed to start video processing", processingError);
+						toast.warning(
+							"Recording uploaded. Processing did not start yet, but the original recording is available.",
+						);
+					}
 
 					if (thumbnailBlob) {
 						try {

--- a/apps/web/workflows/process-video.ts
+++ b/apps/web/workflows/process-video.ts
@@ -48,7 +48,11 @@ export async function processVideoWorkflow(
 		);
 
 		await saveMetadataAndComplete(videoId, result.metadata);
-		await cleanupRawUpload(videoId, rawFileKey);
+
+		const outputKey = `${userId}/${videoId}/result.mp4`;
+		if (rawFileKey !== outputKey) {
+			await cleanupRawUpload(videoId, rawFileKey);
+		}
 
 		return {
 			success: true,


### PR DESCRIPTION
Fixes #1902

## Problem
The in-browser recorder has two upload pipelines: streaming-webm and buffered-raw.

The buffered-raw path never called anything to start server-side processing after the upload finished. As a result:
- videoUploads.phase stayed "uploading" forever, even though uploaded === total.
- getVideoStatus() bails out early whenever a videoUploads row exists (regardless of phase), so transcription/AI summaries never ran.
- The share page polls GetUploadProgress every second indefinitely, since getStalledProcessingMessage only handles processing | generating_thumbnail | complete, not uploading.

This reproduces on any browser using the MP4 fallback recorder (Safari/Firefox), which is what the reporter hit on their self-hosted instance.

## Fix
- Added triggerInstantRecordingProcessing server action: verifies ownership, derives rawFileKey = ${ownerId}/${videoId}/result.mp4 , and calls startVideoProcessingWorkflow.
- useWebRecorder.ts now calls this right after the buffered-raw upload completes, with a non-fatal warning toast on failure (matching the existing pattern for the streaming path).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the buffered-raw (MP4) recording path on Safari/Firefox, where server-side processing was never triggered after upload, leaving `videoUploads.phase` stuck at "uploading" forever.

- Adds `triggerInstantRecordingProcessing` server action that transitions the upload phase to "processing" and starts `processVideoWorkflow` with `rawFileKey = result.mp4`.
- Calls this action in `useWebRecorder.ts` immediately after the buffered-raw upload completes, with a non-fatal toast on failure so thumbnail upload is unaffected.
- Guards `cleanupRawUpload` in `process-video.ts` so it is skipped when `rawFileKey` equals the output key (`result.mp4`), preventing the final video file from being deleted after transcoding.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The three-part fix is coherent: the cleanup guard, the new server action, and the call site all work together correctly without introducing new failure modes.

The previously flagged deletion-of-result.mp4 bug is resolved by the rawFileKey !== outputKey guard. The new server action correctly threads through transitionVideoToProcessing (which updates rawFileKey in the DB before the workflow starts), so validateProcessingRequest's rawFileKey match check passes. The input/output sharing the same S3 key is safe because the media server fully downloads the source before writing output. Error handling in useWebRecorder.ts is non-fatal and consistent with the streaming path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/actions/video/trigger-instant-recording-processing.ts | New server action that validates ownership and triggers processing for buffered-raw MP4 recordings; logic is straightforward and correctly uses the existing startVideoProcessingWorkflow infrastructure. |
| apps/web/workflows/process-video.ts | Adds a guard so cleanupRawUpload is skipped when rawFileKey equals the outputKey (result.mp4), preventing deletion of the final video file when the buffered-raw path re-uses the same key for input and output. |
| apps/web/app/(org)/dashboard/caps/components/web-recorder-dialog/useWebRecorder.ts | Calls triggerInstantRecordingProcessing immediately after the buffered-raw upload completes; error is caught non-fatally and continues with thumbnail upload, matching the existing pattern for the streaming path. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(process-video): skip raw upload clea..."](https://github.com/capsoftware/cap/commit/8d6482e15591649e0a151f6d06e20ade90d25b29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36947221)</sub>

<!-- /greptile_comment -->