### PR TITLE
ci(publish): add swap to Linux runner to fix LTO link OOM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -259,6 +259,20 @@ jobs:
         shell: bash
         run: ./scripts/build-desktop-binaries.sh ${{ matrix.settings.target }}
 
+      # The release profile uses fat LTO + full debuginfo, so the final link
+      # peaks well above the 16GB stock Linux runner and gets OOM-killed
+      # ("runner received a shutdown signal"). Add swap so the link can spill
+      # to disk instead of dying. Linux-only; macOS/Windows are unaffected.
+      - name: Increase swap space (Linux)
+        if: ${{ runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          sudo fallocate -l 10G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -h
+
       - name: Build app
         working-directory: apps/desktop
         run: pnpm build:tauri --target ${{ matrix.settings.target }} --config src-tauri/tauri.prod.conf.json


### PR DESCRIPTION
## Problem

The Linux job of the `publish` workflow fails at the **Build app** step with `The runner has received a shutdown signal … operation was canceled` after a ~12-minute silence during the final Rust link (e.g. [run 27837150474](https://github.com/CapSoftware/Cap/actions/runs/27837150474/job/82387774442)).

It is **not a compile error**:
- The `cap-desktop` lib compiles cleanly (only pre-existing warnings).
- Both macOS builds compile the identical code and succeed.
- `fail-fast: false` and no superseding run — the runner VM died on its own.

## Root cause

`[profile.release]` uses `lto = true` (fat) + `codegen-units = 1` + `debug = true` + `opt-level = "s"`, so the final link holds the whole program IR plus full debuginfo in memory at once. macOS runs on `macos-latest-xlarge` (lots of RAM); Linux runs on stock `ubuntu-24.04` (16 GB). The recently merged editor-clips work grew the binary enough to push peak link memory over 16 GB, OOM-killing the runner.

## Fix

Add a Linux-only step before **Build app** that creates a 10 GB swapfile so the link can spill to disk instead of being OOM-killed. This does **not** change the produced binaries and does **not** affect the macOS/Windows builds (kept on fat LTO + full debuginfo for Sentry symbols).

To pick this up, re-dispatch the `publish` workflow after merging.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a 10 GB swapfile to the Linux GitHub Actions runner immediately before the Tauri build step, preventing the OOM-kill that was occurring during fat-LTO linking. The fix is Linux-only and does not affect the binaries produced or the macOS/Windows build paths.

- A new step using `fallocate`, `mkswap`, and `swapon` creates and activates swap with correct `600` permissions; `free -h` is appended for observability.
- The step is gated on `runner.os == 'Linux'` and placed precisely before `Build app`, where peak link memory spikes — the ordering is intentional and correct.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is entirely additive, touches only the Linux CI runner, and produces identical output binaries.

The swapfile commands (fallocate, chmod 600, mkswap, swapon) are the standard Linux idiom; the sequence and permissions are correct. The if: runner.os == 'Linux' guard keeps macOS and Windows untouched. GitHub-hosted Ubuntu runners use ext4, so fallocate will not produce a holey file that would be rejected by mkswap. The ephemeral nature of runner VMs means no cleanup step is needed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish.yml | Adds a Linux-only swap setup step (10 GB) before the Tauri build to prevent OOM-kill during fat-LTO linking; no changes to produced binaries or other platforms. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(publish): add swap to Linux runner to..."](https://github.com/capsoftware/cap/commit/382172c064483622d3d9c80877001ba8b1ff3d19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38699430)</sub>

<!-- /greptile_comment -->