### PR TITLE
fix: add /embed/ and /.well-known/ to self-hosting proxy whitelist

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -55,7 +55,9 @@ export async function proxy(request: NextRequest) {
 				path.startsWith("/self-hosting") ||
 				path.startsWith("/download") ||
 				path.startsWith("/terms") ||
-				path.startsWith("/verify-otp")
+				path.startsWith("/verify-otp") ||
+			path.startsWith("/embed/") ||
+			path.startsWith("/.well-known/workflow/")
 			) &&
 			process.env.NODE_ENV !== "development"
 		)

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -56,8 +56,8 @@ export async function proxy(request: NextRequest) {
 				path.startsWith("/download") ||
 				path.startsWith("/terms") ||
 				path.startsWith("/verify-otp") ||
-			path.startsWith("/embed/") ||
-			path.startsWith("/.well-known/workflow/")
+				path.startsWith("/embed/") ||
+				path.startsWith("/.well-known/workflow/")
 			) &&
 			process.env.NODE_ENV !== "development"
 		)


### PR DESCRIPTION
## Summary

Adds `/embed/` and `/.well-known/` paths to the self-hosting proxy whitelist in `apps/web/proxy.ts`.

On self-hosted deployments (when `NEXT_PUBLIC_IS_CAP !== "true"`), the proxy middleware redirects all unwhitelisted paths to `/login`. Two important routes were missing:

1. **`/embed/<videoId>`** — breaks iframe embeds on self-hosted instances. The share page works correctly because `/s/` is already whitelisted; `/embed/` was overlooked. This was fully root-caused by the community in #1768.

2. **`/.well-known/workflow/v1/*`** — blocks the workflow/queue dispatch used by transcription, AI summaries, and video processing. The Turbopack standalone build returns the SPA HTML shell instead of routing to the handlers. Root-caused in #1774 and #1944.

### Fix

Two lines added to the existing whitelist pattern:

```diff
 path.startsWith("/verify-otp") ||
+path.startsWith("/embed/") ||
+path.startsWith("/.well-known/")
```

### Verification

- The `/.well-known/` path is reserved by RFC 8615 for well-known URIs — a sensible whitelist entry for workflow routes, ATproto verification, etc.
- Both fixes are identical in shape to existing whitelist entries
- Verified by community members in #1774 and #1768 via curl/private-browser testing

Fixes #1768, #1774, #1944, #906

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the self-hosted proxy allowlist for public routes. The main changes are:

- `/embed/` requests can reach embed pages instead of `/login`.
- `/.well-known/` requests can reach well-known and workflow routes.
- The change is limited to `apps/web/proxy.ts`.

<h3>Confidence Score: 4/5</h3>

The `/.well-known/` allowlist entry should be tightened before merging.

- `/embed/` appears to route through existing video visibility checks.
- `/.well-known/` is broader than the known workflow and static well-known paths.
- Any unprotected handler under that namespace can now be reached without the proxy login gate.

apps/web/proxy.ts

<details open><summary><h3>Security Review</h3></summary>

The broad `/.well-known/` prefix creates a security-boundary risk for any handler under that namespace that does not enforce its own auth or signature checks.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/proxy.ts | Adds `/embed/` and `/.well-known/` to the self-hosted proxy allowlist; the broad well-known prefix should be narrowed or paired with route-level protection. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/proxy.ts:60
**Broad Well-Known Whitelist**

When self-hosted production traffic reaches any dynamic route under `/.well-known/`, this prefix lets it bypass the proxy login gate. The inspected app has workflow routing configured under this namespace, so if any current or later handler there lacks its own auth or signature check, unauthenticated callers can reach processing endpoints that were previously blocked by the proxy.

### Issue 2 of 2
apps/web/proxy.ts:58-60
**Whitelist Indentation Drift**

These two entries are indented differently from the surrounding `path.startsWith(...)` clauses. The repo’s TS formatting rules require tab-aligned indentation, so this hunk can be reformatted or flagged by the formatter.

```suggestion
				path.startsWith("/verify-otp") ||
				path.startsWith("/embed/") ||
				path.startsWith("/.well-known/")
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add /embed/ and /.well-known/ to se..."](https://github.com/capsoftware/cap/commit/7790158acd7a8997e4997262b017e7fd95894852) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40419586)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))
- Context used - AGENTS.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=27801409-c24c-4476-9c6c-180f1ef0a7f2))

<!-- /greptile_comment -->