### PR TITLE
fix(recording): replace blocking dialog with toast for mic not available errors

### DIFF
--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2370,18 +2370,25 @@ async fn handle_spawn_failure(
     }
     .emit(app);
 
-    let mut dialog = MessageDialogBuilder::new(
-        app.dialog().clone(),
-        "An error occurred".to_string(),
-        message.clone(),
-    )
-    .kind(tauri_plugin_dialog::MessageDialogKind::Error);
+    // DeviceNotFound errors are surfaced to the user via the frontend toast; skip the
+    // blocking native dialog so the overlay stays responsive and the error isn't repeated.
+    let is_device_not_found = message.contains("no longer available")
+        || message.contains("DeviceNotFound");
 
-    if let Some(window) = CapWindowId::RecordingControls.get(app) {
-        dialog = dialog.parent(&window);
+    if !is_device_not_found {
+        let mut dialog = MessageDialogBuilder::new(
+            app.dialog().clone(),
+            "An error occurred".to_string(),
+            message.clone(),
+        )
+        .kind(tauri_plugin_dialog::MessageDialogKind::Error);
+
+        if let Some(window) = CapWindowId::RecordingControls.get(app) {
+            dialog = dialog.parent(&window);
+        }
+
+        dialog.blocking_show();
     }
-
-    dialog.blocking_show();
 
     let mut state = state_mtx.write().await;
     let _ = handle_recording_end(

--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -1742,11 +1742,28 @@ function RecordingControls(props: {
 									return;
 								}
 
-								commands.startRecording({
-									capture_target: props.target,
-									mode: rawOptions.mode,
-									capture_system_audio: rawOptions.captureSystemAudio,
-								});
+								commands
+									.startRecording({
+										capture_target: props.target,
+										mode: rawOptions.mode,
+										capture_system_audio: rawOptions.captureSystemAudio,
+									})
+									.catch((e: unknown) => {
+										const msg =
+											e instanceof Error ? e.message : String(e);
+										if (
+											msg.includes("no longer available") ||
+											msg.includes("DeviceNotFound")
+										) {
+											toast.error(
+												"Selected microphone is not available. Please select a different microphone in settings.",
+											);
+										} else {
+											toast.error(
+												`Failed to start recording: ${msg}`,
+											);
+										}
+									});
 							}}
 						>
 							<div


### PR DESCRIPTION
When the selected mic isn't available, a blocking native dialog caused a loop on multi-monitor setups, user dismisses, overlay re-appears, clicks again, repeat 5-7 times.

Fix: catch startRecording errors in the overlay and show a toast instead. 
Skip the blocking dialog in handle_spawn_failure for DeviceNotFound so the overlay stays interactive.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UX loop on multi-monitor setups where a blocking native dialog for mic-unavailable errors would repeatedly re-appear after dismissal. It replaces that dialog with a non-blocking toast on the frontend and suppresses the native dialog in the Rust backend for `DeviceNotFound` errors.

- `recording.rs`: `handle_spawn_failure` now skips the `MessageDialogBuilder` / `blocking_show` path when the error message contains `"no longer available"` or `"DeviceNotFound"`, keeping the overlay interactive.
- `target-select-overlay.tsx`: A `.catch` handler is added to the `startRecording` call that shows a friendly toast for mic errors and a generic fallback for any other rejection; the same two substrings are checked independently on this side, creating a duplicated classification that could drift if either side is updated.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change addresses a real, reproducible loop and the fallback path (generic toast) is still shown for any unrecognised error.

Both changed files have contained, low-risk edits. The only concerns are that the two substring guards are independently maintained in Rust and TypeScript, and the new catch block lacks a console.error call. Neither affects correctness today.

The string-matching in recording.rs and target-select-overlay.tsx should stay in sync; if the underlying audio library changes its error messages, one side will diverge silently.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/recording.rs | Wraps the blocking native dialog in a condition that skips it for DeviceNotFound errors (detected via substring match), allowing the recording overlay to remain interactive; duplicates the same substrings checked on the TypeScript side. |
| apps/desktop/src/routes/target-select-overlay.tsx | Adds a `.catch` handler to `startRecording` that shows a user-friendly toast for mic-unavailable errors and a generic fallback for others; missing `console.error` logging and duplicates the Rust-side string matching. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src-tauri/src/recording.rs:2373-2376
**Duplicate string-matching across Rust and TypeScript**

The same two substrings (`"no longer available"` and `"DeviceNotFound"`) are now hard-coded in both `recording.rs` (to suppress the native dialog) and `target-select-overlay.tsx` (to show the friendly toast). If the underlying audio library changes either error message, the two guards will diverge: the Rust side might still suppress the dialog while the TypeScript side falls through to the generic "Failed to start recording: …" message, or vice-versa. Centralising the classification — e.g., via a dedicated Tauri error variant instead of string matching — would make both sites resilient to message changes.

### Issue 2 of 2
apps/desktop/src/routes/target-select-overlay.tsx:1745-1766
Add `console.error` to match the pattern used by the screenshot error handler and other catch blocks in this file, so there is always a log trail even when the toast copy differs from the raw error.

```suggestion
								commands
									.startRecording({
										capture_target: props.target,
										mode: rawOptions.mode,
										capture_system_audio: rawOptions.captureSystemAudio,
									})
									.catch((e: unknown) => {
										console.error("Failed to start recording", e);
										const msg =
											e instanceof Error ? e.message : String(e);
										if (
											msg.includes("no longer available") ||
											msg.includes("DeviceNotFound")
										) {
											toast.error(
												"Selected microphone is not available. Please select a different microphone in settings.",
											);
										} else {
											toast.error(
												`Failed to start recording: ${msg}`,
											);
										}
									});
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(recording): show toast instead of bl..."](https://github.com/capsoftware/cap/commit/7d29edd8fb05b7621cbca5866fa5f85e413d3235) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41439787)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->