### PR TITLE
fix(enc-ffmpeg): use encoder_time_base in H264PacketEncoder to fix 4-8x playback speed

### DIFF
--- a/crates/enc-ffmpeg/src/video/h264_packet.rs
+++ b/crates/enc-ffmpeg/src/video/h264_packet.rs
@@ -198,8 +198,12 @@ impl H264PacketEncoder {
     }
 
     fn update_pts(&mut self, frame: &mut frame::Video, timestamp: Duration) {
+        // Use encoder_time_base (the value sent to the muxer subprocess via InitVideo),
+        // NOT self.encoder.time_base() which may be overridden by the codec after open.
+        // Mismatching these causes the muxer to rescale PTS using the wrong time base,
+        // producing wrong playback speed (observed as 4-8x too fast with h264_videotoolbox).
+        let tb = self.encoder_time_base;
         if timestamp != Duration::MAX {
-            let tb = self.encoder.time_base();
             let rate = tb.denominator() as f64 / tb.numerator() as f64;
             let pts = (timestamp.as_secs_f64() * rate).round() as i64;
             let first_pts = *self.first_pts.get_or_insert(pts);
@@ -207,7 +211,7 @@ impl H264PacketEncoder {
                 pts - first_pts,
                 self.last_frame_pts,
                 tb,
-                self.encoder.frame_rate(),
+                self.frame_rate,
             );
             self.last_frame_pts = Some(pts);
             frame.set_pts(Some(pts));
@@ -216,8 +220,8 @@ impl H264PacketEncoder {
             let pts = normalize_input_pts(
                 pts - first_pts,
                 self.last_frame_pts,
-                self.encoder.time_base(),
-                self.encoder.frame_rate(),
+                tb,
+                self.frame_rate,
             );
             self.last_frame_pts = Some(pts);
             frame.set_pts(Some(pts));


### PR DESCRIPTION
H264PacketEncoder.update_pts was computing PTS using the FFmpeg encoder's time_base **after** avcodec_open2. 

h264_videotoolbox can override this value after opening, but the `cap-muxer` subprocess is always initialised with the stored `encoder_time_base` (= `input_config.time_base`). 
When these diverge, the muxer rescales PTS against the wrong base and the video plays back at the wrong speed, reported as 4-8x too fast in v0.5.3 on macOS.

Fix: use the stored encoder_time_base and frame_rate (the values already sent to cap-muxer via InitVideo) instead of reading them back from the post-open encoder object, which may have been modified by the codec.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a 4-8x playback speed regression on macOS by correcting how PTS values are computed in `H264PacketEncoder::update_pts`. The root cause is that `h264_videotoolbox` can change the codec's `time_base` after `avcodec_open2`, diverging from the `encoder_time_base` already sent to `cap-muxer` via `InitVideo`, causing the muxer to rescale PTS with the wrong denominator.

- Replaces both `self.encoder.time_base()` and `self.encoder.frame_rate()` calls in `update_pts` with the stored `self.encoder_time_base` and `self.frame_rate` fields, which are the exact values the muxer subprocess was initialized with.
- Hoists `let tb = self.encoder_time_base` before the `if`/`else` branches so both the normal-timestamp path and the fallback `frame.pts()` path use the same consistent base.

<h3>Confidence Score: 5/5</h3>

Minimal, targeted fix that eliminates a time-base mismatch between the encoder and muxer; all three changed call sites are consistently updated.

The change is a one-function, three-site substitution of two struct field reads for two post-open encoder accessor calls. Both fields were already populated at construction with the values sent to cap-muxer, and the public time_base() / frame_rate() accessors already returned them. The fix is internally consistent, well-commented, and accompanied by existing unit tests that cover the encode path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/enc-ffmpeg/src/video/h264_packet.rs | update_pts now reads encoder_time_base and frame_rate from stored struct fields instead of the post-open encoder object, preventing PTS miscalculation when h264_videotoolbox overrides the codec time_base after avcodec_open2 |

<sub>Reviews (1): Last reviewed commit: ["fix(enc-ffmpeg): use encoder\_time\_base i..."](https://github.com/capsoftware/cap/commit/2e0872f97566e3f8199de4b560c42427f42e1a65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41368589)</sub>

<!-- /greptile_comment -->