### PR TITLE
Feature/unlock pro features

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,66 @@
+# ============================================
+# Cap Pro Unlocked - Development Configuration
+# ============================================
+# Copy this file to .env.local and update values as needed
+
+# 🔓 PRO FEATURES UNLOCKED
+# When NEXT_PUBLIC_IS_CAP=false, all pro features are available to everyone
+NEXT_PUBLIC_IS_CAP=false
+
+# Application Settings
+NODE_ENV=development
+VITE_SERVER_URL=http://localhost:3000
+WEB_URL=http://localhost:3000
+
+# Database
+DATABASE_URL=mysql://root:@localhost:3306/planetscale
+
+# Media Server
+MEDIA_SERVER_URL=http://localhost:3456
+MEDIA_SERVER_WEBHOOK_SECRET=dev-webhook-secret-$(openssl rand -hex 16)
+
+# NextAuth Configuration
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=dev-secret-$(openssl rand -hex 32)
+
+# S3/MinIO Storage (for local testing)
+S3_ACCESS_KEY_ID=capS3root
+S3_SECRET_ACCESS_KEY=capS3root
+S3_BUCKET_NAME=capso
+S3_ENDPOINT=http://localhost:9000
+S3_REGION=us-east-1
+
+# Encryption
+DATABASE_ENCRYPTION_KEY=$(openssl rand -hex 32)
+
+# Logging
+LOG_LEVEL=debug
+RUST_LOG=info
+
+# Optional: Disable Stripe in development
+NEXT_PUBLIC_STRIPE_DISABLED=true
+
+# Optional: GitHub Integration (leave empty if not configured)
+# GITHUB_ID=
+# GITHUB_SECRET=
+
+# Optional: Google Integration (leave empty if not configured)
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+
+# ============================================
+# 🎉 UNLOCKED FEATURES IN THIS BUILD
+# ============================================
+# With NEXT_PUBLIC_IS_CAP=false, you have access to:
+# ✅ Unlimited recording duration
+# ✅ Unlimited cloud storage
+# ✅ Shareable links (unlimited)
+# ✅ Google Drive integration
+# ✅ Custom S3 storage
+# ✅ Password-protected videos
+# ✅ Custom domains
+# ✅ Team workspaces with unlimited members
+# ✅ Advanced analytics
+# ✅ All viewer customization settings
+# ✅ Priority support features
+# ============================================

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -1,0 +1,279 @@
+# 🎉 Cap Pro Unlocked - Setup Guide
+
+This is a fork of Cap with **all pro features unlocked for everyone**!
+
+## What's Different?
+
+✅ **All Pro Features Unlocked:**
+- Unlimited recording length (no 5-minute limit)
+- Unlimited cloud storage
+- Google Drive integration
+- Custom S3 storage buckets
+- Password-protected videos
+- Custom domain support
+- Team workspaces with unlimited members
+- Advanced analytics & viewer insights
+- All viewer customization settings
+
+## Quick Start - 2 Ways
+
+### Option 1: Docker Compose (Recommended - 5 minutes)
+
+**Prerequisites:** Docker & Docker Compose installed
+
+```bash
+# Clone your fork (if you haven't already)
+git clone https://github.com/Owie6789/Cap.git
+cd Cap
+
+# Generate a secure secret
+export NEXTAUTH_SECRET=$(openssl rand -hex 32)
+
+# Start all services (MySQL, MinIO, Media Server, Web App)
+docker-compose -f docker-compose-unlocked.yml up -d
+
+# Wait 30-60 seconds for initialization...
+
+# Access Cap at: http://localhost:3000
+```
+
+**What gets installed:**
+- ✅ MySQL database (port 3306)
+- ✅ MinIO S3 storage (ports 9000, 9001)
+- ✅ Media Server (port 3456)
+- ✅ Web App (port 3000)
+
+**Useful commands:**
+```bash
+# View logs
+docker-compose -f docker-compose-unlocked.yml logs -f web
+
+# Stop services
+docker-compose -f docker-compose-unlocked.yml down
+
+# Reset everything (⚠️ removes data)
+docker-compose -f docker-compose-unlocked.yml down -v
+
+# Rebuild images
+docker-compose -f docker-compose-unlocked.yml up -d --build
+```
+
+### Option 2: Local Development (15 minutes)
+
+**Prerequisites:**
+- Node.js 24+
+- Rust 1.88+
+- MySQL 8.0
+- FFmpeg
+
+```bash
+# 1. Install dependencies
+node scripts/setup.js
+pnpm install
+
+# 2. Setup environment
+cp .env.local.example .env.local
+
+# 3. Setup database
+# Make sure MySQL is running, then:
+pnpm db:push
+
+# 4. Start dev servers (in separate terminals)
+
+# Terminal 1: Web app
+cd apps/web
+pnpm dev
+
+# Terminal 2: Media server
+cd apps/media-server
+cargo run
+
+# Terminal 3: Desktop app (optional)
+cd apps/desktop
+pnpm dev
+```
+
+Access at `http://localhost:3000`
+
+## Using the GitHub Actions Workflow
+
+The workflow automatically builds Docker images whenever you push code.
+
+### Trigger a Manual Build
+
+1. Go to **Actions** in your GitHub repo
+2. Click **"Build Cap Pro Unlocked"**
+3. Click **"Run workflow"**
+4. Choose build type:
+   - `web-docker` - Web app only
+   - `desktop-macos` - macOS app
+   - `desktop-windows` - Windows app
+   - `media-server` - Media server only
+   - `all` - Everything
+5. Click **"Run workflow"**
+
+### Pull Built Docker Images
+
+After the workflow completes:
+
+```bash
+# Login to GitHub Container Registry
+docker login ghcr.io -u YOUR_GITHUB_USERNAME
+
+# Pull the web app image
+docker pull ghcr.io/Owie6789/Cap-web:latest
+
+# Pull the media server image
+docker pull ghcr.io/Owie6789/Cap-media-server:latest
+
+# Run with docker-compose
+docker-compose -f docker-compose-unlocked.yml up -d
+```
+
+## Verify Pro Features Are Unlocked
+
+After starting Cap, you should see:
+
+### Desktop App
+- ✅ No "Upgrade to Pro" buttons
+- ✅ All storage integrations available (Google Drive, S3)
+- ✅ Unlimited recording length
+- ✅ All editor features available
+
+### Web App
+- ✅ Unlimited video upload length
+- ✅ All storage options available
+- ✅ Team features with unlimited members
+- ✅ Password protection available
+- ✅ Advanced analytics visible
+
+### Creating a Test Account
+
+The local build doesn't require Stripe:
+
+1. Go to `http://localhost:3000/login`
+2. Click "Sign up"
+3. Use any email (e.g., `test@example.com`)
+4. Set a password
+5. ✅ You're now a "Pro" user with all features!
+
+## How It Works
+
+### The Key Change
+
+In `packages/utils/src/constants/plans.ts`:
+
+```typescript
+export const userIsPro = (user) => {
+  // Always return true - everyone is pro!
+  return true;
+};
+```
+
+This single change unlocks all pro features throughout the app because:
+- Every feature check calls `userIsPro()`
+- Now it always returns `true`
+- All premium features are accessible
+
+### Alternative Approach
+
+You can also set an environment variable:
+
+```bash
+NEXT_PUBLIC_IS_CAP=false  # This also unlocks all pro features
+```
+
+## Troubleshooting
+
+### Services won't start
+
+```bash
+# Check if ports are in use
+lsof -i :3000   # Web app
+lsof -i :3456   # Media server
+lsof -i :3306   # MySQL
+
+# Kill processes if needed (macOS/Linux)
+kill -9 <PID>
+```
+
+### Database errors
+
+```bash
+# Reset database (⚠️ deletes all data)
+docker-compose -f docker-compose-unlocked.yml down -v
+docker-compose -f docker-compose-unlocked.yml up -d
+```
+
+### Memory issues
+
+The Docker stack needs ~4GB RAM. Allocate more in Docker Desktop settings if needed.
+
+### Build failures
+
+Check the GitHub Actions logs:
+1. Go to your repo → **Actions**
+2. Click the failed workflow
+3. View the job logs
+4. Look for error messages
+
+## File Structure
+
+```
+Cap/
+├── packages/utils/src/constants/
+│   └── plans.ts                    # 🔓 Modified: userIsPro always returns true
+├── .github/workflows/
+│   └── build-and-deploy.yml        # 🚀 New: GitHub Actions workflow
+├── docker-compose-unlocked.yml     # 🐳 New: Docker Compose config
+├── .env.local.example              # 📝 New: Environment variables example
+└── SETUP_GUIDE.md                  # 📚 This file
+```
+
+## Next Steps
+
+### Deploy to Production
+
+For cloud deployment:
+
+1. **Docker Swarm:**
+   ```bash
+   docker stack deploy -c docker-compose-unlocked.yml cap-pro
+   ```
+
+2. **Kubernetes:**
+   ```bash
+   # Convert docker-compose to k8s manifests
+   kompose convert -f docker-compose-unlocked.yml
+   kubectl apply -f .
+   ```
+
+3. **Railway / Render / Heroku:**
+   - Push to GitHub
+   - Connect your repo
+   - Set environment variables
+   - Deploy!
+
+### Customize
+
+- Modify pricing page (remove upgrade buttons)
+- Customize branding
+- Add your own features
+- Deploy to your own domain
+
+## Support & Contributions
+
+- 🐛 Found a bug? Open an issue
+- 💡 Have an idea? Create a discussion
+- 🤝 Want to help? Submit a PR
+- 📖 Questions? Check the original Cap documentation: https://cap.so/docs
+
+## Legal Notice
+
+This is a fork of Cap which is licensed under MIT. All modifications maintain the same license. Always respect the original project's licensing and contribution guidelines.
+
+---
+
+**Built with ❤️ from the Cap community**
+
+Enjoy unlimited screen recording with all pro features unlocked! 🎉

--- a/docker-compose-unlocked.yml
+++ b/docker-compose-unlocked.yml
@@ -1,0 +1,153 @@
+version: '3.8'
+
+# Cap Pro Unlocked - All Features Enabled
+# This docker-compose file deploys the complete Cap stack locally
+# with all pro features unlocked for everyone
+
+services:
+  # MySQL Database
+  mysql:
+    image: mysql:8.0
+    container_name: cap-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: planetscale
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - cap-network
+
+  # MinIO (S3-compatible storage)
+  minio:
+    image: minio/minio:latest
+    container_name: cap-minio
+    environment:
+      MINIO_ROOT_USER: capS3root
+      MINIO_ROOT_PASSWORD: capS3root
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - cap-network
+
+  # Media Server (handles video encoding/streaming)
+  media-server:
+    image: ghcr.io/Owie6789/Cap-media-server:latest
+    container_name: cap-media-server
+    ports:
+      - "3456:3456"
+    environment:
+      DATABASE_URL: mysql://root:@mysql:3306/planetscale
+      RUST_LOG: info
+    depends_on:
+      mysql:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3456/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - cap-network
+
+  # Web Application (Next.js)
+  web:
+    image: ghcr.io/Owie6789/Cap-web:latest
+    container_name: cap-web
+    ports:
+      - "3000:3000"
+    environment:
+      # Database Configuration
+      DATABASE_URL: mysql://root:@mysql:3306/planetscale
+      
+      # Pro Features - UNLOCKED FOR EVERYONE
+      NEXT_PUBLIC_IS_CAP: "false"  # This unlocks all pro features
+      
+      # Application URLs
+      WEB_URL: http://localhost:3000
+      MEDIA_SERVER_URL: http://media-server:3456
+      
+      # NextAuth Configuration (required for auth)
+      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_SECRET: dev-secret-change-in-production-$(openssl rand -hex 16)
+      
+      # Optional: Disable Stripe in dev
+      NEXT_PUBLIC_STRIPE_DISABLED: "true"
+      
+      # Logging
+      LOG_LEVEL: info
+    depends_on:
+      mysql:
+        condition: service_healthy
+      media-server:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    networks:
+      - cap-network
+
+volumes:
+  mysql_data:
+    driver: local
+  minio_data:
+    driver: local
+
+networks:
+  cap-network:
+    driver: bridge
+
+# ============================================
+# 🎉 PRO FEATURES UNLOCKED
+# ============================================
+# All the following features are now available:
+#
+# ✅ Unlimited Recording Length
+# ✅ Cloud Storage & Shareable Links (Unlimited)
+# ✅ Google Drive Integration
+# ✅ Custom S3 Storage Support
+# ✅ Password-Protected Videos
+# ✅ Custom Domain Support
+# ✅ Team Workspaces (Unlimited Members)
+# ✅ Advanced Analytics & Viewer Insights
+# ✅ All Viewer Settings (Permissions, Restrictions)
+# ✅ Priority Support Features
+# ============================================
+
+# QUICK START INSTRUCTIONS:
+# 1. Ensure Docker and Docker Compose are installed
+# 2. Update the NEXTAUTH_SECRET with a real secret:
+#    export NEXTAUTH_SECRET=$(openssl rand -hex 32)
+# 3. Run: docker-compose -f docker-compose-unlocked.yml up -d
+# 4. Wait 30-60 seconds for all services to initialize
+# 5. Access Cap at: http://localhost:3000
+#
+# COMMANDS:
+#   Start:   docker-compose -f docker-compose-unlocked.yml up -d
+#   Stop:    docker-compose -f docker-compose-unlocked.yml down
+#   Logs:    docker-compose -f docker-compose-unlocked.yml logs -f web
+#   Rebuild: docker-compose -f docker-compose-unlocked.yml up -d --build
+#
+# SERVICES:
+#   - Web App:     http://localhost:3000
+#   - MinIO Console: http://localhost:9001 (user: capS3root, password: capS3root)
+#   - Media Server: http://localhost:3456
+#   - MySQL:       localhost:3306 (user: root, password: root)

--- a/packages/utils/src/constants/plans.ts
+++ b/packages/utils/src/constants/plans.ts
@@ -16,28 +16,16 @@ export const STRIPE_PLAN_IDS = {
 	},
 };
 
+/**
+ * MODIFIED: All users are Pro (all features unlocked)
+ * This fork removes the paywall - everyone gets unlimited features
+ */
 export const userIsPro = (
 	user?: {
 		stripeSubscriptionStatus?: string | null;
 		thirdPartyStripeSubscriptionId?: string | null;
 	} | null,
 ) => {
-	if (!buildEnv.NEXT_PUBLIC_IS_CAP) return true;
-
-	if (!user) return false;
-
-	const { stripeSubscriptionStatus, thirdPartyStripeSubscriptionId } = user;
-
-	// Check for third-party subscription first
-	if (thirdPartyStripeSubscriptionId) {
-		return true;
-	}
-
-	// Then check regular subscription status
-	return (
-		stripeSubscriptionStatus === "active" ||
-		stripeSubscriptionStatus === "trialing" ||
-		stripeSubscriptionStatus === "complete" ||
-		stripeSubscriptionStatus === "paid"
-	);
+	// 🔓 UNLOCK: Always return true - all pro features available to everyone
+	return true;
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an unlocked local setup for Cap. The main changes are:

- A new example `.env.local` file for local development.
- A new Docker Compose stack for MySQL, MinIO, the media server, and the web app.
- A setup guide for the unlocked fork.
- A `userIsPro` change that treats every user as Pro.

<h3>Confidence Score: 4/5</h3>

The new setup path can fail at startup and can install fixed public secrets.

- The web container uses an empty MySQL password while the database is configured with `root`.
- Docker Compose and dotenv keep `$(openssl rand ...)` as literal text.
- The Pro unlock itself matches the stated fork behavior.

docker-compose-unlocked.yml and .env.local.example

<details open><summary><h3>Security Review</h3></summary>

The new setup examples can install fixed public secrets because `$(openssl rand ...)` is not executed by Docker Compose or dotenv. This affects session signing, media webhook authentication, and the database encryption key.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .env.local.example | Adds local environment defaults, but several secret values are written as shell commands that dotenv will keep literally. |
| SETUP_GUIDE.md | Adds setup instructions for the unlocked fork and points users at the new Compose and env files. |
| docker-compose-unlocked.yml | Adds a local Compose stack, but the web database URL and session secret default are broken for normal Compose usage. |
| packages/utils/src/constants/plans.ts | Changes `userIsPro` to always return true, matching the stated unlocked-fork behavior. |

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocker-compose-unlocked.yml%3A76%0A**Database%20Password%20Mismatch**%0A%0AWhen%20the%20new%20Compose%20stack%20starts%2C%20MySQL%20is%20initialized%20with%20the%20root%20password%20%60root%60%2C%20but%20the%20web%20container%20connects%20as%20%60root%60%20with%20an%20empty%20password.%20The%20app's%20database%20connection%20is%20rejected%2C%20so%20the%20quick-start%20stack%20can%20boot%20into%20a%20web%20service%20that%20fails%20on%20DB-backed%20requests.%0A%0A%23%23%23%20Issue%202%20of%203%0Adocker-compose-unlocked.yml%3A87%0A**Literal%20Session%20Secret**%0A%0ADocker%20Compose%20does%20not%20run%20%60%24%28openssl%20rand%20...%29%60%20inside%20YAML%20environment%20values%2C%20so%20this%20value%20is%20passed%20to%20the%20web%20container%20as%20a%20fixed%20public%20string.%20Instances%20using%20the%20file%20as-is%20share%20the%20same%20%60NEXTAUTH_SECRET%60%2C%20which%20is%20used%20for%20session%20and%20HMAC%20signing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20NEXTAUTH_SECRET%3A%20%24%7BNEXTAUTH_SECRET%3A%3FGenerate%20one%20with%3A%20openssl%20rand%20-hex%2032%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.env.local.example%3A20-34%0A**Dotenv%20Keeps%20Command%20Text**%0A%0ACopying%20this%20file%20to%20%60.env.local%60%20does%20not%20execute%20the%20%60openssl%60%20commands%3B%20dotenv%20keeps%20the%20command%20text%20as%20the%20value.%20That%20leaves%20predictable%20auth%20and%20webhook%20secrets%2C%20and%20the%20literal%20%60DATABASE_ENCRYPTION_KEY%60%20is%20not%20valid%20hex%2C%20so%20encrypted%20database%20fields%20can%20fail%20to%20encrypt%20or%20decrypt.%0A%0A%60%60%60suggestion%0AMEDIA_SERVER_WEBHOOK_SECRET%3Dreplace-with-output-of-openssl-rand-hex-16%0A%0A%23%20NextAuth%20Configuration%0ANEXTAUTH_URL%3Dhttp%3A%2F%2Flocalhost%3A3000%0ANEXTAUTH_SECRET%3Dreplace-with-output-of-openssl-rand-hex-32%0A%0A%23%20S3%2FMinIO%20Storage%20%28for%20local%20testing%29%0AS3_ACCESS_KEY_ID%3DcapS3root%0AS3_SECRET_ACCESS_KEY%3DcapS3root%0AS3_BUCKET_NAME%3Dcapso%0AS3_ENDPOINT%3Dhttp%3A%2F%2Flocalhost%3A9000%0AS3_REGION%3Dus-east-1%0A%0A%23%20Encryption%0ADATABASE_ENCRYPTION_KEY%3Dreplace-with-output-of-openssl-rand-hex-32%0A%60%60%60%0A%0A&pr=1984&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
docker-compose-unlocked.yml:76
**Database Password Mismatch**

When the new Compose stack starts, MySQL is initialized with the root password `root`, but the web container connects as `root` with an empty password. The app's database connection is rejected, so the quick-start stack can boot into a web service that fails on DB-backed requests.

### Issue 2 of 3
docker-compose-unlocked.yml:87
**Literal Session Secret**

Docker Compose does not run `$(openssl rand ...)` inside YAML environment values, so this value is passed to the web container as a fixed public string. Instances using the file as-is share the same `NEXTAUTH_SECRET`, which is used for session and HMAC signing.

```suggestion
      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?Generate one with: openssl rand -hex 32}
```

### Issue 3 of 3
.env.local.example:20-34
**Dotenv Keeps Command Text**

Copying this file to `.env.local` does not execute the `openssl` commands; dotenv keeps the command text as the value. That leaves predictable auth and webhook secrets, and the literal `DATABASE_ENCRYPTION_KEY` is not valid hex, so encrypted database fields can fail to encrypt or decrypt.

```suggestion
MEDIA_SERVER_WEBHOOK_SECRET=replace-with-output-of-openssl-rand-hex-16

# NextAuth Configuration
NEXTAUTH_URL=http://localhost:3000
NEXTAUTH_SECRET=replace-with-output-of-openssl-rand-hex-32

# S3/MinIO Storage (for local testing)
S3_ACCESS_KEY_ID=capS3root
S3_SECRET_ACCESS_KEY=capS3root
S3_BUCKET_NAME=capso
S3_ENDPOINT=http://localhost:9000
S3_REGION=us-east-1

# Encryption
DATABASE_ENCRYPTION_KEY=replace-with-output-of-openssl-rand-hex-32
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🐳 Add docker-compose configuration for ..."](https://github.com/capsoftware/cap/commit/1e7f2ca6c675cdb0e818c7da8ea88c11ffcf64c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42031747)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))
- Context used - AGENTS.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=27801409-c24c-4476-9c6c-180f1ef0a7f2))

<!-- /greptile_comment -->