### PR TITLE
fix(windows): remove Cap Target Select from default excluded windows to prevent ghost overlay

### DIFF
--- a/apps/cli/src/doctor.rs
+++ b/apps/cli/src/doctor.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
+use std::time::Duration;
 
 use crate::{OutputFormat, write_json};
 

--- a/apps/cli/src/doctor.rs
+++ b/apps/cli/src/doctor.rs
@@ -1,8 +1,5 @@
 use serde::Serialize;
-use std::{
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::path::{Path, PathBuf};
 
 use crate::{OutputFormat, write_json};
 
@@ -456,7 +453,7 @@ fn install_check(install: &Result<cap_cli_install::CliInstallStatus, String>) ->
     }
 }
 
-fn capture_ready(permissions: &Permissions, checks: &[Check]) -> bool {
+fn capture_ready(permissions: &Permissions, _checks: &[Check]) -> bool {
     let permission_ready = match permissions.screen_recording {
         #[cfg(target_os = "macos")]
         PermissionStatus::Granted => true,

--- a/apps/cli/src/doctor.rs
+++ b/apps/cli/src/doctor.rs
@@ -453,7 +453,8 @@ fn install_check(install: &Result<cap_cli_install::CliInstallStatus, String>) ->
     }
 }
 
-fn capture_ready(permissions: &Permissions, _checks: &[Check]) -> bool {
+#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
+fn capture_ready(permissions: &Permissions, checks: &[Check]) -> bool {
     let permission_ready = match permissions.screen_recording {
         #[cfg(target_os = "macos")]
         PermissionStatus::Granted => true,

--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -91,6 +91,8 @@ impl MainWindowRecordingStartBehaviour {
     }
 }
 
+// NOTE: Do not add "Cap Target Select" here — on Windows, WDA_EXCLUDEFROMCAPTURE applied to that
+// hidden window causes it to reappear as a ghost overlay after recording ends.
 const DEFAULT_EXCLUDED_WINDOW_TITLES: &[&str] = &[
     "Cap",
     "Cap Settings",

--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -96,7 +96,6 @@ const DEFAULT_EXCLUDED_WINDOW_TITLES: &[&str] = &[
     "Cap Settings",
     "Cap Recording Controls",
     "Cap Camera",
-    "Cap Target Select",
     "Cap Window Capture Occluder",
     "Cap Capture Area",
     "Cap Mode Selection",

--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -416,6 +416,17 @@ pub fn init(app: &AppHandle) {
     };
 
     append_missing_default_excluded_windows(&mut store.excluded_windows);
+
+    const REMOVE_TARGET_SELECT_MIGRATION_KEY: &str = "remove_cap_target_select_exclusion_v1";
+    if let Ok(raw_store) = app.store("store")
+        && raw_store.get(REMOVE_TARGET_SELECT_MIGRATION_KEY).is_none()
+    {
+        store.excluded_windows.retain(|w| {
+            w.window_title.as_deref() != Some("Cap Target Select")
+        });
+        raw_store.set(REMOVE_TARGET_SELECT_MIGRATION_KEY, json!(true));
+    }
+
     crate::posthog::set_telemetry_enabled(store.enable_telemetry);
     register_bundled_muxer_binary(app);
 


### PR DESCRIPTION
## Problem

On Windows, a transparent ghost overlay persists on screen after every recording ends. ESC doesn't dismiss it. Removing "Cap" from Settings → Excluded Windows instantly surfaces it, confirming the mechanism.

## Root Cause

"Cap Target Select" was in DEFAULT_EXCLUDED_WINDOW_TITLES, so apply_content_protection sets WDA_EXCLUDEFROMCAPTURE on the overlay at recording start — even though it's already hidden. When recording ends and WDA_NONE is restored, Windows re-surfaces the hidden window before hide_overlay can suppress it again.

## Fix

Remove "Cap Target Select" from the default exclusion list. The overlay is always hidden before recording starts, so content protection on it is a no-op for capture and only causes this side effect on Windows.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Windows ghost overlay bug by removing `"Cap Target Select"` from `DEFAULT_EXCLUDED_WINDOW_TITLES` and adds a one-time migration to clean up the entry for existing users. Two companion `doctor.rs` compile fixes — making the `Duration` import conditional on macOS and suppressing the unused `checks` parameter warning via `#[cfg_attr]` — are also included.

- Removed `"Cap Target Select"` from the default exclusion list with a protective comment explaining the Windows-specific reason, so future contributors won't re-add it accidentally.
- Added a `REMOVE_TARGET_SELECT_MIGRATION_KEY` migration in `init` following the established `raw_store` pattern, ensuring existing users' persisted settings are cleaned up on the next launch.
- Fixed both previously flagged `doctor.rs` compile errors: `std::time::Duration` is now gated with `#[cfg(target_os = "macos")]`, and the `checks` parameter keeps its name while `#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]` silences the warning on non-macOS platforms.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is correctly scoped, all previously raised issues have been addressed, and the migration follows the established pattern already in production.

All three issues flagged in earlier review rounds have been resolved: the `Duration` import is now correctly conditional, the `checks` parameter compile error is fixed with `#[cfg_attr]`, and a one-time migration strips "Cap Target Select" from existing users' stored settings. The core logic — removing the window title from the default exclusion list — is straightforward and low-risk. No new issues were found.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/cli/src/doctor.rs | Makes `Duration` import conditional on macOS (matching its only usage in `screen_capture_kit_check`), and suppresses the unused-variable warning for the `checks` parameter on non-macOS via `#[cfg_attr]` instead of renaming — resolving both previously flagged compile issues. |
| apps/desktop/src-tauri/src/general_settings.rs | Removes "Cap Target Select" from `DEFAULT_EXCLUDED_WINDOW_TITLES` with an explanatory comment, and adds a one-time migration following the established `raw_store` pattern to strip the entry from existing users' stored settings — resolving the previously flagged gap for users who already had the entry persisted. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `apps/desktop/src-tauri/src/general_settings.rs`, line 116-127 ([link](https://github.com/capsoftware/cap/blob/3fa4c79b12acb61a2f53f7c1d7838ecb9b15a129/apps/desktop/src-tauri/src/general_settings.rs#L116-L127)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Fix is ineffective for existing users**

   `append_missing_default_excluded_windows` only ever **adds** entries that are missing from the stored list — it never removes entries that have been dropped from `DEFAULT_EXCLUDED_WINDOW_TITLES`. Any user who installed Cap before this change already has `"Cap Target Select"` persisted in their `excluded_windows` store, so on startup the function finds it present and leaves it untouched. The ghost overlay bug will persist for all such users; only fresh installs or users who manually reset their settings will benefit.

   A one-time migration is needed in `init`, similar to the `NATIVE_PREVIEW_MIGRATION_KEY` migration at line 424, to remove `"Cap Target Select"` from the stored list if it is found there.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src-tauri/src/general_settings.rs
   Line: 116-127

   Comment:
   **Fix is ineffective for existing users**

   `append_missing_default_excluded_windows` only ever **adds** entries that are missing from the stored list — it never removes entries that have been dropped from `DEFAULT_EXCLUDED_WINDOW_TITLES`. Any user who installed Cap before this change already has `"Cap Target Select"` persisted in their `excluded_windows` store, so on startup the function finds it present and leaves it untouched. The ghost overlay bug will persist for all such users; only fresh installs or users who manually reset their settings will benefit.

   A one-time migration is needed in `init`, similar to the `NATIVE_PREVIEW_MIGRATION_KEY` migration at line 424, to remove `"Cap Target Select"` from the stored list if it is found there.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `apps/cli/src/doctor.rs`, line 456-475 ([link](https://github.com/capsoftware/cap/blob/e4e55aedf5541ab93b83b97bf43eab92ebc9532b/apps/cli/src/doctor.rs#L456-L475)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **macOS compile error: `checks` renamed to `_checks` but still referenced by old name**

   The parameter was renamed to `_checks` to suppress the unused-variable warning on non-macOS platforms, but the `#[cfg(target_os = "macos")]` block on line 470 still refers to the old name `checks`. On macOS, that block is compiled and `checks` is not in scope — this is an unresolved name compile error that breaks the macOS CLI build.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/cli/src/doctor.rs
   Line: 456-475

   Comment:
   **macOS compile error: `checks` renamed to `_checks` but still referenced by old name**

   The parameter was renamed to `_checks` to suppress the unused-variable warning on non-macOS platforms, but the `#[cfg(target_os = "macos")]` block on line 470 still refers to the old name `checks`. On macOS, that block is compiled and `checks` is not in scope — this is an unresolved name compile error that breaks the macOS CLI build.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `apps/desktop/src-tauri/src/general_settings.rs`, line 116-127 ([link](https://github.com/capsoftware/cap/blob/7f3ec98c5c4fbd863009a2bf7dc45009ea17bf9b/apps/desktop/src-tauri/src/general_settings.rs#L116-L127)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Fix is ineffective for existing users**

   `append_missing_default_excluded_windows` only ever **adds** entries absent from the stored list — it never removes entries that were dropped from `DEFAULT_EXCLUDED_WINDOW_TITLES`. Any user who installed Cap before this change already has `"Cap Target Select"` persisted in their `excluded_windows` store; on startup the function finds it present and leaves it untouched. The ghost overlay bug will persist for all such users; only fresh installs benefit.

   A one-time migration in `init` (similar to the `NATIVE_PREVIEW_MIGRATION_KEY` pattern at line 424) is needed to strip `"Cap Target Select"` from the stored list when it is found there.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src-tauri/src/general_settings.rs
   Line: 116-127

   Comment:
   **Fix is ineffective for existing users**

   `append_missing_default_excluded_windows` only ever **adds** entries absent from the stored list — it never removes entries that were dropped from `DEFAULT_EXCLUDED_WINDOW_TITLES`. Any user who installed Cap before this change already has `"Cap Target Select"` persisted in their `excluded_windows` store; on startup the function finds it present and leaves it untouched. The ghost overlay bug will persist for all such users; only fresh installs benefit.

   A one-time migration in `init` (similar to the `NATIVE_PREVIEW_MIGRATION_KEY` pattern at line 424) is needed to strip `"Cap Target Select"` from the stored list when it is found there.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["fix(cli): restore Duration import as cfg..."](https://github.com/capsoftware/cap/commit/740b46335745fddaddd2bb81ed8a62930255acfb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41154200)</sub>

<!-- /greptile_comment -->