### PR TITLE
fix(screenshot): paste as white on Windows when copying from editor

### DIFF
--- a/apps/desktop/src/routes/screenshot-editor/useScreenshotExport.ts
+++ b/apps/desktop/src/routes/screenshot-editor/useScreenshotExport.ts
@@ -15,6 +15,18 @@ import {
 	uploadScreenshotShareBlob,
 } from "./screenshotExport";
 
+function withWhiteBackground(source: HTMLCanvasElement): HTMLCanvasElement {
+	const canvas = document.createElement("canvas");
+	canvas.width = source.width;
+	canvas.height = source.height;
+	const ctx = canvas.getContext("2d");
+	if (!ctx) return source;
+	ctx.fillStyle = "white";
+	ctx.fillRect(0, 0, canvas.width, canvas.height);
+	ctx.drawImage(source, 0, 0);
+	return canvas;
+}
+
 export function useScreenshotExport() {
 	const editorCtx = useScreenshotEditorContext();
 	const {
@@ -168,16 +180,19 @@ export function useScreenshotExport() {
 				toast.loading("Preparing upload", { id: toastId });
 			}
 
+			const needsAlpha = canvasNeedsTransparency(outputCanvas, project);
+			const blobCanvas =
+				destination === "clipboard" && !needsAlpha
+					? withWhiteBackground(outputCanvas)
+					: outputCanvas;
 			const blob =
 				destination === "share"
 					? await canvasToBlob(
-							outputCanvas,
-							canvasNeedsTransparency(outputCanvas, project)
-								? "image/png"
-								: "image/jpeg",
+							blobCanvas,
+							needsAlpha ? "image/png" : "image/jpeg",
 							0.9,
 						)
-					: await canvasToBlob(outputCanvas, "image/png");
+					: await canvasToBlob(blobCanvas, "image/png");
 
 			if (destination === "file") {
 				const buffer = await blob.arrayBuffer();

--- a/apps/desktop/src/routes/screenshot-editor/useScreenshotExport.ts
+++ b/apps/desktop/src/routes/screenshot-editor/useScreenshotExport.ts
@@ -180,7 +180,10 @@ export function useScreenshotExport() {
 				toast.loading("Preparing upload", { id: toastId });
 			}
 
-			const needsAlpha = canvasNeedsTransparency(outputCanvas, project);
+			const needsAlpha =
+				destination === "share" || destination === "clipboard"
+					? canvasNeedsTransparency(outputCanvas, project)
+					: false;
 			const blobCanvas =
 				destination === "clipboard" && !needsAlpha
 					? withWhiteBackground(outputCanvas)


### PR DESCRIPTION
On Windows, copying a screenshot from the editor and pasting it elsewhere results in a white/blank image.

The default screenshot config uses a transparent background. The GPU renderer preserves that transparency, so the clipboard receives a transparent PNG. 
Windows clipboard format (CF_DIB) doesn't carry alpha, so receiving apps silently render transparent pixels as white. 
The automation works because it copies the raw file directly, bypassing the canvas pipeline entirely.

The fix composites the rendered canvas onto white before encoding when the image doesn't actually need transparency. File and Share exports are unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Windows clipboard issue where copying a screenshot from the editor produced a white/blank image in the receiving application. The root cause was that the canvas rendered with a transparent background, and the Windows CF_DIB clipboard format silently drops the alpha channel.

- Adds a `withWhiteBackground` helper that composites the source canvas onto a new opaque-white canvas before encoding.
- For `"clipboard"` exports, the composited canvas is used only when `canvasNeedsTransparency` confirms no transparency is required; `"file"` and `"share"` paths are unaffected.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the white-background composite is applied only when the canvas has no transparent pixels, making the visual result identical on all platforms and fixing the Windows clipboard rendering issue.

The fix is tightly scoped: withWhiteBackground is only invoked for clipboard destinations when the pixel scan confirms full opacity, so file and share exports are untouched. The one notable issue is that canvasNeedsTransparency now runs a full pixel scan even for file exports where its result is never used, but this has no behavioral impact.

No files require special attention beyond the single changed file.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/screenshot-editor/useScreenshotExport.ts | Adds withWhiteBackground helper and composites the clipboard canvas onto white when no transparency is needed; file/share export paths are functionally unchanged. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/routes/screenshot-editor/useScreenshotExport.ts:183-187
`canvasNeedsTransparency` is now called unconditionally for every destination, including `"file"`. For a `"file"` export, `needsAlpha` never affects `blobCanvas` (the condition guards on `"clipboard"`) or the encoding format (the blob ternary guards on `"share"`). On large canvases with a transparent project background this triggers a full pixel scan whose result is then discarded. Guarding the call avoids the scan on the file path.

```suggestion
			const needsAlpha =
				destination !== "file" && canvasNeedsTransparency(outputCanvas, project);
			const blobCanvas =
				destination === "clipboard" && !needsAlpha
					? withWhiteBackground(outputCanvas)
					: outputCanvas;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(screenshot): composite on white back..."](https://github.com/capsoftware/cap/commit/41428368ec6023a06f97d1a5d393e4a0d174471a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41142025)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->