### PR TITLE
fix(web): gate thumbnail and view-count endpoints and tighten CORS

### DIFF
--- a/apps/web/app/api/analytics/route.ts
+++ b/apps/web/app/api/analytics/route.ts
@@ -1,5 +1,12 @@
+import { db } from "@cap/database";
+import { videos } from "@cap/database/schema";
+import { provideOptionalAuth, VideosPolicy } from "@cap/web-backend";
+import { Policy, Video } from "@cap/web-domain";
+import { eq } from "drizzle-orm";
+import { Effect, Exit } from "effect";
 import type { NextRequest } from "next/server";
 import { getVideoAnalytics } from "@/actions/videos/get-analytics";
+import * as EffectRuntime from "@/lib/server";
 
 const parseRangeParam = (value: string | null) => {
 	if (!value) return undefined;
@@ -24,6 +31,22 @@ export async function GET(request: NextRequest) {
 
 	if (!videoId) {
 		return Response.json({ error: "Video ID is required" }, { status: 400 });
+	}
+
+	const id = Video.VideoId.make(videoId);
+
+	// Gate on canView so view counts of private / password-protected videos are
+	// not disclosed to unauthorized callers. Public videos, owners, org/space
+	// members and password-protected videos with a valid cookie still pass.
+	const exit = await Effect.gen(function* () {
+		const videosPolicy = yield* VideosPolicy;
+		return yield* Effect.promise(() =>
+			db().select({ id: videos.id }).from(videos).where(eq(videos.id, id)),
+		).pipe(Policy.withPublicPolicy(videosPolicy.canView(id)));
+	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+
+	if (Exit.isFailure(exit) || !exit.value[0]) {
+		return Response.json({ error: "Video not found" }, { status: 404 });
 	}
 
 	try {

--- a/apps/web/app/api/thumbnail/route.ts
+++ b/apps/web/app/api/thumbnail/route.ts
@@ -1,9 +1,11 @@
 import { db } from "@cap/database";
 import { videos } from "@cap/database/schema";
-import { Storage } from "@cap/web-backend";
-import { Video } from "@cap/web-domain";
+import { provideOptionalAuth, Storage, VideosPolicy } from "@cap/web-backend";
+import { Policy, Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
+import { Effect, Exit } from "effect";
 import type { NextRequest } from "next/server";
+import * as EffectRuntime from "@/lib/server";
 import { runPromise } from "@/lib/server";
 import { decodeStorageVideo } from "@/lib/video-storage";
 import { getHeaders } from "@/utils/helpers";
@@ -25,10 +27,28 @@ export async function GET(request: NextRequest) {
 			},
 		);
 
-	const [query] = await db()
-		.select()
-		.from(videos)
-		.where(eq(videos.id, Video.VideoId.make(videoId)));
+	const id = Video.VideoId.make(videoId);
+
+	// Gate on canView so private / password-protected videos' thumbnails are not
+	// exposed to unauthorized callers (owner, org/space members, public videos
+	// and password-protected videos with a valid cookie still pass).
+	const exit = await Effect.gen(function* () {
+		const videosPolicy = yield* VideosPolicy;
+		return yield* Effect.promise(() =>
+			db().select().from(videos).where(eq(videos.id, id)),
+		).pipe(Policy.withPublicPolicy(videosPolicy.canView(id)));
+	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+
+	if (Exit.isFailure(exit))
+		return new Response(
+			JSON.stringify({ error: true, message: "Video not found" }),
+			{
+				status: 404,
+				headers: getHeaders(origin),
+			},
+		);
+
+	const [query] = exit.value;
 
 	if (!query)
 		return new Response(

--- a/apps/web/utils/helpers.ts
+++ b/apps/web/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { buildEnv } from "@cap/env";
+import { buildEnv, serverEnv } from "@cap/env";
 import { type ClassValue, clsx } from "clsx";
 import type { ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
 import type { NextRequest } from "next/server";
@@ -15,11 +15,44 @@ export const allowedOrigins = [
 	"cap.link",
 ];
 
-export function getHeaders(origin: string | null) {
-	// Allow "*" for custom domains or allowedOrigins for main domains
+// Origins that are trusted to make credentialed (cookie-bearing) cross-origin
+// reads. Only these may receive `Access-Control-Allow-Credentials: true` with a
+// reflected origin. Any other origin gets a wildcard, credential-less response
+// so a malicious site cannot read authenticated responses cross-origin.
+function isTrustedCredentialedOrigin(origin: string) {
+	let host: string;
+	try {
+		host = new URL(origin).hostname;
+	} catch {
+		return false;
+	}
+
+	if (host === "localhost" || host === "cap.so" || host === "cap.link")
+		return true;
+	if (host.endsWith(".cap.so")) return true;
+
+	try {
+		if (host === new URL(serverEnv().WEB_URL).hostname) return true;
+	} catch {}
+
+	return false;
+}
+
+export function getHeaders(origin: string | null): Record<string, string> {
+	// Only reflect the specific origin + allow credentials for trusted origins.
+	// Everyone else gets a wildcard with NO credentials so authenticated
+	// responses can't be read cross-origin (credential-read CSRF).
+	if (origin && isTrustedCredentialedOrigin(origin)) {
+		return {
+			"Access-Control-Allow-Origin": origin,
+			"Access-Control-Allow-Credentials": "true",
+			"Access-Control-Allow-Methods": "GET, OPTIONS",
+			"Access-Control-Allow-Headers": "Content-Type, Authorization",
+		};
+	}
+
 	return {
-		"Access-Control-Allow-Origin": origin || "*",
-		"Access-Control-Allow-Credentials": "true",
+		"Access-Control-Allow-Origin": "*",
 		"Access-Control-Allow-Methods": "GET, OPTIONS",
 		"Access-Control-Allow-Headers": "Content-Type, Authorization",
 	};


### PR DESCRIPTION
Adds canView gating to the thumbnail and view-count endpoints so private videos are not exposed, and limits CORS credentials to trusted origins instead of reflecting any origin.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes two related security gaps: private video thumbnails and view-counts were readable by any caller, and the CORS layer was reflecting any `Origin` header back with `Access-Control-Allow-Credentials: true`, enabling credential-read CSRF from arbitrary origins.

- **Auth gating**: both `/api/thumbnail` and `/api/analytics` now run `canView` through the `VideosPolicy` effect before touching any video data; private, password-protected, and non-existent videos return 404 to unauthorized callers.
- **CORS hardening**: `getHeaders` now only sets `Access-Control-Allow-Origin: <origin>` + `credentials: true` for origins that pass `isTrustedCredentialedOrigin` (localhost, `cap.so`, `cap.link`, their subdomains, and the configured `WEB_URL`); all other origins receive the wildcard header without credentials.

<h3>Confidence Score: 5/5</h3>

Both security fixes are correctly implemented and the existing error-handling paths are preserved; safe to merge.

The CORS credential fix and policy gating are both logically sound. The `withPublicPolicy` pre-check runs before the DB query so access is denied before any data is fetched. The `Exit.isFailure` + empty-result guard in both routes covers all failure modes. No regressions introduced to existing public-video or authenticated-user flows.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/utils/helpers.ts | Adds isTrustedCredentialedOrigin to gate credentials-bearing CORS responses to known origins; fixes the previous bug of reflecting any caller's origin with Allow-Credentials: true |
| apps/web/app/api/thumbnail/route.ts | Adds canView policy gate before serving thumbnail URLs; correct use of Exit.isFailure + empty-result check, though the policy itself issues a second DB query after canView's own repo.getById call |
| apps/web/app/api/analytics/route.ts | Adds canView policy gate before returning view-count data; 404 responses omit CORS headers (consistent with pre-existing behavior for this endpoint) |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/utils/helpers.ts:30-32
`.cap.link` subdomains are not covered by the trusted-origin check, while `.cap.so` subdomains are. If any `*.cap.link` host needs to make credentialed requests (e.g., a future `share.cap.link` embed), it would silently fall through to the wildcard/no-credentials path. Either add the parallel subdomain check or document the intentional asymmetry.

```suggestion
	if (host === "localhost" || host === "cap.so" || host === "cap.link")
		return true;
	if (host.endsWith(".cap.so") || host.endsWith(".cap.link")) return true;
```

### Issue 2 of 2
apps/web/app/api/thumbnail/route.ts:35-40
**Double DB round-trip per request**

`videosPolicy.canView(id)` internally calls `repo.getById(videoId)` to evaluate visibility/ownership (see `buildCanView` in `VideosPolicy.ts`), and then the `Effect.promise` here issues a second `SELECT * FROM videos` for the same row. For the thumbnail route the second query returns the full record (needed for `decodeStorageVideo`), so it can't easily be eliminated — but it's worth being aware that every thumbnail request now hits the DB twice. The analytics route only selects `{ id }` on the second pass so the redundancy there is even more pronounced.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): gate thumbnail and view-count ..."](https://github.com/capsoftware/cap/commit/2a624e0f24339150fd327147161eaf973c0ae85e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38614756)</sub>

<!-- /greptile_comment -->