### PR TITLE
fix(web): use constant-time comparison for media-server webhook secret

### DIFF
--- a/apps/web/app/api/webhooks/media-server/progress/route.ts
+++ b/apps/web/app/api/webhooks/media-server/progress/route.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 import { db } from "@cap/database";
 import { videos, videoUploads } from "@cap/database/schema";
 import { serverEnv } from "@cap/env";
@@ -68,11 +68,16 @@ export async function POST(request: NextRequest) {
 	try {
 		const webhookSecret = serverEnv().MEDIA_SERVER_WEBHOOK_SECRET;
 		const authHeader = request.headers.get("x-media-server-secret");
+		// Hash both sides to a fixed-length digest before the constant-time
+		// compare. This avoids comparing raw inputs whose UTF-8 byte length can
+		// differ from their UTF-16 `.length` (which would throw a RangeError) and
+		// removes the length pre-check that would otherwise leak the secret size.
+		const digest = (value: string) =>
+			createHash("sha256").update(value, "utf8").digest();
 		if (
 			!webhookSecret ||
 			!authHeader ||
-			authHeader.length !== webhookSecret.length ||
-			!timingSafeEqual(Buffer.from(authHeader), Buffer.from(webhookSecret))
+			!timingSafeEqual(digest(authHeader), digest(webhookSecret))
 		) {
 			return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 		}

--- a/apps/web/app/api/webhooks/media-server/progress/route.ts
+++ b/apps/web/app/api/webhooks/media-server/progress/route.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { db } from "@cap/database";
 import { videos, videoUploads } from "@cap/database/schema";
 import { serverEnv } from "@cap/env";
@@ -67,7 +68,12 @@ export async function POST(request: NextRequest) {
 	try {
 		const webhookSecret = serverEnv().MEDIA_SERVER_WEBHOOK_SECRET;
 		const authHeader = request.headers.get("x-media-server-secret");
-		if (!webhookSecret || authHeader !== webhookSecret) {
+		if (
+			!webhookSecret ||
+			!authHeader ||
+			authHeader.length !== webhookSecret.length ||
+			!timingSafeEqual(Buffer.from(authHeader), Buffer.from(webhookSecret))
+		) {
 			return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 		}
 


### PR DESCRIPTION
Uses a constant-time comparison for the media-server webhook shared secret, matching the cron routes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the media-server webhook authentication by replacing a plain `===` string comparison with a constant-time SHA-256-hash-then-`timingSafeEqual` check, bringing it in line with the cron route pattern.

- Both `authHeader` and `webhookSecret` are hashed to a fixed 32-byte SHA-256 digest before `timingSafeEqual` is called, so the buffers are always the same length (no `RangeError`) and no length pre-check is needed (no secret-size side-channel).
- The `!webhookSecret` and `!authHeader` null guards short-circuit on absent configuration or missing header — neither leaks information about the secret's value.

<h3>Confidence Score: 5/5</h3>

The change is a targeted, self-contained security hardening of one auth check — safe to merge.

The hashing approach is correct: SHA-256 always produces a fixed 32-byte buffer, so timingSafeEqual will never throw, and the absence of a length pre-check means the secret size is not leaked through timing. The null guards for a missing config value or missing header are appropriate and do not expose the secret's content. No functional behavior outside the auth gate is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/api/webhooks/media-server/progress/route.ts | Replaces string equality check with SHA-256 hash + timingSafeEqual; correctly addresses prior thread concerns about byte-length mismatch and secret-length timing leak. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(web): hash media-server webhook secr..."](https://github.com/capsoftware/cap/commit/9b64e57d544b570cba4f50538a564cc61d6a8b31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38614836)</sub>

<!-- /greptile_comment -->