### PR TITLE
fix(recording): prevent double-count of VideoStartGate trim in mic_start_time

### DIFF
--- a/crates/recording/src/output_pipeline/core.rs
+++ b/crates/recording/src/output_pipeline/core.rs
@@ -187,7 +187,15 @@ pub(crate) async fn apply_video_start_gate(
                     offset_ns = offset_ns as i64,
                     "Trimmed leading audio samples for encoder-pair alignment"
                 );
-                VideoStartGateAction::UseFrame(AudioFrame::new(trimmed, frame.timestamp))
+                // Advance the timestamp to the first *committed* sample so that
+                // first_timestamp (and therefore mic_start_time in metadata) reflects
+                // the actual capture time after the trim, not the pre-trim buffer start.
+                // Without this, the editor's mic_offset = display_start - mic_start equals
+                // trim_duration and causes it to skip that same duration a second time.
+                let trim_duration = Duration::from_nanos(
+                    trim_samples as u64 * 1_000_000_000 / sample_rate as u64,
+                );
+                VideoStartGateAction::UseFrame(AudioFrame::new(trimmed, frame.timestamp + trim_duration))
             }
             None => {
                 warn!(
@@ -4492,6 +4500,21 @@ mod tests {
                     let expected_trim =
                         ns_to_sample_count(video_start_ns, info.sample_rate) as usize;
                     assert_eq!(new_frame.inner.samples(), 2048 - expected_trim);
+                    // Timestamp must be advanced by the trim so that mic_start_time in
+                    // metadata reflects the first committed sample, preventing the editor
+                    // from double-counting the same gap as a skip offset.
+                    let trim_duration = Duration::from_nanos(
+                        expected_trim as u64 * 1_000_000_000 / info.sample_rate as u64,
+                    );
+                    let expected_ts = Timestamp::Instant(start + trim_duration);
+                    assert_eq!(
+                        new_frame
+                            .timestamp
+                            .signed_duration_since_secs(master_clock.timestamps()),
+                        expected_ts
+                            .signed_duration_since_secs(master_clock.timestamps()),
+                        "gate UseFrame timestamp must be advanced past the trimmed samples"
+                    );
                 }
                 other => panic!("expected UseFrame when audio leads, got {other:?}"),
             }


### PR DESCRIPTION
## Root Cause

When VideoStartGate trims leading samples from the first audio frame to align it with the first video frame, the returned AudioFrame kept the original buffer capture timestamp instead of the adjusted timestamp of the first committed sample.

This flowed into first_timestamp → mic_start_time in project metadata. 
In the editor, mic_offset = display_start − mic_start = trim_duration, so the renderer skipped trim_duration into the audio file, but those samples were already removed by the gate. 
Same gap counted twice: audio arrives late by up to one buffer period (~35 ms at 48 kHz / 1680-sample buffers).

## Fix

Advance the frame timestamp by trim_samples / sample_rate before returning UseFrame, so mic_start_time reflects the first committed sample (≈ video start) and mic_offset collapses to ~0.

No change to the Passthrough path or the stale-startup audio_timing_repair_offset mechanism. 
Added a timestamp assertion to the existing apply_gate_audio_leads_trims_front unit test; all 190 unit tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a double-counting bug where `VideoStartGate` trimmed leading audio samples to align with the first video frame but kept the original buffer-capture timestamp on the returned `AudioFrame`, causing the editor to also skip ahead by `trim_duration` because `mic_offset = display_start − mic_start` equalled the already-removed gap. The fix advances `frame.timestamp` by `trim_samples * 1e9 / sample_rate` nanoseconds before constructing the trimmed `AudioFrame`, collapsing `mic_offset` to near-zero.

- **Core fix** (`apply_video_start_gate`): computes `trim_duration` from the integer trim-sample count and adds it to `frame.timestamp` using the existing `Timestamp + Duration` trait impl, which handles every platform variant (`Instant`, `SystemTime`, `PerformanceCounter`, `MachAbsoluteTime`) correctly.
- **Test update** (`apply_gate_audio_leads_trims_front`): adds an assertion that the returned frame's timestamp equals `start + trim_duration`, comparing via `signed_duration_since_secs` to avoid direct `Timestamp` equality. The formula mirrors the production code's integer round-trip, which is exact for the 20 ms / 48 kHz values in the test.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrow, self-contained timestamp correction with no impact on the Passthrough or DropFrame paths.

The arithmetic is correct, division by zero is guarded by the existing zero-sample early return, integer overflow is not a concern given the 500 ms alignment limit, and the Timestamp + Duration trait handles all platform variants. The new unit-test assertion validates the same computation end-to-end.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/recording/src/output_pipeline/core.rs | Advances the AudioFrame timestamp by `trim_samples / sample_rate` after the VideoStartGate front-trim so that `mic_start_time` in metadata reflects the first committed sample; adds a matching assertion to the existing unit test. |

<sub>Reviews (1): Last reviewed commit: ["fix(recording): advance gate frame times..."](https://github.com/capsoftware/cap/commit/bfbcbbc328d0f74ef694c890e544075110d36d07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41277976)</sub>

<!-- /greptile_comment -->