### PR TITLE
fix(windows): prevent DirectComposition ghost artifacts on recording start/stop

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -85,7 +85,14 @@ pub fn default_studio_recording_quality() -> StudioRecordingQuality {
 impl MainWindowRecordingStartBehaviour {
     pub fn perform(&self, window: &tauri::WebviewWindow) -> tauri::Result<()> {
         match self {
-            Self::Close => window.hide(),
+            Self::Close => {
+                // On Windows, hide() leaves the DirectComposition surface composited on screen as
+                // a white ghost box. minimize() releases the surface without leaving an artifact.
+                #[cfg(windows)]
+                return window.minimize();
+                #[cfg(not(windows))]
+                window.hide()
+            }
             Self::Minimise => window.minimize(),
         }
     }

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -3011,11 +3011,15 @@ async fn handle_recording_end(
         let _ = window.hide();
     }
 
-    // Destroy any target-select overlays that were hidden when recording started
-    // so they don't reappear when the main window comes back.
+    // Destroy any target-select overlays so they don't reappear when the main window comes back.
+    // On Windows, hide() leaves the DirectComposition transparency surface composited on screen
+    // (ghost overlay); closing the window releases the surface entirely.
     let focus_manager = handle.try_state::<crate::target_select_overlay::WindowFocusManager>();
     for (label, window) in handle.webview_windows() {
         if let Ok(CapWindowId::TargetSelectOverlay { display_id }) = CapWindowId::from_str(&label) {
+            #[cfg(windows)]
+            let _ = window.close();
+            #[cfg(not(windows))]
             hide_overlay(&window);
             if let Some(ref fm) = focus_manager {
                 fm.destroy(&display_id, handle.global_shortcut());

--- a/apps/desktop/src-tauri/src/target_select_overlay.rs
+++ b/apps/desktop/src-tauri/src/target_select_overlay.rs
@@ -325,6 +325,11 @@ pub fn close_target_select_overlay_windows(app: &AppHandle) {
     for (id, window) in app.webview_windows() {
         if let Ok(CapWindowId::TargetSelectOverlay { display_id }) = CapWindowId::from_str(&id) {
             saw_overlay = true;
+            // On Windows, hide() leaves the DirectComposition transparency surface composited on
+            // screen (ghost overlay). Closing the window fully releases the surface.
+            #[cfg(windows)]
+            let _ = window.close();
+            #[cfg(not(windows))]
             hide_overlay(&window);
             if let Some(state) = state.as_ref() {
                 state.destroy(&display_id, app.global_shortcut());


### PR DESCRIPTION
On Windows, window.hide() doesn't release the DirectComposition surface, leaving a ghost composited on screen.

- TargetSelectOverlay: call window.close() instead of hide() on Windows to fully release the DComp surface
- Main window: call window.minimize() instead of hide() on Windows — minimized windows have no DComp surface, and the existing unminimize() in handle_recording_end restores it correctly after recording ends

Fixes the transparent overlay ghost and white blank box reported on Windows.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes DirectComposition ghost artifacts on Windows by replacing `hide()` calls with `close()` for overlay windows and `minimize()` for the main window, preventing the DComp surface from persisting on screen during recording start/stop.

- `general_settings.rs`: `Self::Close` now calls `minimize()` on Windows so the main window disappears from view without leaving a DComp surface; the existing `unminimize()` at recording end restores it correctly.
- `recording.rs` / `target_select_overlay.rs`: `TargetSelectOverlay` windows are now fully destroyed (`close()`) on Windows instead of just hidden, releasing the transparent DComp surface that was compositing as a ghost overlay.

<h3>Confidence Score: 4/5</h3>

The fix is safe to merge and correctly addresses the reported ghost artifact on Windows recording start/stop.

The three changed sites correctly use close()/minimize() on Windows, and the camera-cleanup side-effect triggered by the new Destroyed event path is guarded against harm by existing checks. One overlay hide_overlay() call in the display-disconnect path of target_select_overlay.rs is left unfixed, so the DComp artifact can still appear in that less common scenario.

apps/desktop/src-tauri/src/target_select_overlay.rs — the hide_overlay() call around line 101 (stale-display cleanup inside open_target_select_overlay_windows) was not updated with the Windows fix.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/general_settings.rs | Self::Close now calls minimize() instead of hide() on Windows to avoid DComp ghost artifact; on non-Windows behavior is unchanged. The two variants (Close and Minimise) are now identical on Windows, and window.unminimize() at recording end already handles restoration. |
| apps/desktop/src-tauri/src/recording.rs | TargetSelectOverlay windows are now closed (not hidden) on Windows during recording end; explicit fm.destroy() call is redundant with the Destroyed event handler but is idempotent. Triggers an unintended cleanup_camera_after_overlay_close spawn, which is guarded against harm. |
| apps/desktop/src-tauri/src/target_select_overlay.rs | close_target_select_overlay_windows is fixed for Windows, but the parallel hide_overlay() call inside open_target_select_overlay_windows (~line 101) for stale displays is missing the same fix, leaving a residual DComp artifact path on Windows. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/desktop/src-tauri/src/target_select_overlay.rs`, line 93-103 ([link](https://github.com/capsoftware/cap/blob/a72d2128f45afe6ae913c939f3977a1aded4a202/apps/desktop/src-tauri/src/target_select_overlay.rs#L93-L103)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Incomplete Windows fix — DComp artifact still present on display disconnect**

   This `hide_overlay()` call (reached when an overlay's display disappears while the overlay is open) skips the Windows `close()` fix applied in the other three sites. On Windows, hiding instead of closing leaves the ghost DComp surface on screen for the stale display's overlay. The fix should mirror the pattern used in `close_target_select_overlay_windows` below: call `window.close()` on Windows and `hide_overlay()` elsewhere.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src-tauri/src/target_select_overlay.rs
   Line: 93-103

   Comment:
   **Incomplete Windows fix — DComp artifact still present on display disconnect**

   This `hide_overlay()` call (reached when an overlay's display disappears while the overlay is open) skips the Windows `close()` fix applied in the other three sites. On Windows, hiding instead of closing leaves the ghost DComp surface on screen for the stale display's overlay. The fix should mirror the pattern used in `close_target_select_overlay_windows` below: call `window.close()` on Windows and `hide_overlay()` elsewhere.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/desktop/src-tauri/src/recording.rs`, line 3020-3026 ([link](https://github.com/capsoftware/cap/blob/a72d2128f45afe6ae913c939f3977a1aded4a202/apps/desktop/src-tauri/src/recording.rs#L3020-L3026)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`close()` triggers the `Destroyed` event handler, causing a redundant `fm.destroy()` and an unintended `cleanup_camera_after_overlay_close` spawn**

   The `Destroyed` event handler in `lib.rs` (~line 5373) fires when `window.close()` is called on Windows, which both calls `focus_manager.destroy()` again (redundant but idempotent) and spawns `cleanup_camera_after_overlay_close`. That function wasn't designed to run during recording-end cleanup: it checks `is_recording_active_or_pending()` (false at this point) and then proceeds unless a camera window is still present. The camera window exists-but-hidden at this point (line 3031 hides it), so `CapWindowId::Camera.get(&app).is_some()` returns `true` and prevents actual harm — but this is a fragile guard that may not hold if the camera-window lifecycle changes later. The explicit `fm.destroy()` call after `window.close()` is also now redundant: the Destroyed event handler already handles it.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src-tauri/src/recording.rs
   Line: 3020-3026

   Comment:
   **`close()` triggers the `Destroyed` event handler, causing a redundant `fm.destroy()` and an unintended `cleanup_camera_after_overlay_close` spawn**

   The `Destroyed` event handler in `lib.rs` (~line 5373) fires when `window.close()` is called on Windows, which both calls `focus_manager.destroy()` again (redundant but idempotent) and spawns `cleanup_camera_after_overlay_close`. That function wasn't designed to run during recording-end cleanup: it checks `is_recording_active_or_pending()` (false at this point) and then proceeds unless a camera window is still present. The camera window exists-but-hidden at this point (line 3031 hides it), so `CapWindowId::Camera.get(&app).is_some()` returns `true` and prevents actual harm — but this is a fragile guard that may not hold if the camera-window lifecycle changes later. The explicit `fm.destroy()` call after `window.close()` is also now redundant: the Destroyed event handler already handles it.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src-tauri/src/target_select_overlay.rs:93-103
**Incomplete Windows fix — DComp artifact still present on display disconnect**

This `hide_overlay()` call (reached when an overlay's display disappears while the overlay is open) skips the Windows `close()` fix applied in the other three sites. On Windows, hiding instead of closing leaves the ghost DComp surface on screen for the stale display's overlay. The fix should mirror the pattern used in `close_target_select_overlay_windows` below: call `window.close()` on Windows and `hide_overlay()` elsewhere.

### Issue 2 of 2
apps/desktop/src-tauri/src/recording.rs:3020-3026
**`close()` triggers the `Destroyed` event handler, causing a redundant `fm.destroy()` and an unintended `cleanup_camera_after_overlay_close` spawn**

The `Destroyed` event handler in `lib.rs` (~line 5373) fires when `window.close()` is called on Windows, which both calls `focus_manager.destroy()` again (redundant but idempotent) and spawns `cleanup_camera_after_overlay_close`. That function wasn't designed to run during recording-end cleanup: it checks `is_recording_active_or_pending()` (false at this point) and then proceeds unless a camera window is still present. The camera window exists-but-hidden at this point (line 3031 hides it), so `CapWindowId::Camera.get(&app).is_some()` returns `true` and prevents actual harm — but this is a fragile guard that may not hold if the camera-window lifecycle changes later. The explicit `fm.destroy()` call after `window.close()` is also now redundant: the Destroyed event handler already handles it.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(windows): use close/minimize instead..."](https://github.com/capsoftware/cap/commit/a72d2128f45afe6ae913c939f3977a1aded4a202) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41413840)</sub>

<!-- /greptile_comment -->