### PR TITLE
fix: use membership role as source-of-truth for organization roles

### DIFF
--- a/apps/web/__tests__/unit/desktop-organization-branding.test.ts
+++ b/apps/web/__tests__/unit/desktop-organization-branding.test.ts
@@ -144,12 +144,13 @@ describe("desktop organization branding", () => {
 		expect(
 			canEditOrganizationBranding(row({ tombstoneAt: new Date() }), "user-1"),
 		).toBe(false);
+		// memberRole "owner" takes precedence — user CAN edit
 		expect(
 			canEditOrganizationBranding(
 				row({ ownerId: "user-2", role: "owner" }),
 				"user-1",
 			),
-		).toBe(false);
+		).toBe(true);
 	});
 
 	it("validates and normalizes branding patch payloads", () => {

--- a/apps/web/__tests__/unit/roles-permissions.test.ts
+++ b/apps/web/__tests__/unit/roles-permissions.test.ts
@@ -27,14 +27,15 @@ describe("organization role permissions", () => {
 		expect(normalizeAssignableOrganizationRole("owner")).toBeNull();
 	});
 
-	it("derives owner from organization ownership even when membership role differs", () => {
+	it("uses membership role as source-of-truth for organization roles (#1641)", () => {
+		// memberRole takes precedence over ownerId
 		expect(
 			getEffectiveOrganizationRole({
 				userId: "user-1",
 				ownerId: "user-1",
 				memberRole: "member",
 			}),
-		).toBe("owner");
+		).toBe("member");
 		expect(
 			getEffectiveOrganizationRole({
 				userId: "user-2",
@@ -48,7 +49,15 @@ describe("organization role permissions", () => {
 				ownerId: "real-owner",
 				memberRole: "owner",
 			}),
-		).toBe("member");
+		).toBe("owner");
+		// ownerId fallback when membership record is missing
+		expect(
+			getEffectiveOrganizationRole({
+				userId: "user-1",
+				ownerId: "user-1",
+				memberRole: null,
+			}),
+		).toBe("owner");
 	});
 
 	it("allows only owners and admins to view and manage organization members", () => {

--- a/apps/web/app/(org)/dashboard/settings/organization/components/MembersCard.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/MembersCard.tsx
@@ -205,7 +205,8 @@ export const MembersCard = ({ setIsInviteDialogOpen }: MembersCardProps) => {
 	};
 
 	const isMemberOwner = (id: string) => {
-		return id === activeOrganization?.organization.ownerId;
+		const member = activeOrganization?.members.find((m) => m.userId === id);
+		return member?.role === "owner";
 	};
 
 	return (

--- a/apps/web/app/(org)/dashboard/settings/organization/components/MembersCard.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/MembersCard.tsx
@@ -206,7 +206,7 @@ export const MembersCard = ({ setIsInviteDialogOpen }: MembersCardProps) => {
 
 	const isMemberOwner = (id: string) => {
 		const member = activeOrganization?.members.find((m) => m.userId === id);
-		return member?.role === "owner";
+		return member ? member.role === "owner" : id === activeOrganization?.organization.ownerId;
 	};
 
 	return (

--- a/apps/web/lib/permissions/roles.ts
+++ b/apps/web/lib/permissions/roles.ts
@@ -139,6 +139,7 @@ export function isOrganizationOwnerTarget({
 }) {
 	// Prefer membership role over ownerId (see #1641).
 	if (targetRole === "owner") return true;
+	if (targetRole) return false;
 	// Fallback for legacy/missing membership records.
 	return !!targetUserId && !!ownerId && targetUserId === ownerId;
 }

--- a/apps/web/lib/permissions/roles.ts
+++ b/apps/web/lib/permissions/roles.ts
@@ -66,9 +66,15 @@ export function getEffectiveOrganizationRole({
 	ownerId: string | null | undefined;
 	memberRole: string | null | undefined;
 }): OrganizationRole | null {
+	// Prefer organization_members.role as source-of-truth over organization.ownerId
+	// to avoid drift between the two fields (see #1641).
+	const normalizedRole = normalizeOrganizationRole(memberRole);
+	if (normalizedRole === "owner") return "owner";
+	if (normalizedRole) return normalizedRole;
+	// Fallback: if membership record is missing (e.g. legacy data),
+	// derive owner from the organization.ownerId field.
 	if (userId && ownerId && userId === ownerId) return "owner";
-	const role = normalizeOrganizationRole(memberRole);
-	return role === "owner" ? "member" : role;
+	return null;
 }
 
 export function normalizeSpaceRole(
@@ -131,7 +137,10 @@ export function isOrganizationOwnerTarget({
 	ownerId: string | null | undefined;
 	targetRole: OrganizationRole | null | undefined;
 }) {
-	return targetRole === "owner" || (!!targetUserId && targetUserId === ownerId);
+	// Prefer membership role over ownerId (see #1641).
+	if (targetRole === "owner") return true;
+	// Fallback for legacy/missing membership records.
+	return !!targetUserId && !!ownerId && targetUserId === ownerId;
 }
 
 export function canChangeOrganizationMemberRole({


### PR DESCRIPTION
## Summary

Fixes #1641

The `getEffectiveOrganizationRole` function previously used `organizations.ownerId` as the primary source for determining the 'owner' role. This caused two problems:

1. **ownerId overrides memberRole**: When a user matched `ownerId` but their membership record had a different role (e.g. `member`), the function would incorrectly return `owner`.
2. **memberRole='owner' forced to 'member'**: When a user's membership had `role='owner'` but they weren't the `ownerId`, the function would return `member`, silently stripping owner privileges.

## Changes

- `apps/web/lib/permissions/roles.ts`: `getEffectiveOrganizationRole` now uses `memberRole` from `organization_members` as source-of-truth, with `ownerId` only as a fallback when no membership record exists. Same fix applied to `isOrganizationOwnerTarget`.
- `apps/web/app/(org)/dashboard/settings/organization/components/MembersCard.tsx`: `isMemberOwner` now checks `member.role === 'owner'` instead of comparing with `organization.ownerId`.
- Updated existing tests that validated the buggy behavior to expect the correct behavior.

## Validation

- All 945 tests pass
- Typecheck passes (`pnpm tsc -b`)
- Lint passes (`biome lint`)

## How to test

1. Create an organization where user A is the owner
2. Transfer ownership to user B (user A's membership role becomes 'member')
3. Before fix: user A still sees owner privileges (incorrect)
4. After fix: user A correctly sees only member privileges

The reverse scenario (user with membership role='owner' but different ownerId) is also handled correctly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes organization membership role the source of truth for owner checks. The main changes are:

- Updated effective organization role resolution in shared permission helpers.
- Updated members-table owner display logic to read `member.role`.
- Adjusted unit tests for membership-role precedence and ownerId fallback.

<h3>Confidence Score: 4/5</h3>

The changed permission target check needs a fix before merging.

- Known non-owner membership roles can still be overridden by stale `ownerId`.
- Member role and removal flows can reject valid changes for a user who is no longer owner.
- The members UI can expose controls for legacy owner rows that the server rejects.

apps/web/lib/permissions/roles.ts; apps/web/app/(org)/dashboard/settings/organization/components/MembersCard.tsx

<details open><summary><h3>Security Review</h3></summary>

A permission helper can still treat a non-owner membership as owner when stale `ownerId` matches the target user, blocking legitimate member-management actions.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/lib/permissions/roles.ts | Updates effective role resolution, but owner-target detection still falls back to stale ownerId even when a non-owner membership role is known. |
| apps/web/app/(org)/dashboard/settings/organization/components/MembersCard.tsx | Moves UI owner detection to member role, but drops the legacy ownerId fallback used by shared permission helpers. |
| apps/web/__tests__/unit/roles-permissions.test.ts | Updates tests for membership-role precedence and ownerId fallback in the main role helper. |
| apps/web/__tests__/unit/desktop-organization-branding.test.ts | Updates branding permission expectations for membership owner precedence. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/lib/permissions/roles.ts:143
**Stale OwnerId Still Wins**

When `targetRole` is already known to be `"member"` or `"admin"`, this fallback can still classify the target as owner because their id matches stale `ownerId`. In that drift state, `canChangeOrganizationMemberRole` and `canRemoveOrganizationMember` reject changes to a non-owner member, so the member can become stuck even though membership role is now the source of truth.

### Issue 2 of 2
apps/web/app/(org)/dashboard/settings/organization/components/MembersCard.tsx:209
**Legacy Owner Row Loses Protection**

When an organization owner is represented only by `organization.ownerId` or has a stale/missing membership role, this returns false while the shared permission helpers still treat that user as owner through their fallback. The row then shows editable role, Pro-seat, and remove controls that the server rejects, so legacy owner rows become misleading and inconsistent.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use membership role as source-of-tr..."](https://github.com/capsoftware/cap/commit/ff8866888032792a0ba1fa04754f7164524965aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42580821)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))
- Context used - AGENTS.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=27801409-c24c-4476-9c6c-180f1ef0a7f2))

<!-- /greptile_comment -->