### PR TITLE
fix: show clear offline message when share/upload button clicked without internet

### DIFF
--- a/apps/desktop/src/routes/editor/ShareButton.tsx
+++ b/apps/desktop/src/routes/editor/ShareButton.tsx
@@ -29,6 +29,13 @@ function ShareButton() {
 		mutationFn: async () => {
 			setUploadState({ type: "idle" });
 
+			if (!navigator.onLine) {
+				await commands.globalMessageDialog(
+					"You appear to be offline. Please check your internet connection and try again.",
+				);
+				throw new Error("No internet connection");
+			}
+
 			console.log("Starting upload process...");
 
 			// Check authentication first

--- a/apps/desktop/src/routes/editor/ShareButton.tsx
+++ b/apps/desktop/src/routes/editor/ShareButton.tsx
@@ -33,7 +33,7 @@ function ShareButton() {
 				await commands.globalMessageDialog(
 					"You appear to be offline. Please check your internet connection and try again.",
 				);
-				throw new Error("No internet connection");
+				return;
 			}
 
 			console.log("Starting upload process...");

--- a/apps/desktop/src/routes/recordings-overlay.tsx
+++ b/apps/desktop/src/routes/recordings-overlay.tsx
@@ -724,7 +724,7 @@ function createRecordingMutations(
 				await commands.globalMessageDialog(
 					"You appear to be offline. Please check your internet connection and try again.",
 				);
-				throw new Error("No internet connection");
+				return;
 			}
 
 			// Check authentication first

--- a/apps/desktop/src/routes/recordings-overlay.tsx
+++ b/apps/desktop/src/routes/recordings-overlay.tsx
@@ -719,6 +719,14 @@ function createRecordingMutations(
 				return;
 			}
 
+			// Check connectivity first — prevent hanging on network calls when offline
+			if (!navigator.onLine) {
+				await commands.globalMessageDialog(
+					"You appear to be offline. Please check your internet connection and try again.",
+				);
+				throw new Error("No internet connection");
+			}
+
 			// Check authentication first
 			const existingAuth = await authStore.get();
 			if (!existingAuth) {


### PR DESCRIPTION
## Summary

Previously, clicking the share/upload button while offline would silently hang or throw a generic error dialog after the network call timed out. Added a `navigator.onLine` check at the start of both share flows to show a clear "You appear to be offline" dialog immediately.

### Changes

- `apps/desktop/src/routes/editor/ShareButton.tsx` — online check before auth/export/upload
- `apps/desktop/src/routes/recordings-overlay.tsx` — online check before auth/upload

### Notes

#1160 (capitalized email in auth) was traced and confirmed already fixed in main — the auth flow normalizes email case at every touchpoint: `createVerificationToken`, `useVerificationToken`, the JWT callback, and the form submission.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds clearer offline handling for desktop share and upload actions. The main changes are:

- Early offline checks before share export and upload work.
- A native message explaining that the user appears to be offline.
- Updated offline branches that return after the message instead of surfacing a second generic error.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/editor/ShareButton.tsx | Adds an offline check before the editor share flow starts auth, export, or upload work. |
| apps/desktop/src/routes/recordings-overlay.tsx | Adds an offline check before the recordings overlay upload flow starts auth or upload work. |

<sub>Reviews (2): Last reviewed commit: ["fix: prevent duplicate error dialog when..."](https://github.com/capsoftware/cap/commit/a47beb891e474780c95644116e46b6cef22e1eec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40420715)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))
- Context used - AGENTS.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=27801409-c24c-4476-9c6c-180f1ef0a7f2))

<!-- /greptile_comment -->