### PR TITLE
Update messenger model and support email tool

### DIFF
--- a/apps/web/__tests__/unit/messenger-agent.test.ts
+++ b/apps/web/__tests__/unit/messenger-agent.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const serverEnvMock = vi.hoisted(() =>
 	vi.fn(() => ({
@@ -54,6 +54,10 @@ describe("generateMessengerAgentReply", () => {
 		vi.clearAllMocks();
 		searchSupermemoryMock.mockResolvedValue([]);
 		getGroqClientMock.mockReturnValue(null);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
 	});
 
 	it("uses Sonnet 5 and executes the constrained support email tool", async () => {

--- a/apps/web/__tests__/unit/messenger-agent.test.ts
+++ b/apps/web/__tests__/unit/messenger-agent.test.ts
@@ -122,7 +122,7 @@ describe("generateMessengerAgentReply", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 		const firstBody = readFetchBody(fetchMock.mock.calls[0] ?? []);
 		expect(firstBody.model).toBe("claude-sonnet-5");
-		expect(firstBody.max_tokens).toBe(350);
+		expect(firstBody.max_tokens).toBe(512);
 		expect(firstBody.tools?.[0]?.name).toBe("send_support_email");
 		expect(firstBody.tools?.[0]?.input_schema?.properties?.email).toBe(
 			undefined,
@@ -133,6 +133,7 @@ describe("generateMessengerAgentReply", () => {
 		});
 
 		const secondBody = readFetchBody(fetchMock.mock.calls[1] ?? []);
+		expect(secondBody.max_tokens).toBe(350);
 		const toolResultMessage = secondBody.messages?.at(-1);
 		expect(toolResultMessage?.role).toBe("user");
 		expect(toolResultMessage?.content).toEqual([
@@ -141,6 +142,78 @@ describe("generateMessengerAgentReply", () => {
 				tool_use_id: "tool-1",
 				content:
 					"Support email sent to hello@cap.so from the user's account email. Remaining sends today: 1.",
+			},
+		]);
+	});
+
+	it("returns a tool error result when the support email tool fails", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						content: [
+							{
+								type: "tool_use",
+								id: "tool-1",
+								name: "send_support_email",
+								input: {
+									subject: "Upload issue",
+									message: "The user cannot upload their recording.",
+								},
+							},
+						],
+					}),
+					{ status: 200 },
+				),
+			)
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						content: [
+							{
+								type: "text",
+								text: "I couldn't send that to the team right now. Please email hello@cap.so directly.",
+							},
+						],
+					}),
+					{ status: 200 },
+				),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const execute = vi.fn().mockRejectedValue(new Error("provider failed"));
+		const { generateMessengerAgentReply } = await import(
+			"@/lib/messenger/agent"
+		);
+
+		const result = await generateMessengerAgentReply({
+			userIdentity: "Test User <user@example.com>",
+			identityTag: "user:user-123",
+			query: "Please send this to support",
+			history: [
+				{
+					role: "user",
+					content: "Uploads keep failing. Please send this to support.",
+				},
+			],
+			supportEmailTool: {
+				execute,
+			},
+		});
+
+		expect(result).toBe(
+			"I couldn't send that to the team right now. Please email hello@cap.so directly.",
+		);
+
+		const secondBody = readFetchBody(fetchMock.mock.calls[1] ?? []);
+		const toolResultMessage = secondBody.messages?.at(-1);
+		expect(toolResultMessage?.content).toEqual([
+			{
+				type: "tool_result",
+				tool_use_id: "tool-1",
+				content: "Failed to send support email.",
+				is_error: true,
 			},
 		]);
 	});

--- a/apps/web/__tests__/unit/messenger-agent.test.ts
+++ b/apps/web/__tests__/unit/messenger-agent.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const serverEnvMock = vi.hoisted(() =>
+	vi.fn(() => ({
+		ANTHROPIC_API_KEY: "anthropic-key",
+		OPENAI_API_KEY: undefined,
+		GROQ_API_KEY: undefined,
+		SUPERMEMORY_API_KEY: undefined,
+		SUPERMEMORY_KNOWLEDGE_TAG: undefined,
+	})),
+);
+const searchSupermemoryMock = vi.hoisted(() => vi.fn());
+const getGroqClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@cap/env", () => ({
+	serverEnv: serverEnvMock,
+}));
+
+vi.mock("@/lib/groq-client", () => ({
+	GROQ_MODEL: "groq-model",
+	getGroqClient: getGroqClientMock,
+}));
+
+vi.mock("@/lib/messenger/supermemory", () => ({
+	getKnowledgeTag: vi.fn(() => "knowledge"),
+	searchSupermemory: searchSupermemoryMock,
+}));
+
+const readFetchBody = (call: unknown[]) => {
+	const init = call[1] as { body?: unknown };
+	if (typeof init.body !== "string") {
+		throw new Error("Expected fetch body");
+	}
+	return JSON.parse(init.body) as {
+		model?: string;
+		max_tokens?: number;
+		tools?: Array<{
+			name?: string;
+			input_schema?: {
+				properties?: Record<string, unknown>;
+			};
+		}>;
+		messages?: Array<{
+			role?: string;
+			content?: unknown;
+		}>;
+	};
+};
+
+describe("generateMessengerAgentReply", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		searchSupermemoryMock.mockResolvedValue([]);
+		getGroqClientMock.mockReturnValue(null);
+	});
+
+	it("uses Sonnet 5 and executes the constrained support email tool", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						content: [
+							{
+								type: "tool_use",
+								id: "tool-1",
+								name: "send_support_email",
+								input: {
+									subject: "Upload issue",
+									message: "The user cannot upload their recording.",
+									email: "spoof@example.com",
+								},
+							},
+						],
+					}),
+					{ status: 200 },
+				),
+			)
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						content: [
+							{
+								type: "text",
+								text: "Done, I sent that to the team from your account email.",
+							},
+						],
+					}),
+					{ status: 200 },
+				),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const execute = vi.fn().mockResolvedValue({
+			status: "sent" as const,
+			remainingToday: 1,
+		});
+		const { generateMessengerAgentReply } = await import(
+			"@/lib/messenger/agent"
+		);
+
+		const result = await generateMessengerAgentReply({
+			userIdentity: "Test User <user@example.com>",
+			identityTag: "user:user-123",
+			query: "Please send this to support",
+			history: [
+				{
+					role: "user",
+					content: "Uploads keep failing. Please send this to support.",
+				},
+			],
+			supportEmailTool: {
+				execute,
+			},
+		});
+
+		expect(result).toBe(
+			"Done, I sent that to the team from your account email.",
+		);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		const firstBody = readFetchBody(fetchMock.mock.calls[0] ?? []);
+		expect(firstBody.model).toBe("claude-sonnet-5");
+		expect(firstBody.max_tokens).toBe(350);
+		expect(firstBody.tools?.[0]?.name).toBe("send_support_email");
+		expect(firstBody.tools?.[0]?.input_schema?.properties?.email).toBe(
+			undefined,
+		);
+		expect(execute).toHaveBeenCalledWith({
+			subject: "Upload issue",
+			message: "The user cannot upload their recording.",
+		});
+
+		const secondBody = readFetchBody(fetchMock.mock.calls[1] ?? []);
+		const toolResultMessage = secondBody.messages?.at(-1);
+		expect(toolResultMessage?.role).toBe("user");
+		expect(toolResultMessage?.content).toEqual([
+			{
+				type: "tool_result",
+				tool_use_id: "tool-1",
+				content:
+					"Support email sent to hello@cap.so from the user's account email. Remaining sends today: 1.",
+			},
+		]);
+	});
+});

--- a/apps/web/__tests__/unit/messenger-support-email.test.ts
+++ b/apps/web/__tests__/unit/messenger-support-email.test.ts
@@ -1,0 +1,130 @@
+import { User } from "@cap/web-domain";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const whereMock = vi.hoisted(() => vi.fn());
+const valuesMock = vi.hoisted(() => vi.fn());
+const sendEmailMock = vi.hoisted(() => vi.fn());
+const messengerSupportEmailMock = vi.hoisted(() => vi.fn(() => null));
+
+const mockDb = vi.hoisted(() => ({
+	select: vi.fn(() => mockDb),
+	from: vi.fn(() => mockDb),
+	where: whereMock,
+	insert: vi.fn(() => mockDb),
+	values: valuesMock,
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@cap/database", () => ({
+	db: vi.fn(() => mockDb),
+}));
+
+vi.mock("@cap/database/helpers", () => ({
+	nanoId: vi.fn(() => "support-email-123"),
+}));
+
+vi.mock("@cap/database/schema", () => ({
+	messengerSupportEmails: {
+		userId: "userId",
+		createdAt: "createdAt",
+	},
+}));
+
+vi.mock("@cap/database/emails/config", () => ({
+	sendEmail: sendEmailMock,
+}));
+
+vi.mock("@cap/database/emails/messenger-support-email", () => ({
+	MessengerSupportEmail: messengerSupportEmailMock,
+}));
+
+vi.mock("drizzle-orm", () => ({
+	and: vi.fn((...conditions: unknown[]) => ({ type: "and", conditions })),
+	count: vi.fn(() => "count"),
+	eq: vi.fn((left: unknown, right: unknown) => ({ type: "eq", left, right })),
+	gte: vi.fn((left: unknown, right: unknown) => ({ type: "gte", left, right })),
+}));
+
+describe("sendMessengerSupportEmail", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		valuesMock.mockResolvedValue(undefined);
+		sendEmailMock.mockResolvedValue(undefined);
+	});
+
+	it("sends support email from account context and records the send", async () => {
+		whereMock.mockResolvedValueOnce([{ value: 1 }]);
+		const { sendMessengerSupportEmail } = await import(
+			"@/lib/messenger/support-email"
+		);
+
+		const result = await sendMessengerSupportEmail({
+			user: {
+				id: User.UserId.make("user-123"),
+				email: "user@example.com",
+				name: "Test User",
+			},
+			conversationId: "conversation-123",
+			subject: "  Upload\nissue  ",
+			message: "  Uploads keep failing.  ",
+			now: new Date("2026-06-30T18:00:00.000Z"),
+		});
+
+		expect(result).toEqual({
+			status: "sent",
+			remainingToday: 0,
+		});
+		expect(messengerSupportEmailMock).toHaveBeenCalledWith({
+			userEmail: "user@example.com",
+			userName: "Test User",
+			conversationId: "conversation-123",
+			message: "Uploads keep failing.",
+		});
+		expect(sendEmailMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				email: "hello@cap.so",
+				subject: "Messenger support: Upload issue",
+				replyTo: "user@example.com",
+				fromOverride: "Cap Support <richie@send.cap.so>",
+			}),
+		);
+		expect(valuesMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: "support-email-123",
+				conversationId: "conversation-123",
+				userId: "user-123",
+				userEmail: "user@example.com",
+				subject: "Upload issue",
+				message: "Uploads keep failing.",
+				createdAt: new Date("2026-06-30T18:00:00.000Z"),
+			}),
+		);
+	});
+
+	it("does not send after two support emails in the same UTC day", async () => {
+		whereMock.mockResolvedValueOnce([{ value: 2 }]);
+		const { sendMessengerSupportEmail } = await import(
+			"@/lib/messenger/support-email"
+		);
+
+		const result = await sendMessengerSupportEmail({
+			user: {
+				id: User.UserId.make("user-123"),
+				email: "user@example.com",
+				name: "Test User",
+			},
+			conversationId: "conversation-123",
+			subject: "Upload issue",
+			message: "Uploads keep failing.",
+			now: new Date("2026-06-30T18:00:00.000Z"),
+		});
+
+		expect(result).toEqual({
+			status: "rate_limited",
+			remainingToday: 0,
+		});
+		expect(sendEmailMock).not.toHaveBeenCalled();
+		expect(valuesMock).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/__tests__/unit/messenger-support-email.test.ts
+++ b/apps/web/__tests__/unit/messenger-support-email.test.ts
@@ -2,6 +2,7 @@ import { User } from "@cap/web-domain";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const whereMock = vi.hoisted(() => vi.fn());
+const forUpdateMock = vi.hoisted(() => vi.fn());
 const valuesMock = vi.hoisted(() => vi.fn());
 const sendEmailMock = vi.hoisted(() => vi.fn());
 const messengerSupportEmailMock = vi.hoisted(() => vi.fn(() => null));
@@ -10,8 +11,10 @@ const mockDb = vi.hoisted(() => ({
 	select: vi.fn(() => mockDb),
 	from: vi.fn(() => mockDb),
 	where: whereMock,
+	for: forUpdateMock,
 	insert: vi.fn(() => mockDb),
 	values: valuesMock,
+	transaction: vi.fn((callback: (tx: unknown) => unknown) => callback(mockDb)),
 }));
 
 vi.mock("server-only", () => ({}));
@@ -28,6 +31,9 @@ vi.mock("@cap/database/schema", () => ({
 	messengerSupportEmails: {
 		userId: "userId",
 		createdAt: "createdAt",
+	},
+	users: {
+		id: "id",
 	},
 }));
 
@@ -50,11 +56,12 @@ describe("sendMessengerSupportEmail", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		valuesMock.mockResolvedValue(undefined);
+		forUpdateMock.mockResolvedValue([{ id: "user-123" }]);
 		sendEmailMock.mockResolvedValue(undefined);
 	});
 
 	it("sends support email from account context and records the send", async () => {
-		whereMock.mockResolvedValueOnce([{ value: 1 }]);
+		whereMock.mockReturnValueOnce(mockDb).mockResolvedValueOnce([{ value: 1 }]);
 		const { sendMessengerSupportEmail } = await import(
 			"@/lib/messenger/support-email"
 		);
@@ -75,6 +82,7 @@ describe("sendMessengerSupportEmail", () => {
 			status: "sent",
 			remainingToday: 0,
 		});
+		expect(forUpdateMock).toHaveBeenCalledWith("update");
 		expect(messengerSupportEmailMock).toHaveBeenCalledWith({
 			userEmail: "user@example.com",
 			userName: "Test User",
@@ -100,10 +108,16 @@ describe("sendMessengerSupportEmail", () => {
 				createdAt: new Date("2026-06-30T18:00:00.000Z"),
 			}),
 		);
+		const insertCallOrder = valuesMock.mock.invocationCallOrder[0];
+		const sendCallOrder = sendEmailMock.mock.invocationCallOrder[0];
+		if (insertCallOrder === undefined || sendCallOrder === undefined) {
+			throw new Error("Expected insert and send call order");
+		}
+		expect(insertCallOrder).toBeLessThan(sendCallOrder);
 	});
 
 	it("does not send after two support emails in the same UTC day", async () => {
-		whereMock.mockResolvedValueOnce([{ value: 2 }]);
+		whereMock.mockReturnValueOnce(mockDb).mockResolvedValueOnce([{ value: 2 }]);
 		const { sendMessengerSupportEmail } = await import(
 			"@/lib/messenger/support-email"
 		);
@@ -126,5 +140,29 @@ describe("sendMessengerSupportEmail", () => {
 		});
 		expect(sendEmailMock).not.toHaveBeenCalled();
 		expect(valuesMock).not.toHaveBeenCalled();
+	});
+
+	it("does not send when the audit reservation fails", async () => {
+		whereMock.mockReturnValueOnce(mockDb).mockResolvedValueOnce([{ value: 1 }]);
+		valuesMock.mockRejectedValueOnce(new Error("insert failed"));
+		const { sendMessengerSupportEmail } = await import(
+			"@/lib/messenger/support-email"
+		);
+
+		await expect(
+			sendMessengerSupportEmail({
+				user: {
+					id: User.UserId.make("user-123"),
+					email: "user@example.com",
+					name: "Test User",
+				},
+				conversationId: "conversation-123",
+				subject: "Upload issue",
+				message: "Uploads keep failing.",
+				now: new Date("2026-06-30T18:00:00.000Z"),
+			}),
+		).rejects.toThrow("insert failed");
+
+		expect(sendEmailMock).not.toHaveBeenCalled();
 	});
 });

--- a/apps/web/actions/messenger.ts
+++ b/apps/web/actions/messenger.ts
@@ -25,6 +25,7 @@ import {
 	storeConversationInSupermemory,
 	syncCapKnowledgeBase,
 } from "@/lib/messenger/supermemory";
+import { sendMessengerSupportEmail } from "@/lib/messenger/support-email";
 
 const normalizeContent = (content: string) => content.trim().slice(0, 6000);
 
@@ -226,12 +227,30 @@ export const sendMessengerUserMessage = async ({
 	const identity = viewer.user
 		? `${viewer.user.name ?? "User"} <${viewer.user.email}>`
 		: `Anonymous visitor (${effectiveAnonymousId ?? "unknown"})`;
+	const supportEmailUser = viewer.user
+		? {
+				id: viewer.user.id,
+				email: viewer.user.email,
+				name: viewer.user.name,
+			}
+		: null;
 
 	const reply = await generateMessengerAgentReply({
 		userIdentity: identity,
 		identityTag: getIdentityTag(effectiveUserId, effectiveAnonymousId),
 		query: normalized,
 		history,
+		supportEmailTool: supportEmailUser
+			? {
+					execute: ({ subject, message }) =>
+						sendMessengerSupportEmail({
+							user: supportEmailUser,
+							conversationId,
+							subject,
+							message,
+						}),
+				}
+			: null,
 	});
 
 	const responseAt = new Date();

--- a/apps/web/lib/messenger/agent.ts
+++ b/apps/web/lib/messenger/agent.ts
@@ -11,6 +11,49 @@ type ConversationMessage = {
 	content: string;
 };
 
+type SupportEmailToolInput = {
+	subject: string;
+	message: string;
+};
+
+type SupportEmailToolResult =
+	| {
+			status: "sent";
+			remainingToday: number;
+	  }
+	| {
+			status: "rate_limited";
+			remainingToday: 0;
+	  };
+
+type SupportEmailTool = {
+	execute: (input: SupportEmailToolInput) => Promise<SupportEmailToolResult>;
+};
+
+type AnthropicTextBlock = {
+	type: "text";
+	text: string;
+};
+
+type AnthropicToolUseBlock = {
+	type: "tool_use";
+	id: string;
+	name: string;
+	input: unknown;
+};
+
+type AnthropicResponseBlock = AnthropicTextBlock | AnthropicToolUseBlock;
+
+type AnthropicToolResultBlock = {
+	type: "tool_result";
+	tool_use_id: string;
+	content: string;
+	is_error?: boolean;
+};
+
+const MESSENGER_ANTHROPIC_MODEL = "claude-sonnet-5";
+const MESSENGER_MAX_TOKENS = 350;
+
 const normalizeContext = (sections: string[]) =>
 	sections
 		.map((entry) => entry.trim())
@@ -19,12 +62,36 @@ const normalizeContext = (sections: string[]) =>
 		.join("\n\n")
 		.slice(0, 7000);
 
+const supportEmailToolDefinition = {
+	name: "send_support_email",
+	description:
+		"Send a concise support email to the Cap team after the signed-in user explicitly asks or agrees. The server controls the recipient, sender, reply-to address, account email, conversation id, and rate limit.",
+	input_schema: {
+		type: "object",
+		properties: {
+			subject: {
+				type: "string",
+				description: "A concise support email subject.",
+			},
+			message: {
+				type: "string",
+				description:
+					"A concise support email body summarizing the user's issue and relevant context from the chat.",
+			},
+		},
+		required: ["subject", "message"],
+		additionalProperties: false,
+	},
+} as const;
+
 const buildSystemPrompt = ({
 	userIdentity,
 	context,
+	supportEmailAvailable,
 }: {
 	userIdentity: string;
 	context: string;
+	supportEmailAvailable: boolean;
 }) =>
 	[
 		MESSENGER_AGENT_PROMPT,
@@ -42,10 +109,18 @@ Critical rules:
 - Never make up features, pricing, dates, or technical details. If you're not sure, say so honestly. Always use the Cap Reference Guide below for accurate facts, URLs, and pricing.
 - When linking to Cap pages, ALWAYS use the full URL from the reference guide (e.g. https://cap.so/download, not just "cap.so"). Get the exact URL right.
 - If you genuinely can't help, say something like "I'm not sure on that one, let me get someone from the team to take a look" rather than stiff corporate escalation language.
-- Keep responses focused, usually 1-3 short paragraphs max. This is a chat, not an email.
+- Keep responses focused, usually 1-2 short paragraphs max and under 120 words unless the user asks for detailed steps.
 - Be genuinely helpful, personable, and respectful. You represent Cap and should leave the user feeling good about the interaction.
 - ONLY discuss Cap and topics directly related to Cap (screen recording, sharing, account, billing, technical issues with Cap, etc.). If a user asks about other apps, competitors, or unrelated topics, politely steer the conversation back to Cap. Never recommend, compare, or discuss competing products or unrelated software.
-- If you notice the conversation is going in circles, the user seems frustrated, or their issue isn't getting resolved after a few back-and-forth messages, gently suggest they email the team directly at hello@cap.so for more hands-on help. Say something natural like "this one might need a closer look from the team, if you shoot an email to hello@cap.so we can dig into it properly" rather than stiff escalation language.`,
+- If you notice the conversation is going in circles, the user seems frustrated, or their issue isn't getting resolved after a few back-and-forth messages, offer to send it to the team if the support email tool is available. If the tool is unavailable, gently suggest emailing hello@cap.so for more hands-on help.`,
+		supportEmailAvailable
+			? `Support email tool:
+- You can send one support email to hello@cap.so by using send_support_email, but only after the user explicitly asks you to send it or agrees to your offer.
+- Never ask for, accept, or invent a sender or recipient email address. The server uses the signed-in account email automatically.
+- Keep the email subject short and the body factual. Include the user's issue, useful details already shared, and what they need from the team.
+- After the tool result, tell the user briefly whether it was sent. If the tool says rate_limited, say they can still email hello@cap.so directly.`
+			: `Support email:
+- You cannot send support email for this user in the current chat. If a hands-on review is needed, ask them to email hello@cap.so directly.`,
 		CAP_REFERENCE_GUIDE,
 		`The person you're talking to: ${userIdentity}`,
 		context
@@ -61,33 +136,119 @@ const mapHistoryForLlm = (history: ConversationMessage[]) =>
 		content: message.content.slice(0, 6000),
 	}));
 
-const parseAnthropicContent = (payload: unknown) => {
+const parseAnthropicMessage = (payload: unknown) => {
 	if (!payload || typeof payload !== "object") return null;
 	const content = (payload as { content?: unknown }).content;
 	if (!Array.isArray(content)) return null;
-	const text = content
-		.map((block) => {
-			if (!block || typeof block !== "object") return "";
-			const type = (block as { type?: unknown }).type;
-			const value = (block as { text?: unknown }).text;
-			if (type !== "text" || typeof value !== "string") return "";
-			return value;
-		})
+
+	const blocks = content.flatMap((block): AnthropicResponseBlock[] => {
+		if (!block || typeof block !== "object") return [];
+		const type = (block as { type?: unknown }).type;
+		if (type === "text") {
+			const text = (block as { text?: unknown }).text;
+			return typeof text === "string" ? [{ type, text }] : [];
+		}
+		if (type === "tool_use") {
+			const id = (block as { id?: unknown }).id;
+			const name = (block as { name?: unknown }).name;
+			if (typeof id !== "string" || typeof name !== "string") return [];
+			return [
+				{
+					type,
+					id,
+					name,
+					input: (block as { input?: unknown }).input,
+				},
+			];
+		}
+		return [];
+	});
+	if (!blocks.length) return null;
+
+	const text = blocks
+		.map((block) => (block.type === "text" ? block.text : ""))
 		.join("\n")
 		.trim();
-	return text.length > 0 ? text : null;
+
+	return {
+		content: blocks,
+		text: text.length > 0 ? text : null,
+	};
 };
 
-const callAnthropic = async ({
-	systemPrompt,
-	history,
-}: {
-	systemPrompt: string;
-	history: ConversationMessage[];
-}) => {
-	const key = serverEnv().ANTHROPIC_API_KEY;
-	if (!key) return null;
+const readToolString = (input: unknown, key: keyof SupportEmailToolInput) => {
+	if (!input || typeof input !== "object") return null;
+	const value = (input as Record<string, unknown>)[key];
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+};
 
+const readSupportEmailInput = (input: unknown) => {
+	const subject = readToolString(input, "subject");
+	const message = readToolString(input, "message");
+	if (!subject || !message) return null;
+	return {
+		subject,
+		message,
+	};
+};
+
+const formatSupportEmailToolResult = (result: SupportEmailToolResult) => {
+	if (result.status === "sent") {
+		return `Support email sent to hello@cap.so from the user's account email. Remaining sends today: ${result.remainingToday}.`;
+	}
+	return "Support email was not sent because this user has reached the 2 emails per day limit.";
+};
+
+const executeSupportEmailToolUse = async ({
+	toolUse,
+	supportEmailTool,
+}: {
+	toolUse: AnthropicToolUseBlock;
+	supportEmailTool: SupportEmailTool;
+}): Promise<AnthropicToolResultBlock> => {
+	if (toolUse.name !== supportEmailToolDefinition.name) {
+		return {
+			type: "tool_result",
+			tool_use_id: toolUse.id,
+			content: "Unknown tool.",
+			is_error: true,
+		};
+	}
+
+	const input = readSupportEmailInput(toolUse.input);
+	if (!input) {
+		return {
+			type: "tool_result",
+			tool_use_id: toolUse.id,
+			content: "Missing subject or message.",
+			is_error: true,
+		};
+	}
+
+	const result = await supportEmailTool.execute(input);
+	return {
+		type: "tool_result",
+		tool_use_id: toolUse.id,
+		content: formatSupportEmailToolResult(result),
+	};
+};
+
+const postAnthropicMessages = async ({
+	key,
+	systemPrompt,
+	messages,
+	tools,
+}: {
+	key: string;
+	systemPrompt: string;
+	messages: Array<{
+		role: "user" | "assistant";
+		content: string | AnthropicResponseBlock[] | AnthropicToolResultBlock[];
+	}>;
+	tools?: [typeof supportEmailToolDefinition];
+}) => {
 	const response = await fetch("https://api.anthropic.com/v1/messages", {
 		method: "POST",
 		headers: {
@@ -96,11 +257,12 @@ const callAnthropic = async ({
 			"Content-Type": "application/json",
 		},
 		body: JSON.stringify({
-			model: "claude-sonnet-4-6",
+			model: MESSENGER_ANTHROPIC_MODEL,
 			temperature: 0.65,
-			max_tokens: 500,
+			max_tokens: MESSENGER_MAX_TOKENS,
 			system: systemPrompt,
-			messages: mapHistoryForLlm(history),
+			messages,
+			tools,
 		}),
 		signal: AbortSignal.timeout(35000),
 	});
@@ -111,7 +273,77 @@ const callAnthropic = async ({
 	}
 
 	const payload = await response.json();
-	return parseAnthropicContent(payload);
+	return parseAnthropicMessage(payload);
+};
+
+const callAnthropic = async ({
+	systemPrompt,
+	history,
+	supportEmailTool,
+}: {
+	systemPrompt: string;
+	history: ConversationMessage[];
+	supportEmailTool: SupportEmailTool | null;
+}) => {
+	const key = serverEnv().ANTHROPIC_API_KEY;
+	if (!key) return null;
+
+	const initial = await postAnthropicMessages({
+		key,
+		systemPrompt,
+		messages: mapHistoryForLlm(history),
+		tools: supportEmailTool ? [supportEmailToolDefinition] : undefined,
+	});
+
+	if (!initial) return null;
+	const toolUses = supportEmailTool
+		? initial.content.filter((block) => block.type === "tool_use")
+		: [];
+
+	if (!supportEmailTool || toolUses.length === 0) {
+		return initial.text;
+	}
+
+	const toolResults: AnthropicToolResultBlock[] = [];
+	let sentEmailToolResult = false;
+	for (const toolUse of toolUses) {
+		if (sentEmailToolResult) {
+			toolResults.push({
+				type: "tool_result",
+				tool_use_id: toolUse.id,
+				content: "Only one support email can be sent per assistant response.",
+				is_error: true,
+			});
+			continue;
+		}
+		toolResults.push(
+			await executeSupportEmailToolUse({ toolUse, supportEmailTool }),
+		);
+		sentEmailToolResult = true;
+	}
+
+	const final = await postAnthropicMessages({
+		key,
+		systemPrompt,
+		messages: [
+			...mapHistoryForLlm(history),
+			{
+				role: "assistant",
+				content: initial.content,
+			},
+			{
+				role: "user",
+				content: toolResults,
+			},
+		],
+	});
+
+	if (final?.text) return final.text;
+	const firstToolResult = toolResults[0]?.content ?? "";
+	if (firstToolResult.includes("Support email sent")) {
+		return "Done, I sent that to the team from your account email. We'll follow up with you there.";
+	}
+	return "I couldn't send another support email from your account today. You're limited to 2 per day, but you can still email hello@cap.so directly.";
 };
 
 const parseOpenAiContent = (payload: unknown) => {
@@ -147,7 +379,7 @@ const callOpenAi = async ({
 		body: JSON.stringify({
 			model: "gpt-4o-mini",
 			temperature: 0.65,
-			max_tokens: 500,
+			max_tokens: MESSENGER_MAX_TOKENS,
 			messages: [
 				{ role: "system", content: systemPrompt },
 				...mapHistoryForLlm(history),
@@ -178,7 +410,7 @@ const callGroq = async ({
 	const completion = await client.chat.completions.create({
 		model: GROQ_MODEL,
 		temperature: 0.65,
-		max_tokens: 500,
+		max_tokens: MESSENGER_MAX_TOKENS,
 		messages: [
 			{ role: "system", content: systemPrompt },
 			...mapHistoryForLlm(history),
@@ -195,11 +427,13 @@ export const generateMessengerAgentReply = async ({
 	identityTag,
 	query,
 	history,
+	supportEmailTool = null,
 }: {
 	userIdentity: string;
 	identityTag: string;
 	query: string;
 	history: ConversationMessage[];
+	supportEmailTool?: SupportEmailTool | null;
 }) => {
 	const [personalContext, knowledgeContext] = await Promise.all([
 		searchSupermemory({ query, containerTag: identityTag, limit: 4 }).catch(
@@ -215,19 +449,34 @@ export const generateMessengerAgentReply = async ({
 	const systemPrompt = buildSystemPrompt({
 		userIdentity,
 		context: normalizeContext([...knowledgeContext, ...personalContext]),
+		supportEmailAvailable: Boolean(supportEmailTool),
 	});
 
-	const fromAnthropic = await callAnthropic({ systemPrompt, history }).catch(
-		() => null,
-	);
+	const fromAnthropic = await callAnthropic({
+		systemPrompt,
+		history,
+		supportEmailTool,
+	}).catch(() => null);
 	if (fromAnthropic) return fromAnthropic;
 
-	const fromOpenAi = await callOpenAi({ systemPrompt, history }).catch(
-		() => null,
-	);
+	const fallbackSystemPrompt = supportEmailTool
+		? buildSystemPrompt({
+				userIdentity,
+				context: normalizeContext([...knowledgeContext, ...personalContext]),
+				supportEmailAvailable: false,
+			})
+		: systemPrompt;
+
+	const fromOpenAi = await callOpenAi({
+		systemPrompt: fallbackSystemPrompt,
+		history,
+	}).catch(() => null);
 	if (fromOpenAi) return fromOpenAi;
 
-	const fromGroq = await callGroq({ systemPrompt, history }).catch(() => null);
+	const fromGroq = await callGroq({
+		systemPrompt: fallbackSystemPrompt,
+		history,
+	}).catch(() => null);
 	if (fromGroq) return fromGroq;
 
 	return "Oh no, I'm so sorry about this! I'm having a little technical hiccup on my end. Someone from the team will jump in here shortly to help you out though!";

--- a/apps/web/lib/messenger/agent.ts
+++ b/apps/web/lib/messenger/agent.ts
@@ -53,6 +53,7 @@ type AnthropicToolResultBlock = {
 
 const MESSENGER_ANTHROPIC_MODEL = "claude-sonnet-5";
 const MESSENGER_MAX_TOKENS = 350;
+const MESSENGER_TOOL_DISPATCH_MAX_TOKENS = 512;
 
 const normalizeContext = (sections: string[]) =>
 	sections
@@ -227,12 +228,21 @@ const executeSupportEmailToolUse = async ({
 		};
 	}
 
-	const result = await supportEmailTool.execute(input);
-	return {
-		type: "tool_result",
-		tool_use_id: toolUse.id,
-		content: formatSupportEmailToolResult(result),
-	};
+	try {
+		const result = await supportEmailTool.execute(input);
+		return {
+			type: "tool_result",
+			tool_use_id: toolUse.id,
+			content: formatSupportEmailToolResult(result),
+		};
+	} catch {
+		return {
+			type: "tool_result",
+			tool_use_id: toolUse.id,
+			content: "Failed to send support email.",
+			is_error: true,
+		};
+	}
 };
 
 const postAnthropicMessages = async ({
@@ -240,6 +250,7 @@ const postAnthropicMessages = async ({
 	systemPrompt,
 	messages,
 	tools,
+	maxTokens = MESSENGER_MAX_TOKENS,
 }: {
 	key: string;
 	systemPrompt: string;
@@ -248,6 +259,7 @@ const postAnthropicMessages = async ({
 		content: string | AnthropicResponseBlock[] | AnthropicToolResultBlock[];
 	}>;
 	tools?: [typeof supportEmailToolDefinition];
+	maxTokens?: number;
 }) => {
 	const response = await fetch("https://api.anthropic.com/v1/messages", {
 		method: "POST",
@@ -259,7 +271,7 @@ const postAnthropicMessages = async ({
 		body: JSON.stringify({
 			model: MESSENGER_ANTHROPIC_MODEL,
 			temperature: 0.65,
-			max_tokens: MESSENGER_MAX_TOKENS,
+			max_tokens: maxTokens,
 			system: systemPrompt,
 			messages,
 			tools,
@@ -293,11 +305,16 @@ const callAnthropic = async ({
 		systemPrompt,
 		messages: mapHistoryForLlm(history),
 		tools: supportEmailTool ? [supportEmailToolDefinition] : undefined,
+		maxTokens: supportEmailTool
+			? MESSENGER_TOOL_DISPATCH_MAX_TOKENS
+			: MESSENGER_MAX_TOKENS,
 	});
 
 	if (!initial) return null;
 	const toolUses = supportEmailTool
-		? initial.content.filter((block) => block.type === "tool_use")
+		? initial.content.filter(
+				(block): block is AnthropicToolUseBlock => block.type === "tool_use",
+			)
 		: [];
 
 	if (!supportEmailTool || toolUses.length === 0) {
@@ -339,9 +356,12 @@ const callAnthropic = async ({
 	});
 
 	if (final?.text) return final.text;
-	const firstToolResult = toolResults[0]?.content ?? "";
-	if (firstToolResult.includes("Support email sent")) {
+	const firstToolResult = toolResults[0];
+	if (firstToolResult?.content.includes("Support email sent")) {
 		return "Done, I sent that to the team from your account email. We'll follow up with you there.";
+	}
+	if (firstToolResult?.is_error) {
+		return "I couldn't send that to the team right now. Please email hello@cap.so directly.";
 	}
 	return "I couldn't send another support email from your account today. You're limited to 2 per day, but you can still email hello@cap.so directly.";
 };

--- a/apps/web/lib/messenger/constants.ts
+++ b/apps/web/lib/messenger/constants.ts
@@ -292,9 +292,9 @@ COMMON USER TASKS:
 - To set up SSO: contact enterprise team at https://cal.com/cap.so/15min
 `;
 
-export const MESSENGER_AGENT_PROMPT = `You are Millie, you work at Cap. Cap is your company, your team, your people. You're the kind of person who lights up a conversation without even trying. You're warm, genuinely friendly, and you actually enjoy helping people figure things out. You make people feel like they're chatting with a friend who happens to know everything about Cap. You're curious about what people are working on, you remember details from earlier in the conversation, and you always check in to make sure things actually worked.
+export const MESSENGER_AGENT_PROMPT = `You are Millie, you work at Cap. Cap is your company, your team, your people. You're warm, genuinely friendly, and you actually enjoy helping people figure things out. You make people feel like they're chatting with a thoughtful teammate who knows Cap well. You remember details from earlier in the conversation and check in when it helps.
 
-You have a natural, chatty energy. You say things like "oh that's so cool!", "ooh yeah", "honestly", "oh nice!", "ah gotcha", and "haha" when it fits. You ask follow-up questions because you genuinely care, not because a script told you to. If someone shares what they're building or working on, you get excited about it. You're the person on the team everyone loves talking to.
+You have a natural, concise energy. You can say things like "ooh yeah", "honestly", "oh nice!", "ah gotcha", and "haha" when it fits, but don't overdo it. Ask follow-up questions because they move the conversation forward, not because a script told you to.
 
 How to handle technical issues and troubleshooting:
 - NEVER give a vague "what's going on?" response when someone says they have an issue. That's lazy and unhelpful. Always ask specific diagnostic questions to narrow things down fast.
@@ -304,11 +304,11 @@ How to handle technical issues and troubleshooting:
 - If you can guess the likely problem category from context (e.g. they mention recording, sharing, exporting, signing in), jump straight to the relevant diagnostic questions for that area.
 
 Writing style rules you MUST follow:
-- Write like you're messaging a friend who asked for help, warm and natural
+- Write like you're messaging a colleague who asked for help, warm and natural
 - Always use "we" and "our" when talking about Cap and its features, you're part of this team and you love it
 - Never use em dashes (--) or the unicode em dash character, use commas or just start a new sentence
 - Use natural contractions freely (don't, can't, won't, it's, you'll, we've, that's) and occasionally drop an apostrophe (dont, cant, its)
-- Use "!" naturally because you're genuinely enthusiastic, but don't overdo it, keep it real
+- Use "!" sparingly and naturally, keep it real
 - Say "yeah" instead of "yes" most of the time
 - React to things naturally: "oh no, that's frustrating" not "I apologize for the inconvenience", "ooh nice!" not "That's great to hear"
 - Ask follow-up questions to make sure things actually worked out
@@ -316,5 +316,6 @@ Writing style rules you MUST follow:
 - Keep things conversational. If you need to walk through steps, talk through them like you're explaining to a friend, not writing documentation
 - Never use corporate support language or generic phrases like "Thank you for reaching out" or "I understand your frustration" or "Happy to help!"
 - Never use bullet points or numbered lists unless genuinely needed for multi-step instructions
-- Sound like a real, warm person who genuinely enjoys her job and the people she talks to
-- Match the user's message length roughly. Short message, short reply. Chatty message, be chatty back. But NEVER mirror rudeness, anger, sarcasm, or frustration. Always stay warm, polite, and genuinely helpful no matter how the user is acting. If they're upset, that's totally understandable, acknowledge it kindly and focus on fixing the problem. If their message is vague about a problem, don't match the vagueness, ask specific questions to help them`;
+- Sound like a real, warm person who genuinely enjoys her job, but don't monologue
+- Default to 2-5 sentences. Use 1-2 short paragraphs max unless the user asks for depth or step-by-step help
+- Match the user's message length roughly. Short message, short reply. Chatty message, be a little chatty back, but stay tight. But NEVER mirror rudeness, anger, sarcasm, or frustration. Always stay warm, polite, and genuinely helpful no matter how the user is acting. If they're upset, that's totally understandable, acknowledge it kindly and focus on fixing the problem. If their message is vague about a problem, don't match the vagueness, ask specific questions to help them`;

--- a/apps/web/lib/messenger/support-email.ts
+++ b/apps/web/lib/messenger/support-email.ts
@@ -4,7 +4,7 @@ import { db } from "@cap/database";
 import { sendEmail } from "@cap/database/emails/config";
 import { MessengerSupportEmail } from "@cap/database/emails/messenger-support-email";
 import { nanoId } from "@cap/database/helpers";
-import { messengerSupportEmails } from "@cap/database/schema";
+import { messengerSupportEmails, users } from "@cap/database/schema";
 import type { User } from "@cap/web-domain";
 import { and, count, eq, gte } from "drizzle-orm";
 
@@ -50,25 +50,59 @@ export const sendMessengerSupportEmail = async ({
 		throw new Error("Support email message is empty");
 	}
 
-	const [row] = await db()
-		.select({ value: count() })
-		.from(messengerSupportEmails)
-		.where(
-			and(
-				eq(messengerSupportEmails.userId, user.id),
-				gte(
-					messengerSupportEmails.createdAt,
-					getMessengerSupportEmailDayStart(now),
-				),
-			),
-		);
-	const sentToday = row?.value ?? 0;
+	const reserved = await db().transaction(async (tx) => {
+		const [lockedUser] = await tx
+			.select({ id: users.id })
+			.from(users)
+			.where(eq(users.id, user.id))
+			.for("update");
 
-	if (sentToday >= MESSENGER_SUPPORT_EMAIL_DAILY_LIMIT) {
+		if (!lockedUser) {
+			throw new Error("Support email user not found");
+		}
+
+		const [row] = await tx
+			.select({ value: count() })
+			.from(messengerSupportEmails)
+			.where(
+				and(
+					eq(messengerSupportEmails.userId, user.id),
+					gte(
+						messengerSupportEmails.createdAt,
+						getMessengerSupportEmailDayStart(now),
+					),
+				),
+			);
+		const sentToday = row?.value ?? 0;
+
+		if (sentToday >= MESSENGER_SUPPORT_EMAIL_DAILY_LIMIT) {
+			return {
+				status: "rate_limited" as const,
+				remainingToday: 0 as const,
+			};
+		}
+
+		await tx.insert(messengerSupportEmails).values({
+			id: nanoId(),
+			conversationId,
+			userId: user.id,
+			userEmail: user.email,
+			subject: normalizedSubject,
+			message: normalizedMessage,
+			createdAt: now,
+		});
+
 		return {
-			status: "rate_limited" as const,
-			remainingToday: 0 as const,
+			status: "sent" as const,
+			remainingToday: Math.max(
+				0,
+				MESSENGER_SUPPORT_EMAIL_DAILY_LIMIT - sentToday - 1,
+			),
 		};
+	});
+
+	if (reserved.status === "rate_limited") {
+		return reserved;
 	}
 
 	await sendEmail({
@@ -84,21 +118,5 @@ export const sendMessengerSupportEmail = async ({
 		fromOverride: SUPPORT_EMAIL_FROM,
 	});
 
-	await db().insert(messengerSupportEmails).values({
-		id: nanoId(),
-		conversationId,
-		userId: user.id,
-		userEmail: user.email,
-		subject: normalizedSubject,
-		message: normalizedMessage,
-		createdAt: now,
-	});
-
-	return {
-		status: "sent" as const,
-		remainingToday: Math.max(
-			0,
-			MESSENGER_SUPPORT_EMAIL_DAILY_LIMIT - sentToday - 1,
-		),
-	};
+	return reserved;
 };

--- a/apps/web/lib/messenger/support-email.ts
+++ b/apps/web/lib/messenger/support-email.ts
@@ -1,0 +1,104 @@
+import "server-only";
+
+import { db } from "@cap/database";
+import { sendEmail } from "@cap/database/emails/config";
+import { MessengerSupportEmail } from "@cap/database/emails/messenger-support-email";
+import { nanoId } from "@cap/database/helpers";
+import { messengerSupportEmails } from "@cap/database/schema";
+import type { User } from "@cap/web-domain";
+import { and, count, eq, gte } from "drizzle-orm";
+
+const SUPPORT_EMAIL_TO = "hello@cap.so";
+const SUPPORT_EMAIL_FROM = "Cap Support <richie@send.cap.so>";
+export const MESSENGER_SUPPORT_EMAIL_DAILY_LIMIT = 2;
+
+type MessengerSupportUser = {
+	id: User.UserId;
+	email: string;
+	name?: string | null;
+};
+
+const normalizeSubject = (subject: string, userEmail: string) => {
+	const normalized = subject.replace(/\s+/g, " ").trim().slice(0, 140);
+	return normalized || `Support request from ${userEmail}`;
+};
+
+const normalizeMessage = (message: string) => message.trim().slice(0, 4000);
+
+export const getMessengerSupportEmailDayStart = (now = new Date()) => {
+	const start = new Date(now);
+	start.setUTCHours(0, 0, 0, 0);
+	return start;
+};
+
+export const sendMessengerSupportEmail = async ({
+	user,
+	conversationId,
+	subject,
+	message,
+	now = new Date(),
+}: {
+	user: MessengerSupportUser;
+	conversationId: string;
+	subject: string;
+	message: string;
+	now?: Date;
+}) => {
+	const normalizedSubject = normalizeSubject(subject, user.email);
+	const normalizedMessage = normalizeMessage(message);
+	if (!normalizedMessage) {
+		throw new Error("Support email message is empty");
+	}
+
+	const [row] = await db()
+		.select({ value: count() })
+		.from(messengerSupportEmails)
+		.where(
+			and(
+				eq(messengerSupportEmails.userId, user.id),
+				gte(
+					messengerSupportEmails.createdAt,
+					getMessengerSupportEmailDayStart(now),
+				),
+			),
+		);
+	const sentToday = row?.value ?? 0;
+
+	if (sentToday >= MESSENGER_SUPPORT_EMAIL_DAILY_LIMIT) {
+		return {
+			status: "rate_limited" as const,
+			remainingToday: 0 as const,
+		};
+	}
+
+	await sendEmail({
+		email: SUPPORT_EMAIL_TO,
+		subject: `Messenger support: ${normalizedSubject}`,
+		react: MessengerSupportEmail({
+			userEmail: user.email,
+			userName: user.name,
+			conversationId,
+			message: normalizedMessage,
+		}),
+		replyTo: user.email,
+		fromOverride: SUPPORT_EMAIL_FROM,
+	});
+
+	await db().insert(messengerSupportEmails).values({
+		id: nanoId(),
+		conversationId,
+		userId: user.id,
+		userEmail: user.email,
+		subject: normalizedSubject,
+		message: normalizedMessage,
+		createdAt: now,
+	});
+
+	return {
+		status: "sent" as const,
+		remainingToday: Math.max(
+			0,
+			MESSENGER_SUPPORT_EMAIL_DAILY_LIMIT - sentToday - 1,
+		),
+	};
+};

--- a/packages/database/emails/messenger-support-email.tsx
+++ b/packages/database/emails/messenger-support-email.tsx
@@ -1,0 +1,65 @@
+import { CAP_LOGO_URL } from "@cap/utils";
+import {
+	Body,
+	Container,
+	Head,
+	Heading,
+	Html,
+	Img,
+	Preview,
+	Section,
+	Tailwind,
+	Text,
+} from "@react-email/components";
+
+export function MessengerSupportEmail({
+	userEmail,
+	userName,
+	conversationId,
+	message,
+}: {
+	userEmail: string;
+	userName?: string | null;
+	conversationId: string;
+	message: string;
+}) {
+	return (
+		<Html>
+			<Head />
+			<Preview>Messenger support request from {userEmail}</Preview>
+			<Tailwind>
+				<Body className="mx-auto my-auto bg-gray-1 font-sans">
+					<Container className="mx-auto my-10 max-w-[500px] rounded border border-solid border-gray-200 px-10 py-5">
+						<Section className="mt-8">
+							<Img
+								src={CAP_LOGO_URL}
+								width="40"
+								height="40"
+								alt="Cap"
+								className="mx-auto my-0"
+							/>
+						</Section>
+						<Heading className="mx-0 my-7 p-0 text-center text-xl font-semibold text-black">
+							Messenger Support Request
+						</Heading>
+						<Text className="text-sm leading-6 text-black">
+							<strong>From:</strong> {userName ? `${userName} ` : ""}
+							&lt;{userEmail}&gt;
+						</Text>
+						<Text className="text-sm leading-6 text-black">
+							<strong>Conversation:</strong> {conversationId}
+						</Text>
+						<Section className="my-4 rounded-lg bg-gray-50 p-4">
+							<Text className="whitespace-pre-wrap text-sm leading-6 text-gray-700">
+								{message}
+							</Text>
+						</Section>
+						<Text className="text-sm leading-6 text-gray-500">
+							Reply to this email to respond directly to the user.
+						</Text>
+					</Container>
+				</Body>
+			</Tailwind>
+		</Html>
+	);
+}

--- a/packages/database/migrations/0032_past_lester.sql
+++ b/packages/database/migrations/0032_past_lester.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `messenger_support_emails` (
+	`id` varchar(15) NOT NULL,
+	`conversationId` varchar(15) NOT NULL,
+	`userId` varchar(15) NOT NULL,
+	`userEmail` varchar(255) NOT NULL,
+	`subject` varchar(255) NOT NULL,
+	`message` text NOT NULL,
+	`createdAt` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `messenger_support_emails_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+ALTER TABLE `messenger_support_emails` ADD CONSTRAINT `messenger_support_emails_conversationId_messenger_conversations_id_fk` FOREIGN KEY (`conversationId`) REFERENCES `messenger_conversations`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX `support_email_user_created_at_idx` ON `messenger_support_emails` (`userId`,`createdAt`);--> statement-breakpoint
+CREATE INDEX `support_email_conversation_created_at_idx` ON `messenger_support_emails` (`conversationId`,`createdAt`);

--- a/packages/database/migrations/0032_past_lester.sql
+++ b/packages/database/migrations/0032_past_lester.sql
@@ -9,6 +9,6 @@ CREATE TABLE `messenger_support_emails` (
 	CONSTRAINT `messenger_support_emails_id` PRIMARY KEY(`id`)
 );
 --> statement-breakpoint
-ALTER TABLE `messenger_support_emails` ADD CONSTRAINT `messenger_support_emails_conversationId_messenger_conversations_id_fk` FOREIGN KEY (`conversationId`) REFERENCES `messenger_conversations`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `messenger_support_emails` ADD CONSTRAINT `support_email_conversation_fk` FOREIGN KEY (`conversationId`) REFERENCES `messenger_conversations`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX `support_email_user_created_at_idx` ON `messenger_support_emails` (`userId`,`createdAt`);--> statement-breakpoint
 CREATE INDEX `support_email_conversation_created_at_idx` ON `messenger_support_emails` (`conversationId`,`createdAt`);

--- a/packages/database/migrations/meta/0032_snapshot.json
+++ b/packages/database/migrations/meta/0032_snapshot.json
@@ -1,3737 +1,3402 @@
 {
-  "version": "5",
-  "dialect": "mysql",
-  "id": "6054e171-7ead-4eb8-8a27-e2c82223c6f0",
-  "prevId": "1a41e8a7-f0ec-4bfa-8df0-8a5cbabedf97",
-  "tables": {
-    "accounts": {
-      "name": "accounts",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "provider": {
-          "name": "provider",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "providerAccountId": {
-          "name": "providerAccountId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "access_token": {
-          "name": "access_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "expires_in": {
-          "name": "expires_in",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "id_token": {
-          "name": "id_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "refresh_token": {
-          "name": "refresh_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "refresh_token_expires_in": {
-          "name": "refresh_token_expires_in",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "scope": {
-          "name": "scope",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "token_type": {
-          "name": "token_type",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "tempColumn": {
-          "name": "tempColumn",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        }
-      },
-      "indexes": {
-        "user_id_idx": {
-          "name": "user_id_idx",
-          "columns": [
-            "userId"
-          ],
-          "isUnique": false
-        },
-        "provider_account_id_idx": {
-          "name": "provider_account_id_idx",
-          "columns": [
-            "providerAccountId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "accounts_id": {
-          "name": "accounts_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "auth_api_keys": {
-      "name": "auth_api_keys",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(36)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "user_id_created_at_idx": {
-          "name": "user_id_created_at_idx",
-          "columns": [
-            "userId",
-            "createdAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "auth_api_keys_id": {
-          "name": "auth_api_keys_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "comments": {
-      "name": "comments",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(6)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "content": {
-          "name": "content",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "timestamp": {
-          "name": "timestamp",
-          "type": "float",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "authorId": {
-          "name": "authorId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "videoId": {
-          "name": "videoId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "parentCommentId": {
-          "name": "parentCommentId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        }
-      },
-      "indexes": {
-        "video_type_created_idx": {
-          "name": "video_type_created_idx",
-          "columns": [
-            "videoId",
-            "type",
-            "createdAt",
-            "id"
-          ],
-          "isUnique": false
-        },
-        "author_id_idx": {
-          "name": "author_id_idx",
-          "columns": [
-            "authorId"
-          ],
-          "isUnique": false
-        },
-        "parent_comment_id_idx": {
-          "name": "parent_comment_id_idx",
-          "columns": [
-            "parentCommentId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "comments_id": {
-          "name": "comments_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "developer_api_keys": {
-      "name": "developer_api_keys",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "appId": {
-          "name": "appId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "keyType": {
-          "name": "keyType",
-          "type": "varchar(8)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "keyPrefix": {
-          "name": "keyPrefix",
-          "type": "varchar(12)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "keyHash": {
-          "name": "keyHash",
-          "type": "varchar(64)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "encryptedKey": {
-          "name": "encryptedKey",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "lastUsedAt": {
-          "name": "lastUsedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "revokedAt": {
-          "name": "revokedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "key_hash_idx": {
-          "name": "key_hash_idx",
-          "columns": [
-            "keyHash"
-          ],
-          "isUnique": true
-        },
-        "app_key_type_idx": {
-          "name": "app_key_type_idx",
-          "columns": [
-            "appId",
-            "keyType"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {
-        "developer_api_keys_appId_developer_apps_id_fk": {
-          "name": "developer_api_keys_appId_developer_apps_id_fk",
-          "tableFrom": "developer_api_keys",
-          "tableTo": "developer_apps",
-          "columnsFrom": [
-            "appId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "developer_api_keys_id": {
-          "name": "developer_api_keys_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "developer_app_domains": {
-      "name": "developer_app_domains",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "appId": {
-          "name": "appId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "domain": {
-          "name": "domain",
-          "type": "varchar(253)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "developer_app_domains_appId_developer_apps_id_fk": {
-          "name": "developer_app_domains_appId_developer_apps_id_fk",
-          "tableFrom": "developer_app_domains",
-          "tableTo": "developer_apps",
-          "columnsFrom": [
-            "appId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "developer_app_domains_id": {
-          "name": "developer_app_domains_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {
-        "app_domain_unique": {
-          "name": "app_domain_unique",
-          "columns": [
-            "appId",
-            "domain"
-          ]
-        }
-      },
-      "checkConstraint": {}
-    },
-    "developer_apps": {
-      "name": "developer_apps",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ownerId": {
-          "name": "ownerId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "environment": {
-          "name": "environment",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "logoUrl": {
-          "name": "logoUrl",
-          "type": "varchar(1024)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "deletedAt": {
-          "name": "deletedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "owner_deleted_idx": {
-          "name": "owner_deleted_idx",
-          "columns": [
-            "ownerId",
-            "deletedAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "developer_apps_id": {
-          "name": "developer_apps_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "developer_credit_accounts": {
-      "name": "developer_credit_accounts",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "appId": {
-          "name": "appId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ownerId": {
-          "name": "ownerId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "balanceMicroCredits": {
-          "name": "balanceMicroCredits",
-          "type": "bigint unsigned",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "stripeCustomerId": {
-          "name": "stripeCustomerId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "stripePaymentMethodId": {
-          "name": "stripePaymentMethodId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "autoTopUpEnabled": {
-          "name": "autoTopUpEnabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
-        },
-        "autoTopUpThresholdMicroCredits": {
-          "name": "autoTopUpThresholdMicroCredits",
-          "type": "bigint unsigned",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "autoTopUpAmountCents": {
-          "name": "autoTopUpAmountCents",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "app_id_unique": {
-          "name": "app_id_unique",
-          "columns": [
-            "appId"
-          ],
-          "isUnique": true
-        }
-      },
-      "foreignKeys": {
-        "developer_credit_accounts_appId_developer_apps_id_fk": {
-          "name": "developer_credit_accounts_appId_developer_apps_id_fk",
-          "tableFrom": "developer_credit_accounts",
-          "tableTo": "developer_apps",
-          "columnsFrom": [
-            "appId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "developer_credit_accounts_id": {
-          "name": "developer_credit_accounts_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "developer_credit_transactions": {
-      "name": "developer_credit_transactions",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "accountId": {
-          "name": "accountId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "amountMicroCredits": {
-          "name": "amountMicroCredits",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "balanceAfterMicroCredits": {
-          "name": "balanceAfterMicroCredits",
-          "type": "bigint unsigned",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "referenceId": {
-          "name": "referenceId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "referenceType": {
-          "name": "referenceType",
-          "type": "varchar(32)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "account_type_created_idx": {
-          "name": "account_type_created_idx",
-          "columns": [
-            "accountId",
-            "type",
-            "createdAt"
-          ],
-          "isUnique": false
-        },
-        "account_ref_dedup_idx": {
-          "name": "account_ref_dedup_idx",
-          "columns": [
-            "accountId",
-            "referenceId",
-            "referenceType"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {
-        "dev_credit_txn_account_fk": {
-          "name": "dev_credit_txn_account_fk",
-          "tableFrom": "developer_credit_transactions",
-          "tableTo": "developer_credit_accounts",
-          "columnsFrom": [
-            "accountId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "developer_credit_transactions_id": {
-          "name": "developer_credit_transactions_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "developer_daily_storage_snapshots": {
-      "name": "developer_daily_storage_snapshots",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "appId": {
-          "name": "appId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "snapshotDate": {
-          "name": "snapshotDate",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "totalDurationMinutes": {
-          "name": "totalDurationMinutes",
-          "type": "float",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "videoCount": {
-          "name": "videoCount",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "microCreditsCharged": {
-          "name": "microCreditsCharged",
-          "type": "bigint unsigned",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "processedAt": {
-          "name": "processedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "developer_daily_storage_snapshots_appId_developer_apps_id_fk": {
-          "name": "developer_daily_storage_snapshots_appId_developer_apps_id_fk",
-          "tableFrom": "developer_daily_storage_snapshots",
-          "tableTo": "developer_apps",
-          "columnsFrom": [
-            "appId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "developer_daily_storage_snapshots_id": {
-          "name": "developer_daily_storage_snapshots_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {
-        "app_date_unique": {
-          "name": "app_date_unique",
-          "columns": [
-            "appId",
-            "snapshotDate"
-          ]
-        }
-      },
-      "checkConstraint": {}
-    },
-    "developer_videos": {
-      "name": "developer_videos",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "appId": {
-          "name": "appId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "externalUserId": {
-          "name": "externalUserId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'Untitled'"
-        },
-        "duration": {
-          "name": "duration",
-          "type": "float",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "width": {
-          "name": "width",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "height": {
-          "name": "height",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "fps": {
-          "name": "fps",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "s3Key": {
-          "name": "s3Key",
-          "type": "varchar(512)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "transcriptionStatus": {
-          "name": "transcriptionStatus",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "deletedAt": {
-          "name": "deletedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "app_created_idx": {
-          "name": "app_created_idx",
-          "columns": [
-            "appId",
-            "createdAt"
-          ],
-          "isUnique": false
-        },
-        "app_user_idx": {
-          "name": "app_user_idx",
-          "columns": [
-            "appId",
-            "externalUserId"
-          ],
-          "isUnique": false
-        },
-        "app_deleted_idx": {
-          "name": "app_deleted_idx",
-          "columns": [
-            "appId",
-            "deletedAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {
-        "developer_videos_appId_developer_apps_id_fk": {
-          "name": "developer_videos_appId_developer_apps_id_fk",
-          "tableFrom": "developer_videos",
-          "tableTo": "developer_apps",
-          "columnsFrom": [
-            "appId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "developer_videos_id": {
-          "name": "developer_videos_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "folders": {
-      "name": "folders",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "color": {
-          "name": "color",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'normal'"
-        },
-        "public": {
-          "name": "public",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
-        },
-        "settings": {
-          "name": "settings",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "organizationId": {
-          "name": "organizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "createdById": {
-          "name": "createdById",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "parentId": {
-          "name": "parentId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "spaceId": {
-          "name": "spaceId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "organization_id_idx": {
-          "name": "organization_id_idx",
-          "columns": [
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "created_by_id_idx": {
-          "name": "created_by_id_idx",
-          "columns": [
-            "createdById"
-          ],
-          "isUnique": false
-        },
-        "parent_id_idx": {
-          "name": "parent_id_idx",
-          "columns": [
-            "parentId"
-          ],
-          "isUnique": false
-        },
-        "space_id_idx": {
-          "name": "space_id_idx",
-          "columns": [
-            "spaceId"
-          ],
-          "isUnique": false
-        },
-        "public_parent_id_idx": {
-          "name": "public_parent_id_idx",
-          "columns": [
-            "public",
-            "parentId"
-          ],
-          "isUnique": false
-        },
-        "public_space_parent_id_idx": {
-          "name": "public_space_parent_id_idx",
-          "columns": [
-            "public",
-            "spaceId",
-            "parentId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "folders_id": {
-          "name": "folders_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "imported_videos": {
-      "name": "imported_videos",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "orgId": {
-          "name": "orgId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "source": {
-          "name": "source",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "source_id": {
-          "name": "source_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "imported_videos_orgId_source_source_id_pk": {
-          "name": "imported_videos_orgId_source_source_id_pk",
-          "columns": [
-            "orgId",
-            "source",
-            "source_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "messenger_conversations": {
-      "name": "messenger_conversations",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "agent": {
-          "name": "agent",
-          "type": "varchar(32)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "mode": {
-          "name": "mode",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'agent'"
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "anonymousId": {
-          "name": "anonymousId",
-          "type": "varchar(64)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "takeoverByUserId": {
-          "name": "takeoverByUserId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "takeoverAt": {
-          "name": "takeoverAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "lastMessageAt": {
-          "name": "lastMessageAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "user_last_message_idx": {
-          "name": "user_last_message_idx",
-          "columns": [
-            "userId",
-            "lastMessageAt"
-          ],
-          "isUnique": false
-        },
-        "anonymous_last_message_idx": {
-          "name": "anonymous_last_message_idx",
-          "columns": [
-            "anonymousId",
-            "lastMessageAt"
-          ],
-          "isUnique": false
-        },
-        "mode_last_message_idx": {
-          "name": "mode_last_message_idx",
-          "columns": [
-            "mode",
-            "lastMessageAt"
-          ],
-          "isUnique": false
-        },
-        "updated_at_idx": {
-          "name": "updated_at_idx",
-          "columns": [
-            "updatedAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "messenger_conversations_id": {
-          "name": "messenger_conversations_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "messenger_messages": {
-      "name": "messenger_messages",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "conversationId": {
-          "name": "conversationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "role": {
-          "name": "role",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "content": {
-          "name": "content",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "anonymousId": {
-          "name": "anonymousId",
-          "type": "varchar(64)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "conversation_created_at_idx": {
-          "name": "conversation_created_at_idx",
-          "columns": [
-            "conversationId",
-            "createdAt"
-          ],
-          "isUnique": false
-        },
-        "role_created_at_idx": {
-          "name": "role_created_at_idx",
-          "columns": [
-            "role",
-            "createdAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {
-        "messenger_messages_conversationId_messenger_conversations_id_fk": {
-          "name": "messenger_messages_conversationId_messenger_conversations_id_fk",
-          "tableFrom": "messenger_messages",
-          "tableTo": "messenger_conversations",
-          "columnsFrom": [
-            "conversationId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "messenger_messages_id": {
-          "name": "messenger_messages_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "messenger_support_emails": {
-      "name": "messenger_support_emails",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "conversationId": {
-          "name": "conversationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "userEmail": {
-          "name": "userEmail",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "subject": {
-          "name": "subject",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "message": {
-          "name": "message",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "support_email_user_created_at_idx": {
-          "name": "support_email_user_created_at_idx",
-          "columns": [
-            "userId",
-            "createdAt"
-          ],
-          "isUnique": false
-        },
-        "support_email_conversation_created_at_idx": {
-          "name": "support_email_conversation_created_at_idx",
-          "columns": [
-            "conversationId",
-            "createdAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {
-        "messenger_support_emails_conversationId_messenger_conversations_id_fk": {
-          "name": "messenger_support_emails_conversationId_messenger_conversations_id_fk",
-          "tableFrom": "messenger_support_emails",
-          "tableTo": "messenger_conversations",
-          "columnsFrom": [
-            "conversationId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "messenger_support_emails_id": {
-          "name": "messenger_support_emails_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "notifications": {
-      "name": "notifications",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "orgId": {
-          "name": "orgId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "recipientId": {
-          "name": "recipientId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "data": {
-          "name": "data",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "videoId": {
-          "name": "videoId",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "dedupKey": {
-          "name": "dedupKey",
-          "type": "varchar(128)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "readAt": {
-          "name": "readAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "org_id_idx": {
-          "name": "org_id_idx",
-          "columns": [
-            "orgId"
-          ],
-          "isUnique": false
-        },
-        "type_idx": {
-          "name": "type_idx",
-          "columns": [
-            "type"
-          ],
-          "isUnique": false
-        },
-        "read_at_idx": {
-          "name": "read_at_idx",
-          "columns": [
-            "readAt"
-          ],
-          "isUnique": false
-        },
-        "created_at_idx": {
-          "name": "created_at_idx",
-          "columns": [
-            "createdAt"
-          ],
-          "isUnique": false
-        },
-        "recipient_read_idx": {
-          "name": "recipient_read_idx",
-          "columns": [
-            "recipientId",
-            "readAt"
-          ],
-          "isUnique": false
-        },
-        "recipient_created_idx": {
-          "name": "recipient_created_idx",
-          "columns": [
-            "recipientId",
-            "createdAt"
-          ],
-          "isUnique": false
-        },
-        "dedup_key_idx": {
-          "name": "dedup_key_idx",
-          "columns": [
-            "dedupKey"
-          ],
-          "isUnique": true
-        },
-        "type_recipient_created_idx": {
-          "name": "type_recipient_created_idx",
-          "columns": [
-            "type",
-            "recipientId",
-            "createdAt"
-          ],
-          "isUnique": false
-        },
-        "type_recipient_video_created_idx": {
-          "name": "type_recipient_video_created_idx",
-          "columns": [
-            "type",
-            "recipientId",
-            "videoId",
-            "createdAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "notifications_id": {
-          "name": "notifications_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "organization_invites": {
-      "name": "organization_invites",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "organizationId": {
-          "name": "organizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "invitedEmail": {
-          "name": "invitedEmail",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "invitedByUserId": {
-          "name": "invitedByUserId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "role": {
-          "name": "role",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "status": {
-          "name": "status",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'pending'"
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "expiresAt": {
-          "name": "expiresAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        }
-      },
-      "indexes": {
-        "organization_id_idx": {
-          "name": "organization_id_idx",
-          "columns": [
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "invited_email_idx": {
-          "name": "invited_email_idx",
-          "columns": [
-            "invitedEmail"
-          ],
-          "isUnique": false
-        },
-        "invited_by_user_id_idx": {
-          "name": "invited_by_user_id_idx",
-          "columns": [
-            "invitedByUserId"
-          ],
-          "isUnique": false
-        },
-        "status_idx": {
-          "name": "status_idx",
-          "columns": [
-            "status"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "organization_invites_id": {
-          "name": "organization_invites_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "organization_members": {
-      "name": "organization_members",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "organizationId": {
-          "name": "organizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "role": {
-          "name": "role",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "hasProSeat": {
-          "name": "hasProSeat",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "organization_id_idx": {
-          "name": "organization_id_idx",
-          "columns": [
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "user_id_organization_id_idx": {
-          "name": "user_id_organization_id_idx",
-          "columns": [
-            "userId",
-            "organizationId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "organization_members_id": {
-          "name": "organization_members_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "organizations": {
-      "name": "organizations",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ownerId": {
-          "name": "ownerId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "tombstoneAt": {
-          "name": "tombstoneAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "allowedEmailDomain": {
-          "name": "allowedEmailDomain",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "customDomain": {
-          "name": "customDomain",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "domainVerified": {
-          "name": "domainVerified",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "settings": {
-          "name": "settings",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "iconUrl": {
-          "name": "iconUrl",
-          "type": "varchar(1024)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "shareableLinkIconUrl": {
-          "name": "shareableLinkIconUrl",
-          "type": "varchar(1024)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "workosOrganizationId": {
-          "name": "workosOrganizationId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "workosConnectionId": {
-          "name": "workosConnectionId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        }
-      },
-      "indexes": {
-        "owner_id_tombstone_idx": {
-          "name": "owner_id_tombstone_idx",
-          "columns": [
-            "ownerId",
-            "tombstoneAt"
-          ],
-          "isUnique": false
-        },
-        "custom_domain_idx": {
-          "name": "custom_domain_idx",
-          "columns": [
-            "customDomain"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "organizations_id": {
-          "name": "organizations_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "s3_buckets": {
-      "name": "s3_buckets",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ownerId": {
-          "name": "ownerId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "organizationId": {
-          "name": "organizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "region": {
-          "name": "region",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "endpoint": {
-          "name": "endpoint",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "bucketName": {
-          "name": "bucketName",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "accessKeyId": {
-          "name": "accessKeyId",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "secretAccessKey": {
-          "name": "secretAccessKey",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "provider": {
-          "name": "provider",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "('aws')"
-        },
-        "active": {
-          "name": "active",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": true
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "owner_organization_idx": {
-          "name": "owner_organization_idx",
-          "columns": [
-            "ownerId",
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "organization_id_idx": {
-          "name": "organization_id_idx",
-          "columns": [
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "organization_active_idx": {
-          "name": "organization_active_idx",
-          "columns": [
-            "organizationId",
-            "active",
-            "updatedAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "s3_buckets_id": {
-          "name": "s3_buckets_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "sessions": {
-      "name": "sessions",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "sessionToken": {
-          "name": "sessionToken",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "expires": {
-          "name": "expires",
-          "type": "datetime",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "session_token_idx": {
-          "name": "session_token_idx",
-          "columns": [
-            "sessionToken"
-          ],
-          "isUnique": true
-        },
-        "user_id_idx": {
-          "name": "user_id_idx",
-          "columns": [
-            "userId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "sessions_id": {
-          "name": "sessions_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "shared_videos": {
-      "name": "shared_videos",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "videoId": {
-          "name": "videoId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "folderId": {
-          "name": "folderId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "organizationId": {
-          "name": "organizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "sharedByUserId": {
-          "name": "sharedByUserId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "sharedAt": {
-          "name": "sharedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "folder_id_idx": {
-          "name": "folder_id_idx",
-          "columns": [
-            "folderId"
-          ],
-          "isUnique": false
-        },
-        "organization_id_idx": {
-          "name": "organization_id_idx",
-          "columns": [
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "shared_by_user_id_idx": {
-          "name": "shared_by_user_id_idx",
-          "columns": [
-            "sharedByUserId"
-          ],
-          "isUnique": false
-        },
-        "video_id_organization_id_idx": {
-          "name": "video_id_organization_id_idx",
-          "columns": [
-            "videoId",
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "video_id_folder_id_idx": {
-          "name": "video_id_folder_id_idx",
-          "columns": [
-            "videoId",
-            "folderId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "shared_videos_id": {
-          "name": "shared_videos_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "space_members": {
-      "name": "space_members",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "spaceId": {
-          "name": "spaceId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "userId": {
-          "name": "userId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "role": {
-          "name": "role",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'member'"
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "user_id_idx": {
-          "name": "user_id_idx",
-          "columns": [
-            "userId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "space_members_id": {
-          "name": "space_members_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {
-        "space_id_user_id_unique": {
-          "name": "space_id_user_id_unique",
-          "columns": [
-            "spaceId",
-            "userId"
-          ]
-        }
-      },
-      "checkConstraint": {}
-    },
-    "space_videos": {
-      "name": "space_videos",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "spaceId": {
-          "name": "spaceId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "folderId": {
-          "name": "folderId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "videoId": {
-          "name": "videoId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "addedById": {
-          "name": "addedById",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "addedAt": {
-          "name": "addedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "folder_id_idx": {
-          "name": "folder_id_idx",
-          "columns": [
-            "folderId"
-          ],
-          "isUnique": false
-        },
-        "video_id_idx": {
-          "name": "video_id_idx",
-          "columns": [
-            "videoId"
-          ],
-          "isUnique": false
-        },
-        "added_by_id_idx": {
-          "name": "added_by_id_idx",
-          "columns": [
-            "addedById"
-          ],
-          "isUnique": false
-        },
-        "space_id_video_id_idx": {
-          "name": "space_id_video_id_idx",
-          "columns": [
-            "spaceId",
-            "videoId"
-          ],
-          "isUnique": false
-        },
-        "space_id_folder_id_idx": {
-          "name": "space_id_folder_id_idx",
-          "columns": [
-            "spaceId",
-            "folderId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "space_videos_id": {
-          "name": "space_videos_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "spaces": {
-      "name": "spaces",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "primary": {
-          "name": "primary",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "organizationId": {
-          "name": "organizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "createdById": {
-          "name": "createdById",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "iconUrl": {
-          "name": "iconUrl",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "description": {
-          "name": "description",
-          "type": "varchar(1000)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "settings": {
-          "name": "settings",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "password": {
-          "name": "password",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "privacy": {
-          "name": "privacy",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'Private'"
-        },
-        "public": {
-          "name": "public",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
-        }
-      },
-      "indexes": {
-        "organization_id_idx": {
-          "name": "organization_id_idx",
-          "columns": [
-            "organizationId"
-          ],
-          "isUnique": false
-        },
-        "created_by_id_idx": {
-          "name": "created_by_id_idx",
-          "columns": [
-            "createdById"
-          ],
-          "isUnique": false
-        },
-        "public_organization_id_idx": {
-          "name": "public_organization_id_idx",
-          "columns": [
-            "public",
-            "organizationId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "spaces_id": {
-          "name": "spaces_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "storage_integrations": {
-      "name": "storage_integrations",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ownerId": {
-          "name": "ownerId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "organizationId": {
-          "name": "organizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "provider": {
-          "name": "provider",
-          "type": "varchar(64)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "displayName": {
-          "name": "displayName",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "status": {
-          "name": "status",
-          "type": "varchar(32)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'active'"
-        },
-        "active": {
-          "name": "active",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
-        },
-        "encryptedConfig": {
-          "name": "encryptedConfig",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "googleDriveAccessToken": {
-          "name": "googleDriveAccessToken",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "googleDriveAccessTokenExpiresAt": {
-          "name": "googleDriveAccessTokenExpiresAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "googleDriveTokenRefreshLeaseId": {
-          "name": "googleDriveTokenRefreshLeaseId",
-          "type": "varchar(64)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "googleDriveTokenRefreshLeaseExpiresAt": {
-          "name": "googleDriveTokenRefreshLeaseExpiresAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "googleDriveStorageQuotaCache": {
-          "name": "googleDriveStorageQuotaCache",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "owner_provider_idx": {
-          "name": "owner_provider_idx",
-          "columns": [
-            "ownerId",
-            "provider"
-          ],
-          "isUnique": false
-        },
-        "owner_active_idx": {
-          "name": "owner_active_idx",
-          "columns": [
-            "ownerId",
-            "active"
-          ],
-          "isUnique": false
-        },
-        "organization_provider_idx": {
-          "name": "organization_provider_idx",
-          "columns": [
-            "organizationId",
-            "provider"
-          ],
-          "isUnique": false
-        },
-        "organization_active_idx": {
-          "name": "organization_active_idx",
-          "columns": [
-            "organizationId",
-            "active",
-            "status"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "storage_integrations_id": {
-          "name": "storage_integrations_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "storage_objects": {
-      "name": "storage_objects",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "integrationId": {
-          "name": "integrationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ownerId": {
-          "name": "ownerId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "videoId": {
-          "name": "videoId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "objectKey": {
-          "name": "objectKey",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "objectKeyHash": {
-          "name": "objectKeyHash",
-          "type": "varchar(64)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "providerObjectId": {
-          "name": "providerObjectId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "uploadSessionUrl": {
-          "name": "uploadSessionUrl",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "uploadStatus": {
-          "name": "uploadStatus",
-          "type": "varchar(32)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'pending'"
-        },
-        "contentType": {
-          "name": "contentType",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "contentLength": {
-          "name": "contentLength",
-          "type": "bigint unsigned",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {
-        "integration_key_hash_idx": {
-          "name": "integration_key_hash_idx",
-          "columns": [
-            "integrationId",
-            "objectKeyHash"
-          ],
-          "isUnique": true
-        },
-        "integration_status_idx": {
-          "name": "integration_status_idx",
-          "columns": [
-            "integrationId",
-            "uploadStatus"
-          ],
-          "isUnique": false
-        },
-        "video_id_idx": {
-          "name": "video_id_idx",
-          "columns": [
-            "videoId"
-          ],
-          "isUnique": false
-        },
-        "owner_id_idx": {
-          "name": "owner_id_idx",
-          "columns": [
-            "ownerId"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {
-        "storage_objects_integrationId_storage_integrations_id_fk": {
-          "name": "storage_objects_integrationId_storage_integrations_id_fk",
-          "tableFrom": "storage_objects",
-          "tableTo": "storage_integrations",
-          "columnsFrom": [
-            "integrationId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "restrict",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "storage_objects_id": {
-          "name": "storage_objects_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "users": {
-      "name": "users",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "lastName": {
-          "name": "lastName",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "email": {
-          "name": "email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "emailVerified": {
-          "name": "emailVerified",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "image": {
-          "name": "image",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "stripeCustomerId": {
-          "name": "stripeCustomerId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "stripeSubscriptionId": {
-          "name": "stripeSubscriptionId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "thirdPartyStripeSubscriptionId": {
-          "name": "thirdPartyStripeSubscriptionId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "stripeSubscriptionStatus": {
-          "name": "stripeSubscriptionStatus",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "stripeSubscriptionPriceId": {
-          "name": "stripeSubscriptionPriceId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "preferences": {
-          "name": "preferences",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false,
-          "default": "('null')"
-        },
-        "activeOrganizationId": {
-          "name": "activeOrganizationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "onboardingSteps": {
-          "name": "onboardingSteps",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "onboarding_completed_at": {
-          "name": "onboarding_completed_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "customBucket": {
-          "name": "customBucket",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "inviteQuota": {
-          "name": "inviteQuota",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 1
-        },
-        "defaultOrgId": {
-          "name": "defaultOrgId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "authSessionVersion": {
-          "name": "authSessionVersion",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        }
-      },
-      "indexes": {
-        "email_idx": {
-          "name": "email_idx",
-          "columns": [
-            "email"
-          ],
-          "isUnique": true
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "users_id": {
-          "name": "users_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "verification_tokens": {
-      "name": "verification_tokens",
-      "columns": {
-        "identifier": {
-          "name": "identifier",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "token": {
-          "name": "token",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "expires": {
-          "name": "expires",
-          "type": "datetime",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "verification_tokens_identifier": {
-          "name": "verification_tokens_identifier",
-          "columns": [
-            "identifier"
-          ]
-        }
-      },
-      "uniqueConstraints": {
-        "verification_tokens_token_unique": {
-          "name": "verification_tokens_token_unique",
-          "columns": [
-            "token"
-          ]
-        }
-      },
-      "checkConstraint": {}
-    },
-    "video_edits": {
-      "name": "video_edits",
-      "columns": {
-        "videoId": {
-          "name": "videoId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "sourceKey": {
-          "name": "sourceKey",
-          "type": "varchar(512)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "editSpec": {
-          "name": "editSpec",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "video_edits_videoId_videos_id_fk": {
-          "name": "video_edits_videoId_videos_id_fk",
-          "tableFrom": "video_edits",
-          "tableTo": "videos",
-          "columnsFrom": [
-            "videoId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "video_edits_videoId": {
-          "name": "video_edits_videoId",
-          "columns": [
-            "videoId"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "video_uploads": {
-      "name": "video_uploads",
-      "columns": {
-        "video_id": {
-          "name": "video_id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "uploaded": {
-          "name": "uploaded",
-          "type": "bigint unsigned",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "total": {
-          "name": "total",
-          "type": "bigint unsigned",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "started_at": {
-          "name": "started_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "mode": {
-          "name": "mode",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "phase": {
-          "name": "phase",
-          "type": "varchar(32)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'uploading'"
-        },
-        "processing_progress": {
-          "name": "processing_progress",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "processing_message": {
-          "name": "processing_message",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "processing_error": {
-          "name": "processing_error",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "raw_file_key": {
-          "name": "raw_file_key",
-          "type": "varchar(512)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        }
-      },
-      "indexes": {
-        "phase_updated_at_video_id_idx": {
-          "name": "phase_updated_at_video_id_idx",
-          "columns": [
-            "phase",
-            "updated_at",
-            "video_id"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "video_uploads_video_id": {
-          "name": "video_uploads_video_id",
-          "columns": [
-            "video_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    },
-    "videos": {
-      "name": "videos",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "ownerId": {
-          "name": "ownerId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "orgId": {
-          "name": "orgId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'My Video'"
-        },
-        "bucket": {
-          "name": "bucket",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "storageIntegrationId": {
-          "name": "storageIntegrationId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "duration": {
-          "name": "duration",
-          "type": "float",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "width": {
-          "name": "width",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "height": {
-          "name": "height",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "fps": {
-          "name": "fps",
-          "type": "int",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "public": {
-          "name": "public",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": true
-        },
-        "settings": {
-          "name": "settings",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "transcriptionStatus": {
-          "name": "transcriptionStatus",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "source": {
-          "name": "source",
-          "type": "json",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "('{\"type\":\"MediaConvert\"}')"
-        },
-        "folderId": {
-          "name": "folderId",
-          "type": "varchar(15)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(now())"
-        },
-        "effectiveCreatedAt": {
-          "name": "effectiveCreatedAt",
-          "type": "datetime",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false,
-          "generated": {
-            "as": "COALESCE(\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%s.%fZ'),\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%sZ'),\n          `createdAt`\n        )",
-            "type": "stored"
-          }
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "onUpdate": true,
-          "default": "(now())"
-        },
-        "password": {
-          "name": "password",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "xStreamInfo": {
-          "name": "xStreamInfo",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "firstViewEmailSentAt": {
-          "name": "firstViewEmailSentAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "isScreenshot": {
-          "name": "isScreenshot",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
-        },
-        "awsRegion": {
-          "name": "awsRegion",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "awsBucket": {
-          "name": "awsBucket",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "videoStartTime": {
-          "name": "videoStartTime",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "audioStartTime": {
-          "name": "audioStartTime",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "jobId": {
-          "name": "jobId",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "jobStatus": {
-          "name": "jobStatus",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "skipProcessing": {
-          "name": "skipProcessing",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
-        }
-      },
-      "indexes": {
-        "owner_id_idx": {
-          "name": "owner_id_idx",
-          "columns": [
-            "ownerId"
-          ],
-          "isUnique": false
-        },
-        "is_public_idx": {
-          "name": "is_public_idx",
-          "columns": [
-            "public"
-          ],
-          "isUnique": false
-        },
-        "folder_id_idx": {
-          "name": "folder_id_idx",
-          "columns": [
-            "folderId"
-          ],
-          "isUnique": false
-        },
-        "storage_integration_id_idx": {
-          "name": "storage_integration_id_idx",
-          "columns": [
-            "storageIntegrationId"
-          ],
-          "isUnique": false
-        },
-        "org_owner_folder_idx": {
-          "name": "org_owner_folder_idx",
-          "columns": [
-            "orgId",
-            "ownerId",
-            "folderId"
-          ],
-          "isUnique": false
-        },
-        "org_effective_created_idx": {
-          "name": "org_effective_created_idx",
-          "columns": [
-            "orgId",
-            "effectiveCreatedAt"
-          ],
-          "isUnique": false
-        }
-      },
-      "foreignKeys": {
-        "videos_storageIntegrationId_storage_integrations_id_fk": {
-          "name": "videos_storageIntegrationId_storage_integrations_id_fk",
-          "tableFrom": "videos",
-          "tableTo": "storage_integrations",
-          "columnsFrom": [
-            "storageIntegrationId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "restrict",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "videos_id": {
-          "name": "videos_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "checkConstraint": {}
-    }
-  },
-  "views": {},
-  "_meta": {
-    "schemas": {},
-    "tables": {},
-    "columns": {}
-  },
-  "internal": {
-    "tables": {},
-    "indexes": {}
-  }
+	"version": "5",
+	"dialect": "mysql",
+	"id": "6054e171-7ead-4eb8-8a27-e2c82223c6f0",
+	"prevId": "1a41e8a7-f0ec-4bfa-8df0-8a5cbabedf97",
+	"tables": {
+		"accounts": {
+			"name": "accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerAccountId": {
+					"name": "providerAccountId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_in": {
+					"name": "expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_in": {
+					"name": "refresh_token_expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"tempColumn": {
+					"name": "tempColumn",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				},
+				"provider_account_id_idx": {
+					"name": "provider_account_id_idx",
+					"columns": ["providerAccountId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"accounts_id": {
+					"name": "accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"auth_api_keys": {
+			"name": "auth_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(36)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_id_created_at_idx": {
+					"name": "user_id_created_at_idx",
+					"columns": ["userId", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"auth_api_keys_id": {
+					"name": "auth_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"comments": {
+			"name": "comments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(6)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"authorId": {
+					"name": "authorId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"parentCommentId": {
+					"name": "parentCommentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"video_type_created_idx": {
+					"name": "video_type_created_idx",
+					"columns": ["videoId", "type", "createdAt", "id"],
+					"isUnique": false
+				},
+				"author_id_idx": {
+					"name": "author_id_idx",
+					"columns": ["authorId"],
+					"isUnique": false
+				},
+				"parent_comment_id_idx": {
+					"name": "parent_comment_id_idx",
+					"columns": ["parentCommentId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"comments_id": {
+					"name": "comments_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_api_keys": {
+			"name": "developer_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyType": {
+					"name": "keyType",
+					"type": "varchar(8)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyPrefix": {
+					"name": "keyPrefix",
+					"type": "varchar(12)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyHash": {
+					"name": "keyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"encryptedKey": {
+					"name": "encryptedKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"lastUsedAt": {
+					"name": "lastUsedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"revokedAt": {
+					"name": "revokedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"key_hash_idx": {
+					"name": "key_hash_idx",
+					"columns": ["keyHash"],
+					"isUnique": true
+				},
+				"app_key_type_idx": {
+					"name": "app_key_type_idx",
+					"columns": ["appId", "keyType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_api_keys_appId_developer_apps_id_fk": {
+					"name": "developer_api_keys_appId_developer_apps_id_fk",
+					"tableFrom": "developer_api_keys",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_api_keys_id": {
+					"name": "developer_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_app_domains": {
+			"name": "developer_app_domains",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"domain": {
+					"name": "domain",
+					"type": "varchar(253)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_app_domains_appId_developer_apps_id_fk": {
+					"name": "developer_app_domains_appId_developer_apps_id_fk",
+					"tableFrom": "developer_app_domains",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_app_domains_id": {
+					"name": "developer_app_domains_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_domain_unique": {
+					"name": "app_domain_unique",
+					"columns": ["appId", "domain"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_apps": {
+			"name": "developer_apps",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"environment": {
+					"name": "environment",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"logoUrl": {
+					"name": "logoUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_deleted_idx": {
+					"name": "owner_deleted_idx",
+					"columns": ["ownerId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"developer_apps_id": {
+					"name": "developer_apps_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_accounts": {
+			"name": "developer_credit_accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceMicroCredits": {
+					"name": "balanceMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripePaymentMethodId": {
+					"name": "stripePaymentMethodId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"autoTopUpEnabled": {
+					"name": "autoTopUpEnabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"autoTopUpThresholdMicroCredits": {
+					"name": "autoTopUpThresholdMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"autoTopUpAmountCents": {
+					"name": "autoTopUpAmountCents",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_id_unique": {
+					"name": "app_id_unique",
+					"columns": ["appId"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"developer_credit_accounts_appId_developer_apps_id_fk": {
+					"name": "developer_credit_accounts_appId_developer_apps_id_fk",
+					"tableFrom": "developer_credit_accounts",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_accounts_id": {
+					"name": "developer_credit_accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_transactions": {
+			"name": "developer_credit_transactions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amountMicroCredits": {
+					"name": "amountMicroCredits",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceAfterMicroCredits": {
+					"name": "balanceAfterMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"referenceId": {
+					"name": "referenceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"referenceType": {
+					"name": "referenceType",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"account_type_created_idx": {
+					"name": "account_type_created_idx",
+					"columns": ["accountId", "type", "createdAt"],
+					"isUnique": false
+				},
+				"account_ref_dedup_idx": {
+					"name": "account_ref_dedup_idx",
+					"columns": ["accountId", "referenceId", "referenceType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"dev_credit_txn_account_fk": {
+					"name": "dev_credit_txn_account_fk",
+					"tableFrom": "developer_credit_transactions",
+					"tableTo": "developer_credit_accounts",
+					"columnsFrom": ["accountId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_transactions_id": {
+					"name": "developer_credit_transactions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_daily_storage_snapshots": {
+			"name": "developer_daily_storage_snapshots",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"snapshotDate": {
+					"name": "snapshotDate",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"totalDurationMinutes": {
+					"name": "totalDurationMinutes",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"videoCount": {
+					"name": "videoCount",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"microCreditsCharged": {
+					"name": "microCreditsCharged",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processedAt": {
+					"name": "processedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_daily_storage_snapshots_appId_developer_apps_id_fk": {
+					"name": "developer_daily_storage_snapshots_appId_developer_apps_id_fk",
+					"tableFrom": "developer_daily_storage_snapshots",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_daily_storage_snapshots_id": {
+					"name": "developer_daily_storage_snapshots_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_date_unique": {
+					"name": "app_date_unique",
+					"columns": ["appId", "snapshotDate"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_videos": {
+			"name": "developer_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"externalUserId": {
+					"name": "externalUserId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Untitled'"
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"s3Key": {
+					"name": "s3Key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_created_idx": {
+					"name": "app_created_idx",
+					"columns": ["appId", "createdAt"],
+					"isUnique": false
+				},
+				"app_user_idx": {
+					"name": "app_user_idx",
+					"columns": ["appId", "externalUserId"],
+					"isUnique": false
+				},
+				"app_deleted_idx": {
+					"name": "app_deleted_idx",
+					"columns": ["appId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_videos_appId_developer_apps_id_fk": {
+					"name": "developer_videos_appId_developer_apps_id_fk",
+					"tableFrom": "developer_videos",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_videos_id": {
+					"name": "developer_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"folders": {
+			"name": "folders",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"color": {
+					"name": "color",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'normal'"
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parentId": {
+					"name": "parentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				},
+				"parent_id_idx": {
+					"name": "parent_id_idx",
+					"columns": ["parentId"],
+					"isUnique": false
+				},
+				"space_id_idx": {
+					"name": "space_id_idx",
+					"columns": ["spaceId"],
+					"isUnique": false
+				},
+				"public_parent_id_idx": {
+					"name": "public_parent_id_idx",
+					"columns": ["public", "parentId"],
+					"isUnique": false
+				},
+				"public_space_parent_id_idx": {
+					"name": "public_space_parent_id_idx",
+					"columns": ["public", "spaceId", "parentId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"folders_id": {
+					"name": "folders_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"imported_videos": {
+			"name": "imported_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"imported_videos_orgId_source_source_id_pk": {
+					"name": "imported_videos_orgId_source_source_id_pk",
+					"columns": ["orgId", "source", "source_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_conversations": {
+			"name": "messenger_conversations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent": {
+					"name": "agent",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'agent'"
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverByUserId": {
+					"name": "takeoverByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverAt": {
+					"name": "takeoverAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"lastMessageAt": {
+					"name": "lastMessageAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_last_message_idx": {
+					"name": "user_last_message_idx",
+					"columns": ["userId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"anonymous_last_message_idx": {
+					"name": "anonymous_last_message_idx",
+					"columns": ["anonymousId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"mode_last_message_idx": {
+					"name": "mode_last_message_idx",
+					"columns": ["mode", "lastMessageAt"],
+					"isUnique": false
+				},
+				"updated_at_idx": {
+					"name": "updated_at_idx",
+					"columns": ["updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"messenger_conversations_id": {
+					"name": "messenger_conversations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_messages": {
+			"name": "messenger_messages",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"conversationId": {
+					"name": "conversationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"conversation_created_at_idx": {
+					"name": "conversation_created_at_idx",
+					"columns": ["conversationId", "createdAt"],
+					"isUnique": false
+				},
+				"role_created_at_idx": {
+					"name": "role_created_at_idx",
+					"columns": ["role", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"messenger_messages_conversationId_messenger_conversations_id_fk": {
+					"name": "messenger_messages_conversationId_messenger_conversations_id_fk",
+					"tableFrom": "messenger_messages",
+					"tableTo": "messenger_conversations",
+					"columnsFrom": ["conversationId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"messenger_messages_id": {
+					"name": "messenger_messages_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_support_emails": {
+			"name": "messenger_support_emails",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"conversationId": {
+					"name": "conversationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userEmail": {
+					"name": "userEmail",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subject": {
+					"name": "subject",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"message": {
+					"name": "message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"support_email_user_created_at_idx": {
+					"name": "support_email_user_created_at_idx",
+					"columns": ["userId", "createdAt"],
+					"isUnique": false
+				},
+				"support_email_conversation_created_at_idx": {
+					"name": "support_email_conversation_created_at_idx",
+					"columns": ["conversationId", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"messenger_support_emails_conversationId_messenger_conversations_id_fk": {
+					"name": "messenger_support_emails_conversationId_messenger_conversations_id_fk",
+					"tableFrom": "messenger_support_emails",
+					"tableTo": "messenger_conversations",
+					"columnsFrom": ["conversationId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"messenger_support_emails_id": {
+					"name": "messenger_support_emails_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"notifications": {
+			"name": "notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recipientId": {
+					"name": "recipientId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"data": {
+					"name": "data",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dedupKey": {
+					"name": "dedupKey",
+					"type": "varchar(128)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"readAt": {
+					"name": "readAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"org_id_idx": {
+					"name": "org_id_idx",
+					"columns": ["orgId"],
+					"isUnique": false
+				},
+				"type_idx": {
+					"name": "type_idx",
+					"columns": ["type"],
+					"isUnique": false
+				},
+				"read_at_idx": {
+					"name": "read_at_idx",
+					"columns": ["readAt"],
+					"isUnique": false
+				},
+				"created_at_idx": {
+					"name": "created_at_idx",
+					"columns": ["createdAt"],
+					"isUnique": false
+				},
+				"recipient_read_idx": {
+					"name": "recipient_read_idx",
+					"columns": ["recipientId", "readAt"],
+					"isUnique": false
+				},
+				"recipient_created_idx": {
+					"name": "recipient_created_idx",
+					"columns": ["recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"dedup_key_idx": {
+					"name": "dedup_key_idx",
+					"columns": ["dedupKey"],
+					"isUnique": true
+				},
+				"type_recipient_created_idx": {
+					"name": "type_recipient_created_idx",
+					"columns": ["type", "recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"type_recipient_video_created_idx": {
+					"name": "type_recipient_video_created_idx",
+					"columns": ["type", "recipientId", "videoId", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"notifications_id": {
+					"name": "notifications_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_invites": {
+			"name": "organization_invites",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedEmail": {
+					"name": "invitedEmail",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedByUserId": {
+					"name": "invitedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"invited_email_idx": {
+					"name": "invited_email_idx",
+					"columns": ["invitedEmail"],
+					"isUnique": false
+				},
+				"invited_by_user_id_idx": {
+					"name": "invited_by_user_id_idx",
+					"columns": ["invitedByUserId"],
+					"isUnique": false
+				},
+				"status_idx": {
+					"name": "status_idx",
+					"columns": ["status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_invites_id": {
+					"name": "organization_invites_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_members": {
+			"name": "organization_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"hasProSeat": {
+					"name": "hasProSeat",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"user_id_organization_id_idx": {
+					"name": "user_id_organization_id_idx",
+					"columns": ["userId", "organizationId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_members_id": {
+					"name": "organization_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organizations": {
+			"name": "organizations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tombstoneAt": {
+					"name": "tombstoneAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"allowedEmailDomain": {
+					"name": "allowedEmailDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customDomain": {
+					"name": "customDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"domainVerified": {
+					"name": "domainVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"shareableLinkIconUrl": {
+					"name": "shareableLinkIconUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"workosOrganizationId": {
+					"name": "workosOrganizationId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"workosConnectionId": {
+					"name": "workosConnectionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"owner_id_tombstone_idx": {
+					"name": "owner_id_tombstone_idx",
+					"columns": ["ownerId", "tombstoneAt"],
+					"isUnique": false
+				},
+				"custom_domain_idx": {
+					"name": "custom_domain_idx",
+					"columns": ["customDomain"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organizations_id": {
+					"name": "organizations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"s3_buckets": {
+			"name": "s3_buckets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"region": {
+					"name": "region",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"endpoint": {
+					"name": "endpoint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"bucketName": {
+					"name": "bucketName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accessKeyId": {
+					"name": "accessKeyId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"secretAccessKey": {
+					"name": "secretAccessKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('aws')"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_organization_idx": {
+					"name": "owner_organization_idx",
+					"columns": ["ownerId", "organizationId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"s3_buckets_id": {
+					"name": "s3_buckets_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"sessions": {
+			"name": "sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sessionToken": {
+					"name": "sessionToken",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"session_token_idx": {
+					"name": "session_token_idx",
+					"columns": ["sessionToken"],
+					"isUnique": true
+				},
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"sessions_id": {
+					"name": "sessions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"shared_videos": {
+			"name": "shared_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedByUserId": {
+					"name": "sharedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedAt": {
+					"name": "sharedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"shared_by_user_id_idx": {
+					"name": "shared_by_user_id_idx",
+					"columns": ["sharedByUserId"],
+					"isUnique": false
+				},
+				"video_id_organization_id_idx": {
+					"name": "video_id_organization_id_idx",
+					"columns": ["videoId", "organizationId"],
+					"isUnique": false
+				},
+				"video_id_folder_id_idx": {
+					"name": "video_id_folder_id_idx",
+					"columns": ["videoId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"shared_videos_id": {
+					"name": "shared_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"space_members": {
+			"name": "space_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'member'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_members_id": {
+					"name": "space_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"space_id_user_id_unique": {
+					"name": "space_id_user_id_unique",
+					"columns": ["spaceId", "userId"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"space_videos": {
+			"name": "space_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedById": {
+					"name": "addedById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedAt": {
+					"name": "addedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"added_by_id_idx": {
+					"name": "added_by_id_idx",
+					"columns": ["addedById"],
+					"isUnique": false
+				},
+				"space_id_video_id_idx": {
+					"name": "space_id_video_id_idx",
+					"columns": ["spaceId", "videoId"],
+					"isUnique": false
+				},
+				"space_id_folder_id_idx": {
+					"name": "space_id_folder_id_idx",
+					"columns": ["spaceId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_videos_id": {
+					"name": "space_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"spaces": {
+			"name": "spaces",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"primary": {
+					"name": "primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "varchar(1000)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"privacy": {
+					"name": "privacy",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Private'"
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				},
+				"public_organization_id_idx": {
+					"name": "public_organization_id_idx",
+					"columns": ["public", "organizationId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"spaces_id": {
+					"name": "spaces_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_integrations": {
+			"name": "storage_integrations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"displayName": {
+					"name": "displayName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"encryptedConfig": {
+					"name": "encryptedConfig",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"googleDriveAccessToken": {
+					"name": "googleDriveAccessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveAccessTokenExpiresAt": {
+					"name": "googleDriveAccessTokenExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseId": {
+					"name": "googleDriveTokenRefreshLeaseId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseExpiresAt": {
+					"name": "googleDriveTokenRefreshLeaseExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveStorageQuotaCache": {
+					"name": "googleDriveStorageQuotaCache",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_provider_idx": {
+					"name": "owner_provider_idx",
+					"columns": ["ownerId", "provider"],
+					"isUnique": false
+				},
+				"owner_active_idx": {
+					"name": "owner_active_idx",
+					"columns": ["ownerId", "active"],
+					"isUnique": false
+				},
+				"organization_provider_idx": {
+					"name": "organization_provider_idx",
+					"columns": ["organizationId", "provider"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"storage_integrations_id": {
+					"name": "storage_integrations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_objects": {
+			"name": "storage_objects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"integrationId": {
+					"name": "integrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"objectKey": {
+					"name": "objectKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"objectKeyHash": {
+					"name": "objectKeyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerObjectId": {
+					"name": "providerObjectId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploadSessionUrl": {
+					"name": "uploadSessionUrl",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"uploadStatus": {
+					"name": "uploadStatus",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"contentType": {
+					"name": "contentType",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"contentLength": {
+					"name": "contentLength",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"integration_key_hash_idx": {
+					"name": "integration_key_hash_idx",
+					"columns": ["integrationId", "objectKeyHash"],
+					"isUnique": true
+				},
+				"integration_status_idx": {
+					"name": "integration_status_idx",
+					"columns": ["integrationId", "uploadStatus"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"storage_objects_integrationId_storage_integrations_id_fk": {
+					"name": "storage_objects_integrationId_storage_integrations_id_fk",
+					"tableFrom": "storage_objects",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["integrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"storage_objects_id": {
+					"name": "storage_objects_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"lastName": {
+					"name": "lastName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionId": {
+					"name": "stripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"thirdPartyStripeSubscriptionId": {
+					"name": "thirdPartyStripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionStatus": {
+					"name": "stripeSubscriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionPriceId": {
+					"name": "stripeSubscriptionPriceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preferences": {
+					"name": "preferences",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "('null')"
+				},
+				"activeOrganizationId": {
+					"name": "activeOrganizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"onboardingSteps": {
+					"name": "onboardingSteps",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"onboarding_completed_at": {
+					"name": "onboarding_completed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customBucket": {
+					"name": "customBucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"inviteQuota": {
+					"name": "inviteQuota",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"defaultOrgId": {
+					"name": "defaultOrgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"authSessionVersion": {
+					"name": "authSessionVersion",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {
+				"email_idx": {
+					"name": "email_idx",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"users_id": {
+					"name": "users_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"verification_tokens": {
+			"name": "verification_tokens",
+			"columns": {
+				"identifier": {
+					"name": "identifier",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"verification_tokens_identifier": {
+					"name": "verification_tokens_identifier",
+					"columns": ["identifier"]
+				}
+			},
+			"uniqueConstraints": {
+				"verification_tokens_token_unique": {
+					"name": "verification_tokens_token_unique",
+					"columns": ["token"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"video_edits": {
+			"name": "video_edits",
+			"columns": {
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sourceKey": {
+					"name": "sourceKey",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"editSpec": {
+					"name": "editSpec",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"video_edits_videoId_videos_id_fk": {
+					"name": "video_edits_videoId_videos_id_fk",
+					"tableFrom": "video_edits",
+					"tableTo": "videos",
+					"columnsFrom": ["videoId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"video_edits_videoId": {
+					"name": "video_edits_videoId",
+					"columns": ["videoId"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"video_uploads": {
+			"name": "video_uploads",
+			"columns": {
+				"video_id": {
+					"name": "video_id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploaded": {
+					"name": "uploaded",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"total": {
+					"name": "total",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phase": {
+					"name": "phase",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'uploading'"
+				},
+				"processing_progress": {
+					"name": "processing_progress",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processing_message": {
+					"name": "processing_message",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"processing_error": {
+					"name": "processing_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"raw_file_key": {
+					"name": "raw_file_key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"phase_updated_at_video_id_idx": {
+					"name": "phase_updated_at_video_id_idx",
+					"columns": ["phase", "updated_at", "video_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"video_uploads_video_id": {
+					"name": "video_uploads_video_id",
+					"columns": ["video_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"videos": {
+			"name": "videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'My Video'"
+				},
+				"bucket": {
+					"name": "bucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"storageIntegrationId": {
+					"name": "storageIntegrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('{\"type\":\"MediaConvert\"}')"
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"effectiveCreatedAt": {
+					"name": "effectiveCreatedAt",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"generated": {
+						"as": "COALESCE(\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%s.%fZ'),\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%sZ'),\n          `createdAt`\n        )",
+						"type": "stored"
+					}
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"xStreamInfo": {
+					"name": "xStreamInfo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"firstViewEmailSentAt": {
+					"name": "firstViewEmailSentAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"isScreenshot": {
+					"name": "isScreenshot",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"awsRegion": {
+					"name": "awsRegion",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"awsBucket": {
+					"name": "awsBucket",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoStartTime": {
+					"name": "videoStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"audioStartTime": {
+					"name": "audioStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobId": {
+					"name": "jobId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobStatus": {
+					"name": "jobStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"skipProcessing": {
+					"name": "skipProcessing",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				},
+				"is_public_idx": {
+					"name": "is_public_idx",
+					"columns": ["public"],
+					"isUnique": false
+				},
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"storage_integration_id_idx": {
+					"name": "storage_integration_id_idx",
+					"columns": ["storageIntegrationId"],
+					"isUnique": false
+				},
+				"org_owner_folder_idx": {
+					"name": "org_owner_folder_idx",
+					"columns": ["orgId", "ownerId", "folderId"],
+					"isUnique": false
+				},
+				"org_effective_created_idx": {
+					"name": "org_effective_created_idx",
+					"columns": ["orgId", "effectiveCreatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"videos_storageIntegrationId_storage_integrations_id_fk": {
+					"name": "videos_storageIntegrationId_storage_integrations_id_fk",
+					"tableFrom": "videos",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["storageIntegrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"videos_id": {
+					"name": "videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		}
+	},
+	"views": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"tables": {},
+		"indexes": {}
+	}
 }

--- a/packages/database/migrations/meta/0032_snapshot.json
+++ b/packages/database/migrations/meta/0032_snapshot.json
@@ -1,0 +1,3737 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "6054e171-7ead-4eb8-8a27-e2c82223c6f0",
+  "prevId": "1a41e8a7-f0ec-4bfa-8df0-8a5cbabedf97",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_in": {
+          "name": "expires_in",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_in": {
+          "name": "refresh_token_expires_in",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "tempColumn": {
+          "name": "tempColumn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "provider_account_id_idx": {
+          "name": "provider_account_id_idx",
+          "columns": [
+            "providerAccountId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "accounts_id": {
+          "name": "accounts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "auth_api_keys": {
+      "name": "auth_api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "user_id_created_at_idx": {
+          "name": "user_id_created_at_idx",
+          "columns": [
+            "userId",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "auth_api_keys_id": {
+          "name": "auth_api_keys_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "videoId": {
+          "name": "videoId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "parentCommentId": {
+          "name": "parentCommentId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "video_type_created_idx": {
+          "name": "video_type_created_idx",
+          "columns": [
+            "videoId",
+            "type",
+            "createdAt",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "author_id_idx": {
+          "name": "author_id_idx",
+          "columns": [
+            "authorId"
+          ],
+          "isUnique": false
+        },
+        "parent_comment_id_idx": {
+          "name": "parent_comment_id_idx",
+          "columns": [
+            "parentCommentId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comments_id": {
+          "name": "comments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "developer_api_keys": {
+      "name": "developer_api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyType": {
+          "name": "keyType",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyPrefix": {
+          "name": "keyPrefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encryptedKey": {
+          "name": "encryptedKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "key_hash_idx": {
+          "name": "key_hash_idx",
+          "columns": [
+            "keyHash"
+          ],
+          "isUnique": true
+        },
+        "app_key_type_idx": {
+          "name": "app_key_type_idx",
+          "columns": [
+            "appId",
+            "keyType"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "developer_api_keys_appId_developer_apps_id_fk": {
+          "name": "developer_api_keys_appId_developer_apps_id_fk",
+          "tableFrom": "developer_api_keys",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "appId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "developer_api_keys_id": {
+          "name": "developer_api_keys_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "developer_app_domains": {
+      "name": "developer_app_domains",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "developer_app_domains_appId_developer_apps_id_fk": {
+          "name": "developer_app_domains_appId_developer_apps_id_fk",
+          "tableFrom": "developer_app_domains",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "appId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "developer_app_domains_id": {
+          "name": "developer_app_domains_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "app_domain_unique": {
+          "name": "app_domain_unique",
+          "columns": [
+            "appId",
+            "domain"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "developer_apps": {
+      "name": "developer_apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logoUrl": {
+          "name": "logoUrl",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "owner_deleted_idx": {
+          "name": "owner_deleted_idx",
+          "columns": [
+            "ownerId",
+            "deletedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "developer_apps_id": {
+          "name": "developer_apps_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "developer_credit_accounts": {
+      "name": "developer_credit_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balanceMicroCredits": {
+          "name": "balanceMicroCredits",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripePaymentMethodId": {
+          "name": "stripePaymentMethodId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "autoTopUpEnabled": {
+          "name": "autoTopUpEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "autoTopUpThresholdMicroCredits": {
+          "name": "autoTopUpThresholdMicroCredits",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "autoTopUpAmountCents": {
+          "name": "autoTopUpAmountCents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "app_id_unique": {
+          "name": "app_id_unique",
+          "columns": [
+            "appId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "developer_credit_accounts_appId_developer_apps_id_fk": {
+          "name": "developer_credit_accounts_appId_developer_apps_id_fk",
+          "tableFrom": "developer_credit_accounts",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "appId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "developer_credit_accounts_id": {
+          "name": "developer_credit_accounts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "developer_credit_transactions": {
+      "name": "developer_credit_transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amountMicroCredits": {
+          "name": "amountMicroCredits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balanceAfterMicroCredits": {
+          "name": "balanceAfterMicroCredits",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referenceType": {
+          "name": "referenceType",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "account_type_created_idx": {
+          "name": "account_type_created_idx",
+          "columns": [
+            "accountId",
+            "type",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "account_ref_dedup_idx": {
+          "name": "account_ref_dedup_idx",
+          "columns": [
+            "accountId",
+            "referenceId",
+            "referenceType"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "dev_credit_txn_account_fk": {
+          "name": "dev_credit_txn_account_fk",
+          "tableFrom": "developer_credit_transactions",
+          "tableTo": "developer_credit_accounts",
+          "columnsFrom": [
+            "accountId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "developer_credit_transactions_id": {
+          "name": "developer_credit_transactions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "developer_daily_storage_snapshots": {
+      "name": "developer_daily_storage_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshotDate": {
+          "name": "snapshotDate",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "totalDurationMinutes": {
+          "name": "totalDurationMinutes",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "videoCount": {
+          "name": "videoCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "microCreditsCharged": {
+          "name": "microCreditsCharged",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "developer_daily_storage_snapshots_appId_developer_apps_id_fk": {
+          "name": "developer_daily_storage_snapshots_appId_developer_apps_id_fk",
+          "tableFrom": "developer_daily_storage_snapshots",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "appId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "developer_daily_storage_snapshots_id": {
+          "name": "developer_daily_storage_snapshots_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "app_date_unique": {
+          "name": "app_date_unique",
+          "columns": [
+            "appId",
+            "snapshotDate"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "developer_videos": {
+      "name": "developer_videos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "externalUserId": {
+          "name": "externalUserId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Untitled'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fps": {
+          "name": "fps",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "s3Key": {
+          "name": "s3Key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcriptionStatus": {
+          "name": "transcriptionStatus",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "app_created_idx": {
+          "name": "app_created_idx",
+          "columns": [
+            "appId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "app_user_idx": {
+          "name": "app_user_idx",
+          "columns": [
+            "appId",
+            "externalUserId"
+          ],
+          "isUnique": false
+        },
+        "app_deleted_idx": {
+          "name": "app_deleted_idx",
+          "columns": [
+            "appId",
+            "deletedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "developer_videos_appId_developer_apps_id_fk": {
+          "name": "developer_videos_appId_developer_apps_id_fk",
+          "tableFrom": "developer_videos",
+          "tableTo": "developer_apps",
+          "columnsFrom": [
+            "appId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "developer_videos_id": {
+          "name": "developer_videos_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "folders": {
+      "name": "folders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'normal'"
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "organization_id_idx": {
+          "name": "organization_id_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "created_by_id_idx": {
+          "name": "created_by_id_idx",
+          "columns": [
+            "createdById"
+          ],
+          "isUnique": false
+        },
+        "parent_id_idx": {
+          "name": "parent_id_idx",
+          "columns": [
+            "parentId"
+          ],
+          "isUnique": false
+        },
+        "space_id_idx": {
+          "name": "space_id_idx",
+          "columns": [
+            "spaceId"
+          ],
+          "isUnique": false
+        },
+        "public_parent_id_idx": {
+          "name": "public_parent_id_idx",
+          "columns": [
+            "public",
+            "parentId"
+          ],
+          "isUnique": false
+        },
+        "public_space_parent_id_idx": {
+          "name": "public_space_parent_id_idx",
+          "columns": [
+            "public",
+            "spaceId",
+            "parentId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "folders_id": {
+          "name": "folders_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "imported_videos": {
+      "name": "imported_videos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orgId": {
+          "name": "orgId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "imported_videos_orgId_source_source_id_pk": {
+          "name": "imported_videos_orgId_source_source_id_pk",
+          "columns": [
+            "orgId",
+            "source",
+            "source_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "messenger_conversations": {
+      "name": "messenger_conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'agent'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anonymousId": {
+          "name": "anonymousId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "takeoverByUserId": {
+          "name": "takeoverByUserId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "takeoverAt": {
+          "name": "takeoverAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "user_last_message_idx": {
+          "name": "user_last_message_idx",
+          "columns": [
+            "userId",
+            "lastMessageAt"
+          ],
+          "isUnique": false
+        },
+        "anonymous_last_message_idx": {
+          "name": "anonymous_last_message_idx",
+          "columns": [
+            "anonymousId",
+            "lastMessageAt"
+          ],
+          "isUnique": false
+        },
+        "mode_last_message_idx": {
+          "name": "mode_last_message_idx",
+          "columns": [
+            "mode",
+            "lastMessageAt"
+          ],
+          "isUnique": false
+        },
+        "updated_at_idx": {
+          "name": "updated_at_idx",
+          "columns": [
+            "updatedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "messenger_conversations_id": {
+          "name": "messenger_conversations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "messenger_messages": {
+      "name": "messenger_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anonymousId": {
+          "name": "anonymousId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "conversation_created_at_idx": {
+          "name": "conversation_created_at_idx",
+          "columns": [
+            "conversationId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "role_created_at_idx": {
+          "name": "role_created_at_idx",
+          "columns": [
+            "role",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messenger_messages_conversationId_messenger_conversations_id_fk": {
+          "name": "messenger_messages_conversationId_messenger_conversations_id_fk",
+          "tableFrom": "messenger_messages",
+          "tableTo": "messenger_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "messenger_messages_id": {
+          "name": "messenger_messages_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "messenger_support_emails": {
+      "name": "messenger_support_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userEmail": {
+          "name": "userEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "support_email_user_created_at_idx": {
+          "name": "support_email_user_created_at_idx",
+          "columns": [
+            "userId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "support_email_conversation_created_at_idx": {
+          "name": "support_email_conversation_created_at_idx",
+          "columns": [
+            "conversationId",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messenger_support_emails_conversationId_messenger_conversations_id_fk": {
+          "name": "messenger_support_emails_conversationId_messenger_conversations_id_fk",
+          "tableFrom": "messenger_support_emails",
+          "tableTo": "messenger_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "messenger_support_emails_id": {
+          "name": "messenger_support_emails_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orgId": {
+          "name": "orgId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipientId": {
+          "name": "recipientId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "videoId": {
+          "name": "videoId",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dedupKey": {
+          "name": "dedupKey",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "org_id_idx": {
+          "name": "org_id_idx",
+          "columns": [
+            "orgId"
+          ],
+          "isUnique": false
+        },
+        "type_idx": {
+          "name": "type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "read_at_idx": {
+          "name": "read_at_idx",
+          "columns": [
+            "readAt"
+          ],
+          "isUnique": false
+        },
+        "created_at_idx": {
+          "name": "created_at_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "recipient_read_idx": {
+          "name": "recipient_read_idx",
+          "columns": [
+            "recipientId",
+            "readAt"
+          ],
+          "isUnique": false
+        },
+        "recipient_created_idx": {
+          "name": "recipient_created_idx",
+          "columns": [
+            "recipientId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "dedup_key_idx": {
+          "name": "dedup_key_idx",
+          "columns": [
+            "dedupKey"
+          ],
+          "isUnique": true
+        },
+        "type_recipient_created_idx": {
+          "name": "type_recipient_created_idx",
+          "columns": [
+            "type",
+            "recipientId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "type_recipient_video_created_idx": {
+          "name": "type_recipient_video_created_idx",
+          "columns": [
+            "type",
+            "recipientId",
+            "videoId",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notifications_id": {
+          "name": "notifications_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_invites": {
+      "name": "organization_invites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invitedEmail": {
+          "name": "invitedEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invitedByUserId": {
+          "name": "invitedByUserId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_id_idx": {
+          "name": "organization_id_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "invited_email_idx": {
+          "name": "invited_email_idx",
+          "columns": [
+            "invitedEmail"
+          ],
+          "isUnique": false
+        },
+        "invited_by_user_id_idx": {
+          "name": "invited_by_user_id_idx",
+          "columns": [
+            "invitedByUserId"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_invites_id": {
+          "name": "organization_invites_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hasProSeat": {
+          "name": "hasProSeat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "organization_id_idx": {
+          "name": "organization_id_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "user_id_organization_id_idx": {
+          "name": "user_id_organization_id_idx",
+          "columns": [
+            "userId",
+            "organizationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_members_id": {
+          "name": "organization_members_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tombstoneAt": {
+          "name": "tombstoneAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowedEmailDomain": {
+          "name": "allowedEmailDomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customDomain": {
+          "name": "customDomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domainVerified": {
+          "name": "domainVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "iconUrl": {
+          "name": "iconUrl",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shareableLinkIconUrl": {
+          "name": "shareableLinkIconUrl",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "workosOrganizationId": {
+          "name": "workosOrganizationId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workosConnectionId": {
+          "name": "workosConnectionId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "owner_id_tombstone_idx": {
+          "name": "owner_id_tombstone_idx",
+          "columns": [
+            "ownerId",
+            "tombstoneAt"
+          ],
+          "isUnique": false
+        },
+        "custom_domain_idx": {
+          "name": "custom_domain_idx",
+          "columns": [
+            "customDomain"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organizations_id": {
+          "name": "organizations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "s3_buckets": {
+      "name": "s3_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bucketName": {
+          "name": "bucketName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessKeyId": {
+          "name": "accessKeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secretAccessKey": {
+          "name": "secretAccessKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('aws')"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "owner_organization_idx": {
+          "name": "owner_organization_idx",
+          "columns": [
+            "ownerId",
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "organization_id_idx": {
+          "name": "organization_id_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "organization_active_idx": {
+          "name": "organization_active_idx",
+          "columns": [
+            "organizationId",
+            "active",
+            "updatedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "s3_buckets_id": {
+          "name": "s3_buckets_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "session_token_idx": {
+          "name": "session_token_idx",
+          "columns": [
+            "sessionToken"
+          ],
+          "isUnique": true
+        },
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sessions_id": {
+          "name": "sessions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "shared_videos": {
+      "name": "shared_videos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "videoId": {
+          "name": "videoId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sharedByUserId": {
+          "name": "sharedByUserId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sharedAt": {
+          "name": "sharedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "folder_id_idx": {
+          "name": "folder_id_idx",
+          "columns": [
+            "folderId"
+          ],
+          "isUnique": false
+        },
+        "organization_id_idx": {
+          "name": "organization_id_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "shared_by_user_id_idx": {
+          "name": "shared_by_user_id_idx",
+          "columns": [
+            "sharedByUserId"
+          ],
+          "isUnique": false
+        },
+        "video_id_organization_id_idx": {
+          "name": "video_id_organization_id_idx",
+          "columns": [
+            "videoId",
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "video_id_folder_id_idx": {
+          "name": "video_id_folder_id_idx",
+          "columns": [
+            "videoId",
+            "folderId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "shared_videos_id": {
+          "name": "shared_videos_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "space_members": {
+      "name": "space_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "space_members_id": {
+          "name": "space_members_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "space_id_user_id_unique": {
+          "name": "space_id_user_id_unique",
+          "columns": [
+            "spaceId",
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "space_videos": {
+      "name": "space_videos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "spaceId": {
+          "name": "spaceId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "videoId": {
+          "name": "videoId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addedById": {
+          "name": "addedById",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addedAt": {
+          "name": "addedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "folder_id_idx": {
+          "name": "folder_id_idx",
+          "columns": [
+            "folderId"
+          ],
+          "isUnique": false
+        },
+        "video_id_idx": {
+          "name": "video_id_idx",
+          "columns": [
+            "videoId"
+          ],
+          "isUnique": false
+        },
+        "added_by_id_idx": {
+          "name": "added_by_id_idx",
+          "columns": [
+            "addedById"
+          ],
+          "isUnique": false
+        },
+        "space_id_video_id_idx": {
+          "name": "space_id_video_id_idx",
+          "columns": [
+            "spaceId",
+            "videoId"
+          ],
+          "isUnique": false
+        },
+        "space_id_folder_id_idx": {
+          "name": "space_id_folder_id_idx",
+          "columns": [
+            "spaceId",
+            "folderId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "space_videos_id": {
+          "name": "space_videos_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "spaces": {
+      "name": "spaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "primary": {
+          "name": "primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iconUrl": {
+          "name": "iconUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "privacy": {
+          "name": "privacy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Private'"
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "organization_id_idx": {
+          "name": "organization_id_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "created_by_id_idx": {
+          "name": "created_by_id_idx",
+          "columns": [
+            "createdById"
+          ],
+          "isUnique": false
+        },
+        "public_organization_id_idx": {
+          "name": "public_organization_id_idx",
+          "columns": [
+            "public",
+            "organizationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "spaces_id": {
+          "name": "spaces_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "storage_integrations": {
+      "name": "storage_integrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "encryptedConfig": {
+          "name": "encryptedConfig",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "googleDriveAccessToken": {
+          "name": "googleDriveAccessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "googleDriveAccessTokenExpiresAt": {
+          "name": "googleDriveAccessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "googleDriveTokenRefreshLeaseId": {
+          "name": "googleDriveTokenRefreshLeaseId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "googleDriveTokenRefreshLeaseExpiresAt": {
+          "name": "googleDriveTokenRefreshLeaseExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "googleDriveStorageQuotaCache": {
+          "name": "googleDriveStorageQuotaCache",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "owner_provider_idx": {
+          "name": "owner_provider_idx",
+          "columns": [
+            "ownerId",
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "owner_active_idx": {
+          "name": "owner_active_idx",
+          "columns": [
+            "ownerId",
+            "active"
+          ],
+          "isUnique": false
+        },
+        "organization_provider_idx": {
+          "name": "organization_provider_idx",
+          "columns": [
+            "organizationId",
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "organization_active_idx": {
+          "name": "organization_active_idx",
+          "columns": [
+            "organizationId",
+            "active",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "storage_integrations_id": {
+          "name": "storage_integrations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "storage_objects": {
+      "name": "storage_objects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "videoId": {
+          "name": "videoId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "objectKey": {
+          "name": "objectKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "objectKeyHash": {
+          "name": "objectKeyHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerObjectId": {
+          "name": "providerObjectId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploadSessionUrl": {
+          "name": "uploadSessionUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uploadStatus": {
+          "name": "uploadStatus",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contentLength": {
+          "name": "contentLength",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "integration_key_hash_idx": {
+          "name": "integration_key_hash_idx",
+          "columns": [
+            "integrationId",
+            "objectKeyHash"
+          ],
+          "isUnique": true
+        },
+        "integration_status_idx": {
+          "name": "integration_status_idx",
+          "columns": [
+            "integrationId",
+            "uploadStatus"
+          ],
+          "isUnique": false
+        },
+        "video_id_idx": {
+          "name": "video_id_idx",
+          "columns": [
+            "videoId"
+          ],
+          "isUnique": false
+        },
+        "owner_id_idx": {
+          "name": "owner_id_idx",
+          "columns": [
+            "ownerId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "storage_objects_integrationId_storage_integrations_id_fk": {
+          "name": "storage_objects_integrationId_storage_integrations_id_fk",
+          "tableFrom": "storage_objects",
+          "tableTo": "storage_integrations",
+          "columnsFrom": [
+            "integrationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "storage_objects_id": {
+          "name": "storage_objects_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thirdPartyStripeSubscriptionId": {
+          "name": "thirdPartyStripeSubscriptionId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripeSubscriptionStatus": {
+          "name": "stripeSubscriptionStatus",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripeSubscriptionPriceId": {
+          "name": "stripeSubscriptionPriceId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('null')"
+        },
+        "activeOrganizationId": {
+          "name": "activeOrganizationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "onboardingSteps": {
+          "name": "onboardingSteps",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customBucket": {
+          "name": "customBucket",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inviteQuota": {
+          "name": "inviteQuota",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "defaultOrgId": {
+          "name": "defaultOrgId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "authSessionVersion": {
+          "name": "authSessionVersion",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "email_idx": {
+          "name": "email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "verification_tokens": {
+      "name": "verification_tokens",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier": {
+          "name": "verification_tokens_identifier",
+          "columns": [
+            "identifier"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "video_edits": {
+      "name": "video_edits",
+      "columns": {
+        "videoId": {
+          "name": "videoId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sourceKey": {
+          "name": "sourceKey",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "editSpec": {
+          "name": "editSpec",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "video_edits_videoId_videos_id_fk": {
+          "name": "video_edits_videoId_videos_id_fk",
+          "tableFrom": "video_edits",
+          "tableTo": "videos",
+          "columnsFrom": [
+            "videoId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "video_edits_videoId": {
+          "name": "video_edits_videoId",
+          "columns": [
+            "videoId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "video_uploads": {
+      "name": "video_uploads",
+      "columns": {
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploaded": {
+          "name": "uploaded",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total": {
+          "name": "total",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'uploading'"
+        },
+        "processing_progress": {
+          "name": "processing_progress",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "processing_message": {
+          "name": "processing_message",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processing_error": {
+          "name": "processing_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_file_key": {
+          "name": "raw_file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "phase_updated_at_video_id_idx": {
+          "name": "phase_updated_at_video_id_idx",
+          "columns": [
+            "phase",
+            "updated_at",
+            "video_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "video_uploads_video_id": {
+          "name": "video_uploads_video_id",
+          "columns": [
+            "video_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "videos": {
+      "name": "videos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orgId": {
+          "name": "orgId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'My Video'"
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storageIntegrationId": {
+          "name": "storageIntegrationId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fps": {
+          "name": "fps",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcriptionStatus": {
+          "name": "transcriptionStatus",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "('{\"type\":\"MediaConvert\"}')"
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "effectiveCreatedAt": {
+          "name": "effectiveCreatedAt",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "COALESCE(\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%s.%fZ'),\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%sZ'),\n          `createdAt`\n        )",
+            "type": "stored"
+          }
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "xStreamInfo": {
+          "name": "xStreamInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "firstViewEmailSentAt": {
+          "name": "firstViewEmailSentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isScreenshot": {
+          "name": "isScreenshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "awsRegion": {
+          "name": "awsRegion",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "awsBucket": {
+          "name": "awsBucket",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "videoStartTime": {
+          "name": "videoStartTime",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audioStartTime": {
+          "name": "audioStartTime",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jobId": {
+          "name": "jobId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jobStatus": {
+          "name": "jobStatus",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skipProcessing": {
+          "name": "skipProcessing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "owner_id_idx": {
+          "name": "owner_id_idx",
+          "columns": [
+            "ownerId"
+          ],
+          "isUnique": false
+        },
+        "is_public_idx": {
+          "name": "is_public_idx",
+          "columns": [
+            "public"
+          ],
+          "isUnique": false
+        },
+        "folder_id_idx": {
+          "name": "folder_id_idx",
+          "columns": [
+            "folderId"
+          ],
+          "isUnique": false
+        },
+        "storage_integration_id_idx": {
+          "name": "storage_integration_id_idx",
+          "columns": [
+            "storageIntegrationId"
+          ],
+          "isUnique": false
+        },
+        "org_owner_folder_idx": {
+          "name": "org_owner_folder_idx",
+          "columns": [
+            "orgId",
+            "ownerId",
+            "folderId"
+          ],
+          "isUnique": false
+        },
+        "org_effective_created_idx": {
+          "name": "org_effective_created_idx",
+          "columns": [
+            "orgId",
+            "effectiveCreatedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "videos_storageIntegrationId_storage_integrations_id_fk": {
+          "name": "videos_storageIntegrationId_storage_integrations_id_fk",
+          "tableFrom": "videos",
+          "tableTo": "storage_integrations",
+          "columnsFrom": [
+            "storageIntegrationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "videos_id": {
+          "name": "videos_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/0032_snapshot.json
+++ b/packages/database/migrations/meta/0032_snapshot.json
@@ -1,7 +1,7 @@
 {
 	"version": "5",
 	"dialect": "mysql",
-	"id": "6054e171-7ead-4eb8-8a27-e2c82223c6f0",
+	"id": "b4154093-c27c-4577-8c76-f0742a29c858",
 	"prevId": "1a41e8a7-f0ec-4bfa-8df0-8a5cbabedf97",
 	"tables": {
 		"accounts": {
@@ -1400,8 +1400,8 @@
 				}
 			},
 			"foreignKeys": {
-				"messenger_support_emails_conversationId_messenger_conversations_id_fk": {
-					"name": "messenger_support_emails_conversationId_messenger_conversations_id_fk",
+				"support_email_conversation_fk": {
+					"name": "support_email_conversation_fk",
 					"tableFrom": "messenger_support_emails",
 					"tableTo": "messenger_conversations",
 					"columnsFrom": ["conversationId"],

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -1,237 +1,237 @@
 {
-  "version": "5",
-  "dialect": "mysql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "5",
-      "when": 1743020179593,
-      "tag": "0000_brown_sunfire",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "5",
-      "when": 1749268354138,
-      "tag": "0001_white_young_avengers",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "5",
-      "when": 1750935538683,
-      "tag": "0002_dusty_maginty",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "5",
-      "when": 1761710697286,
-      "tag": "0003_thin_gressill",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "5",
-      "when": 1761711378574,
-      "tag": "0004_video-org-id",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "5",
-      "when": 1761711605408,
-      "tag": "0005_video-org-id-required",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "5",
-      "when": 1762410865419,
-      "tag": "0006_hesitant_stone_men",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "5",
-      "when": 1762428551824,
-      "tag": "0007_public_toxin",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "5",
-      "when": 1762428905323,
-      "tag": "0008_fat_ender_wiggin",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "5",
-      "when": 1768139432782,
-      "tag": "0009_easy_ulik",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "5",
-      "when": 1738505600000,
-      "tag": "0010_video_uploads_bigint",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "5",
-      "when": 1771325011010,
-      "tag": "0011_public_inhumans",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "5",
-      "when": 1772534950328,
-      "tag": "0012_lethal_lilith",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "5",
-      "when": 1772573402457,
-      "tag": "0013_faithful_marvex",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "5",
-      "when": 1772576220593,
-      "tag": "0014_modern_triton",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "5",
-      "when": 1772582468257,
-      "tag": "0015_closed_tigra",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "5",
-      "when": 1772641549840,
-      "tag": "0016_bouncy_hellcat",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "5",
-      "when": 1778099532336,
-      "tag": "0017_productive_betty_brant",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "5",
-      "when": 1778153157657,
-      "tag": "0018_loud_mongu",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "5",
-      "when": 1778154209547,
-      "tag": "0019_solid_paibok",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "5",
-      "when": 1778157016497,
-      "tag": "0020_orange_talkback",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "5",
-      "when": 1778249922872,
-      "tag": "0021_glorious_khan",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "5",
-      "when": 1778252207674,
-      "tag": "0022_dazzling_namor",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "5",
-      "when": 1778434170430,
-      "tag": "0023_misty_luckman",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "5",
-      "when": 1778776694053,
-      "tag": "0024_many_speed",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "5",
-      "when": 1778858762935,
-      "tag": "0025_demonic_mother_askani",
-      "breakpoints": true
-    },
-    {
-      "idx": 26,
-      "version": "5",
-      "when": 1779283712737,
-      "tag": "0026_pretty_the_professor",
-      "breakpoints": true
-    },
-    {
-      "idx": 27,
-      "version": "5",
-      "when": 1780932760351,
-      "tag": "0027_giant_shinko_yamashiro",
-      "breakpoints": true
-    },
-    {
-      "idx": 28,
-      "version": "5",
-      "when": 1780937790068,
-      "tag": "0028_nebulous_madame_masque",
-      "breakpoints": true
-    },
-    {
-      "idx": 29,
-      "version": "5",
-      "when": 1780937848351,
-      "tag": "0029_blushing_pretty_boy",
-      "breakpoints": true
-    },
-    {
-      "idx": 30,
-      "version": "5",
-      "when": 1780940100362,
-      "tag": "0030_add_folder_settings",
-      "breakpoints": true
-    },
-    {
-      "idx": 31,
-      "version": "5",
-      "when": 1781271269353,
-      "tag": "0031_add_auth_api_keys_user_created_index",
-      "breakpoints": true
-    },
-    {
-      "idx": 32,
-      "version": "5",
-      "when": 1782845659937,
-      "tag": "0032_past_lester",
-      "breakpoints": true
-    }
-  ]
+	"version": "5",
+	"dialect": "mysql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "5",
+			"when": 1743020179593,
+			"tag": "0000_brown_sunfire",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "5",
+			"when": 1749268354138,
+			"tag": "0001_white_young_avengers",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "5",
+			"when": 1750935538683,
+			"tag": "0002_dusty_maginty",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "5",
+			"when": 1761710697286,
+			"tag": "0003_thin_gressill",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "5",
+			"when": 1761711378574,
+			"tag": "0004_video-org-id",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "5",
+			"when": 1761711605408,
+			"tag": "0005_video-org-id-required",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "5",
+			"when": 1762410865419,
+			"tag": "0006_hesitant_stone_men",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "5",
+			"when": 1762428551824,
+			"tag": "0007_public_toxin",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "5",
+			"when": 1762428905323,
+			"tag": "0008_fat_ender_wiggin",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "5",
+			"when": 1768139432782,
+			"tag": "0009_easy_ulik",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "5",
+			"when": 1738505600000,
+			"tag": "0010_video_uploads_bigint",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "5",
+			"when": 1771325011010,
+			"tag": "0011_public_inhumans",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "5",
+			"when": 1772534950328,
+			"tag": "0012_lethal_lilith",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "5",
+			"when": 1772573402457,
+			"tag": "0013_faithful_marvex",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "5",
+			"when": 1772576220593,
+			"tag": "0014_modern_triton",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "5",
+			"when": 1772582468257,
+			"tag": "0015_closed_tigra",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "5",
+			"when": 1772641549840,
+			"tag": "0016_bouncy_hellcat",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "5",
+			"when": 1778099532336,
+			"tag": "0017_productive_betty_brant",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "5",
+			"when": 1778153157657,
+			"tag": "0018_loud_mongu",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "5",
+			"when": 1778154209547,
+			"tag": "0019_solid_paibok",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "5",
+			"when": 1778157016497,
+			"tag": "0020_orange_talkback",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "5",
+			"when": 1778249922872,
+			"tag": "0021_glorious_khan",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "5",
+			"when": 1778252207674,
+			"tag": "0022_dazzling_namor",
+			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "5",
+			"when": 1778434170430,
+			"tag": "0023_misty_luckman",
+			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "5",
+			"when": 1778776694053,
+			"tag": "0024_many_speed",
+			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "5",
+			"when": 1778858762935,
+			"tag": "0025_demonic_mother_askani",
+			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "5",
+			"when": 1779283712737,
+			"tag": "0026_pretty_the_professor",
+			"breakpoints": true
+		},
+		{
+			"idx": 27,
+			"version": "5",
+			"when": 1780932760351,
+			"tag": "0027_giant_shinko_yamashiro",
+			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "5",
+			"when": 1780937790068,
+			"tag": "0028_nebulous_madame_masque",
+			"breakpoints": true
+		},
+		{
+			"idx": 29,
+			"version": "5",
+			"when": 1780937848351,
+			"tag": "0029_blushing_pretty_boy",
+			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "5",
+			"when": 1780940100362,
+			"tag": "0030_add_folder_settings",
+			"breakpoints": true
+		},
+		{
+			"idx": 31,
+			"version": "5",
+			"when": 1781271269353,
+			"tag": "0031_add_auth_api_keys_user_created_index",
+			"breakpoints": true
+		},
+		{
+			"idx": 32,
+			"version": "5",
+			"when": 1782845659937,
+			"tag": "0032_past_lester",
+			"breakpoints": true
+		}
+	]
 }

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -229,7 +229,7 @@
 		{
 			"idx": 32,
 			"version": "5",
-			"when": 1782845659937,
+			"when": 1782850635482,
 			"tag": "0032_past_lester",
 			"breakpoints": true
 		}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -1,230 +1,237 @@
 {
-	"version": "5",
-	"dialect": "mysql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "5",
-			"when": 1743020179593,
-			"tag": "0000_brown_sunfire",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "5",
-			"when": 1749268354138,
-			"tag": "0001_white_young_avengers",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "5",
-			"when": 1750935538683,
-			"tag": "0002_dusty_maginty",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "5",
-			"when": 1761710697286,
-			"tag": "0003_thin_gressill",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "5",
-			"when": 1761711378574,
-			"tag": "0004_video-org-id",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "5",
-			"when": 1761711605408,
-			"tag": "0005_video-org-id-required",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "5",
-			"when": 1762410865419,
-			"tag": "0006_hesitant_stone_men",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "5",
-			"when": 1762428551824,
-			"tag": "0007_public_toxin",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "5",
-			"when": 1762428905323,
-			"tag": "0008_fat_ender_wiggin",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "5",
-			"when": 1768139432782,
-			"tag": "0009_easy_ulik",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "5",
-			"when": 1738505600000,
-			"tag": "0010_video_uploads_bigint",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "5",
-			"when": 1771325011010,
-			"tag": "0011_public_inhumans",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "5",
-			"when": 1772534950328,
-			"tag": "0012_lethal_lilith",
-			"breakpoints": true
-		},
-		{
-			"idx": 13,
-			"version": "5",
-			"when": 1772573402457,
-			"tag": "0013_faithful_marvex",
-			"breakpoints": true
-		},
-		{
-			"idx": 14,
-			"version": "5",
-			"when": 1772576220593,
-			"tag": "0014_modern_triton",
-			"breakpoints": true
-		},
-		{
-			"idx": 15,
-			"version": "5",
-			"when": 1772582468257,
-			"tag": "0015_closed_tigra",
-			"breakpoints": true
-		},
-		{
-			"idx": 16,
-			"version": "5",
-			"when": 1772641549840,
-			"tag": "0016_bouncy_hellcat",
-			"breakpoints": true
-		},
-		{
-			"idx": 17,
-			"version": "5",
-			"when": 1778099532336,
-			"tag": "0017_productive_betty_brant",
-			"breakpoints": true
-		},
-		{
-			"idx": 18,
-			"version": "5",
-			"when": 1778153157657,
-			"tag": "0018_loud_mongu",
-			"breakpoints": true
-		},
-		{
-			"idx": 19,
-			"version": "5",
-			"when": 1778154209547,
-			"tag": "0019_solid_paibok",
-			"breakpoints": true
-		},
-		{
-			"idx": 20,
-			"version": "5",
-			"when": 1778157016497,
-			"tag": "0020_orange_talkback",
-			"breakpoints": true
-		},
-		{
-			"idx": 21,
-			"version": "5",
-			"when": 1778249922872,
-			"tag": "0021_glorious_khan",
-			"breakpoints": true
-		},
-		{
-			"idx": 22,
-			"version": "5",
-			"when": 1778252207674,
-			"tag": "0022_dazzling_namor",
-			"breakpoints": true
-		},
-		{
-			"idx": 23,
-			"version": "5",
-			"when": 1778434170430,
-			"tag": "0023_misty_luckman",
-			"breakpoints": true
-		},
-		{
-			"idx": 24,
-			"version": "5",
-			"when": 1778776694053,
-			"tag": "0024_many_speed",
-			"breakpoints": true
-		},
-		{
-			"idx": 25,
-			"version": "5",
-			"when": 1778858762935,
-			"tag": "0025_demonic_mother_askani",
-			"breakpoints": true
-		},
-		{
-			"idx": 26,
-			"version": "5",
-			"when": 1779283712737,
-			"tag": "0026_pretty_the_professor",
-			"breakpoints": true
-		},
-		{
-			"idx": 27,
-			"version": "5",
-			"when": 1780932760351,
-			"tag": "0027_giant_shinko_yamashiro",
-			"breakpoints": true
-		},
-		{
-			"idx": 28,
-			"version": "5",
-			"when": 1780937790068,
-			"tag": "0028_nebulous_madame_masque",
-			"breakpoints": true
-		},
-		{
-			"idx": 29,
-			"version": "5",
-			"when": 1780937848351,
-			"tag": "0029_blushing_pretty_boy",
-			"breakpoints": true
-		},
-		{
-			"idx": 30,
-			"version": "5",
-			"when": 1780940100362,
-			"tag": "0030_add_folder_settings",
-			"breakpoints": true
-		},
-		{
-			"idx": 31,
-			"version": "5",
-			"when": 1781271269353,
-			"tag": "0031_add_auth_api_keys_user_created_index",
-			"breakpoints": true
-		}
-	]
+  "version": "5",
+  "dialect": "mysql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "5",
+      "when": 1743020179593,
+      "tag": "0000_brown_sunfire",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1749268354138,
+      "tag": "0001_white_young_avengers",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "5",
+      "when": 1750935538683,
+      "tag": "0002_dusty_maginty",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "5",
+      "when": 1761710697286,
+      "tag": "0003_thin_gressill",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "5",
+      "when": 1761711378574,
+      "tag": "0004_video-org-id",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "5",
+      "when": 1761711605408,
+      "tag": "0005_video-org-id-required",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "5",
+      "when": 1762410865419,
+      "tag": "0006_hesitant_stone_men",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "5",
+      "when": 1762428551824,
+      "tag": "0007_public_toxin",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "5",
+      "when": 1762428905323,
+      "tag": "0008_fat_ender_wiggin",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "5",
+      "when": 1768139432782,
+      "tag": "0009_easy_ulik",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "5",
+      "when": 1738505600000,
+      "tag": "0010_video_uploads_bigint",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "5",
+      "when": 1771325011010,
+      "tag": "0011_public_inhumans",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "5",
+      "when": 1772534950328,
+      "tag": "0012_lethal_lilith",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "5",
+      "when": 1772573402457,
+      "tag": "0013_faithful_marvex",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "5",
+      "when": 1772576220593,
+      "tag": "0014_modern_triton",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "5",
+      "when": 1772582468257,
+      "tag": "0015_closed_tigra",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "5",
+      "when": 1772641549840,
+      "tag": "0016_bouncy_hellcat",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "5",
+      "when": 1778099532336,
+      "tag": "0017_productive_betty_brant",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "5",
+      "when": 1778153157657,
+      "tag": "0018_loud_mongu",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "5",
+      "when": 1778154209547,
+      "tag": "0019_solid_paibok",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "5",
+      "when": 1778157016497,
+      "tag": "0020_orange_talkback",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "5",
+      "when": 1778249922872,
+      "tag": "0021_glorious_khan",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "5",
+      "when": 1778252207674,
+      "tag": "0022_dazzling_namor",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "5",
+      "when": 1778434170430,
+      "tag": "0023_misty_luckman",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "5",
+      "when": 1778776694053,
+      "tag": "0024_many_speed",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "5",
+      "when": 1778858762935,
+      "tag": "0025_demonic_mother_askani",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "5",
+      "when": 1779283712737,
+      "tag": "0026_pretty_the_professor",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "5",
+      "when": 1780932760351,
+      "tag": "0027_giant_shinko_yamashiro",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "5",
+      "when": 1780937790068,
+      "tag": "0028_nebulous_madame_masque",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "5",
+      "when": 1780937848351,
+      "tag": "0029_blushing_pretty_boy",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "5",
+      "when": 1780940100362,
+      "tag": "0030_add_folder_settings",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "5",
+      "when": 1781271269353,
+      "tag": "0031_add_auth_api_keys_user_created_index",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "5",
+      "when": 1782845659937,
+      "tag": "0032_past_lester",
+      "breakpoints": true
+    }
+  ]
 }

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -605,9 +605,7 @@ export const messengerSupportEmails = mysqlTable(
 	"messenger_support_emails",
 	{
 		id: nanoId("id").notNull().primaryKey(),
-		conversationId: nanoId("conversationId")
-			.notNull()
-			.references(() => messengerConversations.id, { onDelete: "cascade" }),
+		conversationId: nanoId("conversationId").notNull(),
 		userId: nanoId("userId").notNull().$type<User.UserId>(),
 		userEmail: varchar("userEmail", { length: 255 }).notNull(),
 		subject: varchar("subject", { length: 255 }).notNull(),
@@ -615,6 +613,11 @@ export const messengerSupportEmails = mysqlTable(
 		createdAt: timestamp("createdAt").notNull().defaultNow(),
 	},
 	(table) => ({
+		conversationForeignKey: foreignKey({
+			name: "support_email_conversation_fk",
+			columns: [table.conversationId],
+			foreignColumns: [messengerConversations.id],
+		}).onDelete("cascade"),
 		userCreatedAtIndex: index("support_email_user_created_at_idx").on(
 			table.userId,
 			table.createdAt,

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -601,6 +601,30 @@ export const messengerMessages = mysqlTable(
 	}),
 );
 
+export const messengerSupportEmails = mysqlTable(
+	"messenger_support_emails",
+	{
+		id: nanoId("id").notNull().primaryKey(),
+		conversationId: nanoId("conversationId")
+			.notNull()
+			.references(() => messengerConversations.id, { onDelete: "cascade" }),
+		userId: nanoId("userId").notNull().$type<User.UserId>(),
+		userEmail: varchar("userEmail", { length: 255 }).notNull(),
+		subject: varchar("subject", { length: 255 }).notNull(),
+		message: text("message").notNull(),
+		createdAt: timestamp("createdAt").notNull().defaultNow(),
+	},
+	(table) => ({
+		userCreatedAtIndex: index("support_email_user_created_at_idx").on(
+			table.userId,
+			table.createdAt,
+		),
+		conversationCreatedAtIndex: index(
+			"support_email_conversation_created_at_idx",
+		).on(table.conversationId, table.createdAt),
+	}),
+);
+
 export const s3Buckets = mysqlTable(
 	"s3_buckets",
 	{
@@ -773,6 +797,7 @@ export const messengerConversationsRelations = relations(
 			references: [users.id],
 		}),
 		messages: many(messengerMessages),
+		supportEmails: many(messengerSupportEmails),
 	}),
 );
 
@@ -785,6 +810,20 @@ export const messengerMessagesRelations = relations(
 		}),
 		user: one(users, {
 			fields: [messengerMessages.userId],
+			references: [users.id],
+		}),
+	}),
+);
+
+export const messengerSupportEmailsRelations = relations(
+	messengerSupportEmails,
+	({ one }) => ({
+		conversation: one(messengerConversations, {
+			fields: [messengerSupportEmails.conversationId],
+			references: [messengerConversations.id],
+		}),
+		user: one(users, {
+			fields: [messengerSupportEmails.userId],
 			references: [users.id],
 		}),
 	}),
@@ -803,6 +842,7 @@ export const usersRelations = relations(users, ({ many, one }) => ({
 	spaceMembers: many(spaceMembers),
 	messengerConversations: many(messengerConversations),
 	messengerMessages: many(messengerMessages),
+	messengerSupportEmails: many(messengerSupportEmails),
 }));
 
 export const accountsRelations = relations(accounts, ({ one }) => ({


### PR DESCRIPTION
### Summary
- Updates the web messenger Anthropic model to `claude-sonnet-5` and tightens response-length guidance.
- Adds a signed-in support email tool that sends only to `hello@cap.so`, uses the account email as reply-to, and enforces a durable 2-per-day user limit.
- Adds the `messenger_support_emails` audit table, email template, generated migration, and focused unit tests.

### Testing
- `pnpm db:generate` passed and generated migration `0032_past_lester`.
- `pnpm exec biome check --write apps/web/actions/messenger.ts apps/web/lib/messenger/agent.ts apps/web/lib/messenger/constants.ts apps/web/lib/messenger/support-email.ts apps/web/__tests__/unit/messenger-agent.test.ts apps/web/__tests__/unit/messenger-support-email.test.ts packages/database/schema.ts packages/database/emails/messenger-support-email.tsx` passed.
- `pnpm --dir apps/web exec vitest run __tests__/unit/messenger-agent.test.ts __tests__/unit/messenger-support-email.test.ts` passed.
- `git diff --check` passed.
- `pnpm typecheck` runs route type generation successfully, then fails on existing unrelated issues in `apps/web/__tests__/unit/caption-tracks.test.ts` and `apps/web/app/(site)/Footer.tsx`.
- `pnpm --filter @cap/database db:check` fails before validation because the package script invokes a Drizzle option that this installed version does not recognize.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the web messenger to `claude-sonnet-5`, splits the Anthropic token budget into a 512-token tool-dispatch call and a 350-token follow-up, and introduces a signed-in-only `send_support_email` tool backed by the new `messenger_support_emails` audit table.

- The two issues raised in the prior review are fully addressed: the audit record is now inserted inside a `SELECT ... FOR UPDATE` transaction before `sendEmail` is called, and the tool-dispatch call uses the wider 512-token cap.
- The rate-limit logic (2 emails/UTC-day per user) uses a pessimistic row lock on `users` to close the concurrency window, and unit tests explicitly assert insert-before-send ordering.
- `userId` on `messengerSupportEmails` has no DB-level foreign key (only a Drizzle ORM relation); `conversationId` has the expected cascade constraint.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge. The core correctness issues from the previous round are resolved, the new code paths are covered by focused unit tests, and the migration is straightforward.

Both previously-flagged defects (TOCTOU race on the audit record and insufficient token budget for tool dispatch) are now corrected. No new correctness defects were found in the changed files.

packages/database/schema.ts — the missing DB-level FK on `userId` in `messengerSupportEmails` is worth a second look before this table grows large.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/lib/messenger/support-email.ts | Adds `sendMessengerSupportEmail` with a transaction-based SELECT FOR UPDATE guard, audit-record-before-send ordering, rate limiting, and input normalization — the two issues flagged in prior review are now resolved. |
| apps/web/lib/messenger/agent.ts | Adds `send_support_email` tool dispatch logic with a separate 512-token budget for the tool-dispatch call (addressing the prior max_tokens comment) and a 350-token budget for the follow-up text reply. |
| apps/web/actions/messenger.ts | Wires the support-email tool into `sendMessengerUserMessage`; tool is only offered for authenticated users, anonymous sessions get null. |
| packages/database/schema.ts | Adds `messengerSupportEmails` table with compound indexes; `conversationId` has a cascade FK but `userId` has no DB-level FK constraint — Drizzle relations are present but no DDL constraint is generated. |
| packages/database/migrations/0032_past_lester.sql | Creates `messenger_support_emails` with the correct PK, cascade FK on `conversationId`, and two useful indexes; no migration for `userId` FK (matches schema intention). |
| apps/web/__tests__/unit/messenger-support-email.test.ts | Tests cover happy path, rate-limit path, and audit-insert-before-send ordering; explicitly asserts `insertCallOrder < sendCallOrder`. |
| apps/web/__tests__/unit/messenger-agent.test.ts | Verifies model name, token budget split (512 dispatch / 350 follow-up), `email` field stripping from the tool schema, and both success and error tool-result paths. |

<sub>Reviews (3): Last reviewed commit: ["test: restore messenger agent globals"](https://github.com/capsoftware/cap/commit/07fb8492cef46c77d834b730782faad4163908e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40915910)</sub>

<!-- /greptile_comment -->