### PR TITLE
fix(web): require canView on transcript and AI metadata endpoints

### DIFF
--- a/apps/web/actions/videos/get-available-translations.ts
+++ b/apps/web/actions/videos/get-available-translations.ts
@@ -2,10 +2,11 @@
 
 import { db } from "@cap/database";
 import { videos } from "@cap/database/schema";
-import { Storage } from "@cap/web-backend";
-import type { Video } from "@cap/web-domain";
+import { provideOptionalAuth, Storage, VideosPolicy } from "@cap/web-backend";
+import { Policy, type Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
-import { Effect } from "effect";
+import { Effect, Exit } from "effect";
+import * as EffectRuntime from "@/lib/server";
 import { runPromise } from "@/lib/server";
 import { decodeStorageVideo } from "@/lib/video-storage";
 import {
@@ -37,10 +38,24 @@ export async function getAvailableTranslations(
 		};
 	}
 
-	const query = await db()
-		.select({ video: videos })
-		.from(videos)
-		.where(eq(videos.id, videoId));
+	const exit = await Effect.gen(function* () {
+		const videosPolicy = yield* VideosPolicy;
+
+		return yield* Effect.promise(() =>
+			db().select({ video: videos }).from(videos).where(eq(videos.id, videoId)),
+		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
+	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+
+	if (Exit.isFailure(exit)) {
+		return {
+			success: false,
+			hasOriginal: false,
+			translations: [],
+			message: "Video not found",
+		};
+	}
+
+	const query = exit.value;
 
 	if (query.length === 0 || !query[0]?.video) {
 		return {

--- a/apps/web/actions/videos/get-transcript.ts
+++ b/apps/web/actions/videos/get-transcript.ts
@@ -3,10 +3,11 @@
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { videos } from "@cap/database/schema";
-import { Storage } from "@cap/web-backend";
-import type { Video } from "@cap/web-domain";
+import { provideOptionalAuth, Storage, VideosPolicy } from "@cap/web-backend";
+import { Policy, type Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
-import { Effect, Option } from "effect";
+import { Effect, Exit, Option } from "effect";
+import * as EffectRuntime from "@/lib/server";
 import { runPromise } from "@/lib/server";
 import { decodeStorageVideo } from "@/lib/video-storage";
 
@@ -22,10 +23,19 @@ export async function getTranscript(
 		};
 	}
 
-	const query = await db()
-		.select({ video: videos })
-		.from(videos)
-		.where(eq(videos.id, videoId));
+	const exit = await Effect.gen(function* () {
+		const videosPolicy = yield* VideosPolicy;
+
+		return yield* Effect.promise(() =>
+			db().select({ video: videos }).from(videos).where(eq(videos.id, videoId)),
+		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
+	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+
+	if (Exit.isFailure(exit)) {
+		return { success: false, message: "Video not found" };
+	}
+
+	const query = exit.value;
 
 	if (query.length === 0) {
 		return { success: false, message: "Video not found" };

--- a/apps/web/actions/videos/translate-transcript.ts
+++ b/apps/web/actions/videos/translate-transcript.ts
@@ -2,11 +2,13 @@
 
 import { db } from "@cap/database";
 import { videos } from "@cap/database/schema";
-import { Storage } from "@cap/web-backend";
-import type { Video } from "@cap/web-domain";
+import { provideOptionalAuth, Storage, VideosPolicy } from "@cap/web-backend";
+import { Policy, type Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
-import { Effect, Option } from "effect";
+import { Effect, Exit, Option } from "effect";
 import { GROQ_MODEL, getGroqClient } from "@/lib/groq-client";
+import { isRateLimited, RATE_LIMIT_IDS } from "@/lib/rate-limit";
+import * as EffectRuntime from "@/lib/server";
 import { runPromise } from "@/lib/server";
 import { decodeStorageVideo } from "@/lib/video-storage";
 import {
@@ -46,10 +48,23 @@ export async function translateTranscript(
 		};
 	}
 
-	const query = await db()
-		.select({ video: videos })
-		.from(videos)
-		.where(eq(videos.id, videoId));
+	if (await isRateLimited(RATE_LIMIT_IDS.TRANSLATE_TRANSCRIPT)) {
+		return { success: false, message: "Too many requests" };
+	}
+
+	const exit = await Effect.gen(function* () {
+		const videosPolicy = yield* VideosPolicy;
+
+		return yield* Effect.promise(() =>
+			db().select({ video: videos }).from(videos).where(eq(videos.id, videoId)),
+		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
+	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+
+	if (Exit.isFailure(exit)) {
+		return { success: false, message: "Video not found" };
+	}
+
+	const query = exit.value;
 
 	if (query.length === 0 || !query[0]?.video) {
 		return { success: false, message: "Video not found" };

--- a/apps/web/app/api/video/ai/route.ts
+++ b/apps/web/app/api/video/ai/route.ts
@@ -2,10 +2,13 @@ import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { users, videos } from "@cap/database/schema";
 import type { VideoMetadata } from "@cap/database/types";
-import type { Video } from "@cap/web-domain";
+import { provideOptionalAuth, VideosPolicy } from "@cap/web-backend";
+import { Policy, type Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
+import { Effect, Exit } from "effect";
 import type { NextRequest } from "next/server";
 import { startAiGeneration } from "@/lib/generate-ai";
+import * as EffectRuntime from "@/lib/server";
 import { isAiGenerationEnabled } from "@/utils/flags";
 
 export const dynamic = "force-dynamic";
@@ -27,10 +30,22 @@ export async function GET(request: NextRequest) {
 			);
 		}
 
-		const result = await db()
-			.select()
-			.from(videos)
-			.where(eq(videos.id, videoId));
+		const exit = await Effect.gen(function* () {
+			const videosPolicy = yield* VideosPolicy;
+
+			return yield* Effect.promise(() =>
+				db().select().from(videos).where(eq(videos.id, videoId)),
+			).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
+		}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+
+		if (Exit.isFailure(exit)) {
+			return Response.json(
+				{ error: true, message: "Video not found" },
+				{ status: 404 },
+			);
+		}
+
+		const result = exit.value;
 		if (result.length === 0 || !result[0]) {
 			return Response.json(
 				{ error: true, message: "Video not found" },

--- a/apps/web/lib/rate-limit.ts
+++ b/apps/web/lib/rate-limit.ts
@@ -1,0 +1,76 @@
+import { checkRateLimit } from "@vercel/firewall";
+import { headers as nextHeaders } from "next/headers";
+
+/**
+ * Best-effort per-key rate limiting backed by the Vercel Firewall.
+ *
+ * IMPORTANT: each `ruleId` passed here must also be configured as a Rate Limit
+ * rule in the Vercel Firewall dashboard (Firewall → Rate Limiting) with a
+ * `@vercel/firewall` rule condition whose ID matches `ruleId`, plus the desired
+ * window / limit / action. An ID that has no matching dashboard rule fails
+ * OPEN (`checkRateLimit` returns `{ rateLimited: false, error: "not-found" }`),
+ * so this helper never breaks self-hosted deploys that lack the firewall — but
+ * it also provides no protection until the rule exists.
+ *
+ * Mirrors the existing pattern in `actions/collections/password.ts` and
+ * `actions/send-download-link.ts`:
+ *  - only enforced in production,
+ *  - best-effort (any error → not limited) so a firewall/IP-header outage can
+ *    never take down the underlying feature.
+ *
+ * @param ruleId   Stable rule id, also configured in the Vercel Firewall.
+ * @param opts.key Optional bucket key (e.g. per-email / per-user). Defaults to
+ *                 the caller IP (the firewall's default behaviour).
+ * @param opts.headers Optional request headers (required inside Hono handlers
+ *                 where `next/headers` is unavailable; defaults to the App
+ *                 Router request headers).
+ * @returns `true` when the request should be rejected.
+ */
+export async function isRateLimited(
+	ruleId: string,
+	opts?: { key?: string; headers?: Headers },
+): Promise<boolean> {
+	if (process.env.NODE_ENV !== "production") return false;
+
+	try {
+		const headersList = opts?.headers ?? (await nextHeaders());
+		const request = new Request("https://cap.so/api/rate-limit", {
+			method: "POST",
+			headers: headersList,
+		});
+
+		const { rateLimited } = await checkRateLimit(ruleId, {
+			request,
+			...(opts?.key ? { rateLimitKey: opts.key } : {}),
+		});
+
+		return rateLimited;
+	} catch (error) {
+		console.warn(`Rate limit check failed for "${ruleId}":`, error);
+		return false;
+	}
+}
+
+/**
+ * Canonical Vercel Firewall rate-limit rule ids introduced by the security
+ * hardening pass. Each MUST be created in the Vercel Firewall dashboard for the
+ * corresponding protection to take effect (see `isRateLimited`).
+ */
+export const RATE_LIMIT_IDS = {
+	/** Email OTP verification attempts (brute-force guard). Suggested: 10 / 10m per key (email). */
+	AUTH_OTP_VERIFY: "rl_auth_otp_verify",
+	/** Email OTP / magic-link send (mailbomb + token-reseed guard). Suggested: 5 / 10m per key (email). */
+	AUTH_OTP_SEND: "rl_auth_otp_send",
+	/** Unauthed Loom download/convert (ffmpeg + memory DoS). Suggested: 10 / 1m per IP. */
+	LOOM_DOWNLOAD: "rl_loom_download",
+	/** Unauthed transcript translation (Groq cost). Suggested: 10 / 1m per IP. */
+	TRANSLATE_TRANSCRIPT: "rl_translate_transcript",
+	/** Anonymous support-chat messages (Groq + Supermemory cost). Suggested: 20 / 1m per IP. */
+	MESSENGER_MESSAGE: "rl_messenger_message",
+	/** Unauthed analytics view tracking (Tinybird ingest + notifications). Suggested: 60 / 1m per IP. */
+	ANALYTICS_TRACK: "rl_analytics_track",
+	/** Unauthed guest checkout (Stripe object/cost abuse). Suggested: 10 / 10m per IP. */
+	GUEST_CHECKOUT: "rl_guest_checkout",
+	/** Unauthed desktop log → Discord forwarding (spam). Suggested: 10 / 1m per IP. */
+	DESKTOP_LOGS: "rl_desktop_logs",
+} as const;


### PR DESCRIPTION
Gates the transcript, translate-transcript, available-translations and AI-metadata endpoints behind the same canView policy used elsewhere, so private and password-protected videos' content is no longer readable by unauthorized callers. Also rate-limits the translation endpoint.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes an authorization gap by wrapping the transcript, translate-transcript, available-translations, and AI-metadata endpoints in the same `canView` policy already used elsewhere, and adds Vercel Firewall rate limiting to the translation endpoint.

- All four endpoints now use `Policy.withPublicPolicy(videosPolicy.canView(videoId))` via `provideOptionalAuth`; policy failures and not-found cases both return the same opaque message to avoid leaking video existence for private/password-protected content.
- `apps/web/lib/rate-limit.ts` introduces a shared `isRateLimited` helper backed by `@vercel/firewall`; it is best-effort (fails open on error) and no-ops outside production, matching the pattern already established in `actions/collections/password.ts`.
- The `RATE_LIMIT_IDS` constants beyond `TRANSLATE_TRANSCRIPT` are placeholders for future rules; only the translation endpoint is wired in this PR.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change only adds access-control gates and a rate-limit check; existing authorized callers are unaffected.

The authorization fix is applied consistently across all four endpoints using the same well-established pattern. The rate-limit helper is best-effort (fails open), so there is no availability risk. No logic regressions were found in the happy paths.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/actions/videos/get-transcript.ts | Adds canView policy gate via withPublicPolicy before the video DB fetch; access-denied and not-found cases both surface as the same "Video not found" response (information-safe). |
| apps/web/actions/videos/get-available-translations.ts | Applies the same canView-gated Effect pattern; storage listing remains inside the try/catch so policy failures are cleanly separated from storage errors. |
| apps/web/actions/videos/translate-transcript.ts | Adds both rate limiting (Vercel Firewall, IP-based) and canView policy before the expensive Groq translation path; ordering is correct (fast-reject first). |
| apps/web/app/api/video/ai/route.ts | Adds canView policy on top of the existing auth guard; previously any authenticated user could read AI metadata for any video by ID — now restricted to users with view permission. |
| apps/web/lib/rate-limit.ts | New shared Vercel Firewall rate-limit helper; best-effort (fails open), production-only, well-documented. Only TRANSLATE_TRANSCRIPT is wired up in this PR; the other IDs are reserved constants for future use. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/actions/videos/get-transcript.ts`, line 17 ([link](https://github.com/capsoftware/cap/blob/ce6d478d2e2409b9502a8af4241df66e765aece1/apps/web/actions/videos/get-transcript.ts#L17)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Redundant session lookup alongside `provideOptionalAuth`**

   `getCurrentUser()` is called here and the resulting `user` is stored, but the only thing it feeds downstream is the error-log field `userId: user?.id` on line 82. The actual access-control decision is now made by `provideOptionalAuth` inside the Effect pipeline, which performs its own independent session read. Every call to `getTranscript` therefore hits the session store twice. The `user` variable could be removed; the logging could rely on the `ownerId` already present on the `video` object, or `provideOptionalAuth` could be made to surface the resolved user if needed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/actions/videos/get-transcript.ts
   Line: 17

   Comment:
   **Redundant session lookup alongside `provideOptionalAuth`**

   `getCurrentUser()` is called here and the resulting `user` is stored, but the only thing it feeds downstream is the error-log field `userId: user?.id` on line 82. The actual access-control decision is now made by `provideOptionalAuth` inside the Effect pipeline, which performs its own independent session read. Every call to `getTranscript` therefore hits the session store twice. The `user` variable could be removed; the logging could rely on the `ownerId` already present on the `video` object, or `provideOptionalAuth` could be made to surface the resolved user if needed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(web): require canView on transcript ..."](https://github.com/capsoftware/cap/commit/ce6d478d2e2409b9502a8af4241df66e765aece1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38614746)</sub>

<!-- /greptile_comment -->