### PR TITLE
fix(desktop): keep the update-ready toast inside the main window

### DIFF
--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -1597,36 +1597,42 @@ function createUpdateReadyToast() {
 	createTauriEventListener(events.updateReady, (update) => {
 		toast.custom(
 			(t) => (
-				<div class="flex gap-3 items-center px-4 py-3 rounded-xl border shadow-lg bg-gray-1 border-gray-4 text-gray-12">
+				// The main window is only 330px wide, so the toast must fit inside it
+				// (never exceed the viewport) and stack its actions below the message
+				// rather than racing them on one line — otherwise the card overflows
+				// the window edge and gets clipped.
+				<div class="flex flex-col gap-2.5 px-4 py-3 rounded-xl border shadow-lg bg-gray-1 border-gray-4 text-gray-12 w-[min(24rem,calc(100vw-2rem))]">
 					<p class="text-sm">
 						{update.installed
 							? `Cap ${update.version} has been installed — restart to apply`
 							: `Cap ${update.version} is ready to install`}
 					</p>
-					<button
-						type="button"
-						class="px-2.5 py-1 text-xs font-medium rounded-lg transition-colors bg-blue-9 text-white hover:bg-blue-10"
-						onClick={() => {
-							toast.dismiss(t.id);
-							const install = update.installed
-								? Promise.resolve(null)
-								: commands.updatesDownloadAndInstall();
-							// On Windows the NSIS installer restarts Cap itself, so the
-							// relaunch call is unreachable there; that matches update.tsx.
-							install
-								.then(() => relaunch())
-								.catch((e) => console.error("Failed to install update:", e));
-						}}
-					>
-						{update.installed ? "Restart now" : "Install and restart"}
-					</button>
-					<button
-						type="button"
-						class="px-2.5 py-1 text-xs font-medium rounded-lg transition-colors text-gray-11 hover:text-gray-12"
-						onClick={() => toast.dismiss(t.id)}
-					>
-						Dismiss
-					</button>
+					<div class="flex gap-2 items-center">
+						<button
+							type="button"
+							class="px-2.5 py-1 text-xs font-medium rounded-lg transition-colors bg-blue-9 text-white hover:bg-blue-10"
+							onClick={() => {
+								toast.dismiss(t.id);
+								const install = update.installed
+									? Promise.resolve(null)
+									: commands.updatesDownloadAndInstall();
+								// On Windows the NSIS installer restarts Cap itself, so the
+								// relaunch call is unreachable there; that matches update.tsx.
+								install
+									.then(() => relaunch())
+									.catch((e) => console.error("Failed to install update:", e));
+							}}
+						>
+							{update.installed ? "Restart now" : "Install and restart"}
+						</button>
+						<button
+							type="button"
+							class="px-2.5 py-1 text-xs font-medium rounded-lg transition-colors text-gray-11 hover:text-gray-12"
+							onClick={() => toast.dismiss(t.id)}
+						>
+							Dismiss
+						</button>
+					</div>
 				</div>
 			),
 			{


### PR DESCRIPTION
## Problem

The "update installed — restart to apply" toast rendered clipped and cramped in the main window: the first letter of each wrapped line was cut off ("**C**ap", "**n**ightly", "**h**as", "**r**estart") and the button squashed to "Restart\nnow".

The toast laid its message and both buttons out in a single horizontal `flex` row with no width cap, but the main window is only **330px** wide (`windows.rs` → `Self::Main => (330.0, 395.0)`). Pinned bottom-right, the card overflowed the window's left edge and the webview clipped it.

The plain toasts elsewhere never hit this because they're short single lines. This one surfaced with the nightly channel, where the "installed, restart to apply" state actually shows up.

## Fix

- Cap the card to the viewport width — `w-[min(24rem,calc(100vw-2rem))]` — so it fits the 330px window (≈298px with clean margins) yet still caps at 24rem on wider windows. Mirrors the existing pattern in `TrackManager.tsx`.
- Stack the `Restart now` / `Dismiss` buttons **below** the message instead of racing them horizontally, so nothing wraps mid-word.

CSS/JSX-only, scoped to the toast. No changelog/version-switcher changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the update-ready toast overflowing and clipping text in the 330 px main window. The change is CSS/JSX only and doesn't touch any update logic.

- Adds `w-[min(24rem,calc(100vw-2rem))]` to cap the card width to the viewport, giving ~298 px of usable space on the narrowest window while still allowing up to 24 rem on wider surfaces.
- Changes the root `flex` row to `flex-col` so the message text sits above a dedicated button row (`flex gap-2 items-center`), eliminating the mid-word line breaks and squashed button labels.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely cosmetic Tailwind/JSX rearrangement with no changes to the install or relaunch logic.

The update, relaunch, and dismiss logic is byte-for-byte identical to the original. Only the wrapping divs and class strings changed. The w-[min(24rem,calc(100vw-2rem))] pattern is a well-established Tailwind idiom, and at 330 px the math (330 − 32 = 298 px) gives comfortable margins. Both button label combinations ("Restart now"/"Dismiss" and "Install and restart"/"Dismiss") fit inside the constrained row without risk of overflow.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/(window-chrome)/new-main/index.tsx | Layout-only fix for the update-ready toast: switches container to flex-col with a viewport-capped width so the card stays within the 330px main window, and moves buttons into their own horizontal row below the message. |

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): keep the update-ready toas..."](https://github.com/capsoftware/cap/commit/5d4b94ecb223f79700fc438e603f0314080ca1a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42411364)</sub>

<!-- /greptile_comment -->