### PR TITLE
[codex] simplify pro plan copy

### DIFF
--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -844,7 +844,7 @@ function InstantQualitySetting(props: {
 			(t) => (
 				<div class="flex gap-3 items-center px-4 py-3 rounded-xl border shadow-lg bg-gray-1 border-gray-4 text-gray-12">
 					<p class="text-sm">
-						Upgrade to Cap Pro to record Instant Mode videos above 720p.
+						Upgrade to Pro to record Instant Mode videos above 720p.
 					</p>
 					<button
 						type="button"
@@ -869,7 +869,7 @@ function InstantQualitySetting(props: {
 			description={
 				props.hasCapPro
 					? "Choose the maximum upload resolution for Instant recordings."
-					: "Instant recordings are locked to 720p. Cap Pro unlocks higher resolutions."
+					: "Instant recordings are locked to 720p. Pro unlocks higher resolutions."
 			}
 		>
 			<div class="flex flex-col items-end gap-1.5">
@@ -911,8 +911,8 @@ function CapProSection(props: {
 }) {
 	return (
 		<Section
-			title="Cap Pro"
-			description="Settings available with a Cap Pro license."
+			title="Pro"
+			description="Settings available with a Pro license."
 			pro
 		>
 			<SectionRows>

--- a/apps/desktop/src/routes/(window-chrome)/settings/license.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/license.tsx
@@ -29,14 +29,12 @@ export default function Page() {
 					<div class="flex justify-center items-center w-full h-screen">
 						<div class="flex flex-col items-center p-6 mx-auto space-y-3 w-full max-w-md text-white rounded-3xl border bg-gray-2 border-gray-3">
 							<div class="flex flex-col gap-2 items-center">
-								<h3 class="text-2xl font-medium text-gray-12">
-									Cap Pro License
-								</h3>
+								<h3 class="text-2xl font-medium text-gray-12">Pro License</h3>
 							</div>
 							<p class="text-center text-gray-11">
 								Your account is upgraded to{" "}
-								<span class="font-semibold text-blue-500">Cap Pro</span> and
-								already includes a commercial license.
+								<span class="font-semibold text-blue-500">Pro</span> and already
+								includes a commercial license.
 							</p>
 						</div>
 					</div>

--- a/apps/desktop/src/routes/(window-chrome)/upgrade.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/upgrade.tsx
@@ -436,7 +436,6 @@ export default function Page() {
 								</div>
 							</div>
 
-							{/* Cap Pro */}
 							<div
 								onMouseEnter={() => {
 									const riveInstance = ProRive();
@@ -463,7 +462,7 @@ export default function Page() {
 										<Pro class="w-[250px]" />
 										<div class="space-y-1 text-center">
 											<h3 class="text-2xl font-medium tracking-tight leading-5 text-gray-1">
-												Cap Pro
+												Pro
 											</h3>
 											<p class="text-[0.875rem] text-gray-9">
 												For professional use and teams.
@@ -514,7 +513,7 @@ export default function Page() {
 										class="rounded-full! text-lg! w-full mx-auto"
 										onClick={openCheckoutInExternalBrowser}
 									>
-										{loading() ? "Loading..." : "Upgrade to Cap Pro"}
+										{loading() ? "Loading..." : "Upgrade to Pro"}
 									</Button>
 								</div>
 							</div>

--- a/apps/web/__tests__/unit/save-video-edits.test.ts
+++ b/apps/web/__tests__/unit/save-video-edits.test.ts
@@ -147,7 +147,7 @@ describe("saveVideoEdits", () => {
 		expect(insertMock).not.toHaveBeenCalled();
 	});
 
-	it("requires Cap Pro before saving edits", async () => {
+	it("requires Pro before saving edits", async () => {
 		getCurrentUserMock.mockResolvedValueOnce({ id: "user-1", isPro: false });
 		const { saveVideoEdits } = await import("@/actions/videos/save-edits");
 
@@ -157,7 +157,7 @@ describe("saveVideoEdits", () => {
 				sourceDuration: 10,
 				keepRanges: [{ start: 0, end: 10 }],
 			}),
-		).rejects.toThrow("Cap Pro is required to edit videos");
+		).rejects.toThrow("Pro is required to edit videos");
 
 		expect(selectMock).not.toHaveBeenCalled();
 	});

--- a/apps/web/actions/collections/logo.ts
+++ b/apps/web/actions/collections/logo.ts
@@ -110,7 +110,7 @@ async function setSpaceLogo(
 	if (!(await isOrganizationOwnerPro(space.organizationId))) {
 		return {
 			success: false,
-			error: "Upgrade to Cap Pro to customize the collection logo",
+			error: "Upgrade to Pro to customize the collection logo",
 		};
 	}
 
@@ -182,7 +182,7 @@ async function setFolderLogo(
 	if (!(await isOrganizationOwnerPro(folder.organizationId))) {
 		return {
 			success: false,
-			error: "Upgrade to Cap Pro to customize the collection logo",
+			error: "Upgrade to Pro to customize the collection logo",
 		};
 	}
 

--- a/apps/web/actions/collections/visibility.ts
+++ b/apps/web/actions/collections/visibility.ts
@@ -77,7 +77,7 @@ export async function setSpaceCollectionVisibility(input: {
 	) {
 		return {
 			success: false,
-			error: "Upgrade to Cap Pro to create a public collection link",
+			error: "Upgrade to Pro to create a public collection link",
 		};
 	}
 

--- a/apps/web/actions/loom.ts
+++ b/apps/web/actions/loom.ts
@@ -434,7 +434,7 @@ export async function importFromLoom({
 	if (!userIsPro(user)) {
 		return {
 			success: false,
-			error: "Importing from Loom requires a Cap Pro subscription.",
+			error: "Importing from Loom requires a Pro subscription.",
 		};
 	}
 
@@ -631,7 +631,7 @@ export async function importFromLoomCsv({
 			importedCount: 0,
 			failedCount: 0,
 			results: [],
-			error: "Importing from Loom requires a Cap Pro subscription.",
+			error: "Importing from Loom requires a Pro subscription.",
 		};
 	}
 

--- a/apps/web/actions/organization/create-space.ts
+++ b/apps/web/actions/organization/create-space.ts
@@ -87,7 +87,7 @@ export async function createSpace(
 		) {
 			return {
 				success: false,
-				error: "Upgrade to Cap Pro to create a public collection link",
+				error: "Upgrade to Pro to create a public collection link",
 			};
 		}
 

--- a/apps/web/actions/organization/get-subscription-details.ts
+++ b/apps/web/actions/organization/get-subscription-details.ts
@@ -63,7 +63,7 @@ export async function getSubscriptionDetails(
 		interval === "year" ? unitAmount / 100 / 12 : unitAmount / 100;
 
 	return {
-		planName: "Cap Pro",
+		planName: "Pro",
 		status: subscription.status,
 		billingInterval: interval,
 		pricePerSeat,

--- a/apps/web/actions/organization/storage.ts
+++ b/apps/web/actions/organization/storage.ts
@@ -31,7 +31,7 @@ import { requireOrganizationSettingsManager } from "./authorization";
 const googleDriveProvider = "googleDrive";
 const settingsPath = "/dashboard/settings/organization/integrations";
 const proRequiredMessage =
-	"Cap Pro is required to manage organization integrations";
+	"Pro is required to manage organization integrations";
 
 type OrganizationStorageProvider = "s3" | "googleDrive";
 

--- a/apps/web/actions/organization/update-space.ts
+++ b/apps/web/actions/organization/update-space.ts
@@ -76,7 +76,7 @@ export async function updateSpace(formData: FormData) {
 	) {
 		return {
 			success: false,
-			error: "Upgrade to Cap Pro to create a public collection link",
+			error: "Upgrade to Pro to create a public collection link",
 		};
 	}
 

--- a/apps/web/actions/videos/save-edits.ts
+++ b/apps/web/actions/videos/save-edits.ts
@@ -117,7 +117,7 @@ export async function saveVideoEdits(
 ) {
 	const user = await getCurrentUser();
 	if (!user) throw new Error("Unauthorized");
-	if (!userIsPro(user)) throw new Error("Cap Pro is required to edit videos");
+	if (!userIsPro(user)) throw new Error("Pro is required to edit videos");
 
 	const [video] = await db()
 		.select()

--- a/apps/web/app/(org)/dashboard/analytics/components/AnalyticsDashboard.tsx
+++ b/apps/web/app/(org)/dashboard/analytics/components/AnalyticsDashboard.tsx
@@ -88,7 +88,7 @@ export function AnalyticsDashboard() {
 			}
 
 			if (data.subscription === true) {
-				toast.success("You are already on the Cap Pro plan");
+				toast.success("You are already on the Pro plan");
 				return;
 			}
 
@@ -314,7 +314,7 @@ export function AnalyticsDashboard() {
 									>
 										{proCheckoutMutation.isPending
 											? "Loading..."
-											: "Upgrade to Cap Pro"}
+											: "Upgrade to Pro"}
 									</Button>
 								</div>
 							</div>

--- a/apps/web/app/(org)/dashboard/settings/organization/components/BillingSummaryCard.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/BillingSummaryCard.tsx
@@ -71,7 +71,7 @@ export function BillingSummaryCard() {
 		return (
 			<Card className="flex flex-wrap gap-6 justify-between items-center w-full">
 				<CardHeader>
-					<CardTitle>Upgrade to Cap Pro</CardTitle>
+					<CardTitle>Upgrade to Pro</CardTitle>
 					<CardDescription>
 						Get unlimited sharing, custom domains, Cap AI, and more.
 					</CardDescription>

--- a/apps/web/app/(org)/dashboard/settings/organization/components/CustomDomainDialog/CustomDomainDialog.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/CustomDomainDialog/CustomDomainDialog.tsx
@@ -286,6 +286,20 @@ const CustomDomainDialog = ({
 		],
 	);
 
+	useEffect(() => {
+		if (stepState.currentIndex === 2) {
+			const timeoutId = setTimeout(() => {
+				handleClose();
+			}, 8000);
+
+			return () => clearTimeout(timeoutId);
+		}
+
+		if (isVerified) {
+			handleNext();
+		}
+	}, [isVerified, stepState.currentIndex, handleClose, handleNext]);
+
 	if (!currentStep) {
 		return null;
 	}
@@ -342,17 +356,6 @@ const CustomDomainDialog = ({
 			orgId: activeOrganization?.organization.id as string,
 		});
 	};
-
-	useEffect(() => {
-		//if current step is success, close dialog in 8 seconds
-		if (stepState.currentIndex === 2) {
-			setTimeout(() => {
-				handleClose();
-			}, 8000);
-		} else if (isVerified) {
-			handleNext();
-		}
-	}, [isVerified, stepState.currentIndex, handleClose, handleNext]);
 
 	return (
 		<>
@@ -466,7 +469,7 @@ const CustomDomainDialog = ({
 											handleClose();
 										}}
 									>
-										Upgrade To Cap Pro
+										Upgrade To Pro
 									</Button>
 								))}
 						</DialogFooter>

--- a/apps/web/app/(org)/dashboard/settings/organization/components/CustomDomainDialog/SubscribeContent.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/CustomDomainDialog/SubscribeContent.tsx
@@ -1,8 +1,26 @@
 import { motion } from "motion/react";
 
-const SubscribeContent = () => {
-	const capsDomainText = "caps.yourdomain.com";
+const capsDomainText = "caps.yourdomain.com";
+const capsDomainLetters = capsDomainText
+	.split("")
+	.reduce<{ delay: number; key: string; letter: string }[]>(
+		(letters, letter) => {
+			const occurrence = letters.filter(
+				(item) => item.letter === letter,
+			).length;
 
+			letters.push({
+				delay: 0.9 + letters.length * 0.075,
+				key: `${letter}-${occurrence}`,
+				letter,
+			});
+
+			return letters;
+		},
+		[],
+	);
+
+const SubscribeContent = () => {
 	return (
 		<div className="flex absolute z-10 flex-col gap-3 justify-center items-center w-full h-full backdrop-blur-md">
 			<div className="flex flex-col items-center mb-1">
@@ -12,7 +30,7 @@ const SubscribeContent = () => {
 					transition={{ duration: 0.3, ease: "easeOut" }}
 					className="text-lg text-center text-gray-12"
 				>
-					This feature requires Cap Pro
+					This feature requires Pro
 				</motion.p>
 				<motion.p
 					initial={{ y: -10, filter: "blur(5px)", opacity: 0 }}
@@ -34,7 +52,6 @@ const SubscribeContent = () => {
 						"linear-gradient(322deg,rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 19%, rgba(199, 199, 199, 1) 29%, rgba(217, 217, 217, 1) 52%, rgba(255, 255, 255, 1) 62%, rgba(158, 158, 158, 1) 83%, rgba(163, 163, 163, 1) 93%)",
 				}}
 			>
-				{/* Moving shine overlay */}
 				<motion.div
 					className="absolute inset-0 z-10 rounded-xl"
 					initial={{ x: "-100%" }}
@@ -57,14 +74,14 @@ const SubscribeContent = () => {
 				/>
 
 				<div className="flex relative z-10">
-					{capsDomainText.split("").map((letter, idx) => (
+					{capsDomainLetters.map(({ delay, key, letter }) => (
 						<motion.span
-							key={idx}
+							key={key}
 							className="text-[13px] font-medium relative z-0 text-black/50 mix-blend-screen"
 							initial={{ opacity: 0, y: -5 }}
 							animate={{ opacity: 1, y: 0 }}
 							transition={{
-								delay: 0.9 + idx * 0.075,
+								delay,
 								duration: 0.2,
 								ease: "easeOut",
 							}}

--- a/apps/web/app/(org)/dashboard/settings/organization/integrations/storage-integrations.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/integrations/storage-integrations.tsx
@@ -45,7 +45,7 @@ const s3ProviderOptions = [
 ];
 
 const proRequiredMessage =
-	"Cap Pro is required to manage organization integrations";
+	"Pro is required to manage organization integrations";
 
 const getOrganizationId = (settings: OrganizationStorageSettings) =>
 	settings.organization.id as Organisation.OrganisationId;

--- a/apps/web/app/(org)/onboarding/components/InviteTeamPage.tsx
+++ b/apps/web/app/(org)/onboarding/components/InviteTeamPage.tsx
@@ -85,7 +85,7 @@ export function InviteTeamPage() {
 			}
 			const data = await response.json();
 			if (data.subscription === true) {
-				toast.success("You are already on the Cap Pro plan");
+				toast.success("You are already on the Pro plan");
 				return;
 			}
 

--- a/apps/web/app/(site)/(seo)/solutions/agencies/page.tsx
+++ b/apps/web/app/(site)/(seo)/solutions/agencies/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import { AgenciesPage } from "@/components/pages/seo/AgenciesPage";
 
 // Create FAQ structured data for SEO
@@ -23,7 +22,7 @@ const createFaqStructuredData = () => {
 		{
 			question: "How long can we record on the free version?",
 			answer:
-				"The free version supports recordings up to 5 minutes. For longer client presentations and unlimited recording time, upgrade to Cap Pro at $8.16/month (billed annually).",
+				"The free version supports recordings up to 5 minutes. For longer client presentations and unlimited recording time, upgrade to Pro at $8.16/month (billed annually).",
 		},
 		{
 			question: "Is Cap secure enough for confidential client work?",
@@ -33,12 +32,12 @@ const createFaqStructuredData = () => {
 		{
 			question: "Can we use our own branding with Cap?",
 			answer:
-				"Yes. Cap Pro includes custom domain support (cap.yourdomain.com) so share links reflect your agency's brand. You can also use your own S3 storage for complete data ownership.",
+				"Yes. Pro includes custom domain support (cap.yourdomain.com) so share links reflect your agency's brand. You can also use your own S3 storage for complete data ownership.",
 		},
 		{
 			question: "How does Cap pricing work for agency teams?",
 			answer:
-				"Cap Pro is $8.16/month per user (billed annually) and includes unlimited cloud storage, custom domains, team workspaces, and all collaboration features. Volume discounts are available for teams over 10 users.",
+				"Pro is $8.16/month per user (billed annually) and includes unlimited cloud storage, custom domains, team workspaces, and all collaboration features. Volume discounts are available for teams over 10 users.",
 		},
 	];
 
@@ -119,16 +118,10 @@ export const metadata: Metadata = {
 export default function Page() {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{ __html: createFaqStructuredData() }}
-			/>
-			<Script
-				id="software-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{ __html: createSoftwareStructuredData() }}
-			/>
+			<script type="application/ld+json">{createFaqStructuredData()}</script>
+			<script type="application/ld+json">
+				{createSoftwareStructuredData()}
+			</script>
 			<AgenciesPage />
 		</>
 	);

--- a/apps/web/app/(site)/features/FeaturesPage.tsx
+++ b/apps/web/app/(site)/features/FeaturesPage.tsx
@@ -33,9 +33,12 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Link from "next/link";
+import type { ComponentProps } from "react";
+
+type FeatureIcon = ComponentProps<typeof FontAwesomeIcon>["icon"];
 
 interface Feature {
-	icon: any;
+	icon: FeatureIcon;
 	title: string;
 	description: string;
 	category: "recording" | "ai" | "sharing" | "editing" | "platform" | "privacy";
@@ -375,7 +378,7 @@ export const FeaturesPage = () => {
 							size="lg"
 							className="flex justify-center items-center w-full font-medium text-md sm:w-auto"
 						>
-							Upgrade to Cap Pro
+							Upgrade to Pro
 						</Button>
 					</div>
 				</div>
@@ -383,7 +386,7 @@ export const FeaturesPage = () => {
 
 			<div className="pb-32 wrapper">
 				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 auto-rows-[minmax(200px,_auto)] grid-flow-dense">
-					{features.map((feature, index) => {
+					{features.map((feature) => {
 						const sizeClasses = {
 							small: "col-span-1",
 							medium: "col-span-1 md:col-span-2",
@@ -392,7 +395,7 @@ export const FeaturesPage = () => {
 
 						return (
 							<div
-								key={index}
+								key={feature.title}
 								className={`
                   ${sizeClasses[feature.size || "small"]}
                   group relative overflow-hidden rounded-xl border p-6
@@ -418,7 +421,7 @@ export const FeaturesPage = () => {
 											href="/pricing"
 											className="inline-flex items-center px-2 py-1 ml-2 text-xs font-medium text-white bg-gradient-to-br from-blue-400 to-blue-600 rounded-full transition-all duration-200 hover:from-blue-500 hover:to-blue-700"
 										>
-											Cap Pro
+											Pro
 										</Link>
 									)}
 									{feature.isComingSoon && (

--- a/apps/web/app/(site)/features/instant-mode/InstantModePage.tsx
+++ b/apps/web/app/(site)/features/instant-mode/InstantModePage.tsx
@@ -13,7 +13,7 @@ const instantModeConfig: FeaturePageConfig = {
 			description:
 				"Cloud-powered screen recording for instant sharing and team collaboration. Perfect for quick updates, feedback sessions, and async communication that keeps teams moving fast.",
 			primaryCta: "Download for Free",
-			secondaryCta: "Upgrade to Cap Pro",
+			secondaryCta: "Upgrade to Pro",
 			features: [
 				"Instant shareable links",
 				"Upload during recording",
@@ -229,17 +229,17 @@ const instantModeConfig: FeaturePageConfig = {
 				{
 					question: "How long can I record for free in Instant Mode?",
 					answer:
-						"Free accounts can record up to 5 minutes per recording in Instant Mode. Upgrade to Cap Pro for unlimited recording length, unlimited storage, and advanced collaboration features.",
+						"Free accounts can record up to 5 minutes per recording in Instant Mode. Upgrade to Pro for unlimited recording length, unlimited storage, and advanced collaboration features.",
 				},
 				{
 					question: "Are my recordings secure in Instant Mode?",
 					answer:
-						"Yes, all recordings are encrypted in transit and at rest. You control who has access to your recordings, and you can delete them anytime. Cap Pro includes additional security features like password protection.",
+						"Yes, all recordings are encrypted in transit and at rest. You control who has access to your recordings, and you can delete them anytime. Pro includes additional security features like password protection.",
 				},
 				{
 					question: "Can viewers download my recordings?",
 					answer:
-						"By default, viewers can only watch recordings in the browser. Cap Pro allows you to control download permissions and add password protection for sensitive content.",
+						"By default, viewers can only watch recordings in the browser. Pro allows you to control download permissions and add password protection for sensitive content.",
 				},
 				{
 					question: "How fast are recordings processed?",
@@ -252,14 +252,14 @@ const instantModeConfig: FeaturePageConfig = {
 						"Instant Mode requires an internet connection for cloud processing and sharing. For offline recording, use Studio Mode which works completely locally.",
 				},
 				{
-					question: "What happens to my recordings if I upgrade to Cap Pro?",
+					question: "What happens to my recordings if I upgrade to Pro?",
 					answer:
 						"All existing recordings remain accessible, and you unlock unlimited recording length, advanced collaboration features, team workspaces, viewer analytics, and priority support.",
 				},
 				{
 					question: "Can I edit recordings made in Instant Mode?",
 					answer:
-						"Basic editing like trimming is available for all recordings. Cap Pro includes advanced editing features and the ability to download recordings for external editing.",
+						"Basic editing like trimming is available for all recordings. Pro includes advanced editing features and the ability to download recordings for external editing.",
 				},
 			],
 		},
@@ -275,7 +275,7 @@ const instantModeConfig: FeaturePageConfig = {
 			description:
 				"Join thousands of teams using Cap Instant Mode for faster communication and better collaboration. Get started free, upgrade for unlimited features.",
 			primaryButton: "Download for Free",
-			secondaryButton: "Upgrade to Cap Pro",
+			secondaryButton: "Upgrade to Pro",
 		},
 	},
 	customSections: {

--- a/apps/web/app/(site)/features/studio-mode/StudioModePage.tsx
+++ b/apps/web/app/(site)/features/studio-mode/StudioModePage.tsx
@@ -259,7 +259,7 @@ const studioModeConfig: FeaturePageConfig = {
 				{
 					question: "How does pricing work for Studio Mode?",
 					answer:
-						"Studio Mode is completely free for personal usage. For commercial usage, you need the Desktop License, which is included with Cap Pro or can be purchased separately.",
+						"Studio Mode is completely free for personal usage. For commercial usage, you need the Desktop License, which is included with Pro or can be purchased separately.",
 				},
 			],
 		},
@@ -275,7 +275,7 @@ const studioModeConfig: FeaturePageConfig = {
 			description:
 				"Download Cap and experience the power of Studio Mode for yourself. Create stunning, professional-quality recordings that engage your audience.",
 			primaryButton: "Download Cap Free",
-			secondaryButton: "Upgrade to Cap Pro",
+			secondaryButton: "Upgrade to Pro",
 		},
 	},
 	customSections: {

--- a/apps/web/app/(site)/tools/loom-downloader/page.tsx
+++ b/apps/web/app/(site)/tools/loom-downloader/page.tsx
@@ -61,7 +61,7 @@ const pageContent: ToolPageContent = {
 		"Download any public Loom video as an MP4 — or skip the one-by-one downloads and migrate your whole Loom library to Cap with 20% off using code MIGRATE20.",
 	featuresTitle: "Download Loom videos, then move your whole library to Cap",
 	featuresDescription:
-		"Cap's Loom downloader is free, fast, and requires zero setup. When you're ready to leave Loom for good, Cap Pro's built-in <a href=\"/loom-alternative\">Loom video importer</a> moves your entire workspace in one click.",
+		"Cap's Loom downloader is free, fast, and requires zero setup. When you're ready to leave Loom for good, Pro's built-in <a href=\"/loom-alternative\">Loom video importer</a> moves your entire workspace in one click.",
 	features: [
 		{
 			title: "Instant Downloads",
@@ -81,12 +81,12 @@ const pageContent: ToolPageContent = {
 		{
 			title: "Import Your Whole Loom Library",
 			description:
-				'Cap Pro includes a built-in <a href="/loom-alternative">Loom video importer</a> that transfers every Loom video you\'ve recorded — titles, transcripts, and chapters included — without manual re-uploads.',
+				'Pro includes a built-in <a href="/loom-alternative">Loom video importer</a> that transfers every Loom video you\'ve recorded — titles, transcripts, and chapters included — without manual re-uploads.',
 		},
 		{
 			title: "Half the Price of Loom",
 			description:
-				"Cap Pro starts from just $8.16/user/month vs Loom's $18/user/month. Use code <strong>MIGRATE20</strong> at checkout for an extra 20% off your first year.",
+				"Pro starts from just $8.16/user/month vs Loom's $18/user/month. Use code <strong>MIGRATE20</strong> at checkout for an extra 20% off your first year.",
 		},
 		{
 			title: "Open Source & Privacy-First",
@@ -108,12 +108,12 @@ const pageContent: ToolPageContent = {
 		{
 			question: "What is MIGRATE20 and how do I use it?",
 			answer:
-				'<strong>MIGRATE20</strong> is a 20% discount code for new Cap Pro subscribers who are switching from Loom. Just apply it at <a href="/pricing">checkout on the pricing page</a> to take 20% off your first year of Cap Pro — including the built-in Loom video importer.',
+				'<strong>MIGRATE20</strong> is a 20% discount code for new Pro subscribers who are switching from Loom. Just apply it at <a href="/pricing">checkout on the pricing page</a> to take 20% off your first year of Pro — including the built-in Loom video importer.',
 		},
 		{
 			question: "Can I import all my Loom videos into Cap at once?",
 			answer:
-				'Yes. Cap Pro\'s built-in <a href="/loom-alternative">Loom video importer</a> connects to your Loom workspace and transfers every video in one go — titles, transcripts, chapters, and all — without you having to download and re-upload anything manually.',
+				'Yes. Pro\'s built-in <a href="/loom-alternative">Loom video importer</a> connects to your Loom workspace and transfers every video in one go — titles, transcripts, chapters, and all — without you having to download and re-upload anything manually.',
 		},
 		{
 			question: "Why migrate from Loom to Cap?",
@@ -144,8 +144,8 @@ const pageContent: ToolPageContent = {
 	cta: {
 		title: "Ready to leave Loom for good?",
 		description:
-			"Skip the one-by-one downloads. Cap Pro imports your entire Loom library in one click — and costs half what Loom charges. Use MIGRATE20 at checkout for an extra 20% off your first year.",
-		buttonText: "Migrate to Cap Pro — save 20%",
+			"Skip the one-by-one downloads. Pro imports your entire Loom library in one click — and costs half what Loom charges. Use MIGRATE20 at checkout for an extra 20% off your first year.",
+		buttonText: "Migrate to Pro — save 20%",
 		buttonHref:
 			"/pricing?promo=MIGRATE20&utm_source=loom-downloader&utm_campaign=migrate20",
 		secondaryButtonText: "Download Cap free",
@@ -165,12 +165,9 @@ const breadcrumbSchema = createBreadcrumbSchema([
 export default function LoomDownloaderPage() {
 	return (
 		<>
-			<script
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify(breadcrumbSchema),
-				}}
-			/>
+			<script type="application/ld+json">
+				{JSON.stringify(breadcrumbSchema)}
+			</script>
 			<ToolsPageTemplate
 				content={pageContent}
 				toolComponent={<LoomDownloader />}

--- a/apps/web/app/Layout/providers.tsx
+++ b/apps/web/app/Layout/providers.tsx
@@ -230,7 +230,7 @@ function CapDevtools() {
 		<div className="flex flex-col p-4 space-y-4">
 			<h1 className="text-2xl font-semibold">Cap Devtools</h1>
 			<div className="space-y-2">
-				<h1 className="text-lg font-semibold">Cap Pro</h1>
+				<h1 className="text-lg font-semibold">Pro</h1>
 				<p className="text-xs text-muted-foreground">
 					Toggle the current user's Pro status (dev only)
 				</p>

--- a/apps/web/app/s/[videoId]/_components/ShareHeader.tsx
+++ b/apps/web/app/s/[videoId]/_components/ShareHeader.tsx
@@ -439,7 +439,7 @@ export const ShareHeader = ({
 						size="sm"
 						variant="blue"
 					>
-						Upgrade To Cap Pro
+						Upgrade To Pro
 					</Button>
 				</div>
 			)}

--- a/apps/web/app/s/[videoId]/_components/tabs/Summary.tsx
+++ b/apps/web/app/s/[videoId]/_components/tabs/Summary.tsx
@@ -140,6 +140,7 @@ export const Summary: React.FC<SummaryProps> = ({
 								viewBox="0 0 24 24"
 								stroke="currentColor"
 							>
+								<title>AI features</title>
 								<path
 									strokeLinecap="round"
 									strokeLinejoin="round"
@@ -152,9 +153,8 @@ export const Summary: React.FC<SummaryProps> = ({
 							Unlock Cap AI
 						</h3>
 						<p className="mb-4 text-sm leading-relaxed text-gray-600">
-							Upgrade to Cap Pro to access AI-powered features including
-							automatic titles, video summaries, and intelligent chapter
-							generation.
+							Upgrade to Pro to access AI-powered features including automatic
+							titles, video summaries, and intelligent chapter generation.
 						</p>
 						<Button
 							href="/pricing"
@@ -162,7 +162,7 @@ export const Summary: React.FC<SummaryProps> = ({
 							size="sm"
 							className="mx-auto"
 						>
-							Upgrade to Cap Pro
+							Upgrade to Pro
 						</Button>
 					</div>
 				</div>
@@ -251,16 +251,17 @@ export const Summary: React.FC<SummaryProps> = ({
 							<h3 className="mb-2 text-lg font-medium">Chapters</h3>
 							<div className="divide-y">
 								{aiData.chapters.map((chapter) => (
-									<div
+									<button
+										type="button"
 										key={chapter.start}
-										className="flex items-center p-2 rounded transition-colors cursor-pointer hover:bg-gray-100"
+										className="flex items-center p-2 w-full text-left rounded transition-colors cursor-pointer hover:bg-gray-100"
 										onClick={() => handleSeek(chapter.start)}
 									>
 										<span className="w-16 text-xs text-gray-500">
 											{formatTime(chapter.start)}
 										</span>
 										<span className="ml-2 text-sm">{chapter.title}</span>
-									</div>
+									</button>
 								))}
 							</div>
 						</div>

--- a/apps/web/components/UpgradeModal.tsx
+++ b/apps/web/components/UpgradeModal.tsx
@@ -165,12 +165,12 @@ const UpgradeModalImpl = ({
 			}
 
 			if (data.subscription === true) {
-				toast.success("You are already on the Cap Pro plan");
+				toast.success("You are already on the Pro plan");
 				onOpenChange(false);
 			}
 
 			if (data.subscription === true) {
-				toast.success("You are already on the Cap Pro plan");
+				toast.success("You are already on the Pro plan");
 				onOpenChange(false);
 			}
 
@@ -218,7 +218,7 @@ const UpgradeModalImpl = ({
 								<div className="flex relative flex-col flex-1 justify-center items-center py-6 w-full">
 									<div className="flex flex-col items-center">
 										<h1 className="text-3xl font-medium text-gray-12">
-											Upgrade to Cap Pro
+											Upgrade to Pro
 										</h1>
 									</div>
 									<p className="mt-1 text-lg text-center text-gray-11">
@@ -301,7 +301,7 @@ const UpgradeModalImpl = ({
 									>
 										{proCheckoutMutation.isPending
 											? "Loading..."
-											: "Upgrade to Cap Pro"}
+											: "Upgrade to Pro"}
 									</Button>
 									{dismissible && (
 										<button

--- a/apps/web/components/UsageButton.tsx
+++ b/apps/web/components/UsageButton.tsx
@@ -19,7 +19,7 @@ export const UsageButton = memo(
 		const { sidebarCollapsed } = useDashboardContext();
 		if (subscribed) {
 			return (
-				<Tooltip position="right" content="Cap Pro">
+				<Tooltip position="right" content="Pro">
 					<Link
 						className="flex justify-center mx-auto w-full"
 						href="/dashboard/settings/workspace"
@@ -41,7 +41,7 @@ export const UsageButton = memo(
 								)}
 								icon={faCheck}
 							/>
-							{sidebarCollapsed ? null : <p className="text-white">Cap Pro</p>}
+							{sidebarCollapsed ? null : <p className="text-white">Pro</p>}
 						</Button>
 					</Link>
 				</Tooltip>

--- a/apps/web/components/pages/FaqPage.tsx
+++ b/apps/web/components/pages/FaqPage.tsx
@@ -20,7 +20,7 @@ const faqContent: FaqItem[] = [
 	{
 		title: "How much does it cost?",
 		answer:
-			"Cap offers a free version for personal use. You can upgrade to Cap Pro for just $8.16/month (when billed annually) to unlock unlimited cloud storage, unlimited recording length, custom domain support, advanced team features, password-protected videos, analytics, and priority support. We also offer commercial licenses and self-hosted options for businesses.",
+			"Cap offers a free version for personal use. You can upgrade to Pro for just $8.16/month (when billed annually) to unlock unlimited cloud storage, unlimited recording length, custom domain support, advanced team features, password-protected videos, analytics, and priority support. We also offer commercial licenses and self-hosted options for businesses.",
 	},
 	{
 		title: "Which platforms does Cap support?",
@@ -35,7 +35,7 @@ const faqContent: FaqItem[] = [
 	{
 		title: "Can I import my Loom videos to Cap?",
 		answer:
-			"Yes! Cap Pro includes a built-in Loom video importer that lets you seamlessly transfer your existing Loom recordings into Cap. Just paste your Loom video links and Cap handles the rest — keeping all your content organized in one place.",
+			"Yes! Pro includes a built-in Loom video importer that lets you seamlessly transfer your existing Loom recordings into Cap. Just paste your Loom video links and Cap handles the rest — keeping all your content organized in one place.",
 	},
 	{
 		title: "Can I self-host Cap?",

--- a/apps/web/components/pages/HomePage/Pricing/EnterpriseCard.tsx
+++ b/apps/web/components/pages/HomePage/Pricing/EnterpriseCard.tsx
@@ -62,7 +62,7 @@ export const EnterpriseCard = () => {
 
 			<div className="pt-8 mt-8 border-t border-gray-4">
 				<p className="mb-4 text-sm font-medium text-gray-12">
-					Everything in Cap Pro, plus:
+					Everything in Pro, plus:
 				</p>
 				<ul className="space-y-3">
 					{enterpriseFeatures.map((feature) => (

--- a/apps/web/components/pages/HomePage/Pricing/ProCard.tsx
+++ b/apps/web/components/pages/HomePage/Pricing/ProCard.tsx
@@ -68,7 +68,7 @@ export const ProCard = () => {
 			}
 
 			if (data.subscription === true) {
-				toast.success("You are already on the Cap Pro plan");
+				toast.success("You are already on the Pro plan");
 			}
 
 			if (data.url) {
@@ -110,7 +110,7 @@ export const ProCard = () => {
 
 			<div className="mt-6 space-y-3 min-h-[120px]">
 				<BillingToggle
-					ariaLabel="Billing cycle for Cap Pro"
+					ariaLabel="Billing cycle for Pro"
 					value={isAnnually ? "annual" : "monthly"}
 					onChange={(value) => setIsAnnually(value === "annual")}
 					options={[
@@ -141,7 +141,7 @@ export const ProCard = () => {
 				onClick={() => planCheckout.mutate()}
 				disabled={isLoading}
 				className="mt-6 w-full font-medium"
-				aria-label="Purchase Cap Pro License"
+				aria-label="Purchase Pro License"
 			>
 				{isLoading ? "Loading..." : copy.cta}
 			</Button>

--- a/apps/web/components/pages/TermsPage.tsx
+++ b/apps/web/components/pages/TermsPage.tsx
@@ -30,7 +30,7 @@ export const TermsPage = () => {
 							Cap provides a platform that allows users to record their screen
 							and webcam, edit their recordings, generate shareable links, and
 							collaborate with others through "Spaces." We offer a free plan
-							with usage limits and a paid "Cap Pro" plan.
+							with usage limits and a paid "Pro" plan.
 						</li>
 						<li>
 							<h3>User Accounts</h3>

--- a/apps/web/components/pages/_components/ComparePlans.tsx
+++ b/apps/web/components/pages/_components/ComparePlans.tsx
@@ -183,7 +183,7 @@ export const ComparePlans = () => {
 				short: "Desktop",
 				price: "$29/yr",
 			},
-			{ key: "pro", name: "Cap Pro", short: "Pro", price: "$8.16/user/mo" },
+			{ key: "pro", name: "Pro", short: "Pro", price: "$8.16/user/mo" },
 		],
 		[],
 	);
@@ -253,7 +253,7 @@ export const ComparePlans = () => {
 			}
 
 			if (data.subscription === true) {
-				toast.success("You are already on the Cap Pro plan");
+				toast.success("You are already on the Pro plan");
 				return;
 			}
 
@@ -323,7 +323,7 @@ export const ComparePlans = () => {
 				Compare plans
 			</h2>
 			<p className="mx-auto mb-12 max-w-md text-center text-gray-10">
-				Everything you get with Free, Desktop License, and Cap Pro.
+				Everything you get with Free, Desktop License, and Pro.
 			</p>
 
 			<div className="hidden p-4 rounded-2xl border shadow-sm md:block bg-gray-1 border-gray-5">

--- a/apps/web/components/pages/_components/UpgradeToPro.tsx
+++ b/apps/web/components/pages/_components/UpgradeToPro.tsx
@@ -2,7 +2,7 @@ import { Button } from "@cap/ui";
 import { useRive } from "@rive-app/react-canvas";
 
 const UpgradeToPro = ({
-	text = "Upgrade To Cap Pro",
+	text = "Upgrade To Pro",
 	onClick,
 }: {
 	text?: string;

--- a/apps/web/components/pages/seo/AgenciesPage.tsx
+++ b/apps/web/components/pages/seo/AgenciesPage.tsx
@@ -21,13 +21,7 @@ const PlatformSupportArt = memo(() => {
 	return <PlatformSupportRive className="w-[120px] h-[80px]" />;
 });
 
-const FAQItem = ({
-	faq,
-	index,
-}: {
-	faq: { question: string; answer: string };
-	index: number;
-}) => {
+const FAQItem = ({ faq }: { faq: { question: string; answer: string } }) => {
 	const [isOpen, setIsOpen] = useState(false);
 
 	return (
@@ -265,7 +259,7 @@ export const agenciesContent: SeoPageContent = {
 		{
 			question: "How long can we record on the free version?",
 			answer:
-				"The free version supports recordings up to 5 minutes. For longer client presentations and unlimited recording time, upgrade to Cap Pro at $8.16/month (billed annually).",
+				"The free version supports recordings up to 5 minutes. For longer client presentations and unlimited recording time, upgrade to Pro at $8.16/month (billed annually).",
 		},
 		{
 			question: "Is Cap secure enough for confidential client work?",
@@ -275,12 +269,12 @@ export const agenciesContent: SeoPageContent = {
 		{
 			question: "Can we use our own branding with Cap?",
 			answer:
-				"Yes. Cap Pro includes custom domain support (cap.yourdomain.com) so share links reflect your agency's brand. You can also use your own S3 storage for complete data ownership.",
+				"Yes. Pro includes custom domain support (cap.yourdomain.com) so share links reflect your agency's brand. You can also use your own S3 storage for complete data ownership.",
 		},
 		{
 			question: "How does Cap pricing work for agency teams?",
 			answer:
-				"Cap Pro is $8.16/month per user (billed annually) and includes unlimited cloud storage, custom domains, team workspaces, and all collaboration features. Volume discounts are available for teams over 10 users.",
+				"Pro is $8.16/month per user (billed annually) and includes unlimited cloud storage, custom domains, team workspaces, and all collaboration features. Volume discounts are available for teams over 10 users.",
 		},
 	],
 
@@ -331,7 +325,7 @@ export const agenciesContent: SeoPageContent = {
 		title: "Getting Started with Cap for Your Agency",
 		steps: [
 			"Download Cap for all team members (available on Mac and Windows)",
-			"Set up Cap Pro with custom domain for professional share links",
+			"Set up Pro with custom domain for professional share links",
 			"Connect your own S3 storage for complete data ownership (optional)",
 			"Create agency guidelines for video updates (length, format, etc.)",
 			"Train team on Instant vs Studio Mode for different use cases",
@@ -341,7 +335,7 @@ export const agenciesContent: SeoPageContent = {
 
 	cta: {
 		title: "Ready to Transform Your Agency's Client Communication?",
-		buttonText: "Upgrade to Cap Pro",
+		buttonText: "Upgrade to Pro",
 	},
 };
 
@@ -391,7 +385,7 @@ export const AgenciesPage = () => {
 								size="lg"
 								className="relative z-[20] w-full sm:w-auto font-medium text-md"
 							>
-								Upgrade to Cap Pro
+								Upgrade to Pro
 							</Button>
 						</motion.div>
 					</div>
@@ -612,8 +606,8 @@ export const AgenciesPage = () => {
 					</div>
 					<div className="mx-auto mb-10 max-w-3xl">
 						<div className="space-y-4">
-							{agenciesContent.faqs.map((faq, index) => (
-								<FAQItem key={index} faq={faq} index={index} />
+							{agenciesContent.faqs.map((faq) => (
+								<FAQItem key={faq.question} faq={faq} />
 							))}
 						</div>
 					</div>

--- a/apps/web/components/pages/seo/BestScreenRecorderPage.tsx
+++ b/apps/web/components/pages/seo/BestScreenRecorderPage.tsx
@@ -249,7 +249,7 @@ export const bestScreenRecorderContent: SeoPageContent = {
 		{
 			question: "What is the best screen recorder for teams?",
 			answer:
-				"Cap is the best screen recorder for teams because of its built-in sharing and collaboration features. Instant shareable links work anywhere — Slack, email, Notion, Jira. Viewers can leave timestamped comments directly on recordings, making async feedback fast and structured. Cap Pro adds unlimited recording time, custom branding, and team management.",
+				"Cap is the best screen recorder for teams because of its built-in sharing and collaboration features. Instant shareable links work anywhere — Slack, email, Notion, Jira. Viewers can leave timestamped comments directly on recordings, making async feedback fast and structured. Pro adds unlimited recording time, custom branding, and team management.",
 		},
 	],
 

--- a/apps/web/components/pages/seo/HowToScreenRecordPage.tsx
+++ b/apps/web/components/pages/seo/HowToScreenRecordPage.tsx
@@ -204,7 +204,7 @@ export const howToScreenRecordContent: SeoPageContent = {
 		{
 			question: "How long can I screen record?",
 			answer:
-				"With Cap's desktop app, there are no time limits on screen recordings. You can record for as long as you need, whether it is a 30-second quick demo or a 2-hour training session. Cap's Instant Mode (browser-based) supports recordings up to 5 minutes on the free plan. For unlimited browser-based recording length, Cap Pro is available at an affordable monthly price. The macOS built-in recorder and Windows Game Bar also have no strict time limits, though they lack the sharing and editing features that Cap provides.",
+				"With Cap's desktop app, there are no time limits on screen recordings. You can record for as long as you need, whether it is a 30-second quick demo or a 2-hour training session. Cap's Instant Mode (browser-based) supports recordings up to 5 minutes on the free plan. For unlimited browser-based recording length, Pro is available at an affordable monthly price. The macOS built-in recorder and Windows Game Bar also have no strict time limits, though they lack the sharing and editing features that Cap provides.",
 		},
 		{
 			question: "What format do screen recordings save in?",

--- a/apps/web/components/pages/seo/LoomAlternativePage.tsx
+++ b/apps/web/components/pages/seo/LoomAlternativePage.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Clapperboard, Zap } from "lucide-react";
-import Script from "next/script";
 import { SeoPageTemplate } from "../../seo/SeoPageTemplate";
 import type { SeoPageContent } from "../../seo/types";
 
@@ -141,7 +140,7 @@ export const loomAlternativeContent: SeoPageContent = {
 		{
 			question: "Can I import my existing Loom videos into Cap?",
 			answer:
-				"Yes! Cap Pro includes a built-in Loom video importer. Simply paste your Loom video links and Cap will import them directly into your library. It's the easiest way to migrate from Loom without losing any of your existing content.",
+				"Yes! Pro includes a built-in Loom video importer. Simply paste your Loom video links and Cap will import them directly into your library. It's the easiest way to migrate from Loom without losing any of your existing content.",
 		},
 	],
 
@@ -246,11 +245,7 @@ const createFaqStructuredData = () => {
 export const LoomAlternativePage = () => {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{ __html: createFaqStructuredData() }}
-			/>
+			<script type="application/ld+json">{createFaqStructuredData()}</script>
 			<SeoPageTemplate
 				showLogosInHeader
 				showLoomComparisonSlider

--- a/apps/web/components/pages/seo/ObsAlternativePage.tsx
+++ b/apps/web/components/pages/seo/ObsAlternativePage.tsx
@@ -248,7 +248,7 @@ export const obsAlternativeContent: SeoPageContent = {
 		{
 			question: "Is Cap free like OBS?",
 			answer:
-				"Yes. Cap's Studio Mode is completely free for personal use with no time limits and no watermarks. Instant Mode on the free plan supports recordings up to 5 minutes. Cap Pro ($9.99/month) removes Instant Mode time limits and adds team features. The core software is open source and free to use, just like OBS.",
+				"Yes. Cap's Studio Mode is completely free for personal use with no time limits and no watermarks. Instant Mode on the free plan supports recordings up to 5 minutes. Pro ($9.99/month) removes Instant Mode time limits and adds team features. The core software is open source and free to use, just like OBS.",
 		},
 		{
 			question: "Is Cap open source like OBS?",

--- a/apps/web/components/pages/seo/OpenSourceScreenRecorderPage.tsx
+++ b/apps/web/components/pages/seo/OpenSourceScreenRecorderPage.tsx
@@ -229,7 +229,7 @@ export const openSourceScreenRecorderContent: SeoPageContent = {
 		{
 			question: "Is Cap's open source version free?",
 			answer:
-				"Yes. Cap's Studio Mode is completely free for personal use with no time limits and no watermarks. Instant Mode on the free plan supports recordings up to 5 minutes. Cap Pro ($9.99/month) removes Instant Mode time limits and adds team features. The core software will always be open source and free to use.",
+				"Yes. Cap's Studio Mode is completely free for personal use with no time limits and no watermarks. Instant Mode on the free plan supports recordings up to 5 minutes. Pro ($9.99/month) removes Instant Mode time limits and adds team features. The core software will always be open source and free to use.",
 		},
 		{
 			question:

--- a/apps/web/components/pages/seo/RecordScreenPage.tsx
+++ b/apps/web/components/pages/seo/RecordScreenPage.tsx
@@ -237,7 +237,7 @@ export const recordScreenContent: SeoPageContent = {
 		{
 			question: "Is there a time limit when recording your screen with Cap?",
 			answer:
-				"Studio Mode in Cap has no time limit on screen recordings — record as long as you need completely free. Instant Mode on the free plan supports recordings up to 5 minutes. Upgrading to Cap Pro removes this limit for Instant Mode as well.",
+				"Studio Mode in Cap has no time limit on screen recordings — record as long as you need completely free. Instant Mode on the free plan supports recordings up to 5 minutes. Upgrading to Pro removes this limit for Instant Mode as well.",
 		},
 		{
 			question: "How do I share a screen recording?",

--- a/apps/web/components/pages/seo/ScreenRecordWindowsPage.tsx
+++ b/apps/web/components/pages/seo/ScreenRecordWindowsPage.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Clapperboard, Zap } from "lucide-react";
-import Script from "next/script";
 import { SeoPageTemplate } from "../../seo/SeoPageTemplate";
 import type { SeoPageContent } from "../../seo/types";
 
@@ -230,7 +229,7 @@ export const screenRecordWindowsContent: SeoPageContent = {
 		{
 			question: "Is Cap really a free screen recorder for Windows?",
 			answer:
-				"Yes. Cap is 100% free to use locally on Windows with no watermarks, no time limits, and no feature gates. It is open source so you can inspect the code yourself. Cap Pro is available for teams that want cloud storage and advanced sharing, but the core <a href='/free-screen-recorder'>free screen recorder</a> is fully functional.",
+				"Yes. Cap is 100% free to use locally on Windows with no watermarks, no time limits, and no feature gates. It is open source so you can inspect the code yourself. Pro is available for teams that want cloud storage and advanced sharing, but the core <a href='/free-screen-recorder'>free screen recorder</a> is fully functional.",
 		},
 		{
 			question: "Can I record my screen with audio on Windows?",
@@ -323,18 +322,10 @@ const createSoftwareAppStructuredData = () => {
 export const ScreenRecordWindowsPage = () => {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{ __html: createFaqStructuredData() }}
-			/>
-			<Script
-				id="software-app-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{
-					__html: createSoftwareAppStructuredData(),
-				}}
-			/>
+			<script type="application/ld+json">{createFaqStructuredData()}</script>
+			<script type="application/ld+json">
+				{createSoftwareAppStructuredData()}
+			</script>
 			<SeoPageTemplate content={screenRecordWindowsContent} />
 		</>
 	);

--- a/apps/web/components/pages/seo/ScreenRecorderPage.tsx
+++ b/apps/web/components/pages/seo/ScreenRecorderPage.tsx
@@ -80,7 +80,7 @@ export const screenRecorderContent: SeoPageContent = {
 		{
 			question: "Is Cap a free screen recorder?",
 			answer:
-				"Yes, Cap offers a powerful free version, making it one of the best free screen recorders available. The local version is 100% free with no usage limits, but Cap Pro is available for users who need additional features.",
+				"Yes, Cap offers a powerful free version, making it one of the best free screen recorders available. The local version is 100% free with no usage limits, but Pro is available for users who need additional features.",
 		},
 		{
 			question: "How does Cap compare to OBS?",

--- a/apps/web/components/pages/seo/ScreenRecordingPage.tsx
+++ b/apps/web/components/pages/seo/ScreenRecordingPage.tsx
@@ -186,7 +186,7 @@ export const screenRecordingContent: SeoPageContent = {
 		{
 			question: "Does Cap screen recording have a time limit?",
 			answer:
-				"Studio Mode in Cap has no time limit on recordings — record as long as you need. Instant Mode on the free plan supports recordings up to 5 minutes. Cap Pro removes this limit for Instant Mode recordings as well.",
+				"Studio Mode in Cap has no time limit on recordings — record as long as you need. Instant Mode on the free plan supports recordings up to 5 minutes. Pro removes this limit for Instant Mode recordings as well.",
 		},
 	],
 

--- a/apps/web/components/pages/seo/ScreenRecordingSoftwarePage.tsx
+++ b/apps/web/components/pages/seo/ScreenRecordingSoftwarePage.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Clapperboard, Zap } from "lucide-react";
-import Script from "next/script";
 import { SeoPageTemplate } from "../../seo/SeoPageTemplate";
 import type { SeoPageContent } from "../../seo/types";
 
@@ -38,7 +37,7 @@ export const screenRecordingSoftwareContent: SeoPageContent = {
 		{
 			title: "Unlimited Recording and Cloud Storage",
 			description:
-				"Record as long as you need with no time limits. Store and share your recordings with unlimited cloud storage on Cap Pro.",
+				"Record as long as you need with no time limits. Store and share your recordings with unlimited cloud storage on Pro.",
 		},
 		{
 			title: "Instant Sharing with Links",
@@ -158,7 +157,7 @@ export const screenRecordingSoftwareContent: SeoPageContent = {
 		{
 			question: "Can I share recordings with others?",
 			answer:
-				"Yes, Cap generates instant shareable links the moment you stop recording. Share with colleagues, clients, or students in seconds. Cap Pro includes built-in thread commenting so recipients can leave feedback directly on your videos.",
+				"Yes, Cap generates instant shareable links the moment you stop recording. Share with colleagues, clients, or students in seconds. Pro includes built-in thread commenting so recipients can leave feedback directly on your videos.",
 		},
 		{
 			question: "How does Cap compare to other screen recording software?",
@@ -168,7 +167,7 @@ export const screenRecordingSoftwareContent: SeoPageContent = {
 		{
 			question: "What is the best screen recording software in 2026?",
 			answer:
-				"Cap is the best screen recording software for users who want a balance of quality, simplicity, and value. It records in up to 4K at 60fps, shares instantly via link, is open-source, and offers a generous free plan. For teams, Cap Pro adds cloud storage, thread commenting, and custom domains at a fraction of competitors' prices.",
+				"Cap is the best screen recording software for users who want a balance of quality, simplicity, and value. It records in up to 4K at 60fps, shares instantly via link, is open-source, and offers a generous free plan. For teams, Pro adds cloud storage, thread commenting, and custom domains at a fraction of competitors' prices.",
 		},
 		{
 			question: "How does screen recording software work?",
@@ -215,11 +214,7 @@ const createFaqStructuredData = () => {
 export const ScreenRecordingSoftwarePage = () => {
 	return (
 		<>
-			<Script
-				id="faq-structured-data"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{ __html: createFaqStructuredData() }}
-			/>
+			<script type="application/ld+json">{createFaqStructuredData()}</script>
 			<SeoPageTemplate content={screenRecordingSoftwareContent} />
 		</>
 	);

--- a/apps/web/components/pages/seo/VideoRecordingSoftwarePage.tsx
+++ b/apps/web/components/pages/seo/VideoRecordingSoftwarePage.tsx
@@ -224,7 +224,7 @@ export const videoRecordingSoftwareContent: SeoPageContent = {
 		{
 			question: "Is Cap video recording software free?",
 			answer:
-				"Yes. Cap's Studio Mode is completely free for personal use with no time limits, no watermarks, and no hidden fees. Instant Mode is free for recordings up to 5 minutes. Cap Pro at $9.99/month removes Instant Mode limits and adds team features — but the core video recording software is free to use forever.",
+				"Yes. Cap's Studio Mode is completely free for personal use with no time limits, no watermarks, and no hidden fees. Instant Mode is free for recordings up to 5 minutes. Pro at $9.99/month removes Instant Mode limits and adds team features — but the core video recording software is free to use forever.",
 		},
 		{
 			question: "Does Cap video recording software work on Mac and Windows?",

--- a/apps/web/components/tools/LoomDownloader.tsx
+++ b/apps/web/components/tools/LoomDownloader.tsx
@@ -122,7 +122,7 @@ function MigrationBanner() {
 					<span className="font-mono font-semibold text-blue-700">
 						{MIGRATE_PROMO_CODE}
 					</span>{" "}
-					at checkout for 20% off Cap Pro.
+					at checkout for 20% off Pro.
 				</p>
 			</div>
 			<div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:gap-3">
@@ -187,7 +187,7 @@ function MigrationSuccessState({
 						Bring your whole Loom library to Cap
 					</h3>
 					<p className="text-sm leading-relaxed text-gray-700 sm:text-base">
-						Skip the one-by-one downloads. Cap Pro's built-in Loom importer
+						Skip the one-by-one downloads. Pro's built-in Loom importer
 						transfers your entire Loom workspace to Cap in a single click —
 						titles, transcripts, and all. Use{" "}
 						<span className="font-mono font-semibold text-blue-700">
@@ -205,7 +205,7 @@ function MigrationSuccessState({
 							href={MIGRATE_CHECKOUT_HREF}
 							className="w-full sm:w-auto"
 						>
-							Migrate with Cap Pro — save 20%
+							Migrate with Pro — save 20%
 						</Button>
 						<Button
 							variant="white"
@@ -484,7 +484,7 @@ export function LoomDownloader() {
 					href={MIGRATE_CHECKOUT_HREF}
 					className="inline-flex items-center gap-1 text-xs font-semibold text-blue-600 hover:text-blue-700 hover:underline"
 				>
-					Import Loom videos with Cap Pro
+					Import Loom videos with Pro
 					<svg
 						className="w-3 h-3"
 						fill="none"

--- a/apps/web/content/changelog/17.mdx
+++ b/apps/web/content/changelog/17.mdx
@@ -9,4 +9,4 @@ image:
 - Improved progress overlay for thumbnail actions (copy to clipboard, save, create shareable link) messaging/state
 - Fixed reliability of export/rendering process
 - Sentry error reporting for helping with debugging
-- Fixed Cap Pro upgrade window (sizing + closing panic)
+- Fixed Pro upgrade window (sizing + closing panic)

--- a/apps/web/content/docs/commercial-license.mdx
+++ b/apps/web/content/docs/commercial-license.mdx
@@ -8,7 +8,7 @@ image: "/docs/commercial-licensing.webp"
 The Cap Desktop application you can download from our [download page](/download) is free to use,
 but requires a commercial license to be used for commercial purposes.
 You can obtain a commercial license by purchasing them standalone,
-or by purchasing Cap Pro. For more information, see [our pricing page](/pricing).
+or by purchasing Pro. For more information, see [our pricing page](/pricing).
 
 This license does **not** apply to versions of the app you build yourself from our [source code](https://github.com/CapSoftware/Cap),
 only to binaries that **we distribute**.

--- a/apps/web/data/homepage-copy.ts
+++ b/apps/web/data/homepage-copy.ts
@@ -169,7 +169,7 @@ export const homepageCopy: HomePageCopy = {
 			{ label: "Open source", href: "/open-source-screen-recorder" },
 		],
 		cta: {
-			primaryButton: "Upgrade to Cap Pro",
+			primaryButton: "Upgrade to Pro",
 			secondaryButton: "View on GitHub",
 			freeVersionText:
 				"No credit card required. Record locally, share when you choose.",
@@ -325,7 +325,7 @@ export const homepageCopy: HomePageCopy = {
 		},
 		pro: {
 			badge: "Best value",
-			title: "Cap Pro",
+			title: "Pro",
 			description:
 				"Everything in Desktop plus unlimited cloud features for seamless sharing and collaboration.",
 			features: [
@@ -356,9 +356,9 @@ export const homepageCopy: HomePageCopy = {
 		title: "Questions? We've Got Answers.",
 		items: [
 			{
-				question: "What is the difference between Cap Pro and Desktop License?",
+				question: "What is the difference between Pro and Desktop License?",
 				answer:
-					"Cap Pro is a paid plan that includes all the features of the Desktop License plus cloud features for seamless sharing and collaboration. Desktop License grants you commercial usage rights for a single user.",
+					"Pro is a paid plan that includes all the features of the Desktop License plus cloud features for seamless sharing and collaboration. Desktop License grants you commercial usage rights for a single user.",
 			},
 			{
 				question: "Is there a free version?",
@@ -373,7 +373,7 @@ export const homepageCopy: HomePageCopy = {
 			{
 				question: "How does Cap AI work?",
 				answer:
-					"Cap AI is a powerful tool that can be used to generate titles, summaries, clickable chapters, and transcriptions for your recordings. It's available for all Cap Pro users and has no usage limits.",
+					"Cap AI is a powerful tool that can be used to generate titles, summaries, clickable chapters, and transcriptions for your recordings. It's available for all Pro users and has no usage limits.",
 			},
 			{
 				question: "How is Cap different from Loom?",
@@ -388,7 +388,7 @@ export const homepageCopy: HomePageCopy = {
 			{
 				question: "Do you offer team plans?",
 				answer:
-					"Yes! Cap Pro includes team workspaces where you can organize recordings, manage permissions, and collaborate. Volume discounts available for teams over 10 users. Contact us for custom enterprise features.",
+					"Yes! Pro includes team workspaces where you can organize recordings, manage permissions, and collaborate. Volume discounts available for teams over 10 users. Contact us for custom enterprise features.",
 			},
 			{
 				question: "Which platforms do you support?",
@@ -398,7 +398,7 @@ export const homepageCopy: HomePageCopy = {
 			{
 				question: "Can I use Cap for commercial purposes?",
 				answer:
-					"Absolutely! Any paid plan (Desktop License or Cap Pro) includes full commercial usage rights. Use Cap for client work, sell courses, or embed recordings anywhere. The free version is for personal use only.",
+					"Absolutely! Any paid plan (Desktop License or Pro) includes full commercial usage rights. Use Cap for client work, sell courses, or embed recordings anywhere. The free version is for personal use only.",
 			},
 			{
 				question: "Is my data secure?",
@@ -408,14 +408,14 @@ export const homepageCopy: HomePageCopy = {
 			{
 				question: "What about GDPR/HIPAA compliance?",
 				answer:
-					"Cap Pro supports custom S3 buckets in any region for GDPR compliance. For HIPAA and other regulations, our self-hosted option gives you complete control. We also offer signed BAAs for enterprise customers.",
+					"Pro supports custom S3 buckets in any region for GDPR compliance. For HIPAA and other regulations, our self-hosted option gives you complete control. We also offer signed BAAs for enterprise customers.",
 			},
 		],
 	},
 	readyToGetStarted: {
 		title: "Ready To Upgrade How You Communicate?",
 		buttons: {
-			primary: "Upgrade to Cap Pro",
+			primary: "Upgrade to Pro",
 			secondary: "Download For Free",
 		},
 	},

--- a/apps/web/lib/messenger/agent.ts
+++ b/apps/web/lib/messenger/agent.ts
@@ -31,7 +31,7 @@ const buildSystemPrompt = ({
 		`You are chatting with a Cap user in a live support chat. This is a real conversation, not a ticket. Write like you're messaging a colleague, not composing a formal email.
 
 Critical rules:
-- You ARE a Cap employee. Cap is YOUR company. ALWAYS use "we", "our", "us" when talking about Cap, its features, plans, and decisions. Never refer to Cap in the third person like an outsider. For example say "we built this to be lightweight" not "Cap is lightweight", say "our Pro plan includes..." not "Cap Pro includes...", say "we support Mac and Windows" not "Cap works on Mac and Windows". You're on the team, talk like it.
+- You ARE a Cap employee. Cap is YOUR company. ALWAYS use "we", "our", "us" when talking about Cap, its features, plans, and decisions. Never refer to Cap in the third person like an outsider. For example say "we built this to be lightweight" not "Cap is lightweight", say "our Pro plan includes..." not "Pro includes...", say "we support Mac and Windows" not "Cap works on Mac and Windows". You're on the team, talk like it.
 - NEVER use em dashes (the long dash character). Use commas, periods, or just start a new sentence instead.
 - NEVER use markdown formatting (no **bold**, no *italics*, no headers, no code blocks unless sharing actual code snippets).
 - Don't over-explain. If the answer is simple, keep it simple.

--- a/apps/web/lib/messenger/constants.ts
+++ b/apps/web/lib/messenger/constants.ts
@@ -87,7 +87,7 @@ PLATFORM SUPPORT:
 PRICING (early adopter beta pricing, locked in for lifetime of subscription):
 - Free plan: personal use, Studio Mode, unlimited local recordings, shareable links up to 5 minutes, export to MP4 or GIF, web recorder
 - Desktop License: $58 one-time (lifetime) or $29/year, commercial usage rights, Studio Mode with full editor, unlimited local recordings, shareable links up to 5 minutes, export to MP4 or GIF
-- Cap Pro: $8.16/mo per user (billed annually) or $12/mo per user (billed monthly), includes everything in Desktop License plus unlimited cloud storage and bandwidth, unlimited shareable links (no 5-minute limit), auto-generated AI titles/summaries/chapters/transcriptions, custom domain (cap.yourdomain.com), password-protected shares, viewer analytics, team workspaces, Loom video importer, custom S3 bucket support, priority support
+- Pro: $8.16/mo per user (billed annually) or $12/mo per user (billed monthly), includes everything in Desktop License plus unlimited cloud storage and bandwidth, unlimited shareable links (no 5-minute limit), auto-generated AI titles/summaries/chapters/transcriptions, custom domain (cap.yourdomain.com), password-protected shares, viewer analytics, team workspaces, Loom video importer, custom S3 bucket support, priority support
 - Enterprise: custom pricing, contact via https://cal.com/cap.so/15min, includes SLAs, priority support, Loom video importer, bulk discounts, managed self-hosting, SAML SSO via WorkOS, advanced security controls
 - Early adopters keep their pricing forever, even after beta ends and regular prices change.
 - Student discount available at https://cap.so/student-discount
@@ -174,14 +174,14 @@ SHARING & COLLABORATION:
 - Custom domains (Pro): use your own domain for shared links (e.g. videos.yourcompany.com), configure in organization settings with DNS verification
 - Viewer analytics (Pro): track views, unique viewers, engagement over time (24h, 7d, 30d, lifetime)
 
-AI FEATURES (CAP PRO):
+AI FEATURES (PRO):
 - Auto-generated titles: AI creates descriptive titles from video content
 - Auto-generated summaries: markdown summaries of video content
 - Auto-generated chapters: clickable timestamped chapters for easy navigation
 - Transcription: automatic speech-to-text via Deepgram, generates VTT captions, editable, downloadable, supports translation to other languages
 - All AI processing happens server-side, never on the users device
 
-LOOM IMPORT (CAP PRO):
+LOOM IMPORT (PRO):
 - Import Loom videos to Cap at https://cap.so/dashboard/import/loom
 - Paste a Loom video URL and Cap downloads and processes it
 - Imported videos appear in your dashboard like regular recordings
@@ -235,7 +235,7 @@ TROUBLESHOOTING - COMMON ISSUES:
 - Export failing: try a different compression preset. If frame decode errors occur, Cap automatically falls back to FFmpeg decoder.
 - Shared link not working: make sure the video finished uploading and processing. Check if password protection is enabled.
 - Custom domain not working: verify DNS settings in organization settings. Domain verification can take a few minutes.
-- Loom import failing: make sure the Loom video is public (not private or password-protected), the link hasnt expired, and you have an active Cap Pro subscription.
+- Loom import failing: make sure the Loom video is public (not private or password-protected), the link hasnt expired, and you have an active Pro subscription.
 - Crash recovery: if Cap crashes during a Studio Mode recording, recovered segments can be found in Settings > Recordings. Crash-recoverable recording must be enabled in settings.
 
 TROUBLESHOOTING - SIGNIN ISSUES:
@@ -261,12 +261,12 @@ FAQ:
 - Can I self-host? Yes, full self-hosting with Docker Compose.
 - What happens after beta? Early adopters keep their pricing forever.
 - Is there a commercial license? Yes, for businesses using the desktop app. Pro plan includes commercial license.
-- Can I import Loom videos? Yes, Cap Pro includes a built-in Loom importer.
+- Can I import Loom videos? Yes, Pro includes a built-in Loom importer.
 
 COMMON USER TASKS:
 - To download Cap: go to https://cap.so/download
 - To upgrade to Pro: go to https://cap.so/pricing
-- To import Loom videos: go to https://cap.so/dashboard/import/loom (requires Cap Pro)
+- To import Loom videos: go to https://cap.so/dashboard/import/loom (requires Pro)
 - To view docs: go to https://cap.so/docs
 - To self-host: go to https://cap.so/self-hosting
 - To book an enterprise call: go to https://cal.com/cap.so/15min

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -78,7 +78,7 @@ Provide visual answers to support tickets. Create help videos and documentation.
 
 - **Personal Use**: Free forever (5-minute recording limit)
 - **Desktop License**: $29/year or $58 lifetime (unlimited recording)
-- **Cap Pro**: $12/month ($8.16/month when billed annually) - includes cloud storage and AI features
+- **Pro**: $12/month ($8.16/month when billed annually) - includes cloud storage and AI features
 - **Teams**: Custom pricing for organizations
 
 ## Privacy & Security

--- a/packages/web-backend/src/Folders/index.ts
+++ b/packages/web-backend/src/Folders/index.ts
@@ -45,7 +45,7 @@ export class Folders extends Effect.Service<Folders>()("Folders", {
 
 				if (!userIsPro(owner ?? null))
 					return yield* new Policy.PolicyDeniedError({
-						reason: "Upgrade to Cap Pro to create a public collection link",
+						reason: "Upgrade to Pro to create a public collection link",
 					});
 			});
 


### PR DESCRIPTION
## Summary

- Replaces the branded pro-plan label with neutral `Pro` copy across dashboard, upgrade flows, desktop settings, marketing pages, backend validation messages, and support prompt content.
- Updates the affected unit-test expectation for the renamed error copy.
- Cleans up scoped Biome issues in files touched by the copy update.

## Validation

- `pnpm dlx @biomejs/biome@2.2.0 check --write ... --max-diagnostics=100`
- `git diff --check`
- Repository search for the removed phrase returned no matches.
- `pnpm --filter @cap/web test -- save-video-edits` could not run because this worktree has no `node_modules` and `vitest` is unavailable.