### PR TITLE
fix(web): restrict comment deletion to the author's own replies

### DIFF
--- a/apps/web/app/api/video/comment/delete/route.ts
+++ b/apps/web/app/api/video/comment/delete/route.ts
@@ -41,13 +41,18 @@ export async function DELETE(request: NextRequest) {
 			);
 		}
 
-		// Delete the comment and all its replies
+		// Delete the comment and only the replies authored by the same user.
+		// Replies written by other users are preserved (never delete others'
+		// content), even though that can leave them visually orphaned.
 		await db()
 			.delete(comments)
 			.where(
-				or(
-					eq(comments.id, commentId.value),
-					eq(comments.parentCommentId, commentId.value),
+				and(
+					eq(comments.authorId, user.id),
+					or(
+						eq(comments.id, commentId.value),
+						eq(comments.parentCommentId, commentId.value),
+					),
 				),
 			);
 


### PR DESCRIPTION
Restricts comment deletion so a user can only delete their own comment and their own replies, instead of also deleting replies authored by other users.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR narrows the comment-delete query to only remove replies authored by the same user, rather than all replies to the deleted parent comment. The ownership pre-check (lines 27–42) that guards access to the parent comment is unchanged.

- The `DELETE` query now wraps the existing `or(id = X, parentCommentId = X)` predicate inside `and(authorId = user.id, …)`, preventing other users' replies from being wiped when a parent comment is deleted.
- No other logic, auth checks, or response shapes are modified.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single, targeted predicate addition that correctly restricts bulk deletion to the requesting user's own content.

The existing ownership pre-check (verify the parent comment belongs to the caller before proceeding) is untouched. The new `authorId = user.id` constraint in the delete query is the minimal, correct fix: it scopes the bulk delete to the caller's own replies without opening any new surface for data loss or privilege escalation.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/api/video/comment/delete/route.ts | Adds `authorId = user.id` guard to the bulk-delete query so only the requesting user's own replies are removed alongside a deleted parent comment; ownership of the parent is already enforced by the pre-check at line 27. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): restrict comment deletion to t..."](https://github.com/capsoftware/cap/commit/342c97863e15d8682fb1d4dd655f4399c2cf709b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38614853)</sub>

<!-- /greptile_comment -->