### PR TITLE
fix: reduce linux release debug output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -257,7 +257,11 @@ jobs:
 
       - name: Build desktop binaries
         shell: bash
-        run: ./scripts/build-desktop-binaries.sh ${{ matrix.settings.target }}
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            export CARGO_PROFILE_RELEASE_DEBUG=0
+          fi
+          ./scripts/build-desktop-binaries.sh ${{ matrix.settings.target }}
 
       # The release profile uses fat LTO + full debuginfo, so the final link
       # peaks well above the 16GB stock Linux runner and gets OOM-killed
@@ -280,7 +284,7 @@ jobs:
 
       - name: Build app
         working-directory: apps/desktop
-        run: pnpm build:tauri --target ${{ matrix.settings.target }} --config src-tauri/tauri.prod.conf.json ${{ runner.os == 'Windows' && '--bundles nsis' || runner.os == 'Linux' && '--bundles deb --verbose' || '' }}
+        run: ${{ runner.os == 'Linux' && 'CARGO_PROFILE_RELEASE_DEBUG=0 ' || '' }}pnpm build:tauri --target ${{ matrix.settings.target }} --config src-tauri/tauri.prod.conf.json ${{ runner.os == 'Windows' && '--bundles nsis' || runner.os == 'Linux' && '--bundles deb --verbose' || '' }}
         env:
           # https://github.com/tauri-apps/tauri-action/issues/740
           CI: false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Summary
- Disable Cargo release debuginfo for Linux release sidecar and Tauri package builds.
- Leave macOS and Windows release builds unchanged so their debug-symbol upload flow is preserved.

Testing
- `CARGO_PROFILE_RELEASE_DEBUG=0 ./scripts/build-desktop-binaries.sh x86_64-unknown-linux-gnu`
- `CARGO_PROFILE_RELEASE_DEBUG=0 cargo check -p cap-desktop --release --target x86_64-unknown-linux-gnu`
- `node -e 'const fs = require("fs"); const text = fs.readFileSync(".github/workflows/publish.yml", "utf8"); const checks = [/export CARGO_PROFILE_RELEASE_DEBUG=0/, /runner\\.os == '\''Linux'\'' && '\''CARGO_PROFILE_RELEASE_DEBUG=0 '\'' \\|\\| '\'''\''/]; for (const check of checks) { if (!check.test(text)) throw new Error(`missing ${check}`); } console.log("Linux release debug override present");'`

Notes
- `pnpm exec actionlint .github/workflows/publish.yml` and `pnpm exec prettier --check .github/workflows/publish.yml` could not run because those commands are not installed in this workspace.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f19b8-4d42-7297-a9b4-2b3cb4e14743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f19b8-4d42-7297-a9b4-2b3cb4e14743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR disables Cargo release debuginfo (`CARGO_PROFILE_RELEASE_DEBUG=0`) for Linux-only builds to reduce memory pressure during the release sidecar and Tauri package build steps, while deliberately leaving macOS and Windows builds unaffected to preserve their debug-symbol upload flow.

- The \"Build desktop binaries\" step uses a clean bash `if` block to export the env var only on Linux, which is idiomatic and correct.
- The \"Build app\" step prepends the assignment inline via a GitHub Actions ternary; this correctly avoids setting the env var on macOS/Windows (unlike adding it to the `env:` block with a conditional empty-string value, which would pass `CARGO_PROFILE_RELEASE_DEBUG=''` to Cargo and may be invalid). The inline approach is therefore the safer choice here, though it does make the `run:` line quite long.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is narrowly scoped to Linux-only builds and does not touch macOS or Windows paths.

Both build steps correctly guard the env var behind a Linux check. The inline ternary prefix on the 'Build app' run line is unconventional but functionally correct — the env block alternative would pass an empty string to Cargo on non-Linux runners, which Cargo may reject as an invalid debug level. No functional regressions are expected.

No files require special attention; the single changed file is straightforward.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish.yml | Adds CARGO_PROFILE_RELEASE_DEBUG=0 for Linux in two steps: a clean bash conditional in 'Build desktop binaries' and an inline ternary prefix in 'Build app'; both correctly avoid touching macOS/Windows builds. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/publish.yml:287-290
The `env:` block is the idiomatic place for environment variables in GitHub Actions steps, and would be cleaner than embedding the assignment as a command prefix. The `env:` approach also avoids the risk of the leading-space trimming quirk in YAML scalars that starts the line with whitespace when the runner is not Linux.

A conditional env-var entry keeps the `run:` line readable and consistent with how the other vars (e.g. `LD_LIBRARY_PATH`) are already handled in this step.

```suggestion
        run: pnpm build:tauri --target ${{ matrix.settings.target }} --config src-tauri/tauri.prod.conf.json ${{ runner.os == 'Windows' && '--bundles nsis' || runner.os == 'Linux' && '--bundles deb --verbose' || '' }}
        env:
          # https://github.com/tauri-apps/tauri-action/issues/740
          CI: false
          CARGO_PROFILE_RELEASE_DEBUG: ${{ runner.os == 'Linux' && '0' || '' }}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: reduce linux release debug output"](https://github.com/capsoftware/cap/commit/1b36e19cd81baee3f21e1edc3f4a7874671b283e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40899509)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->