### PR TITLE
fix(macos): release leaked window delegate Box and ObjC class on window close

### DIFF
--- a/apps/desktop/src-tauri/src/platform/macos/delegates.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/delegates.rs
@@ -369,8 +369,12 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
         fn get_or_register_delegate_class<R: Runtime>() -> &'static Class {
             static CLASS: std::sync::OnceLock<&'static Class> = std::sync::OnceLock::new();
             CLASS.get_or_init(|| {
+                if let Some(existing) = Class::get("CapWindowDelegate") {
+                    return existing;
+                }
+
                 let mut decl = ClassDecl::new("CapWindowDelegate", class!(NSObject))
-                    .expect("CapWindowDelegate class already registered");
+                    .expect("failed to register CapWindowDelegate");
 
                 decl.add_ivar::<id>("window");
                 decl.add_ivar::<*mut c_void>("app_box");

--- a/apps/desktop/src-tauri/src/platform/macos/delegates.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/delegates.rs
@@ -368,7 +368,7 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
         // be baked into the shared class for all `R`.
         fn get_or_register_delegate_class<R: Runtime>() -> &'static Class {
             static CLASS: std::sync::OnceLock<&'static Class> = std::sync::OnceLock::new();
-            *CLASS.get_or_init(|| {
+            CLASS.get_or_init(|| {
                 let mut decl = ClassDecl::new("CapWindowDelegate", class!(NSObject))
                     .expect("CapWindowDelegate class already registered");
 

--- a/apps/desktop/src-tauri/src/platform/macos/delegates.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/delegates.rs
@@ -135,9 +135,9 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
                 // that was leaked via `Box::into_raw` when this delegate was created.
                 let app_box: *mut c_void = *this.get_ivar("app_box");
                 if !app_box.is_null() {
-                    drop(Box::from_raw(app_box as *mut WindowState<R>));
                     let this_mut = this as *const Object as *mut Object;
                     (*this_mut).set_ivar("app_box", std::ptr::null_mut::<c_void>());
+                    drop(Box::from_raw(app_box as *mut WindowState<R>));
                 }
 
                 // Restore the previous delegate before releasing this one, so any

--- a/apps/desktop/src-tauri/src/platform/macos/delegates.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/delegates.rs
@@ -373,8 +373,13 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
                     return existing;
                 }
 
-                let mut decl = ClassDecl::new("CapWindowDelegate", class!(NSObject))
-                    .expect("failed to register CapWindowDelegate");
+                let mut decl = match ClassDecl::new("CapWindowDelegate", class!(NSObject)) {
+                    Some(decl) => decl,
+                    None => {
+                        return Class::get("CapWindowDelegate")
+                            .expect("CapWindowDelegate should exist if already registered");
+                    }
+                };
 
                 decl.add_ivar::<id>("window");
                 decl.add_ivar::<*mut c_void>("app_box");

--- a/apps/desktop/src-tauri/src/platform/macos/delegates.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/delegates.rs
@@ -88,10 +88,13 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
         this: &Object,
         func: F,
     ) {
-        let ptr = unsafe {
-            let x: *mut c_void = *this.get_ivar("app_box");
-            &mut *(x as *mut WindowState<R>)
-        };
+        let x: *mut c_void = unsafe { *this.get_ivar("app_box") };
+        // `app_box` is nulled out in `windowWillClose:`; ignore any late
+        // callbacks that arrive after that instead of dereferencing null.
+        if x.is_null() {
+            return;
+        }
+        let ptr = unsafe { &mut *(x as *mut WindowState<R>) };
         func(ptr);
     }
 

--- a/apps/desktop/src-tauri/src/platform/macos/delegates.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/delegates.rs
@@ -122,10 +122,15 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
             })
         }
         extern "C" fn on_window_will_close<R: Runtime>(this: &Object, _cmd: Sel, notification: id) {
-            suppress_delegate_panic("windowWillClose:", (), || unsafe {
-                let super_del: id = *this.get_ivar("super_delegate");
-                let _: () = msg_send![super_del, windowWillClose: notification];
+            let super_del: id = unsafe { *this.get_ivar("super_delegate") };
 
+            // Forward to the previous delegate first, but don't let a panic there
+            // skip the cleanup below (which would bring back the leak).
+            suppress_delegate_panic("windowWillClose:", (), || unsafe {
+                let _: () = msg_send![super_del, windowWillClose: notification];
+            });
+
+            suppress_delegate_panic("windowWillClose:cleanup", (), || unsafe {
                 // Drop the boxed `WindowState<R>` (and the `Window<R>` handle it holds)
                 // that was leaked via `Box::into_raw` when this delegate was created.
                 let app_box: *mut c_void = *this.get_ivar("app_box");
@@ -373,26 +378,88 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
                 decl.add_ivar::<id>("super_delegate");
 
                 unsafe {
-                    decl.add_method(sel!(windowShouldClose:), on_window_should_close as extern "C" fn(&Object, Sel, id) -> BOOL);
-                    decl.add_method(sel!(windowWillClose:), on_window_will_close::<R> as extern "C" fn(&Object, Sel, id));
-                    decl.add_method(sel!(windowDidResize:), on_window_did_resize::<R> as extern "C" fn(&Object, Sel, id));
-                    decl.add_method(sel!(windowDidMove:), on_window_did_move as extern "C" fn(&Object, Sel, id));
-                    decl.add_method(sel!(windowDidChangeBackingProperties:), on_window_did_change_backing_properties as extern "C" fn(&Object, Sel, id));
-                    decl.add_method(sel!(windowDidBecomeKey:), on_window_did_become_key as extern "C" fn(&Object, Sel, id));
-                    decl.add_method(sel!(windowDidResignKey:), on_window_did_resign_key as extern "C" fn(&Object, Sel, id));
-                    decl.add_method(sel!(draggingEntered:), on_dragging_entered as extern "C" fn(&Object, Sel, id) -> BOOL);
-                    decl.add_method(sel!(prepareForDragOperation:), on_prepare_for_drag_operation as extern "C" fn(&Object, Sel, id) -> BOOL);
-                    decl.add_method(sel!(performDragOperation:), on_perform_drag_operation as extern "C" fn(&Object, Sel, id) -> BOOL);
-                    decl.add_method(sel!(concludeDragOperation:), on_conclude_drag_operation as extern "C" fn(&Object, Sel, id));
-                    decl.add_method(sel!(draggingExited:), on_dragging_exited as extern "C" fn(&Object, Sel, id));
-                    decl.add_method(sel!(window:willUseFullScreenPresentationOptions:), on_window_will_use_full_screen_presentation_options as extern "C" fn(&Object, Sel, id, NSUInteger) -> NSUInteger);
-                    decl.add_method(sel!(windowDidEnterFullScreen:), on_window_did_enter_full_screen::<R> as extern "C" fn(&Object, Sel, id));
-                    decl.add_method(sel!(windowWillEnterFullScreen:), on_window_will_enter_full_screen::<R> as extern "C" fn(&Object, Sel, id));
-                    decl.add_method(sel!(windowDidExitFullScreen:), on_window_did_exit_full_screen::<R> as extern "C" fn(&Object, Sel, id));
-                    decl.add_method(sel!(windowWillExitFullScreen:), on_window_will_exit_full_screen::<R> as extern "C" fn(&Object, Sel, id));
-                    decl.add_method(sel!(windowDidFailToEnterFullScreen:), on_window_did_fail_to_enter_full_screen as extern "C" fn(&Object, Sel, id));
-                    decl.add_method(sel!(effectiveAppearanceDidChange:), on_effective_appearance_did_change as extern "C" fn(&Object, Sel, id));
-                    decl.add_method(sel!(effectiveAppearanceDidChangedOnMainThread:), on_effective_appearance_did_changed_on_main_thread as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(
+                        sel!(windowShouldClose:),
+                        on_window_should_close as extern "C" fn(&Object, Sel, id) -> BOOL,
+                    );
+                    decl.add_method(
+                        sel!(windowWillClose:),
+                        on_window_will_close::<R> as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(windowDidResize:),
+                        on_window_did_resize::<R> as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(windowDidMove:),
+                        on_window_did_move as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(windowDidChangeBackingProperties:),
+                        on_window_did_change_backing_properties as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(windowDidBecomeKey:),
+                        on_window_did_become_key as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(windowDidResignKey:),
+                        on_window_did_resign_key as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(draggingEntered:),
+                        on_dragging_entered as extern "C" fn(&Object, Sel, id) -> BOOL,
+                    );
+                    decl.add_method(
+                        sel!(prepareForDragOperation:),
+                        on_prepare_for_drag_operation as extern "C" fn(&Object, Sel, id) -> BOOL,
+                    );
+                    decl.add_method(
+                        sel!(performDragOperation:),
+                        on_perform_drag_operation as extern "C" fn(&Object, Sel, id) -> BOOL,
+                    );
+                    decl.add_method(
+                        sel!(concludeDragOperation:),
+                        on_conclude_drag_operation as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(draggingExited:),
+                        on_dragging_exited as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(window:willUseFullScreenPresentationOptions:),
+                        on_window_will_use_full_screen_presentation_options
+                            as extern "C" fn(&Object, Sel, id, NSUInteger) -> NSUInteger,
+                    );
+                    decl.add_method(
+                        sel!(windowDidEnterFullScreen:),
+                        on_window_did_enter_full_screen::<R> as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(windowWillEnterFullScreen:),
+                        on_window_will_enter_full_screen::<R> as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(windowDidExitFullScreen:),
+                        on_window_did_exit_full_screen::<R> as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(windowWillExitFullScreen:),
+                        on_window_will_exit_full_screen::<R> as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(windowDidFailToEnterFullScreen:),
+                        on_window_did_fail_to_enter_full_screen as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(effectiveAppearanceDidChange:),
+                        on_effective_appearance_did_change as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(effectiveAppearanceDidChangedOnMainThread:),
+                        on_effective_appearance_did_changed_on_main_thread
+                            as extern "C" fn(&Object, Sel, id),
+                    );
                 }
 
                 decl.register()

--- a/apps/desktop/src-tauri/src/platform/macos/delegates.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/delegates.rs
@@ -11,8 +11,7 @@
 /// (Hoppscotch) https://github.com/hoppscotch/hoppscotch/blob/286fcd2bb08a84f027b10308d1e18da368f95ebf/packages/hoppscotch-selfhost-desktop/src-tauri/src/mac/window.rs
 /// (Electron) https://github.com/electron/electron/blob/38512efd25a159ddc64a54c22ef9eb6dd60064ec/shell/browser/native_window_mac.mm#L1454
 ///
-use objc::{msg_send, sel, sel_impl};
-use rand::{Rng, distributions::Alphanumeric};
+use objc::{class, msg_send, sel, sel_impl};
 use tauri::{Emitter, LogicalPosition, Runtime, Window};
 
 pub struct UnsafeWindowHandle(pub *mut std::ffi::c_void);
@@ -72,7 +71,8 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
     use cocoa::appkit::NSWindow;
     use cocoa::base::{BOOL, id};
     use cocoa::foundation::NSUInteger;
-    use objc::runtime::{Object, Sel};
+    use objc::declare::ClassDecl;
+    use objc::runtime::{Class, Object, Sel};
     use std::ffi::c_void;
 
     let Ok(ns_win) = window.ns_window() else {
@@ -118,10 +118,25 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
                 msg_send![super_del, windowShouldClose: sender]
             })
         }
-        extern "C" fn on_window_will_close(this: &Object, _cmd: Sel, notification: id) {
+        extern "C" fn on_window_will_close<R: Runtime>(this: &Object, _cmd: Sel, notification: id) {
             suppress_delegate_panic("windowWillClose:", (), || unsafe {
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, windowWillClose: notification];
+
+                // Drop the boxed `WindowState<R>` (and the `Window<R>` handle it holds)
+                // that was leaked via `Box::into_raw` when this delegate was created.
+                let app_box: *mut c_void = *this.get_ivar("app_box");
+                if !app_box.is_null() {
+                    drop(Box::from_raw(app_box as *mut WindowState<R>));
+                    let this_mut = this as *const Object as *mut Object;
+                    (*this_mut).set_ivar("app_box", std::ptr::null_mut::<c_void>());
+                }
+
+                // NSWindow does not retain its delegate, so the `alloc` reference taken
+                // when this delegate was created is the only owning reference. Release
+                // it now that the window is closing.
+                let this_id = this as *const Object as id;
+                let _: () = msg_send![this_id, release];
             });
         }
         extern "C" fn on_window_did_resize<R: Runtime>(this: &Object, _cmd: Sel, notification: id) {
@@ -329,48 +344,60 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
             );
         }
 
-        let window_label = window.label().to_string();
+        // Register the delegate class once and reuse it for every window. Previously a brand
+        // new class was registered (with a randomized name) on every call to `setup`, which
+        // permanently leaked Objective-C class metadata for the lifetime of the process.
+        fn get_or_register_delegate_class<R: Runtime>() -> &'static Class {
+            static CLASS: std::sync::OnceLock<&'static Class> = std::sync::OnceLock::new();
+            *CLASS.get_or_init(|| {
+                let mut decl = ClassDecl::new("CapWindowDelegate", class!(NSObject))
+                    .expect("CapWindowDelegate class already registered");
+
+                decl.add_ivar::<id>("window");
+                decl.add_ivar::<*mut c_void>("app_box");
+                decl.add_ivar::<id>("toolbar");
+                decl.add_ivar::<id>("super_delegate");
+
+                unsafe {
+                    decl.add_method(sel!(windowShouldClose:), on_window_should_close as extern "C" fn(&Object, Sel, id) -> BOOL);
+                    decl.add_method(sel!(windowWillClose:), on_window_will_close::<R> as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(sel!(windowDidResize:), on_window_did_resize::<R> as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(sel!(windowDidMove:), on_window_did_move as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(sel!(windowDidChangeBackingProperties:), on_window_did_change_backing_properties as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(sel!(windowDidBecomeKey:), on_window_did_become_key as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(sel!(windowDidResignKey:), on_window_did_resign_key as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(sel!(draggingEntered:), on_dragging_entered as extern "C" fn(&Object, Sel, id) -> BOOL);
+                    decl.add_method(sel!(prepareForDragOperation:), on_prepare_for_drag_operation as extern "C" fn(&Object, Sel, id) -> BOOL);
+                    decl.add_method(sel!(performDragOperation:), on_perform_drag_operation as extern "C" fn(&Object, Sel, id) -> BOOL);
+                    decl.add_method(sel!(concludeDragOperation:), on_conclude_drag_operation as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(sel!(draggingExited:), on_dragging_exited as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(sel!(window:willUseFullScreenPresentationOptions:), on_window_will_use_full_screen_presentation_options as extern "C" fn(&Object, Sel, id, NSUInteger) -> NSUInteger);
+                    decl.add_method(sel!(windowDidEnterFullScreen:), on_window_did_enter_full_screen::<R> as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(sel!(windowWillEnterFullScreen:), on_window_will_enter_full_screen::<R> as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(sel!(windowDidExitFullScreen:), on_window_did_exit_full_screen::<R> as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(sel!(windowWillExitFullScreen:), on_window_will_exit_full_screen::<R> as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(sel!(windowDidFailToEnterFullScreen:), on_window_did_fail_to_enter_full_screen as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(sel!(effectiveAppearanceDidChange:), on_effective_appearance_did_change as extern "C" fn(&Object, Sel, id));
+                    decl.add_method(sel!(effectiveAppearanceDidChangedOnMainThread:), on_effective_appearance_did_changed_on_main_thread as extern "C" fn(&Object, Sel, id));
+                }
+
+                decl.register()
+            })
+        }
 
         let app_state = WindowState {
             window,
             controls_inset,
         };
         let app_box = Box::into_raw(Box::new(app_state)) as *mut c_void;
-        let random_str: String = rand::thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(20)
-            .map(char::from)
-            .collect();
 
-        // We need to ensure we have a unique delegate name, otherwise we will panic while trying to create a duplicate
-        // delegate with the same name.
-        let delegate_name = format!("windowDelegate_cap_{window_label}_{random_str}");
+        let delegate_class = get_or_register_delegate_class::<R>();
+        let delegate: id = msg_send![delegate_class, alloc];
+        (*delegate).set_ivar("window", ns_win_id);
+        (*delegate).set_ivar("app_box", app_box);
+        (*delegate).set_ivar("toolbar", cocoa::base::nil);
+        (*delegate).set_ivar("super_delegate", current_delegate);
 
-        ns_win_id.setDelegate_(cocoa::delegate!(&delegate_name, {
-            window: id = ns_win_id,
-            app_box: *mut c_void = app_box,
-            toolbar: id = cocoa::base::nil,
-            super_delegate: id = current_delegate,
-            (windowShouldClose:) => on_window_should_close as extern "C" fn(&Object, Sel, id) -> BOOL,
-            (windowWillClose:) => on_window_will_close as extern "C" fn(&Object, Sel, id),
-            (windowDidResize:) => on_window_did_resize::<R> as extern "C" fn(&Object, Sel, id),
-            (windowDidMove:) => on_window_did_move as extern "C" fn(&Object, Sel, id),
-            (windowDidChangeBackingProperties:) => on_window_did_change_backing_properties as extern "C" fn(&Object, Sel, id),
-            (windowDidBecomeKey:) => on_window_did_become_key as extern "C" fn(&Object, Sel, id),
-            (windowDidResignKey:) => on_window_did_resign_key as extern "C" fn(&Object, Sel, id),
-            (draggingEntered:) => on_dragging_entered as extern "C" fn(&Object, Sel, id) -> BOOL,
-            (prepareForDragOperation:) => on_prepare_for_drag_operation as extern "C" fn(&Object, Sel, id) -> BOOL,
-            (performDragOperation:) => on_perform_drag_operation as extern "C" fn(&Object, Sel, id) -> BOOL,
-            (concludeDragOperation:) => on_conclude_drag_operation as extern "C" fn(&Object, Sel, id),
-            (draggingExited:) => on_dragging_exited as extern "C" fn(&Object, Sel, id),
-            (window:willUseFullScreenPresentationOptions:) => on_window_will_use_full_screen_presentation_options as extern "C" fn(&Object, Sel, id, NSUInteger) -> NSUInteger,
-            (windowDidEnterFullScreen:) => on_window_did_enter_full_screen::<R> as extern "C" fn(&Object, Sel, id),
-            (windowWillEnterFullScreen:) => on_window_will_enter_full_screen::<R> as extern "C" fn(&Object, Sel, id),
-            (windowDidExitFullScreen:) => on_window_did_exit_full_screen::<R> as extern "C" fn(&Object, Sel, id),
-            (windowWillExitFullScreen:) => on_window_will_exit_full_screen::<R> as extern "C" fn(&Object, Sel, id),
-            (windowDidFailToEnterFullScreen:) => on_window_did_fail_to_enter_full_screen as extern "C" fn(&Object, Sel, id),
-            (effectiveAppearanceDidChange:) => on_effective_appearance_did_change as extern "C" fn(&Object, Sel, id),
-            (effectiveAppearanceDidChangedOnMainThread:) => on_effective_appearance_did_changed_on_main_thread as extern "C" fn(&Object, Sel, id)
-        }))
+        ns_win_id.setDelegate_(delegate)
     }
 }

--- a/apps/desktop/src-tauri/src/platform/macos/delegates.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/delegates.rs
@@ -132,8 +132,13 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
                     (*this_mut).set_ivar("app_box", std::ptr::null_mut::<c_void>());
                 }
 
-                // NSWindow does not retain its delegate, so the `alloc` reference taken
-                // when this delegate was created is the only owning reference. Release
+                // Restore the previous delegate before releasing this one, so any
+                // further delegate callbacks during teardown don't hit a freed object.
+                let window: id = *this.get_ivar("window");
+                let _: () = msg_send![window, setDelegate: super_del];
+
+                // NSWindow does not retain its delegate, so the reference taken when
+                // this delegate was created (`new`) is the only owning one. Release
                 // it now that the window is closing.
                 let this_id = this as *const Object as id;
                 let _: () = msg_send![this_id, release];
@@ -347,6 +352,12 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
         // Register the delegate class once and reuse it for every window. Previously a brand
         // new class was registered (with a randomized name) on every call to `setup`, which
         // permanently leaked Objective-C class metadata for the lifetime of the process.
+        //
+        // NOTE: `static CLASS` below is a single process-wide instance shared across every
+        // monomorphization of this function, not one per `R`. `setup` is only ever called
+        // with `R = tauri::Wry` in this app, so this is fine in practice; if it were ever
+        // called with a different `R`, the first call's `on_*::<R>` method pointers would
+        // be baked into the shared class for all `R`.
         fn get_or_register_delegate_class<R: Runtime>() -> &'static Class {
             static CLASS: std::sync::OnceLock<&'static Class> = std::sync::OnceLock::new();
             *CLASS.get_or_init(|| {
@@ -392,7 +403,7 @@ pub fn setup<R: Runtime>(window: Window<R>, controls_inset: LogicalPosition<f64>
         let app_box = Box::into_raw(Box::new(app_state)) as *mut c_void;
 
         let delegate_class = get_or_register_delegate_class::<R>();
-        let delegate: id = msg_send![delegate_class, alloc];
+        let delegate: id = msg_send![delegate_class, new];
         (*delegate).set_ivar("window", ns_win_id);
         (*delegate).set_ivar("app_box", app_box);
         (*delegate).set_ivar("toolbar", cocoa::base::nil);

--- a/crates/recording/examples/memory-leak-detector.rs
+++ b/crates/recording/examples/memory-leak-detector.rs
@@ -491,7 +491,10 @@ async fn run_cycles_test(
     }
 
     println!("\n=== Cycle Summary ===");
-    println!("{:>6} {:>14} {:>10}", "Cycle", "Footprint(MB)", "Delta prev");
+    println!(
+        "{:>6} {:>14} {:>10}",
+        "Cycle", "Footprint(MB)", "Delta prev"
+    );
     let mut prev = baseline;
     for (i, f) in results.iter().enumerate() {
         let delta = f - prev;
@@ -551,8 +554,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match mode {
         "full" => {
-            run_memory_test(duration, include_camera, include_mic, fragmented, use_oop_muxer)
-                .await?;
+            run_memory_test(
+                duration,
+                include_camera,
+                include_mic,
+                fragmented,
+                use_oop_muxer,
+            )
+            .await?;
         }
         "screen-only" => {
             run_memory_test(duration, false, false, fragmented, use_oop_muxer).await?;
@@ -587,8 +596,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(8);
 
-            run_cycles_test(cycles, cycle_duration, include_camera, include_mic, fragmented)
-                .await?;
+            run_cycles_test(
+                cycles,
+                cycle_duration,
+                include_camera,
+                include_mic,
+                fragmented,
+            )
+            .await?;
         }
         _ => {
             println!("Cap Memory Leak Detector");
@@ -607,10 +622,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("  --no-camera         Disable camera");
             println!("  --no-mic            Disable microphone");
             println!("  --no-fragmented     Disable fragmented MP4 encoding");
-            println!("  --cycles <n>        Number of record start/stop cycles (default: 8, cycles mode)");
-            println!("  --cycle-duration <secs>  Recording duration per cycle (default: 8, cycles mode)");
+            println!(
+                "  --cycles <n>        Number of record start/stop cycles (default: 8, cycles mode)"
+            );
+            println!(
+                "  --cycle-duration <secs>  Recording duration per cycle (default: 8, cycles mode)"
+            );
             println!("  --oop-muxer         Use the out-of-process cap-muxer for fragmented MP4");
-            println!("                      (requires cap-muxer binary; set CAP_MUXER_BIN or build it)");
+            println!(
+                "                      (requires cap-muxer binary; set CAP_MUXER_BIN or build it)"
+            );
             println!();
             println!("Examples:");
             println!("  # Test full pipeline with camera, mic, fragmented MP4 for 2 minutes");


### PR DESCRIPTION
## Summary

setup() in apps/desktop/src-tauri/src/platform/macos/delegates.rs (used for traffic-light positioning on Editor, ScreenshotEditor, Settings, Upgrade and ModeSelect windows) leaked on every call:

1. A boxed WindowState (holding a live Window handle) was never freed.
2. A brand new Objective-C delegate class with a randomized name was registered every call and never disposed, along with its alloc'd instance.

Since closing these windows destroys and later rebuilds the underlying webview window, every open/close cycle permanently leaked a window handle plus a new ObjC class. This code has been in place since Nov 2024.

## Changes

- Register the delegate class once (OnceLock) and reuse it for every window; only alloc a new instance per window.
- windowWillClose: now drops the boxed window state and releases the delegate instance's alloc reference.

## Test plan
- [x] cargo dev build compiles cleanly
- [x] Dev app launches and runs without crashes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two memory leaks that accumulated on every open/close cycle of the traffic-light delegate windows: `Box<WindowState<R>>` was never freed because `Box::into_raw` was never balanced, and a new Objective-C class (with a randomized name) was registered on every `setup()` call and never disposed.

- The delegate class is now registered exactly once via `std::sync::OnceLock` and reused for every window, eliminating the per-call ObjC class leak.
- `windowWillClose:` now drops the boxed `WindowState`, nulls the ivar, restores the previous delegate, and calls `release` to balance the `new` allocation — all with careful ordering to avoid use-after-free on late callbacks.
- `with_window_state` now guards against the null `app_box` left behind after close, addressing the previously-flagged SIGSEGV path for enqueued post-close delegate callbacks.

<h3>Confidence Score: 5/5</h3>

The change correctly fixes two long-standing leaks and handles the cleanup ordering carefully; the one open question (class registration failure) affects only an edge-case startup path and leaves the rest of the delegate logic intact.

The core leak fixes are well-structured: the `OnceLock` class-registration correctly avoids duplicate registration across `setup()` calls, the `windowWillClose:` cleanup sequence (drop box → null ivar → restore delegate → release) is ordered to prevent dangling-reference callbacks, and the null guard in `with_window_state` closes the previously-flagged crash path. The only concern is a robustness gap in the `OnceLock` initializer: a panic there would poison the lock for the process lifetime, but this requires an ObjC class name collision that is very unlikely in practice and does not affect the correctness of the leak fix itself.

No files require special attention beyond the single changed file.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/platform/macos/delegates.rs | Fixes two memory leaks: `Box<WindowState>` is now properly dropped in `windowWillClose:`, and the delegate ObjC class is registered once via `OnceLock` instead of per-call. The `app_box` null guard addresses the previously-flagged SIGSEGV path for late callbacks. One robustness gap remains: if `ClassDecl::new` returns `None` the `expect` panic inside `OnceLock::get_or_init` poisons the lock, permanently breaking all subsequent `setup()` calls for the process lifetime. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src-tauri/src/platform/macos/delegates.rs`, line 87-96 ([link](https://github.com/capsoftware/cap/blob/c713ff1e3cd354f65b2a6b6167cb027ddfe2c511/apps/desktop/src-tauri/src/platform/macos/delegates.rs#L87-L96)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`with_window_state` dereferences `app_box` without a null check**

   `on_window_will_close` sets `app_box` to `null` (line 132) and then calls `release`, potentially freeing the delegate. If any subsequent delegate message (e.g. a `windowDidResize:` notification enqueued on the main thread before the window fully closed) fires after `windowWillClose:` returns, `with_window_state` will cast a null pointer to `&mut WindowState<R>` — a SIGSEGV that `suppress_delegate_panic`'s `catch_unwind` will not catch. Adding a null guard here would prevent the crash without changing normal-path behavior.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src-tauri/src/platform/macos/delegates.rs
   Line: 87-96

   Comment:
   **`with_window_state` dereferences `app_box` without a null check**

   `on_window_will_close` sets `app_box` to `null` (line 132) and then calls `release`, potentially freeing the delegate. If any subsequent delegate message (e.g. a `windowDidResize:` notification enqueued on the main thread before the window fully closed) fires after `windowWillClose:` returns, `with_window_state` will cast a null pointer to `&mut WindowState<R>` — a SIGSEGV that `suppress_delegate_panic`'s `catch_unwind` will not catch. Adding a null guard here would prevent the crash without changing normal-path behavior.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(macos): cargo fmt and make windowWil..."](https://github.com/capsoftware/cap/commit/9f4bb63d54872105c53fdd3b351c536cd997f709) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37397018)</sub>

<!-- /greptile_comment -->