### PR TITLE
fix(timestamp): correct mach tick conversion in Duration arithmetic + compensate mic input latency

### DIFF
--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -110,6 +110,8 @@ const coversDefaultExclusion = (
 type ExtendedGeneralSettingsStore = GeneralSettingsStore;
 
 const MAX_FPS_OPTIONS = [
+	{ value: 24, label: "24 FPS" },
+	{ value: 25, label: "25 FPS" },
 	{ value: 30, label: "30 FPS" },
 	{ value: 60, label: "60 FPS (Recommended)" },
 	{ value: 120, label: "120 FPS" },

--- a/crates/audio/src/latency.rs
+++ b/crates/audio/src/latency.rs
@@ -574,10 +574,33 @@ mod macos {
     pub(super) fn estimate_input_latency(
         sample_rate: u32,
         buffer_size_frames: u32,
-        _device_name: Option<&str>,
+        device_name: Option<&str>,
     ) -> Option<InputLatencyInfo> {
-        let device = System::default_input_device().ok()?;
+        // Resolve the actual device being recorded from; the system-default
+        // input may be a different device with very different latency
+        // characteristics (e.g. a Bluetooth headset while recording from a
+        // wired interface).
+        let device = input_device_by_name(device_name)
+            .or_else(|| System::default_input_device().ok())?;
         compute_input_latency(&device, sample_rate, buffer_size_frames).ok()
+    }
+
+    fn input_device_by_name(device_name: Option<&str>) -> Option<Device> {
+        let target = device_name?;
+        System::devices().ok()?.into_iter().find(|device| {
+            has_input_streams(device)
+                && device
+                    .name()
+                    .is_ok_and(|name| name.to_string() == target)
+        })
+    }
+
+    fn has_input_streams(device: &Device) -> bool {
+        device.streams().is_ok_and(|streams| {
+            streams
+                .iter()
+                .any(|stream| is_input_stream(stream).unwrap_or(false))
+        })
     }
 
     fn compute_input_latency(

--- a/crates/recording/src/feeds/microphone.rs
+++ b/crates/recording/src/feeds/microphone.rs
@@ -697,6 +697,24 @@ impl MicrophoneFeed {
                     CallbackSampleRateEstimator::new(callback_sample_rate);
                 let mut pending_samples = VecDeque::new();
 
+                let latency_info = estimate_input_latency(
+                    callback_sample_rate,
+                    buffer_size_frames.unwrap_or(1024),
+                    Some(&label),
+                );
+                let capture_latency = Duration::from_secs_f64(
+                    latency_info
+                        .device_latency_secs
+                        .clamp(0.0, MAX_CAPTURE_LATENCY_COMPENSATION_SECS),
+                );
+                if !capture_latency.is_zero() {
+                    info!(
+                        "🎤 Compensating capture timestamps by {:.1}ms input pipeline latency (transport: {:?})",
+                        capture_latency.as_secs_f64() * 1000.0,
+                        latency_info.transport
+                    );
+                }
+
                 let stream = match device.build_input_stream_raw(
                     &stream_config,
                     sample_format,
@@ -730,7 +748,8 @@ impl MicrophoneFeed {
                                 sample_rate: effective_sample_rate.sample_rate,
                                 channels: callback_channels,
                                 info: info.clone(),
-                                timestamp: Timestamp::from_cpal(input_timestamp.capture),
+                                timestamp: Timestamp::from_cpal(input_timestamp.capture)
+                                    - capture_latency,
                             };
 
                             if !effective_sample_rate.settled {
@@ -913,6 +932,14 @@ const ABS_MIN_BUFFER_FRAMES: u32 = 128;
 const WIRELESS_TARGET_LATENCY_MS: u32 = 80;
 const WIRELESS_MIN_LATENCY_MS: u32 = 50;
 const WIRELESS_MAX_LATENCY_MS: u32 = 200;
+
+// The cpal capture timestamp (mHostTime / QPC) marks when samples left the
+// audio HAL, not when the sound reached the microphone. The gap between the
+// two is the input pipeline latency (device latency + safety offset + stream
+// latency), which otherwise lands in the recording as the mic track running
+// late relative to video. Buffer latency is deliberately excluded: the
+// callback timestamp already refers to the first frame of the buffer.
+const MAX_CAPTURE_LATENCY_COMPENSATION_SECS: f64 = 0.5;
 
 fn stream_config_with_latency(
     config: &SupportedStreamConfig,

--- a/crates/timestamp/src/macos.rs
+++ b/crates/timestamp/src/macos.rs
@@ -64,9 +64,12 @@ impl Add<Duration> for MachAbsoluteTimestamp {
 
     fn add(self, rhs: Duration) -> Self::Output {
         let info = TimeBaseInfo::new();
-        let freq = info.numer as f64 / info.denom as f64;
+        // ns = ticks * numer / denom, so ticks = ns * denom / numer.
+        // On Apple Silicon (numer/denom = 125/3) multiplying by numer/denom
+        // instead would add ~1736x the intended duration.
+        let ticks = rhs.as_nanos() as f64 * info.denom as f64 / info.numer as f64;
 
-        Self((self.0 as f64 + rhs.as_nanos() as f64 * freq) as u64)
+        Self((self.0 as f64 + ticks) as u64)
     }
 }
 
@@ -75,8 +78,52 @@ impl Sub<Duration> for MachAbsoluteTimestamp {
 
     fn sub(self, rhs: Duration) -> Self::Output {
         let info = TimeBaseInfo::new();
-        let freq = info.numer as f64 / info.denom as f64;
+        let ticks = rhs.as_nanos() as f64 * info.denom as f64 / info.numer as f64;
 
-        Self((self.0 as f64 - rhs.as_nanos() as f64 * freq) as u64)
+        Self((self.0 as f64 - ticks).max(0.0) as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_duration_roundtrips_through_duration_since() {
+        let base = MachAbsoluteTimestamp::now();
+        let added = base + Duration::from_millis(35);
+
+        let roundtrip = added.duration_since(base);
+        let error_us = (roundtrip.as_micros() as i128 - 35_000).abs();
+        assert!(
+            error_us < 10,
+            "35ms add must survive the tick conversion roundtrip, got {roundtrip:?}"
+        );
+    }
+
+    #[test]
+    fn sub_duration_roundtrips_through_duration_since() {
+        let base = MachAbsoluteTimestamp::now();
+        let subtracted = base - Duration::from_millis(120);
+
+        let roundtrip = base.duration_since(subtracted);
+        let error_us = (roundtrip.as_micros() as i128 - 120_000).abs();
+        assert!(
+            error_us < 10,
+            "120ms sub must survive the tick conversion roundtrip, got {roundtrip:?}"
+        );
+    }
+
+    #[test]
+    fn add_then_sub_is_identity() {
+        let base = MachAbsoluteTimestamp::now();
+        let d = Duration::from_millis(500);
+        let roundtrip = (base + d) - d;
+
+        let drift = roundtrip.duration_since(base).max(base.duration_since(roundtrip));
+        assert!(
+            drift < Duration::from_micros(10),
+            "add/sub of the same duration must cancel out, drifted {drift:?}"
+        );
     }
 }


### PR DESCRIPTION
## Bug 1: Duration arithmetic ~1736x off on Apple Silicon

Add/Sub<Duration> for MachAbsoluteTimestamp multiplied by numer/denom when converting ns→ticks instead of dividing. Harmless on Intel (1/1), but on Apple Silicon (125/3) every Timestamp + Duration applied ~1736x the intended offset.

This made #1966's frame.timestamp + trim_duration push mic_start_time forward by seconds-to-minutes on M-series Macs in 0.5.4, desyncing the mic track.
Added roundtrip tests that fail against the old code on Apple Silicon.

## Bug 2: mic timestamps use HAL delivery time, not capture time

cpal's capture timestamp marks when samples left the audio HAL, not when sound hit the mic. That gap (device latency + safety offset + stream latency) was already measured by estimate_input_latency but never applied, so mic tracks ran 10–50ms late on wired mics, 100ms+ on Bluetooth. 
Timestamps are now shifted back by the measured device latency (clamped 0–500ms, buffer latency excluded).

## Feature: 24/25 FPS options

Added to the max framerate dropdown. Backend already clamps 1–120, UI-only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two correctness bugs in the Mac audio pipeline and adds 24/25 FPS options to the settings UI. The changes are well-scoped and include tests for the arithmetic fix.

- **Timestamp arithmetic fix (`macos.rs`)**: Inverts the `numer/denom` ratio in `Add<Duration>` and `Sub<Duration>` for `MachAbsoluteTimestamp`. The old code computed `ns * (numer/denom)` (ticks → ns direction) instead of `ns * (denom/numer)` (ns → ticks), causing ~1736x offset on Apple Silicon. Three roundtrip tests verify the fix.
- **Mic capture latency compensation (`microphone.rs`, `latency.rs`)**: Shifts each callback's capture timestamp back by the measured input-pipeline latency (`device_latency + safety_offset + stream_latency`, capped at 500ms, buffer excluded) to compensate for the gap between HAL delivery time and actual microphone capture. Device name lookup now resolves the named device via `input_device_by_name` rather than falling back to the system-default input unconditionally.

<h3>Confidence Score: 5/5</h3>

Safe to merge; both fixes are arithmetically correct, device fallback is preserved, and the latency cap prevents wild overcorrection.

The timestamp arithmetic inversion is verified by three new roundtrip tests. The latency compensation touches only the mic capture timestamp, is clamped to 500ms, and excludes buffer latency correctly. Device name resolution properly falls back to the system default when no match is found. No data paths are left unguarded.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/timestamp/src/macos.rs | Corrects numer/denom inversion in Add/Sub<Duration> for MachAbsoluteTimestamp; adds three roundtrip tests that catch the regression on Apple Silicon. |
| crates/audio/src/latency.rs | Adds input_device_by_name helper to resolve the recording device by name instead of always using System::default_input_device(); falls back to default if no match is found. |
| crates/recording/src/feeds/microphone.rs | Applies the measured input-pipeline latency (device + safety offset + stream latency, capped at 500ms) to each capture timestamp, correcting the systematic mic-track delay. |
| apps/desktop/src/routes/(window-chrome)/settings/general.tsx | Adds 24 and 25 FPS options to the max framerate dropdown; backend already accepts 1–120 so no server-side changes needed. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/timestamp/src/macos.rs`, line 8-11 ([link](https://github.com/capsoftware/cap/blob/ab74f72bb6943de335eee968bd8f159fdf0581b7/crates/timestamp/src/macos.rs#L8-L11)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The comment on the inner field says "Nanoseconds" but the value is actually Mach absolute time **ticks**. `MachAbsoluteTimestamp::now()` stores the raw result of `mach_absolute_time()` (ticks), and `duration_since` multiplies by `numer/denom` to convert ticks → nanoseconds. The misleading comment likely contributed to the original numer/denom inversion bug. Fixing it here avoids the same mistake creeping back in.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/timestamp/src/macos.rs
   Line: 8-11

   Comment:
   The comment on the inner field says "Nanoseconds" but the value is actually Mach absolute time **ticks**. `MachAbsoluteTimestamp::now()` stores the raw result of `mach_absolute_time()` (ticks), and `duration_since` multiplies by `numer/denom` to convert ticks → nanoseconds. The misleading comment likely contributed to the original numer/denom inversion bug. Fixing it here avoids the same mistake creeping back in.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(audio): resolve macOS input latency ..."](https://github.com/capsoftware/cap/commit/1fbdeab6f58102442fc12dae595d125d2b7c2eba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42280855)</sub>

<!-- /greptile_comment -->