### PR TITLE
fix: area picker click-drag regression and screenshot editor window lifecycle

### DIFF
--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -234,7 +234,11 @@ function Inner() {
 					<Route path="/mode-select" component={ModeSelectPage} />
 					<Route path="/notifications" component={NotificationsPage} />
 					<Route path="/recordings-overlay" component={RecordingsOverlayPage} />
-					<Route path="/screenshot-editor" component={ScreenshotEditorPage} />
+					<Route
+						path="/screenshot-editor"
+						info={{ AUTO_SHOW_WINDOW: false }}
+						component={ScreenshotEditorPage}
+					/>
 					<Route
 						path="/target-select-overlay"
 						component={TargetSelectOverlayPage}

--- a/apps/desktop/src/components/Cropper.tsx
+++ b/apps/desktop/src/components/Cropper.tsx
@@ -716,8 +716,12 @@ export function Cropper(
 				// While pointer capture is held the drag is still ours even if the window
 				// loses focus (e.g. another overlay or the camera window grabs it on
 				// Windows). Real pointer loss arrives via pointercancel/lostpointercapture.
+				// Defer the capture check by one microtask so setPointerCapture has time
+				// to finalize before we decide the session is orphaned.
 				blur: () => {
-					if (!target.hasPointerCapture?.(pointerId)) finish();
+					queueMicrotask(() => {
+						if (!target.hasPointerCapture?.(pointerId)) finish();
+					});
 				},
 			});
 			createEventListenerMap(target, {


### PR DESCRIPTION
## Summary

Fixes two high-impact desktop bugs reported by the community:

1. **Area picker immediately releases click-drag** (#1915) — On some WebKit/Tauri builds, the Cropper's blur handler fires synchronously before `setPointerCapture` has established, immediately killing the drag session. Defers the check with `queueMicrotask` so capture completes first.

2. **Main window auto-opens and webcam activates after closing screenshot editor** (#1863) — The `/screenshot-editor` route was missing the `AUTO_SHOW_WINDOW: false` flag that `/editor` already uses. Added it so the router does not force-show the main window when navigating away from the screenshot editor.

### Changes

- `apps/desktop/src/components/Cropper.tsx` — `queueMicrotask` in blur handler
- `apps/desktop/src/app.tsx` — `AUTO_SHOW_WINDOW: false` on `/screenshot-editor` route

### Verification

Both fixes follow existing patterns. The `queueMicrotask` approach is safe because `finish()` already guards against double-call. The route fix matches `/editor`'s pattern exactly.

### Notes

The microphone audio bugs (#1740, #1817) share the same root cause (mic feed lock not released between recordings) — already fixed in main by stale-lock auto-recovery.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two desktop window and pointer-drag regressions. The main changes are:

- Adds `AUTO_SHOW_WINDOW: false` to the `/screenshot-editor` route.
- Defers the Cropper blur-time pointer-capture check with `queueMicrotask`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The screenshot editor is still shown by its current window open and re-show paths.
- The Cropper drag cleanup remains guarded against duplicate teardown.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/app.tsx | Adds screenshot-editor route metadata to suppress the app-level auto-show path. |
| apps/desktop/src/components/Cropper.tsx | Defers Cropper blur handling so pointer capture can settle before ending the drag session. |

<sub>Reviews (1): Last reviewed commit: ["fix: prevent area picker from immediatel..."](https://github.com/capsoftware/cap/commit/9be96b9805a4dba69d7ae73617f98e272c72ca28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40419372)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))
- Context used - AGENTS.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=27801409-c24c-4476-9c6c-180f1ef0a7f2))

<!-- /greptile_comment -->