### PR TITLE
fix(web): add ownership checks to folder, space and org video actions

### DIFF
--- a/apps/web/actions/folders/add-videos.ts
+++ b/apps/web/actions/folders/add-videos.ts
@@ -12,6 +12,7 @@ import {
 import type { Folder, Space, Video } from "@cap/web-domain";
 import { and, eq, inArray } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import { getSpaceAccess } from "@/actions/organization/space-authorization";
 
 export async function addVideosToFolder(
 	folderId: Folder.FolderId,
@@ -30,12 +31,30 @@ export async function addVideosToFolder(
 		}
 
 		const [folder] = await db()
-			.select({ id: folders.id, spaceId: folders.spaceId })
+			.select({
+				id: folders.id,
+				spaceId: folders.spaceId,
+				createdById: folders.createdById,
+			})
 			.from(folders)
 			.where(eq(folders.id, folderId));
 
 		if (!folder) {
 			throw new Error("Folder not found");
+		}
+
+		// Verify the caller can edit the destination folder. Mirrors
+		// FoldersPolicy.canEdit: personal folders (no space) are creator-only,
+		// space folders require space-admin or org admin/owner access.
+		if (folder.spaceId === null) {
+			if (folder.createdById !== user.id) {
+				throw new Error("You don't have permission to manage this folder");
+			}
+		} else {
+			const access = await getSpaceAccess(user.id, folder.spaceId);
+			if (!access?.canManage) {
+				throw new Error("You don't have permission to manage this folder");
+			}
 		}
 
 		const userVideos = await db()

--- a/apps/web/actions/folders/add-videos.ts
+++ b/apps/web/actions/folders/add-videos.ts
@@ -48,12 +48,12 @@ export async function addVideosToFolder(
 		// space folders require space-admin or org admin/owner access.
 		if (folder.spaceId === null) {
 			if (folder.createdById !== user.id) {
-				throw new Error("You don't have permission to manage this folder");
+				throw new Error("Folder not found");
 			}
 		} else {
 			const access = await getSpaceAccess(user.id, folder.spaceId);
 			if (!access?.canManage) {
-				throw new Error("You don't have permission to manage this folder");
+				throw new Error("Folder not found");
 			}
 		}
 

--- a/apps/web/actions/folders/get-folder-videos.ts
+++ b/apps/web/actions/folders/get-folder-videos.ts
@@ -2,9 +2,11 @@
 
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
-import { sharedVideos, spaceVideos } from "@cap/database/schema";
+import { folders, sharedVideos, spaceVideos } from "@cap/database/schema";
 import type { Folder, Space, Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
+import { getOrganizationAccess } from "@/actions/organization/authorization";
+import { getSpaceAccess } from "@/actions/organization/space-authorization";
 
 export async function getFolderVideoIds(
 	folderId: Folder.FolderId,
@@ -19,6 +21,41 @@ export async function getFolderVideoIds(
 
 		if (!folderId) {
 			throw new Error("Folder ID is required");
+		}
+
+		// Ensure the caller can see this folder before disclosing its contents.
+		const [folder] = await db()
+			.select({
+				spaceId: folders.spaceId,
+				organizationId: folders.organizationId,
+				createdById: folders.createdById,
+			})
+			.from(folders)
+			.where(eq(folders.id, folderId));
+
+		if (!folder) {
+			throw new Error("Folder not found");
+		}
+
+		if (folder.spaceId === null) {
+			const access = await getOrganizationAccess(
+				user.id,
+				folder.organizationId,
+			);
+			if (!access && folder.createdById !== user.id) {
+				throw new Error("Folder not found");
+			}
+		} else {
+			// getSpaceAccess returns a non-null object even for non-members (with
+			// both roles null), so a bare `!access` check would NOT block them.
+			// Require an actual org or space role to view the folder's contents.
+			const access = await getSpaceAccess(user.id, folder.spaceId);
+			if (
+				!access ||
+				(access.organizationRole === null && access.spaceRole === null)
+			) {
+				throw new Error("Folder not found");
+			}
 		}
 
 		const isAllSpacesEntry = user.activeOrganizationId === spaceId;

--- a/apps/web/actions/folders/get-folder-videos.ts
+++ b/apps/web/actions/folders/get-folder-videos.ts
@@ -5,7 +5,6 @@ import { getCurrentUser } from "@cap/database/auth/session";
 import { folders, sharedVideos, spaceVideos } from "@cap/database/schema";
 import type { Folder, Space, Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
-import { getOrganizationAccess } from "@/actions/organization/authorization";
 import { getSpaceAccess } from "@/actions/organization/space-authorization";
 
 export async function getFolderVideoIds(
@@ -38,11 +37,10 @@ export async function getFolderVideoIds(
 		}
 
 		if (folder.spaceId === null) {
-			const access = await getOrganizationAccess(
-				user.id,
-				folder.organizationId,
-			);
-			if (!access && folder.createdById !== user.id) {
+			// Personal folders are creator-only (mirrors FoldersPolicy.canEdit and
+			// add-videos.ts); org membership must NOT grant access to another user's
+			// personal folder.
+			if (folder.createdById !== user.id) {
 				throw new Error("Folder not found");
 			}
 		} else {

--- a/apps/web/actions/folders/moveVideoToFolder.ts
+++ b/apps/web/actions/folders/moveVideoToFolder.ts
@@ -39,10 +39,18 @@ export async function moveVideoToFolder({
 
 	const isAllSpacesEntry = spaceId === user.activeOrganizationId;
 
-	// If folderId is provided, verify it exists and belongs to the same organization
+	// If a destination folder is provided, load it once (scoped to the caller's
+	// org) so each branch can also verify the caller may WRITE to that specific
+	// folder — not just that the source space/folder is manageable.
+	let destinationFolder:
+		| { spaceId: string | null; createdById: string }
+		| undefined;
 	if (folderId) {
-		const [folder] = await db()
-			.select()
+		[destinationFolder] = await db()
+			.select({
+				spaceId: folders.spaceId,
+				createdById: folders.createdById,
+			})
 			.from(folders)
 			.where(
 				and(
@@ -51,7 +59,7 @@ export async function moveVideoToFolder({
 				),
 			);
 
-		if (!folder) {
+		if (!destinationFolder) {
 			throw new Error("Folder not found or not accessible");
 		}
 	}
@@ -60,6 +68,11 @@ export async function moveVideoToFolder({
 		const access = await getSpaceAccess(user.id, spaceId);
 		if (!access?.canManage) {
 			throw new Error("You don't have permission to manage this space");
+		}
+
+		// The destination folder must belong to the same space being managed.
+		if (destinationFolder && destinationFolder.spaceId !== spaceId) {
+			throw new Error("Folder not found or not accessible");
 		}
 
 		await db()
@@ -76,6 +89,11 @@ export async function moveVideoToFolder({
 			user.activeOrganizationId,
 		);
 
+		// The destination must be an org-level (non-space) folder.
+		if (destinationFolder && destinationFolder.spaceId !== null) {
+			throw new Error("Folder not found or not accessible");
+		}
+
 		await db()
 			.update(sharedVideos)
 			.set({
@@ -88,6 +106,15 @@ export async function moveVideoToFolder({
 				),
 			);
 	} else {
+		// Personal move: the destination must be the caller's own personal folder.
+		if (
+			destinationFolder &&
+			(destinationFolder.spaceId !== null ||
+				destinationFolder.createdById !== user.id)
+		) {
+			throw new Error("Folder not found or not accessible");
+		}
+
 		await db()
 			.update(videos)
 			.set({

--- a/apps/web/actions/folders/moveVideoToFolder.ts
+++ b/apps/web/actions/folders/moveVideoToFolder.ts
@@ -13,6 +13,7 @@ import { and, eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { requireOrganizationSettingsManager } from "@/actions/organization/authorization";
 import { getSpaceAccess } from "@/actions/organization/space-authorization";
+
 export async function moveVideoToFolder({
 	videoId,
 	folderId,

--- a/apps/web/actions/folders/moveVideoToFolder.ts
+++ b/apps/web/actions/folders/moveVideoToFolder.ts
@@ -11,6 +11,8 @@ import {
 import type { Folder, Space, Video } from "@cap/web-domain";
 import { and, eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
+import { requireOrganizationSettingsManager } from "@/actions/organization/authorization";
+import { getSpaceAccess } from "@/actions/organization/space-authorization";
 export async function moveVideoToFolder({
 	videoId,
 	folderId,
@@ -54,6 +56,11 @@ export async function moveVideoToFolder({
 	}
 
 	if (spaceId && !isAllSpacesEntry) {
+		const access = await getSpaceAccess(user.id, spaceId);
+		if (!access?.canManage) {
+			throw new Error("You don't have permission to manage this space");
+		}
+
 		await db()
 			.update(spaceVideos)
 			.set({
@@ -63,6 +70,11 @@ export async function moveVideoToFolder({
 				and(eq(spaceVideos.videoId, videoId), eq(spaceVideos.spaceId, spaceId)),
 			);
 	} else if (spaceId && isAllSpacesEntry) {
+		await requireOrganizationSettingsManager(
+			user.id,
+			user.activeOrganizationId,
+		);
+
 		await db()
 			.update(sharedVideos)
 			.set({
@@ -80,7 +92,7 @@ export async function moveVideoToFolder({
 			.set({
 				folderId: folderId === null ? null : folderId,
 			})
-			.where(eq(videos.id, videoId));
+			.where(and(eq(videos.id, videoId), eq(videos.ownerId, user.id)));
 	}
 
 	// Always revalidate the main caps page

--- a/apps/web/actions/organizations/get-organization-videos.ts
+++ b/apps/web/actions/organizations/get-organization-videos.ts
@@ -5,6 +5,7 @@ import { getCurrentUser } from "@cap/database/auth/session";
 import { sharedVideos } from "@cap/database/schema";
 import type { Organisation } from "@cap/web-domain";
 import { and, eq, isNull } from "drizzle-orm";
+import { getOrganizationAccess } from "@/actions/organization/authorization";
 
 export async function getOrganizationVideoIds(
 	organizationId: Organisation.OrganisationId,
@@ -18,6 +19,12 @@ export async function getOrganizationVideoIds(
 
 		if (!organizationId) {
 			throw new Error("Organization ID is required");
+		}
+
+		// Only members/owner of the organization may see its shared videos.
+		const access = await getOrganizationAccess(user.id, organizationId);
+		if (!access) {
+			throw new Error("Organization not found");
 		}
 
 		const videoIds = await db()

--- a/apps/web/actions/spaces/get-space-videos.ts
+++ b/apps/web/actions/spaces/get-space-videos.ts
@@ -5,6 +5,8 @@ import { getCurrentUser } from "@cap/database/auth/session";
 import { sharedVideos, spaceVideos } from "@cap/database/schema";
 import type { Space } from "@cap/web-domain";
 import { and, eq, isNull } from "drizzle-orm";
+import { getOrganizationAccess } from "@/actions/organization/authorization";
+import { getSpaceAccess } from "@/actions/organization/space-authorization";
 
 export async function getSpaceVideoIds(spaceId: Space.SpaceIdOrOrganisationId) {
 	try {
@@ -19,6 +21,25 @@ export async function getSpaceVideoIds(spaceId: Space.SpaceIdOrOrganisationId) {
 		}
 
 		const isAllSpacesEntry = user.activeOrganizationId === spaceId;
+
+		// Only members/owner of the space (or organization) may see its videos.
+		if (isAllSpacesEntry) {
+			const access = await getOrganizationAccess(user.id, spaceId);
+			if (!access) {
+				throw new Error("Space not found");
+			}
+		} else {
+			// getSpaceAccess returns a non-null object even for non-members (with
+			// both roles null), so a bare `!access` check would NOT block them.
+			// Require an actual org or space role to view the space's videos.
+			const access = await getSpaceAccess(user.id, spaceId);
+			if (
+				!access ||
+				(access.organizationRole === null && access.spaceRole === null)
+			) {
+				throw new Error("Space not found");
+			}
+		}
 
 		const videoIds = isAllSpacesEntry
 			? await db()

--- a/apps/web/app/(org)/dashboard/folder/[id]/page.tsx
+++ b/apps/web/app/(org)/dashboard/folder/[id]/page.tsx
@@ -4,6 +4,7 @@ import { makeCurrentUserLayer } from "@cap/web-backend";
 import { Folder } from "@cap/web-domain";
 import { Effect } from "effect";
 import { notFound } from "next/navigation";
+import { getOrganizationAccess } from "@/actions/organization/authorization";
 import {
 	getChildFolders,
 	getFolderBreadcrumb,
@@ -30,6 +31,24 @@ const FolderPage = async (props: PageProps<"/dashboard/folder/[id]">) => {
 
 	const user = await getCurrentUser();
 	if (!user || !user.activeOrganizationId) return notFound();
+
+	// Ensure the folder belongs to a space/org the caller can access before
+	// disclosing its contents (mirrors FoldersPolicy: personal folders are
+	// creator-only, space/org folders require org membership/ownership).
+	const folderForAccess = await getFolderById(folderId).pipe(
+		Effect.provide(makeCurrentUserLayer(user)),
+		runPromise,
+	);
+
+	if (folderForAccess.spaceId === null) {
+		if (folderForAccess.createdById !== user.id) return notFound();
+	} else {
+		const access = await getOrganizationAccess(
+			user.id,
+			folderForAccess.organizationId,
+		);
+		if (!access) return notFound();
+	}
 
 	return Effect.gen(function* () {
 		const [childFolders, breadcrumb, videosData, share] = yield* Effect.all(

--- a/apps/web/app/(org)/dashboard/folder/[id]/page.tsx
+++ b/apps/web/app/(org)/dashboard/folder/[id]/page.tsx
@@ -4,7 +4,7 @@ import { makeCurrentUserLayer } from "@cap/web-backend";
 import { Folder } from "@cap/web-domain";
 import { Effect } from "effect";
 import { notFound } from "next/navigation";
-import { getOrganizationAccess } from "@/actions/organization/authorization";
+import { getSpaceAccess } from "@/actions/organization/space-authorization";
 import {
 	getChildFolders,
 	getFolderBreadcrumb,
@@ -32,22 +32,31 @@ const FolderPage = async (props: PageProps<"/dashboard/folder/[id]">) => {
 	const user = await getCurrentUser();
 	if (!user || !user.activeOrganizationId) return notFound();
 
-	// Ensure the folder belongs to a space/org the caller can access before
+	// Ensure the folder belongs to a space the caller can access before
 	// disclosing its contents (mirrors FoldersPolicy: personal folders are
-	// creator-only, space/org folders require org membership/ownership).
+	// creator-only, space folders require space/org membership). A missing folder
+	// surfaces as notFound() rather than an unhandled 500.
 	const folderForAccess = await getFolderById(folderId).pipe(
 		Effect.provide(makeCurrentUserLayer(user)),
+		Effect.catchAll(() => Effect.succeed(null)),
 		runPromise,
 	);
+
+	if (!folderForAccess) return notFound();
 
 	if (folderForAccess.spaceId === null) {
 		if (folderForAccess.createdById !== user.id) return notFound();
 	} else {
-		const access = await getOrganizationAccess(
-			user.id,
-			folderForAccess.organizationId,
-		);
-		if (!access) return notFound();
+		// getSpaceAccess returns a non-null object even for non-members (both roles
+		// null), so check for an actual role. Using space access (not org-only)
+		// keeps legitimate space members who aren't org members from being blocked.
+		const access = await getSpaceAccess(user.id, folderForAccess.spaceId);
+		if (
+			!access ||
+			(access.organizationRole === null && access.spaceRole === null)
+		) {
+			return notFound();
+		}
 	}
 
 	return Effect.gen(function* () {


### PR DESCRIPTION
Adds ownership and membership checks to the folder, space and organization video actions so a user can only move, add to, or list videos they actually have access to.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds ownership and membership gates to six server actions and one page that previously disclosed or mutated video/folder data without verifying whether the caller actually had access. The approach — creator-only for personal folders, role-check via `getSpaceAccess`/`getOrganizationAccess` for space/org-backed folders — is consistent across all changed files and correctly mirrors the policy in `FoldersPolicy`.

- `moveVideoToFolder.ts` correctly scopes the destination-folder lookup to `user.activeOrganizationId` and adds `eq(videos.ownerId, user.id)` to the personal-move UPDATE.
- `get-organization-videos.ts` and `get-space-videos.ts` add the expected membership guards and correctly distinguish the all-spaces (org-ID) case from a real space ID.
- `add-videos.ts` and `get-folder-videos.ts` introduce new folder lookups but omit `eq(folders.organizationId, user.activeOrganizationId)` from the WHERE clause, unlike the equivalent lookup in `moveVideoToFolder.ts` — leaving a cross-org boundary gap.

<h3>Confidence Score: 4/5</h3>

Mostly safe, but two of the six changed files have a cross-org boundary gap in their new folder lookups that should be patched before merging.

The folder lookups added in `add-videos.ts` and `get-folder-videos.ts` do not constrain the query to `user.activeOrganizationId`, unlike the equivalent lookup in `moveVideoToFolder.ts` in the same PR. A user who created or has manage access to a folder in another organisation can pass that foreign folder ID, pass the ownership/role check, and either probe cross-org folder existence or insert `sharedVideos`/`spaceVideos` rows in the current org that reference a foreign folder's primary key.

apps/web/actions/folders/add-videos.ts and apps/web/actions/folders/get-folder-videos.ts — both need `eq(folders.organizationId, user.activeOrganizationId)` added to their new folder WHERE clauses.

<details open><summary><h3>Security Review</h3></summary>

- **Cross-org folder ID targeting (`add-videos.ts`, `get-folder-videos.ts`)**: Both new folder lookups are missing `eq(folders.organizationId, user.activeOrganizationId)`. A user who created (or has `canManage` access to) a folder in a different organisation can pass that foreign `folderId`, pass the ownership/role check, and either probe folder existence across org boundaries (`get-folder-videos.ts`) or write `sharedVideos`/`spaceVideos` rows for the current org that carry a cross-org `folderId` FK (`add-videos.ts`). `moveVideoToFolder.ts` in the same PR correctly scopes its lookup with the org constraint.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/actions/folders/add-videos.ts | Adds folder ownership gate, but folder lookup lacks org scope — a user who created a folder in another org can target it cross-org, producing corrupt FK references in sharedVideos/spaceVideos. |
| apps/web/actions/folders/get-folder-videos.ts | Adds pre-check before disclosing folder contents, but the folder lookup is also unscoped to the caller's org, enabling cross-org folder probing via a valid folderId from another organization. |
| apps/web/actions/folders/moveVideoToFolder.ts | Correctly adds space/org permission checks per branch and adds ownerId guard to the personal-move UPDATE; destination folder lookup is properly scoped to user.activeOrganizationId. |
| apps/web/actions/organizations/get-organization-videos.ts | Adds getOrganizationAccess membership check before listing org videos; straightforward and correct. |
| apps/web/actions/spaces/get-space-videos.ts | Correctly routes to getOrganizationAccess for the all-spaces (org-ID) case and getSpaceAccess with a role-presence guard for actual space IDs. |
| apps/web/app/(org)/dashboard/folder/[id]/page.tsx | Pre-flight access check correctly uses Effect.catchAll to surface missing folders as notFound() instead of a 500; mirrors the access policy used in the server actions. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/actions/folders/add-videos.ts:33-40
The folder lookup is not scoped to `user.activeOrganizationId`. In `moveVideoToFolder.ts` the equivalent query correctly adds `eq(folders.organizationId, user.activeOrganizationId)` to the WHERE clause. Without it, a caller who created a personal folder in a different organisation (or holds `canManage` over a space in another org) can pass that foreign `folderId`, pass the ownership check, and the subsequent inserts will write `sharedVideos`/`spaceVideos` rows for the current org that carry a `folderId` pointing to another org's folder — corrupting cross-org FK references.

```suggestion
		const [folder] = await db()
			.select({
				id: folders.id,
				spaceId: folders.spaceId,
				createdById: folders.createdById,
			})
			.from(folders)
			.where(
				and(
					eq(folders.id, folderId),
					eq(folders.organizationId, user.activeOrganizationId),
				),
			);
```

### Issue 2 of 2
apps/web/actions/folders/get-folder-videos.ts:25-33
Same org-scoping omission as `add-videos.ts`. The folder lookup here is also missing `eq(folders.organizationId, ...)`. Without it, a user who owns (or has space access to) a folder in another organisation can probe whether any given UUID is a valid folder across the entire system, and the access-check logic will evaluate the foreign folder's `spaceId`/`createdById` instead of rejecting it outright. Adding the org constraint is the consistent fix mirroring `moveVideoToFolder.ts`.

```suggestion
		// Ensure the caller can see this folder before disclosing its contents.
		const [folder] = await db()
			.select({
				spaceId: folders.spaceId,
				organizationId: folders.organizationId,
				createdById: folders.createdById,
			})
			.from(folders)
			.where(
				and(
					eq(folders.id, folderId),
					eq(folders.organizationId, user.activeOrganizationId),
				),
			);
```

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(web): validate destination folder ma..."](https://github.com/capsoftware/cap/commit/a27d0ccbcc46ac381b84af87cb34ae94e7e33cb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38614765)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->