### PR TITLE
fix(web): rate-limit expensive endpoints and stop analytics tenant spoofing

### DIFF
--- a/apps/web/actions/loom.ts
+++ b/apps/web/actions/loom.ts
@@ -32,6 +32,7 @@ import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { start } from "workflow/api";
 import { requireOrganizationAccess } from "@/actions/organization/authorization";
+import { isRateLimited, RATE_LIMIT_IDS } from "@/lib/rate-limit";
 import { runPromise } from "@/lib/server";
 import { importLoomVideoWorkflow } from "@/workflows/import-loom-video";
 
@@ -254,6 +255,13 @@ export async function downloadLoomVideo(
 			success: false,
 			error:
 				"Invalid Loom URL. Please paste a valid Loom video link (e.g. https://www.loom.com/share/abc123).",
+		};
+	}
+
+	if (await isRateLimited(RATE_LIMIT_IDS.LOOM_DOWNLOAD)) {
+		return {
+			success: false,
+			error: "Too many requests. Please wait a moment, then try again.",
 		};
 	}
 

--- a/apps/web/actions/messenger.ts
+++ b/apps/web/actions/messenger.ts
@@ -25,6 +25,7 @@ import {
 	storeConversationInSupermemory,
 	syncCapKnowledgeBase,
 } from "@/lib/messenger/supermemory";
+import { isRateLimited, RATE_LIMIT_IDS } from "@/lib/rate-limit";
 
 const normalizeContent = (content: string) => content.trim().slice(0, 6000);
 
@@ -212,6 +213,16 @@ export const sendMessengerUserMessage = async ({
 		}).catch(() => undefined);
 		revalidateMessengerPaths(conversationId);
 		return { mode: "human" as const };
+	}
+
+	const rateLimitSubject =
+		effectiveUserId ?? effectiveAnonymousId ?? activeAnonymousId;
+	if (
+		await isRateLimited(RATE_LIMIT_IDS.MESSENGER_MESSAGE, {
+			...(rateLimitSubject ? { key: `messenger:${rateLimitSubject}` } : {}),
+		})
+	) {
+		throw new Error("Too many messages. Please wait a moment, then try again.");
 	}
 
 	const history = await db()

--- a/apps/web/actions/messenger.ts
+++ b/apps/web/actions/messenger.ts
@@ -175,6 +175,22 @@ export const sendMessengerUserMessage = async ({
 		throw new Error("Unauthorized");
 	}
 
+	// Rate-limit BEFORE any DB writes so a limited request can't persist a
+	// message row or advance the conversation timestamp (DB spam) — not just
+	// skip the expensive agent reply.
+	const rateLimitSubject =
+		viewer.user?.id ??
+		conversation.userId ??
+		activeAnonymousId ??
+		conversation.anonymousId;
+	if (
+		await isRateLimited(RATE_LIMIT_IDS.MESSENGER_MESSAGE, {
+			...(rateLimitSubject ? { key: `messenger:${rateLimitSubject}` } : {}),
+		})
+	) {
+		throw new Error("Too many messages. Please wait a moment, then try again.");
+	}
+
 	const now = new Date();
 
 	await db()
@@ -213,16 +229,6 @@ export const sendMessengerUserMessage = async ({
 		}).catch(() => undefined);
 		revalidateMessengerPaths(conversationId);
 		return { mode: "human" as const };
-	}
-
-	const rateLimitSubject =
-		effectiveUserId ?? effectiveAnonymousId ?? activeAnonymousId;
-	if (
-		await isRateLimited(RATE_LIMIT_IDS.MESSENGER_MESSAGE, {
-			...(rateLimitSubject ? { key: `messenger:${rateLimitSubject}` } : {}),
-		})
-	) {
-		throw new Error("Too many messages. Please wait a moment, then try again.");
 	}
 
 	const history = await db()

--- a/apps/web/app/api/analytics/track/route.ts
+++ b/apps/web/app/api/analytics/track/route.ts
@@ -153,11 +153,13 @@ export async function POST(request: NextRequest) {
 
 			// Derive the tenant strictly from the looked-up video record so a
 			// caller cannot spoof another tenant's analytics via body.orgId /
-			// body.ownerId. Uses the video's org id (what every analytics reader
-			// filters tenant_id by); falls back to host/public only when the video
-			// is unknown or not attached to an org.
+			// body.ownerId. Prefer the video's org id (what every analytics reader
+			// filters tenant_id by), then fall back to per-owner scoping, and only
+			// to host/public when the video is unknown.
 			const tenantId =
-				videoRecord?.orgId || (hostname ? `domain:${hostname}` : "public");
+				videoRecord?.orgId ??
+				videoRecord?.ownerId ??
+				(hostname ? `domain:${hostname}` : "public");
 
 			const tinybird = yield* Tinybird;
 			yield* tinybird.appendEvents([

--- a/apps/web/app/api/analytics/track/route.ts
+++ b/apps/web/app/api/analytics/track/route.ts
@@ -12,6 +12,7 @@ import {
 	createAnonymousViewNotification,
 	sendFirstViewEmail,
 } from "@/lib/Notification";
+import { isRateLimited, RATE_LIMIT_IDS } from "@/lib/rate-limit";
 import { runPromise } from "@/lib/server";
 
 interface TrackPayload {
@@ -51,6 +52,10 @@ export async function POST(request: NextRequest) {
 
 	if (!body?.videoId) {
 		return Response.json({ error: "videoId is required" }, { status: 400 });
+	}
+
+	if (await isRateLimited(RATE_LIMIT_IDS.ANALYTICS_TRACK)) {
+		return Response.json({ error: "Too many requests" }, { status: 429 });
 	}
 
 	const parsedSessionId =
@@ -108,6 +113,7 @@ export async function POST(request: NextRequest) {
 				db()
 					.select({
 						ownerId: videos.ownerId,
+						orgId: videos.orgId,
 						firstViewEmailSentAt: videos.firstViewEmailSentAt,
 						videoName: videos.name,
 						createdAt: videos.createdAt,
@@ -123,6 +129,7 @@ export async function POST(request: NextRequest) {
 					() =>
 						[] as {
 							ownerId: string;
+							orgId: string | null;
 							firstViewEmailSentAt: Date | null;
 							videoName: string;
 							createdAt: Date;
@@ -144,11 +151,13 @@ export async function POST(request: NextRequest) {
 				return;
 			}
 
+			// Derive the tenant strictly from the looked-up video record so a
+			// caller cannot spoof another tenant's analytics via body.orgId /
+			// body.ownerId. Uses the video's org id (what every analytics reader
+			// filters tenant_id by); falls back to host/public only when the video
+			// is unknown or not attached to an org.
 			const tenantId =
-				body.orgId ||
-				videoRecord?.ownerId ||
-				body.ownerId ||
-				(hostname ? `domain:${hostname}` : "public");
+				videoRecord?.orgId || (hostname ? `domain:${hostname}` : "public");
 
 			const tinybird = yield* Tinybird;
 			yield* tinybird.appendEvents([

--- a/apps/web/app/api/desktop/[...route]/root.ts
+++ b/apps/web/app/api/desktop/[...route]/root.ts
@@ -20,6 +20,7 @@ import { type Context, Hono } from "hono";
 import { PostHog } from "posthog-node";
 import type Stripe from "stripe";
 import { z } from "zod";
+import { isRateLimited, RATE_LIMIT_IDS } from "@/lib/rate-limit";
 import { runPromise } from "@/lib/server";
 import { withAuth, withOptionalAuth } from "../../utils";
 import {
@@ -335,6 +336,14 @@ app.post(
 	),
 	withOptionalAuth,
 	async (c) => {
+		if (
+			await isRateLimited(RATE_LIMIT_IDS.DESKTOP_LOGS, {
+				headers: c.req.raw.headers,
+			})
+		) {
+			return c.json({ error: "Too many requests" }, { status: 429 });
+		}
+
 		const {
 			log,
 			os,

--- a/apps/web/app/api/settings/billing/guest-checkout/route.ts
+++ b/apps/web/app/api/settings/billing/guest-checkout/route.ts
@@ -2,9 +2,18 @@ import { buildEnv, serverEnv } from "@cap/env";
 import { stripe } from "@cap/utils";
 import type { NextRequest } from "next/server";
 import { PostHog } from "posthog-node";
+import { isRateLimited, RATE_LIMIT_IDS } from "@/lib/rate-limit";
 
 export async function POST(request: NextRequest) {
 	console.log("Starting guest checkout process");
+
+	if (await isRateLimited(RATE_LIMIT_IDS.GUEST_CHECKOUT)) {
+		return Response.json(
+			{ error: "Too many requests. Please try again later." },
+			{ status: 429 },
+		);
+	}
+
 	const { priceId, quantity } = await request.json();
 
 	console.log("Received guest checkout request:", { priceId, quantity });

--- a/apps/web/app/api/tools/loom-download/route.ts
+++ b/apps/web/app/api/tools/loom-download/route.ts
@@ -4,6 +4,7 @@ import {
 	fetchConvertedVideoViaMediaServer,
 	isMediaServerConfigured,
 } from "@/lib/media-client";
+import { isRateLimited, RATE_LIMIT_IDS } from "@/lib/rate-limit";
 import { convertRemoteVideoToMp4Buffer } from "@/lib/video-convert";
 
 function isHlsUrl(url: string): boolean {
@@ -160,6 +161,13 @@ async function tryMp4CandidateDownload(
 }
 
 export async function GET(request: NextRequest) {
+	if (await isRateLimited(RATE_LIMIT_IDS.LOOM_DOWNLOAD)) {
+		return NextResponse.json(
+			{ error: "Too many requests. Please try again in a moment." },
+			{ status: 429 },
+		);
+	}
+
 	const videoId = request.nextUrl.searchParams.get("id");
 	const videoName = request.nextUrl.searchParams.get("name");
 

--- a/apps/web/lib/rate-limit.ts
+++ b/apps/web/lib/rate-limit.ts
@@ -1,0 +1,76 @@
+import { checkRateLimit } from "@vercel/firewall";
+import { headers as nextHeaders } from "next/headers";
+
+/**
+ * Best-effort per-key rate limiting backed by the Vercel Firewall.
+ *
+ * IMPORTANT: each `ruleId` passed here must also be configured as a Rate Limit
+ * rule in the Vercel Firewall dashboard (Firewall → Rate Limiting) with a
+ * `@vercel/firewall` rule condition whose ID matches `ruleId`, plus the desired
+ * window / limit / action. An ID that has no matching dashboard rule fails
+ * OPEN (`checkRateLimit` returns `{ rateLimited: false, error: "not-found" }`),
+ * so this helper never breaks self-hosted deploys that lack the firewall — but
+ * it also provides no protection until the rule exists.
+ *
+ * Mirrors the existing pattern in `actions/collections/password.ts` and
+ * `actions/send-download-link.ts`:
+ *  - only enforced in production,
+ *  - best-effort (any error → not limited) so a firewall/IP-header outage can
+ *    never take down the underlying feature.
+ *
+ * @param ruleId   Stable rule id, also configured in the Vercel Firewall.
+ * @param opts.key Optional bucket key (e.g. per-email / per-user). Defaults to
+ *                 the caller IP (the firewall's default behaviour).
+ * @param opts.headers Optional request headers (required inside Hono handlers
+ *                 where `next/headers` is unavailable; defaults to the App
+ *                 Router request headers).
+ * @returns `true` when the request should be rejected.
+ */
+export async function isRateLimited(
+	ruleId: string,
+	opts?: { key?: string; headers?: Headers },
+): Promise<boolean> {
+	if (process.env.NODE_ENV !== "production") return false;
+
+	try {
+		const headersList = opts?.headers ?? (await nextHeaders());
+		const request = new Request("https://cap.so/api/rate-limit", {
+			method: "POST",
+			headers: headersList,
+		});
+
+		const { rateLimited } = await checkRateLimit(ruleId, {
+			request,
+			...(opts?.key ? { rateLimitKey: opts.key } : {}),
+		});
+
+		return rateLimited;
+	} catch (error) {
+		console.warn(`Rate limit check failed for "${ruleId}":`, error);
+		return false;
+	}
+}
+
+/**
+ * Canonical Vercel Firewall rate-limit rule ids introduced by the security
+ * hardening pass. Each MUST be created in the Vercel Firewall dashboard for the
+ * corresponding protection to take effect (see `isRateLimited`).
+ */
+export const RATE_LIMIT_IDS = {
+	/** Email OTP verification attempts (brute-force guard). Suggested: 10 / 10m per key (email). */
+	AUTH_OTP_VERIFY: "rl_auth_otp_verify",
+	/** Email OTP / magic-link send (mailbomb + token-reseed guard). Suggested: 5 / 10m per key (email). */
+	AUTH_OTP_SEND: "rl_auth_otp_send",
+	/** Unauthed Loom download/convert (ffmpeg + memory DoS). Suggested: 10 / 1m per IP. */
+	LOOM_DOWNLOAD: "rl_loom_download",
+	/** Unauthed transcript translation (Groq cost). Suggested: 10 / 1m per IP. */
+	TRANSLATE_TRANSCRIPT: "rl_translate_transcript",
+	/** Anonymous support-chat messages (Groq + Supermemory cost). Suggested: 20 / 1m per IP. */
+	MESSENGER_MESSAGE: "rl_messenger_message",
+	/** Unauthed analytics view tracking (Tinybird ingest + notifications). Suggested: 60 / 1m per IP. */
+	ANALYTICS_TRACK: "rl_analytics_track",
+	/** Unauthed guest checkout (Stripe object/cost abuse). Suggested: 10 / 10m per IP. */
+	GUEST_CHECKOUT: "rl_guest_checkout",
+	/** Unauthed desktop log → Discord forwarding (spam). Suggested: 10 / 1m per IP. */
+	DESKTOP_LOGS: "rl_desktop_logs",
+} as const;


### PR DESCRIPTION
Rate-limits the unauthenticated Loom download, messenger, analytics tracking, guest-checkout and desktop-log endpoints, and derives the analytics tenant from the video record instead of trusting client-supplied ids.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens five unauthenticated or lightly-authenticated endpoints by adding Vercel Firewall-backed rate limiting through a new shared `isRateLimited` helper, and fixes a tenant-spoofing path in the analytics tracking route by deriving `tenantId` from the DB-fetched video record instead of trusting client-supplied `body.orgId`/`body.ownerId`.

- **`apps/web/lib/rate-limit.ts`**: New helper that wraps `@vercel/firewall`'s `checkRateLimit`, fails open on any error, is a no-op outside production, and accepts an optional per-user key or explicit headers (needed for Hono handlers where `next/headers` is unavailable).
- **`apps/web/app/api/analytics/track/route.ts`**: Tenant derivation now reads `orgId` and `ownerId` exclusively from the looked-up `videos` row, eliminating the spoofing vector; rate limit guard added before the Tinybird ingest path.
- **`apps/web/actions/messenger.ts`**: Rate limit guard correctly placed *before* the `messengerMessages` insert and conversation timestamp update, addressing the DB-spam concern raised in the previous review.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all five endpoints are guarded correctly, the tenant-spoofing fix is sound, and the previously raised messenger DB-write ordering issue is resolved.

The rate-limit helper fails open so it cannot break self-hosted or development deployments. The analytics tenant fix removes client trust entirely for existing videos. The messenger guard is now placed before any database writes. No new defects were introduced in the changed paths.

No files require special attention beyond the pre-existing isRateLimited name shadowing inside importFromLoom in apps/web/actions/loom.ts, which was flagged in a previous review pass.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/lib/rate-limit.ts | New shared rate-limit helper backed by Vercel Firewall; fails open on error, skips in non-production, and accepts an optional per-user key and explicit headers for non-App-Router callers. Well-documented with clear rule-ID registry. |
| apps/web/app/api/analytics/track/route.ts | Adds rate limiting before expensive work and fixes tenant spoofing by deriving tenantId exclusively from the DB-fetched video record (orgId → ownerId) instead of trusting client-supplied body fields. |
| apps/web/actions/messenger.ts | Rate limit guard moved before the DB insert and conversation timestamp update, fixing the previously flagged issue where DB spam was possible even on rate-limited requests. |
| apps/web/actions/loom.ts | Adds IP-based rate limiting to the unauthenticated downloadLoomVideo action; note that the imported isRateLimited is shadowed by a local const of the same name inside importFromLoom (previously flagged). |
| apps/web/app/api/tools/loom-download/route.ts | Rate limit guard added as the first check in the GET handler, before any URL parsing or video conversion work. |
| apps/web/app/api/settings/billing/guest-checkout/route.ts | Rate limit correctly placed before request.json() parsing, preventing Stripe object creation on abusive requests. |
| apps/web/app/api/desktop/[...route]/root.ts | Rate limit guard added to the desktop log endpoint; correctly passes c.req.raw.headers explicitly since nextHeaders() is unavailable in Hono handlers. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/web/actions/messenger.ts`, line 180-226 ([link](https://github.com/capsoftware/cap/blob/b245d7baf1172be23a22abc0fcb6c8a24860395e/apps/web/actions/messenger.ts#L180-L226)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Rate limit check placed after DB writes**

   The user message is inserted into `messengerMessages` (line 180) and `messengerConversations` is updated (line 192) before `isRateLimited` is evaluated at line 221. When a request is rejected by the rate limiter, the message already lives in the database without a corresponding AI reply. On the user's next (successful) retry the orphaned message is still in the history, so the AI receives the same user turn twice with no assistant turn between them, corrupting the conversation state.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/actions/messenger.ts
   Line: 180-226

   Comment:
   **Rate limit check placed after DB writes**

   The user message is inserted into `messengerMessages` (line 180) and `messengerConversations` is updated (line 192) before `isRateLimited` is evaluated at line 221. When a request is rejected by the rate limiter, the message already lives in the database without a corresponding AI reply. On the user's next (successful) retry the orphaned message is still in the history, so the AI receives the same user turn twice with no assistant turn between them, corrupting the conversation state.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `apps/web/actions/loom.ts`, line 451-457 ([link](https://github.com/capsoftware/cap/blob/b245d7baf1172be23a22abc0fcb6c8a24860395e/apps/web/actions/loom.ts#L451-L457)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Imported `isRateLimited` shadowed by local variable**

   The new top-level import `import { isRateLimited, RATE_LIMIT_IDS } from "@/lib/rate-limit"` is shadowed inside `importFromLoom` by `const isRateLimited = await createLoomImportRateLimitCheck(user.id)`. The local binding wins within that function scope, so there is no runtime breakage today, but the identical names make the code misleading — a future reader may confuse the two, or a linter may flag it as a shadowing error. Consider renaming the local variable (e.g. `loomImportRateLimitCheck`) to avoid the collision.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/actions/loom.ts
   Line: 451-457

   Comment:
   **Imported `isRateLimited` shadowed by local variable**

   The new top-level import `import { isRateLimited, RATE_LIMIT_IDS } from "@/lib/rate-limit"` is shadowed inside `importFromLoom` by `const isRateLimited = await createLoomImportRateLimitCheck(user.id)`. The local binding wins within that function scope, so there is no runtime breakage today, but the identical names make the code misleading — a future reader may confuse the two, or a linter may flag it as a shadowing error. Consider renaming the local variable (e.g. `loomImportRateLimitCheck`) to avoid the collision.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(web): rate-limit messenger before pe..."](https://github.com/capsoftware/cap/commit/9f7c282f4b59f11b051910e6b634c558245f8625) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38614773)</sub>

<!-- /greptile_comment -->