### PR TITLE
fix(web): cap maximum upload size

### DIFF
--- a/apps/web/app/api/upload/[...route]/multipart.ts
+++ b/apps/web/app/api/upload/[...route]/multipart.ts
@@ -291,7 +291,9 @@ app.post(
 					z.object({
 						partNumber: z.number(),
 						etag: z.string(),
-						size: z.number(),
+						// Non-negative so a negative size can't drag the summed total
+						// below the cap and bypass the upload-size limit.
+						size: z.number().nonnegative(),
 					}),
 				),
 				durationInSecs: stringOrNumberOptional,
@@ -413,16 +415,35 @@ app.post(
 			}
 			if (totalUploadSize > MAX_UPLOAD_BYTES) {
 				// Avoid leaving the parts as incomplete-MPU storage and a stale
-				// videoUploads row, mirroring the free-plan rejection cleanup. The
-				// 413 stands regardless of cleanup success.
+				// videoUploads row, mirroring the free-plan rejection cleanup. Each
+				// step is caught independently so a failed abort doesn't skip the DB
+				// cleanup (and vice versa). The 413 stands regardless of either.
 				yield* Effect.gen(function* () {
 					const [bucket] = yield* Storage.getAccessForVideo(video);
-					yield* bucket.multipart.abort(fileKey, uploadId);
-					yield* db.use((db) =>
-						db
-							.delete(Db.videoUploads)
-							.where(eq(Db.videoUploads.videoId, videoId)),
-					);
+					yield* bucket.multipart
+						.abort(fileKey, uploadId)
+						.pipe(
+							Effect.catchAll((error) =>
+								Effect.logError(
+									"Failed to abort rejected oversized multipart upload",
+									error,
+								),
+							),
+						);
+					yield* db
+						.use((db) =>
+							db
+								.delete(Db.videoUploads)
+								.where(eq(Db.videoUploads.videoId, videoId)),
+						)
+						.pipe(
+							Effect.catchAll((error) =>
+								Effect.logError(
+									"Failed to delete videoUploads row for rejected upload",
+									error,
+								),
+							),
+						);
 				}).pipe(
 					Effect.catchAll((error) =>
 						Effect.logError(

--- a/apps/web/app/api/upload/[...route]/multipart.ts
+++ b/apps/web/app/api/upload/[...route]/multipart.ts
@@ -4,6 +4,7 @@ import { serverEnv } from "@cap/env";
 import { userIsPro } from "@cap/utils";
 import {
 	Database,
+	MAX_UPLOAD_BYTES,
 	makeCurrentUserLayer,
 	provideOptionalAuth,
 	Storage,
@@ -34,10 +35,6 @@ const MEDIA_SERVER_PRESIGNED_PUT_EXPIRES_SECONDS = 3 * 60 * 60;
 // Clients stop at the cap and then finalize, so reported durations can land
 // slightly past the limit for honest recordings.
 const FREE_PLAN_DURATION_GRACE_SECONDS = 30;
-// Upper bound on a completed multipart upload to prevent unbounded storage
-// abuse. Generous on purpose so legitimate long/high-bitrate recordings are
-// never blocked; kept in sync with MAX_UPLOAD_BYTES in S3BucketAccess.ts.
-const MAX_UPLOAD_BYTES = 100 * 1024 * 1024 * 1024; // 100 GiB
 
 const runPromiseAnyEnv = runPromise as <A, E>(
 	effect: Effect.Effect<A, E, unknown>,
@@ -409,7 +406,11 @@ app.post(
 			// here before persisting (and before paying to assemble it). Part sizes
 			// are client-reported, so this raises the bar rather than enforcing
 			// authoritatively.
-			const totalUploadSize = parts.reduce((acc, part) => acc + part.size, 0);
+			let totalUploadSize = 0;
+			for (const part of parts) {
+				totalUploadSize += part.size;
+				if (totalUploadSize > MAX_UPLOAD_BYTES) break;
+			}
 			if (totalUploadSize > MAX_UPLOAD_BYTES) {
 				// Avoid leaving the parts as incomplete-MPU storage and a stale
 				// videoUploads row, mirroring the free-plan rejection cleanup. The

--- a/apps/web/app/api/upload/[...route]/multipart.ts
+++ b/apps/web/app/api/upload/[...route]/multipart.ts
@@ -291,9 +291,10 @@ app.post(
 					z.object({
 						partNumber: z.number(),
 						etag: z.string(),
-						// Non-negative so a negative size can't drag the summed total
-						// below the cap and bypass the upload-size limit.
-						size: z.number().nonnegative(),
+						// A non-negative integer (bytes) so neither a negative nor a
+						// fractional size can drag the summed total below the cap and
+						// bypass the upload-size limit.
+						size: z.number().int().nonnegative(),
 					}),
 				),
 				durationInSecs: stringOrNumberOptional,

--- a/apps/web/app/api/upload/[...route]/multipart.ts
+++ b/apps/web/app/api/upload/[...route]/multipart.ts
@@ -34,6 +34,10 @@ const MEDIA_SERVER_PRESIGNED_PUT_EXPIRES_SECONDS = 3 * 60 * 60;
 // Clients stop at the cap and then finalize, so reported durations can land
 // slightly past the limit for honest recordings.
 const FREE_PLAN_DURATION_GRACE_SECONDS = 30;
+// Upper bound on a completed multipart upload to prevent unbounded storage
+// abuse. Generous on purpose so legitimate long/high-bitrate recordings are
+// never blocked; kept in sync with MAX_UPLOAD_BYTES in S3BucketAccess.ts.
+const MAX_UPLOAD_BYTES = 100 * 1024 * 1024 * 1024; // 100 GiB
 
 const runPromiseAnyEnv = runPromise as <A, E>(
 	effect: Effect.Effect<A, E, unknown>,
@@ -397,6 +401,40 @@ app.post(
 							: "Recording exceeds the free plan duration limit. Upgrade to Cap Pro to upload longer recordings.",
 					);
 				}
+			}
+
+			// Server-side backstop for the maximum upload size. Presigned POST URLs
+			// enforce a content-length-range policy, but presigned PUT part URLs
+			// cannot enforce a total size, so reject an oversized assembled upload
+			// here before persisting (and before paying to assemble it). Part sizes
+			// are client-reported, so this raises the bar rather than enforcing
+			// authoritatively.
+			const totalUploadSize = parts.reduce((acc, part) => acc + part.size, 0);
+			if (totalUploadSize > MAX_UPLOAD_BYTES) {
+				// Avoid leaving the parts as incomplete-MPU storage and a stale
+				// videoUploads row, mirroring the free-plan rejection cleanup. The
+				// 413 stands regardless of cleanup success.
+				yield* Effect.gen(function* () {
+					const [bucket] = yield* Storage.getAccessForVideo(video);
+					yield* bucket.multipart.abort(fileKey, uploadId);
+					yield* db.use((db) =>
+						db
+							.delete(Db.videoUploads)
+							.where(eq(Db.videoUploads.videoId, videoId)),
+					);
+				}).pipe(
+					Effect.catchAll((error) =>
+						Effect.logError(
+							"Failed to clean up rejected oversized multipart upload",
+							error,
+						),
+					),
+				);
+
+				c.status(413);
+				return c.text(
+					"Upload exceeds the maximum allowed size and cannot be completed.",
+				);
 			}
 
 			return yield* Effect.gen(function* () {

--- a/packages/web-backend/src/S3Buckets/S3BucketAccess.ts
+++ b/packages/web-backend/src/S3Buckets/S3BucketAccess.ts
@@ -286,12 +286,16 @@ export const createS3BucketAccess = Effect.gen(function* () {
 							| [unknown, unknown, unknown]
 							| undefined;
 						const callerMin =
-							callerRange && typeof callerRange[1] === "number"
+							callerRange &&
+							typeof callerRange[1] === "number" &&
+							Number.isFinite(callerRange[1])
 								? Math.max(0, callerRange[1])
 								: 0;
 						const callerMax =
-							callerRange && typeof callerRange[2] === "number"
-								? callerRange[2]
+							callerRange &&
+							typeof callerRange[2] === "number" &&
+							Number.isFinite(callerRange[2])
+								? Math.max(0, callerRange[2])
 								: MAX_UPLOAD_BYTES;
 						const otherConditions = callerConditions.filter(
 							(condition) => !isLengthRange(condition),

--- a/packages/web-backend/src/S3Buckets/S3BucketAccess.ts
+++ b/packages/web-backend/src/S3Buckets/S3BucketAccess.ts
@@ -274,23 +274,38 @@ export const createS3BucketAccess = Effect.gen(function* () {
 					Effect.map((client) => {
 						// Enforce an upper bound on the uploaded object size. The POST
 						// policy rejects the upload at S3 if the body exceeds this,
-						// closing the unbounded-storage hole for presigned POSTs. If a
-						// caller already supplies a content-length-range we defer to it
-						// rather than emitting a second, conflicting range.
+						// closing the unbounded-storage hole for presigned POSTs. We emit
+						// exactly one content-length-range whose max never exceeds
+						// MAX_UPLOAD_BYTES, even if a caller supplied a looser one, so a
+						// caller can tighten but never raise/disable the cap.
 						const callerConditions = args.Conditions ?? [];
-						const hasContentLengthRange = callerConditions.some(
-							(condition) =>
-								Array.isArray(condition) &&
-								condition[0] === "content-length-range",
+						const isLengthRange = (condition: unknown): boolean =>
+							Array.isArray(condition) &&
+							condition[0] === "content-length-range";
+						const callerRange = callerConditions.find(isLengthRange) as
+							| [unknown, unknown, unknown]
+							| undefined;
+						const callerMin =
+							callerRange && typeof callerRange[1] === "number"
+								? Math.max(0, callerRange[1])
+								: 0;
+						const callerMax =
+							callerRange && typeof callerRange[2] === "number"
+								? callerRange[2]
+								: MAX_UPLOAD_BYTES;
+						const otherConditions = callerConditions.filter(
+							(condition) => !isLengthRange(condition),
 						);
 						return createPresignedPost(client, {
 							...args,
-							Conditions: hasContentLengthRange
-								? callerConditions
-								: [
-										["content-length-range", 0, MAX_UPLOAD_BYTES],
-										...callerConditions,
-									],
+							Conditions: [
+								[
+									"content-length-range",
+									callerMin,
+									Math.min(callerMax, MAX_UPLOAD_BYTES),
+								],
+								...otherConditions,
+							],
 							Bucket: provider.bucket,
 							Key: key,
 						});

--- a/packages/web-backend/src/S3Buckets/S3BucketAccess.ts
+++ b/packages/web-backend/src/S3Buckets/S3BucketAccess.ts
@@ -271,21 +271,30 @@ export const createS3BucketAccess = Effect.gen(function* () {
 		) =>
 			wrapS3Promise(
 				provider.getPublic.pipe(
-					Effect.map((client) =>
-						createPresignedPost(client, {
+					Effect.map((client) => {
+						// Enforce an upper bound on the uploaded object size. The POST
+						// policy rejects the upload at S3 if the body exceeds this,
+						// closing the unbounded-storage hole for presigned POSTs. If a
+						// caller already supplies a content-length-range we defer to it
+						// rather than emitting a second, conflicting range.
+						const callerConditions = args.Conditions ?? [];
+						const hasContentLengthRange = callerConditions.some(
+							(condition) =>
+								Array.isArray(condition) &&
+								condition[0] === "content-length-range",
+						);
+						return createPresignedPost(client, {
 							...args,
-							// Enforce an upper bound on the uploaded object size. The POST
-							// policy rejects the upload at S3 if the body exceeds this,
-							// closing the unbounded-storage hole for presigned POSTs.
-							// Any caller-supplied conditions are preserved.
-							Conditions: [
-								["content-length-range", 0, MAX_UPLOAD_BYTES],
-								...(args.Conditions ?? []),
-							],
+							Conditions: hasContentLengthRange
+								? callerConditions
+								: [
+										["content-length-range", 0, MAX_UPLOAD_BYTES],
+										...callerConditions,
+									],
 							Bucket: provider.bucket,
 							Key: key,
-						}),
-					),
+						});
+					}),
 				),
 			),
 		multipart: {

--- a/packages/web-backend/src/S3Buckets/S3BucketAccess.ts
+++ b/packages/web-backend/src/S3Buckets/S3BucketAccess.ts
@@ -14,6 +14,11 @@ import { S3BucketClientProvider } from "./S3BucketClientProvider.ts";
 const DEFAULT_PRESIGNED_GET_EXPIRES_SECONDS = 3600;
 const DEFAULT_PRESIGNED_PUT_EXPIRES_SECONDS = 3600;
 
+// Upper bound on a single upload to prevent unbounded storage abuse. Generous
+// on purpose so legitimate long/high-bitrate recordings are never blocked;
+// tune here if the product ever needs a larger ceiling.
+export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024 * 1024; // 100 GiB
+
 type NodeReadableWebStream = Parameters<typeof Readable.fromWeb>[0];
 
 const wrapS3Promise = <T>(
@@ -269,6 +274,14 @@ export const createS3BucketAccess = Effect.gen(function* () {
 					Effect.map((client) =>
 						createPresignedPost(client, {
 							...args,
+							// Enforce an upper bound on the uploaded object size. The POST
+							// policy rejects the upload at S3 if the body exceeds this,
+							// closing the unbounded-storage hole for presigned POSTs.
+							// Any caller-supplied conditions are preserved.
+							Conditions: [
+								["content-length-range", 0, MAX_UPLOAD_BYTES],
+								...(args.Conditions ?? []),
+							],
 							Bucket: provider.bucket,
 							Key: key,
 						}),

--- a/packages/web-backend/src/index.ts
+++ b/packages/web-backend/src/index.ts
@@ -10,6 +10,7 @@ export { Organisations } from "./Organisations/index.ts";
 export { OrganisationsPolicy } from "./Organisations/OrganisationsPolicy.ts";
 export * from "./Rpcs.ts";
 export { S3Buckets } from "./S3Buckets/index.ts";
+export { MAX_UPLOAD_BYTES } from "./S3Buckets/S3BucketAccess.ts";
 export { Spaces } from "./Spaces/index.ts";
 export { SpacesPolicy } from "./Spaces/SpacesPolicy.ts";
 export * from "./Storage/GoogleDrive.ts";


### PR DESCRIPTION
Caps the maximum upload size on presigned POST uploads and at multipart completion to prevent unbounded storage usage.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR caps upload sizes at 100 GiB by enforcing a `content-length-range` policy on all presigned POST URLs and adding a server-side total-size gate at multipart completion. It also tightens the part-size Zod schema to `z.number().int().nonnegative()` and imports `MAX_UPLOAD_BYTES` from a single exported source of truth.

- **`S3BucketAccess.ts`**: Injects a `content-length-range` condition into every presigned POST, capping the effective max at `MAX_UPLOAD_BYTES` even when a caller supplies a looser range, and exports the constant.
- **`multipart.ts`**: Sums client-reported part sizes against `MAX_UPLOAD_BYTES` before calling `CompleteMultipartUpload`; on excess it aborts the incomplete MPU, deletes the `videoUploads` row (each step independently guarded), and returns 413. Part `size` is now validated as a non-negative integer, closing both the negative-value and fractional-value bypass paths.
- **`index.ts`**: Re-exports `MAX_UPLOAD_BYTES` so it can be shared without duplication.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge; the upload cap and schema hardening are self-contained and do not alter any existing data path.

The changes are additive guards — a new schema constraint, a new presigned-POST policy injection, and a new total-size check with cleanup. All previously flagged issues (negative-size bypass, MAX_UPLOAD_BYTES duplication, fractional-size bypass) have been addressed. The cleanup logic for the 413 path correctly handles abort and delete independently so a failure in one step does not suppress the other.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/api/upload/[...route]/multipart.ts | Imports MAX_UPLOAD_BYTES from @cap/web-backend (removing duplication), tightens the part-size schema to z.number().int().nonnegative(), and adds a total-size gate with MPU abort + DB row cleanup before the 413 response. |
| packages/web-backend/src/S3Buckets/S3BucketAccess.ts | Adds MAX_UPLOAD_BYTES (100 GiB) and injects a content-length-range condition into every presigned POST URL, capping the max at that constant while respecting a caller-supplied tighter range. |
| packages/web-backend/src/index.ts | Re-exports MAX_UPLOAD_BYTES so callers can share the single source of truth without duplicating the constant. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/app/api/upload/[...route]/multipart.ts`, line 293-299 ([link](https://github.com/capsoftware/cap/blob/24a0832f463f4fcb5bc11139a784385a258170ba/apps/web/app/api/upload/[...route]/multipart.ts#L293-L299)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Negative-size bypass of the upload cap** — `z.number()` accepts any real number, including negatives. A client that submits `size: -N` for each part makes `totalUploadSize` negative, so `totalUploadSize > MAX_UPLOAD_BYTES` is always `false` and the guard never fires. Adding `.nonnegative()` (i.e., `z.number().nonnegative()`) to the `size` field closes this bypass at the schema layer before the cap logic is ever reached.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/app/api/upload/[...route]/multipart.ts
   Line: 293-299

   Comment:
   **Negative-size bypass of the upload cap** — `z.number()` accepts any real number, including negatives. A client that submits `size: -N` for each part makes `totalUploadSize` negative, so `totalUploadSize > MAX_UPLOAD_BYTES` is always `false` and the guard never fires. Adding `.nonnegative()` (i.e., `z.number().nonnegative()`) to the `size` field closes this bypass at the schema layer before the cap logic is ever reached.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["fix(web): require integer part sizes and..."](https://github.com/capsoftware/cap/commit/a663a44eaaa391eaddaff8e7b4b6f4c818e4ad6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38614779)</sub>

<!-- /greptile_comment -->