### PR TITLE
fix(recording): prevent double mic offset in studio editor after AV start gate trim

### DIFF
--- a/crates/recording/src/output_pipeline/core.rs
+++ b/crates/recording/src/output_pipeline/core.rs
@@ -196,7 +196,15 @@ pub(crate) async fn apply_video_start_gate(
                     offset_ns = offset_ns as i64,
                     "Trimmed leading audio samples for encoder-pair alignment"
                 );
-                VideoStartGateAction::UseFrame(AudioFrame::new(trimmed, frame.timestamp))
+                // Advance the timestamp to the first *committed* sample so that
+                // first_timestamp (and therefore mic_start_time in metadata) reflects
+                // the actual capture time after the trim, not the pre-trim buffer start.
+                // Without this, the editor's mic_offset = display_start - mic_start equals
+                // trim_duration and causes it to skip that same duration a second time.
+                let trim_duration = Duration::from_nanos(
+                    trim_samples as u64 * 1_000_000_000 / sample_rate as u64,
+                );
+                VideoStartGateAction::UseFrame(AudioFrame::new(trimmed, frame.timestamp + trim_duration))
             }
             None => {
                 warn!(
@@ -4706,6 +4714,21 @@ mod tests {
                     let expected_trim =
                         ns_to_sample_count(video_start_ns, info.sample_rate) as usize;
                     assert_eq!(new_frame.inner.samples(), 2048 - expected_trim);
+                    // Timestamp must be advanced by the trim so that mic_start_time in
+                    // metadata reflects the first committed sample, preventing the editor
+                    // from double-counting the same gap as a skip offset.
+                    let trim_duration = Duration::from_nanos(
+                        expected_trim as u64 * 1_000_000_000 / info.sample_rate as u64,
+                    );
+                    let expected_ts = Timestamp::Instant(start + trim_duration);
+                    assert_eq!(
+                        new_frame
+                            .timestamp
+                            .signed_duration_since_secs(master_clock.timestamps()),
+                        expected_ts
+                            .signed_duration_since_secs(master_clock.timestamps()),
+                        "gate UseFrame timestamp must be advanced past the trimmed samples"
+                    );
                 }
                 other => panic!("expected UseFrame when audio leads, got {other:?}"),
             }


### PR DESCRIPTION
When mic audio arrives before the first video frame, apply_video_start_gate trims the leading samples to align audio with video start. 
The trimmed AudioFrame kept the original pre-trim timestamp, so mic_start_time in metadata reflected the buffer start rather than the first committed sample.

The editor computes mic_offset = latest_start - mic_start_time and seeks that many seconds into the audio file. With the wrong timestamp, mic_offset was inflated by the trim duration, causing the editor to skip that same gap a second time. 
Result: mic audio starts late by the trim amount (typically 20–150ms) in studio recording exports.

Fix: advance frame.timestamp by trim_duration in the UseFrame path so first_timestamp (and therefore mic_start_time) reflects the actual first committed sample. mic_offset then computes to ~0 and the editor plays from the start of the already-trimmed file.

Only affects studio mode MultipleSegments recordings opened in the editor. Instant recordings are unaffected (audio/video are muxed at capture time, editor offset calculation is not involved).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a double-offset bug in studio mode recordings where mic audio was delayed in the editor by the same duration that `apply_video_start_gate` had already trimmed. The root cause was that the trimmed `AudioFrame` kept the original pre-trim timestamp, so `mic_start_time` in the recording metadata reflected the buffer start rather than the first committed sample.

- **Production fix:** `frame.timestamp + trim_duration` is now passed to `AudioFrame::new` in the `UseFrame` path, so `first_timestamp` (and therefore `mic_start_time`) correctly reflects the first kept sample.
- **Test coverage:** A new assertion in the existing `apply_gate_audio_leads_trims_front` test verifies that the returned frame's timestamp equals `start + trim_duration`, directly exercising the corrected behaviour.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is isolated to the UseFrame branch of apply_video_start_gate and has no impact on Passthrough or DropFrame paths or on instant recordings.

The arithmetic is correct: trim_samples is already guarded against zero (sample_rate == 0 returns Passthrough before this code runs), the multiplication trim_samples * 1_000_000_000 fits comfortably in u64 given the 500 ms alignment limit, and the small rounding residual (~1 sample period at most) is negligible. The fix correctly maps back to wall-clock time after the integer sample-count round-trip. The new test assertion directly validates the changed behaviour.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/recording/src/output_pipeline/core.rs | Advances AudioFrame.timestamp by trim_duration in the UseFrame path of apply_video_start_gate, plus a new test assertion verifying the corrected timestamp value. |

<sub>Reviews (1): Last reviewed commit: ["fix(recording): advance gate frame times..."](https://github.com/capsoftware/cap/commit/07680667083a072989df5f7d6490d39b12c25329) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41418126)</sub>

<!-- /greptile_comment -->