### PR TITLE
fix(web): escape backslashes in analytics ClickHouse literals

### DIFF
--- a/apps/web/actions/videos/get-analytics.ts
+++ b/apps/web/actions/videos/get-analytics.ts
@@ -13,7 +13,11 @@ const MIN_RANGE_DAYS = 1;
 const MAX_RANGE_DAYS = 90;
 const DEFAULT_RANGE_DAYS = MAX_RANGE_DAYS;
 
-const escapeLiteral = (value: string) => value.replace(/'/g, "''");
+// Escape backslashes BEFORE quotes: ClickHouse honors C-style `\'` inside
+// single-quoted literals, so doubling quotes alone lets a trailing backslash
+// neutralise the doubled quote and break out of the string (SQL injection).
+const escapeLiteral = (value: string) =>
+	value.replace(/\\/g, "\\\\").replace(/'/g, "''");
 const formatDate = (date: Date) => date.toISOString().slice(0, 10);
 const formatDateTime = (date: Date) =>
 	date.toISOString().slice(0, 19).replace("T", " ");

--- a/apps/web/app/(org)/dashboard/analytics/data.ts
+++ b/apps/web/app/(org)/dashboard/analytics/data.ts
@@ -47,7 +47,11 @@ const ROLLING_RANGE_CONFIG: Record<
 
 const LIFETIME_FALLBACK_DAYS = 30;
 
-const escapeLiteral = (value: string) => value.replace(/'/g, "''");
+// Escape backslashes BEFORE quotes: ClickHouse honors C-style `\'` inside
+// single-quoted literals, so doubling quotes alone lets a trailing backslash
+// neutralise the doubled quote and break out of the string (SQL injection).
+const escapeLiteral = (value: string) =>
+	value.replace(/\\/g, "\\\\").replace(/'/g, "''");
 const toDateString = (date: Date) => date.toISOString().slice(0, 10);
 const toDateTimeString = (date: Date) =>
 	date.toISOString().slice(0, 19).replace("T", " ");


### PR DESCRIPTION
Escapes backslashes (not just single quotes) when interpolating values into the ClickHouse/Tinybird analytics queries, closing a SQL injection through the analytics video/cap id parameters.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a SQL injection vulnerability in ClickHouse/Tinybird analytics queries by escaping backslashes before single quotes in the `escapeLiteral` helper. The previous implementation only doubled single quotes, which allowed a trailing backslash in attacker-controlled input (video/cap IDs, org IDs) to neutralise the doubled quote and break out of the string literal.

- Both `get-analytics.ts` and `data.ts` receive the identical one-line fix (`replace(/\\\\/g, \"\\\\\\\\")` applied before the quote doubling), and all 14+ interpolation sites in `data.ts` already route through `escapeLiteral`, so coverage is complete.
- The ordering of the two replacements (backslash first, then quote) is correct and the accompanying comment clearly documents why the sequence matters.

<h3>Confidence Score: 5/5</h3>

Targeted, correct security fix with no logic changes — safe to merge.

The change is a minimal, well-reasoned patch to a single escaping function replicated across two files. All dynamic values in both files already flow through escapeLiteral, the replacement order is correct (backslashes before quotes), and no other code paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/actions/videos/get-analytics.ts | Fixes SQL injection by escaping backslashes before single quotes in escapeLiteral; all dynamic values (orgId, pathname) are consistently wrapped. |
| apps/web/app/(org)/dashboard/analytics/data.ts | Same escapeLiteral hardening applied; all 14 tenant_id and pathname interpolation sites confirmed to go through the updated function. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): escape backslashes in analytic..."](https://github.com/capsoftware/cap/commit/17ff6ccf7d88948cd22f81fa0492396fff6eb7a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38614734)</sub>

<!-- /greptile_comment -->