### PR TITLE
fix(web): exclude sub-folder videos from public space root

### DIFF
--- a/apps/web/lib/public-collections.ts
+++ b/apps/web/lib/public-collections.ts
@@ -474,6 +474,7 @@ async function getPublicSpaceVideos(
 	const offset = (page - 1) * PUBLIC_COLLECTION_PAGE_SIZE;
 	const where = and(
 		eq(spaceVideos.spaceId, collection.id as Space.SpaceIdOrOrganisationId),
+		isNull(spaceVideos.folderId),
 		eq(videos.public, true),
 		isNull(organizations.tombstoneAt),
 		videoPasswordPredicate(


### PR DESCRIPTION
Excludes videos placed inside sub-folders from the public space root listing, so they are not surfaced before the sub-folder itself is made public.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single `isNull(spaceVideos.folderId)` predicate to the `getPublicSpaceVideos` query, preventing videos that live inside sub-folders from surfacing in the public space root listing before their parent folder is made public.

- The fix is applied to the shared `where` variable used by both the paginated video list query and the total-count query, keeping them consistent.
- No other root-listing code paths (`getPublicOrgFolderVideos`, `getPublicSpaceFolderVideos`, `getPublicUserFolderVideos`) are affected, as those are all folder-scoped queries and already filter by a specific `folderId`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-predicate addition to an existing WHERE clause with no side effects on other query paths.

The fix is narrow and self-contained: one null-check predicate added to a shared `where` variable that both the video list and count queries already use, so pagination totals stay in sync with the filtered results. The other folder-scoped functions are unaffected. No logic regressions are apparent.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/lib/public-collections.ts | Adds `isNull(spaceVideos.folderId)` to the WHERE clause in `getPublicSpaceVideos` so sub-folder videos are excluded from the space root listing; the fix is applied to the shared `where` variable, so both the paginated query and the total-count query benefit consistently. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): exclude sub-folder videos from..."](https://github.com/capsoftware/cap/commit/dd2afeba23009f33ba1b366ea711eb0f54d68b32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38614850)</sub>

<!-- /greptile_comment -->