### PR TITLE
[codex] align contributor setup docs and pnpm config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ There are many ways to contribute to Cap. You can:
 - [Suggest a feature (via Discord)](https://discord.com/invite/y8gdQ3WRN3)
 - Submit a PR
 
-## Runing Cap
+## Running Cap
 
 ### Development Requirements
 
@@ -28,20 +28,20 @@ Before anything else, make sure you have the following installed:
 
 - Node Version 20+
 - Rust 1.88.0+
-- pnpm 8.10.5+
+- pnpm 10.5.2
 - Docker ([OrbStack](https://orbstack.dev/) recommended)
 
 ### General Setup
 
-Run `pnpm install`, then run `pnpm cap-setup` to install native dependencies such as FFmpeg.
+Run `pnpm install`, then run `pnpm env-setup` to generate a `.env` file configured for your environment.
+It will ask you which apps you intend to run, whether you'd like to use Docker to run S3 (MinIO) and MySQL locally,
+and allow you to provide overrides as needed.
+
+Then run `pnpm cap-setup` to install native dependencies such as FFmpeg.
 
 On Windows, llvm, clang, and VCPKG must be installed.
 On MacOS, cmake must be installed.
 `pnpm cap-setup` does not yet install these dependencies for you.
-
-Run `pnpm env-setup` to generate a `.env` file configured for your environment.
-It will ask you which apps you intend to run, whether you'd like to use Docker to run S3 (MinIO) and MySQL locally,
-and allow you to provide overrides as needed.
 
 To run both `@cap/desktop` and `@cap/web` together, use `pnpm dev`.
 To run only one of them, use `pnpm dev:desktop` or `pnpm dev:web` respectively.

--- a/package.json
+++ b/package.json
@@ -59,13 +59,6 @@
 		"turbo": "^2.3.4",
 		"typescript": "^5.8.3"
 	},
-	"pnpm": {
-		"peerDependencyRules": {
-			"allowedVersions": {
-				"next-auth>next": ">=16.0.0"
-			}
-		}
-	},
 	"packageManager": "pnpm@10.5.2",
 	"name": "cap",
 	"engines": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,7 @@ packages:
   - "crates/tauri-plugin-*"
   - "infra"
   - "scripts/orgIdBackfill"
+
+peerDependencyRules:
+  allowedVersions:
+    next-auth>next: ">=16.0.0"


### PR DESCRIPTION
## Summary

- Move pnpm peer dependency rules from `package.json` to `pnpm-workspace.yaml` so the pinned pnpm version no longer warns that the config is ignored.
- Update `CONTRIBUTING.md` to match the repo's pinned pnpm version.
- Align the CONTRIBUTING setup order with README by running `pnpm env-setup` before `pnpm cap-setup`.

## Why

While testing the contributor setup path from a fresh clone, pnpm printed a warning on every command because `package.json#pnpm.peerDependencyRules` is no longer read by current pnpm. The contributor guide also had stale setup instructions that disagreed with README and `packageManager`.

## Verification

- `pnpm --version`
- `pnpm install --lockfile-only`
- `pnpm install`
- `pnpm exec biome check --write CONTRIBUTING.md package.json`
- `git diff --check`
- Fresh clone setup: `pnpm install`, `pnpm env-setup`, `pnpm cap-setup`
- Web-only local app path: `cd apps/web && pnpm dev`, then `curl -I http://127.0.0.1:3000` returned `HTTP/1.1 200 OK`

Note: I did not fully verify `pnpm dev:web` in my environment because Docker image pulls for MySQL and MinIO did not complete after several minutes. The web-only documented path above was verified successfully.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a pnpm configuration warning by migrating `peerDependencyRules` from `package.json` (ignored by pnpm v9+) to `pnpm-workspace.yaml`, and updates `CONTRIBUTING.md` to reflect the current pinned pnpm version and the correct setup order.

- **`pnpm-workspace.yaml`**: Adds `peerDependencyRules.allowedVersions` for `next-auth>next`, which is the canonical location for this setting in pnpm v9+; the equivalent block is removed from `package.json`.
- **`CONTRIBUTING.md`**: Fixes a "Runing" typo, updates the required pnpm version from `8.10.5+` to `10.5.2` to match `packageManager`, and moves `pnpm env-setup` before `pnpm cap-setup` to align with README and the actual dependency order.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three files contain documentation and config-only changes with no runtime logic affected.

The peerDependencyRules migration is a straightforward move between two config files; pnpm's official docs confirm the setting is valid in pnpm-workspace.yaml. The CONTRIBUTING.md edits correct a stale version pin and a logical ordering mismatch. No source code is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CONTRIBUTING.md | Fixes "Runing" typo, updates pnpm version to match packageManager field (10.5.2), and reorders setup steps so env-setup runs before cap-setup |
| package.json | Removes pnpm.peerDependencyRules block that pnpm v10 no longer reads from package.json |
| pnpm-workspace.yaml | Adds peerDependencyRules.allowedVersions for next-auth>next — the correct location for this config in pnpm v9+ |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: align contributor setup docs"](https://github.com/capsoftware/cap/commit/47b79bb673bea1fac8922acab75170540e22c264) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38621011)</sub>

<!-- /greptile_comment -->