### PR TITLE
feat(desktop): custom recordings storage path

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -6,7 +6,7 @@ use specta::Type;
 use std::collections::BTreeMap;
 #[cfg(target_os = "macos")]
 use tauri::Listener;
-use tauri::{AppHandle, Wry};
+use tauri::{AppHandle, Manager, Wry};
 use tauri_plugin_store::StoreExt;
 use tracing::{error, instrument};
 use uuid::Uuid;
@@ -218,6 +218,8 @@ pub struct GeneralSettingsStore {
     pub enable_telemetry: bool,
     #[serde(default)]
     pub out_of_process_muxer: bool,
+    #[serde(default)]
+    pub recordings_path: Option<String>,
 }
 
 fn default_enable_native_camera_preview() -> bool {
@@ -314,6 +316,7 @@ impl Default for GeneralSettingsStore {
             has_completed_onboarding: false,
             enable_telemetry: true,
             out_of_process_muxer: cap_recording::DEFAULT_OUT_OF_PROCESS_MUXER,
+            recordings_path: None,
         }
     }
 }
@@ -328,6 +331,23 @@ pub enum AppTheme {
 }
 
 impl GeneralSettingsStore {
+    pub fn recordings_dir(app: &AppHandle<Wry>) -> std::path::PathBuf {
+        let custom = Self::get(app)
+            .ok()
+            .flatten()
+            .and_then(|s| s.recordings_path)
+            .and_then(|p| {
+                let path = std::path::PathBuf::from(&p);
+                if path.is_absolute() { Some(path) } else { None }
+            });
+
+        let path = custom.unwrap_or_else(|| {
+            app.path().app_data_dir().unwrap().join("recordings")
+        });
+        std::fs::create_dir_all(&path).unwrap_or_default();
+        path
+    }
+
     // The effective value: the native preview is macOS-only; it is not
     // reliable on Windows, so the stored setting is ignored there and the
     // websocket preview is always used.

--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -333,6 +333,7 @@ pub enum AppTheme {
 impl GeneralSettingsStore {
     pub fn recordings_dir(app: &AppHandle<Wry>) -> std::path::PathBuf {
         let custom = Self::get(app)
+            .map_err(|e| tracing::warn!("Failed to read general settings for recordings_dir: {e}"))
             .ok()
             .flatten()
             .and_then(|s| s.recordings_path)
@@ -344,7 +345,9 @@ impl GeneralSettingsStore {
         let path = custom.unwrap_or_else(|| {
             app.path().app_data_dir().unwrap().join("recordings")
         });
-        std::fs::create_dir_all(&path).unwrap_or_default();
+        if let Err(e) = std::fs::create_dir_all(&path) {
+            tracing::warn!(?path, %e, "Failed to create recordings directory");
+        }
         path
     }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4269,7 +4269,8 @@ async fn pick_recordings_folder(app: AppHandle) -> Result<Option<String>, String
             let _ = tx.send(
                 path.as_ref()
                     .and_then(|p| p.as_path())
-                    .map(|p| p.to_string_lossy().to_string()),
+                    .and_then(|p| p.to_str())
+                    .map(|s| s.to_string()),
             );
         });
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4257,6 +4257,43 @@ async fn set_server_url(app: MutableState<'_, App>, server_url: String) -> Resul
 #[tauri::command]
 #[specta::specta]
 #[instrument(skip(app))]
+async fn pick_recordings_folder(app: AppHandle) -> Result<Option<String>, String> {
+    use tauri_plugin_dialog::DialogExt;
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    app.dialog()
+        .file()
+        .set_title("Choose Recordings Folder")
+        .pick_folder(move |path| {
+            let _ = tx.send(
+                path.as_ref()
+                    .and_then(|p| p.as_path())
+                    .map(|p| p.to_string_lossy().to_string()),
+            );
+        });
+
+    let result = rx.await.map_err(|e| e.to_string())?;
+    if let Some(ref path) = result {
+        general_settings::GeneralSettingsStore::update(&app, |s| {
+            s.recordings_path = Some(path.clone());
+        })?;
+    }
+    Ok(result)
+}
+
+#[tauri::command]
+#[specta::specta]
+#[instrument(skip(app))]
+async fn reset_recordings_folder(app: AppHandle) -> Result<(), String> {
+    general_settings::GeneralSettingsStore::update(&app, |s| {
+        s.recordings_path = None;
+    })
+}
+
+#[tauri::command]
+#[specta::specta]
+#[instrument(skip(app))]
 async fn set_camera_preview_state(
     app: MutableState<'_, App>,
     state: CameraPreviewState,
@@ -4590,6 +4627,8 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             delete_recording_directory,
             set_pretty_name,
             set_server_url,
+            pick_recordings_folder,
+            reset_recordings_folder,
             set_camera_preview_state,
             set_camera_window_position,
             ignore_camera_window_position,
@@ -6171,9 +6210,7 @@ pub(crate) async fn wait_for_recording_ready(app: &AppHandle, path: &Path) -> Re
 }
 
 fn recordings_path(app: &AppHandle) -> PathBuf {
-    let path = app.path().app_data_dir().unwrap().join("recordings");
-    std::fs::create_dir_all(&path).unwrap_or_default();
-    path
+    general_settings::GeneralSettingsStore::recordings_dir(app)
 }
 
 // fn recording_path(app: &AppHandle, recording_id: &str) -> PathBuf {

--- a/apps/desktop/src-tauri/src/logging.rs
+++ b/apps/desktop/src-tauri/src/logging.rs
@@ -1,4 +1,4 @@
-use crate::{ArcLock, feeds::microphone::MicrophoneFeed, permissions, web_api::ManagerExt};
+use crate::{ArcLock, feeds::microphone::MicrophoneFeed, general_settings::GeneralSettingsStore, permissions, web_api::ManagerExt};
 use cap_recording::diagnostics::{
     CameraDiagnostics, CameraFormatInfo, DisplayDiagnostics, HardwareInfo, MicrophoneDiagnostics,
     StorageInfo,
@@ -208,7 +208,7 @@ pub async fn upload_log_file(app: &AppHandle) -> Result<(), String> {
         .path()
         .app_data_dir()
         .map_err(|e| format!("Failed to get app data dir: {e}"))?;
-    let recordings_dir = app_data_dir.join("recordings");
+    let recordings_dir = GeneralSettingsStore::recordings_dir(&app);
 
     let is_recording = {
         let app_lock = app.state::<ArcLock<crate::App>>();

--- a/apps/desktop/src-tauri/src/recovery.rs
+++ b/apps/desktop/src-tauri/src/recovery.rs
@@ -4,10 +4,10 @@ use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use specta::Type;
 use std::path::PathBuf;
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 use tracing::info;
 
-use crate::create_screenshot;
+use crate::{create_screenshot, general_settings::GeneralSettingsStore};
 
 const RECOVERY_CUTOFF_DATE: (i32, u32, u32) = (2025, 12, 31);
 
@@ -44,11 +44,7 @@ pub struct IncompleteRecordingInfo {
 pub async fn find_incomplete_recordings(
     app: AppHandle,
 ) -> Result<Vec<IncompleteRecordingInfo>, String> {
-    let recordings_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| e.to_string())?
-        .join("recordings");
+    let recordings_dir = GeneralSettingsStore::recordings_dir(&app);
 
     if !recordings_dir.exists() {
         return Ok(Vec::new());

--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -642,14 +642,22 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 				<StorageSection
 					recordingsPath={settings.recordingsPath ?? null}
 					onPick={async () => {
-						const path = await commands.pickRecordingsFolder();
-						if (path !== null) {
-							setSettings("recordingsPath", path);
+						try {
+							const path = await commands.pickRecordingsFolder();
+							if (path !== null) {
+								setSettings("recordingsPath", path);
+							}
+						} catch (e) {
+							toast.error(`Failed to choose recordings folder: ${e instanceof Error ? e.message : String(e)}`);
 						}
 					}}
 					onReset={async () => {
-						await commands.resetRecordingsFolder();
-						setSettings("recordingsPath", null);
+						try {
+							await commands.resetRecordingsFolder();
+							setSettings("recordingsPath", null);
+						} catch (e) {
+							toast.error(`Failed to reset recordings folder: ${e instanceof Error ? e.message : String(e)}`);
+						}
 					}}
 				/>
 

--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -639,6 +639,20 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 					</SectionRows>
 				</Section>
 
+				<StorageSection
+					recordingsPath={settings.recordingsPath ?? null}
+					onPick={async () => {
+						const path = await commands.pickRecordingsFolder();
+						if (path !== null) {
+							setSettings("recordingsPath", path);
+						}
+					}}
+					onReset={async () => {
+						await commands.resetRecordingsFolder();
+						setSettings("recordingsPath", null);
+					}}
+				/>
+
 				<DefaultProjectNameCard
 					onChange={(value) =>
 						handleChange("defaultProjectNameTemplate", value)
@@ -684,6 +698,43 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 				/>
 			</SettingsPageContent>
 		</div>
+	);
+}
+
+function StorageSection(props: {
+	recordingsPath: string | null;
+	onPick: () => Promise<void>;
+	onReset: () => Promise<void>;
+}) {
+	const defaultLabel = "Default (Application Support)";
+	const displayPath = () => props.recordingsPath ?? defaultLabel;
+	const isCustom = () => props.recordingsPath !== null;
+
+	return (
+		<Section
+			title="Storage"
+			description="Where Cap saves your recordings."
+		>
+			<SectionCard padded>
+				<div class="flex flex-col gap-3">
+					<div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-3 border border-gray-4 min-w-0">
+						<span class="flex-1 text-xs text-gray-12 truncate font-mono">
+							{displayPath()}
+						</span>
+					</div>
+					<div class="flex justify-end gap-2">
+						<Show when={isCustom()}>
+							<Button size="sm" variant="gray" onClick={props.onReset}>
+								Reset to Default
+							</Button>
+						</Show>
+						<Button size="sm" variant="dark" onClick={props.onPick}>
+							Choose Folder
+						</Button>
+					</div>
+				</div>
+			</SectionCard>
+		</Section>
 	);
 }
 

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -355,6 +355,12 @@ async setPrettyName(prettyName: string) : Promise<null> {
 async setServerUrl(serverUrl: string) : Promise<null> {
     return await TAURI_INVOKE("set_server_url", { serverUrl });
 },
+async pickRecordingsFolder() : Promise<string | null> {
+    return await TAURI_INVOKE("pick_recordings_folder");
+},
+async resetRecordingsFolder() : Promise<null> {
+    return await TAURI_INVOKE("reset_recordings_folder");
+},
 async setCameraPreviewState(state: CameraPreviewState) : Promise<null> {
     return await TAURI_INVOKE("set_camera_preview_state", { state });
 },
@@ -663,7 +669,7 @@ export type ExportSettings = ({ format: "Mp4" } & Mp4ExportSettings) | ({ format
 export type FileType = "recording" | "screenshot"
 export type Flags = { captions: boolean }
 export type FramesRendered = { renderedCount: number; totalFrames: number; type: "FramesRendered" }
-export type GeneralSettingsStore = { instanceId?: string; uploadIndividualFiles?: boolean; hideDockIcon?: boolean; autoCreateShareableLink?: boolean; enableNotifications?: boolean; disableAutoOpenLinks?: boolean; hasCompletedStartup?: boolean; theme?: AppTheme; commercialLicense?: CommercialLicense | null; lastVersion?: string | null; windowTransparency?: boolean; postStudioRecordingBehaviour?: PostStudioRecordingBehaviour; mainWindowRecordingStartBehaviour?: MainWindowRecordingStartBehaviour; custom_cursor_capture2?: boolean; serverUrl?: string; recordingCountdown?: number | null; enableNativeCameraPreview: boolean; autoZoomOnClicks?: boolean; captureKeyboardEvents?: boolean; postDeletionBehaviour?: PostDeletionBehaviour; excludedWindows?: WindowExclusion[]; deleteInstantRecordingsAfterUpload?: boolean; instantModeMaxResolution?: number; defaultProjectNameTemplate?: string | null; crashRecoveryRecording?: boolean; maxFps?: number; transcriptionHints?: string[]; editorPreviewQuality?: EditorPreviewQuality; studioRecordingQuality?: StudioRecordingQuality; mainWindowPosition?: WindowPosition | null; cameraWindowPosition?: WindowPosition | null; cameraWindowPositionsByMonitorName?: { [key in string]: WindowPosition }; hasCompletedOnboarding?: boolean; enableTelemetry?: boolean; outOfProcessMuxer?: boolean }
+export type GeneralSettingsStore = { instanceId?: string; uploadIndividualFiles?: boolean; hideDockIcon?: boolean; autoCreateShareableLink?: boolean; enableNotifications?: boolean; disableAutoOpenLinks?: boolean; hasCompletedStartup?: boolean; theme?: AppTheme; commercialLicense?: CommercialLicense | null; lastVersion?: string | null; windowTransparency?: boolean; postStudioRecordingBehaviour?: PostStudioRecordingBehaviour; mainWindowRecordingStartBehaviour?: MainWindowRecordingStartBehaviour; custom_cursor_capture2?: boolean; serverUrl?: string; recordingCountdown?: number | null; enableNativeCameraPreview: boolean; autoZoomOnClicks?: boolean; captureKeyboardEvents?: boolean; postDeletionBehaviour?: PostDeletionBehaviour; excludedWindows?: WindowExclusion[]; deleteInstantRecordingsAfterUpload?: boolean; instantModeMaxResolution?: number; defaultProjectNameTemplate?: string | null; crashRecoveryRecording?: boolean; maxFps?: number; transcriptionHints?: string[]; editorPreviewQuality?: EditorPreviewQuality; studioRecordingQuality?: StudioRecordingQuality; mainWindowPosition?: WindowPosition | null; cameraWindowPosition?: WindowPosition | null; cameraWindowPositionsByMonitorName?: { [key in string]: WindowPosition }; hasCompletedOnboarding?: boolean; enableTelemetry?: boolean; outOfProcessMuxer?: boolean; recordingsPath?: string | null }
 export type GifExportSettings = { fps: number; resolution_base: XY<number>; quality: GifQuality | null }
 export type GifQuality = { 
 /**


### PR DESCRIPTION
Adds a setting that lets users choose where Cap saves recordings, instead of always using the default Application Support directory.

A new Storage section in General Settings shows the current recordings folder with a Choose Folder button (native folder picker) and a Reset to Default button that appears when a custom path is active. 
The chosen path persists across restarts. 
Logging and crash recovery also respect the custom path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a user-configurable recordings storage path in General Settings, replacing the hardcoded Application Support directory. The chosen path is persisted in the settings store, and logging and crash-recovery scanning are updated to respect it.

- `GeneralSettingsStore::recordings_dir()` centralises path resolution: it reads the stored custom path, validates it is absolute, falls back to the default with a warning on failure, and ensures the directory exists via `create_dir_all`.
- Two new Tauri commands (`pick_recordings_folder` / `reset_recordings_folder`) drive a new `StorageSection` component with "Choose Folder" and "Reset to Default" buttons; both async handlers have proper `try/catch` with toast notifications on error.
- All three former hardcoded `app_data_dir().join("recordings")` sites (lib.rs, logging.rs, recovery.rs) are unified through the new helper.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core path-resolution and security logic is sound and all three previously hardcoded directory sites are consistently unified.

The change is internally consistent: error paths log warnings, the absolute-path validation guards against relative inputs, and the existing symlink/traversal protections in `delete_recording_directory` are unaffected. The two findings are minor UX gaps (a platform-mismatched label and deferred write-permission feedback) that don't affect data integrity or correctness.

The platform label in `general.tsx` and the write-permission check in `lib.rs` (`pick_recordings_folder`) are worth a second look before shipping to Windows/Linux users.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/general_settings.rs | Adds `recordings_path: Option<String>` field and a new `recordings_dir()` helper that validates the stored path is absolute, logs on error, and falls back to the default Application Support directory. |
| apps/desktop/src-tauri/src/lib.rs | Adds `pick_recordings_folder` and `reset_recordings_folder` Tauri commands; delegates `recordings_path()` to the new `GeneralSettingsStore::recordings_dir()` helper. |
| apps/desktop/src-tauri/src/logging.rs | Updates `upload_log_file` to derive the recordings directory from `GeneralSettingsStore::recordings_dir` instead of the hardcoded Application Support path. |
| apps/desktop/src-tauri/src/recovery.rs | Updates `find_incomplete_recordings` to use `GeneralSettingsStore::recordings_dir` for crash recovery scanning, correctly respecting custom paths. |
| apps/desktop/src/routes/(window-chrome)/settings/general.tsx | Adds the `StorageSection` component with path display, Choose Folder button, and Reset to Default button; both async handlers have try/catch with toast.error on failure. The default path label is macOS-specific. |
| apps/desktop/src/utils/tauri.ts | Adds generated `pickRecordingsFolder`/`resetRecordingsFolder` bindings and extends `GeneralSettingsStore` type with the new `recordingsPath` field. |

<sub>Reviews (2): Last reviewed commit: ["fix: add error logging, safe path conver..."](https://github.com/capsoftware/cap/commit/b9df99c1ec3279928bfbef385bae6975be18249e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41144553)</sub>

<!-- /greptile_comment -->