### PR TITLE
fix(web): add baseline security response headers

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -94,13 +94,33 @@ const nextConfig = {
 					},
 					{
 						key: "X-DNS-Prefetch-Control",
-						value: "on",
+						value: "off",
 					},
 					{
 						key: "Strict-Transport-Security",
 						value: "max-age=63072000; includeSubDomains",
 					},
 				],
+			},
+			// Clickjacking protection for the authenticated/interactive app
+			// surfaces only. Shared videos (/s, /embed) and public collections
+			// (/c) are intentionally embeddable, so X-Frame-Options is NOT applied
+			// to them.
+			{
+				source: "/dashboard/:path*",
+				headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }],
+			},
+			{
+				source: "/onboarding/:path*",
+				headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }],
+			},
+			{
+				source: "/login",
+				headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }],
+			},
+			{
+				source: "/signup",
+				headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }],
 			},
 		];
 	},

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -79,6 +79,31 @@ const nextConfig = {
 			},
 		].filter(Boolean),
 	},
+	async headers() {
+		return [
+			{
+				source: "/:path*",
+				headers: [
+					{
+						key: "X-Content-Type-Options",
+						value: "nosniff",
+					},
+					{
+						key: "Referrer-Policy",
+						value: "strict-origin-when-cross-origin",
+					},
+					{
+						key: "X-DNS-Prefetch-Control",
+						value: "on",
+					},
+					{
+						key: "Strict-Transport-Security",
+						value: "max-age=63072000; includeSubDomains",
+					},
+				],
+			},
+		];
+	},
 	async rewrites() {
 		return [
 			{

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -103,25 +103,20 @@ const nextConfig = {
 				],
 			},
 			// Clickjacking protection for the authenticated/interactive app
-			// surfaces only. Shared videos (/s, /embed) and public collections
-			// (/c) are intentionally embeddable, so X-Frame-Options is NOT applied
-			// to them.
-			{
-				source: "/dashboard/:path*",
+			// surfaces (including subpaths). Shared videos (/s, /embed) and public
+			// collections (/c) are intentionally embeddable, so X-Frame-Options is
+			// NOT applied to them.
+			...[
+				"/dashboard/:path*",
+				"/onboarding/:path*",
+				"/admin/:path*",
+				"/verify-otp/:path*",
+				"/login/:path*",
+				"/signup/:path*",
+			].map((source) => ({
+				source,
 				headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }],
-			},
-			{
-				source: "/onboarding/:path*",
-				headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }],
-			},
-			{
-				source: "/login",
-				headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }],
-			},
-			{
-				source: "/signup",
-				headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }],
-			},
+			})),
 		];
 	},
 	async rewrites() {


### PR DESCRIPTION
Adds baseline security response headers (X-Content-Type-Options, Referrer-Policy, HSTS, DNS-prefetch-control) globally. No framing restriction is added, so embedded videos keep working.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a baseline set of security response headers to the Next.js app — `X-Content-Type-Options`, `Referrer-Policy`, `X-DNS-Prefetch-Control`, and HSTS — applied globally, with targeted `X-Frame-Options: SAMEORIGIN` guards on sensitive authenticated routes. Previous feedback on DNS prefetch direction, HSTS preload deferral, and admin/verify-otp coverage has been addressed.

- **Global headers** (`/:path*`): `nosniff`, `strict-origin-when-cross-origin` referrer policy, DNS prefetch off, and a 2-year HSTS with `includeSubDomains` (no `preload`, intentionally deferred).
- **Clickjacking protection**: `X-Frame-Options: SAMEORIGIN` added for `/dashboard`, `/onboarding`, `/admin`, `/verify-otp`, `/login`, and `/signup`; public embeddable routes (`/s`, `/embed`, `/c`) are deliberately excluded.
- **Gap**: `/invite/:path*` (the org-invite acceptance page) is not in the protected list and can still be embedded cross-origin.

<h3>Confidence Score: 4/5</h3>

Safe to merge after adding /invite/:path* to the framing-protection list — everything else in the header baseline is correct and the intentional omissions are well-documented.

The invite-acceptance page (/invite/[inviteId]) was left out of the X-Frame-Options route list. It has interactive buttons that POST to org-membership API endpoints, so a cross-origin iframe embedding it is a real clickjacking vector. All other parts of the change look correct.

apps/web/next.config.mjs — the framing-protection route list needs /invite/:path* added.

<details open><summary><h3>Security Review</h3></summary>

- **Clickjacking on invite acceptance** (`apps/web/next.config.mjs`, line 109): `/invite/[inviteId]` is excluded from the `X-Frame-Options: SAMEORIGIN` protection added by this PR. The page lets authenticated users accept or decline org invitations via direct API calls, making it a viable clickjacking target for forcing unintended org-membership changes.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/next.config.mjs | Adds global security response headers and per-route X-Frame-Options protection; the /invite/:path* route is missing from the clickjacking-protection list. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/next.config.mjs:109-119
**Invite acceptance route missing clickjacking protection**

`/invite/[inviteId]` is not in the `X-Frame-Options` protection list. That page renders "Accept" and "Decline" buttons that immediately POST to `/api/invite/accept` and `/api/invite/decline`, changing the authenticated user's org membership. A transparent iframe embedding this page lets an attacker trick a logged-in user into joining a malicious workspace. Adding `"/invite/:path*"` to the array here closes the gap.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(web): extend clickjacking protection..."](https://github.com/capsoftware/cap/commit/799e004339dc090bd66e27d26f927078e7f0c4c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38614843)</sub>

<!-- /greptile_comment -->