### PR TITLE
docs(web): add changelog for 0.5.6 desktop release

### DIFF
--- a/apps/web/content/changelog/99.mdx
+++ b/apps/web/content/changelog/99.mdx
@@ -1,0 +1,25 @@
+---
+title: Mic Mute for Instant Recordings, Nightly Builds & Multi-Monitor Fixes
+app: Cap Desktop
+publishedAt: "2026-07-09"
+version: 0.5.6
+image:
+---
+
+This release adds microphone muting during instant recordings, an optional nightly update channel, and important fixes for recordings stopping early, lost start clicks, slow-motion recordings on high-refresh monitors, and windows on multi-monitor setups.
+
+## Features
+
+- **Mute your mic mid-recording** - The mic icon in the recording bar is now a mute toggle during instant recordings, so you can silence your microphone without stopping the recording. System audio keeps recording as normal.
+- **Nightly update channel** - Opt into nightly builds from Settings to get the newest changes early. Nightly updates install automatically in the background and prompt you to restart when ready, and switching back to stable returns you to the latest stable release.
+- **24 and 25 FPS capture options** - The max capture framerate setting now includes 24 and 25 FPS for film and PAL-friendly workflows.
+
+## Fixes
+
+- **Recordings no longer stop after a few seconds** - Reopening the recording bar for a new instant recording could carry over stale state from a previous session and trip the recording limit almost immediately. The bar now fully resets between recordings.
+- **Recording start clicks no longer vanish** - Clicking record from the target picker could silently do nothing while the windows closed around it. The click is now handled reliably, and if a recording fails to start, the main window reappears with a clear error message.
+- **Slow-motion recordings repaired** - Recordings on high-refresh-rate Windows monitors could come out stretched and out of sync with their audio. New recordings capture at the correct speed, and affected existing recordings are automatically repaired when opened in the editor, keeping the original file as a backup.
+- **Better mic sync** - Microphone timestamps now account for measured input latency, macOS resolves the correct input device when measuring it, and a macOS timestamp conversion bug affecting audio alignment has been fixed.
+- **Multi-monitor and mixed-DPI fixes** - Windows now restore, center, and follow correctly across monitors with different display scaling, overlays size correctly on HiDPI Windows setups, and moving a window between monitors with different scaling no longer breaks its layout.
+- **Update toast fits the window** - The "update installed, restart to apply" toast no longer overflows the main window and clips its text and buttons.
+- **Integrations page when signed out** - The integrations settings page no longer errors when you are not signed in.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `apps/web/content/changelog/99.mdx` — the Cap Desktop changelog covering everything shipped since the last public release with a changelog (0.5.4), i.e. versions 0.5.5 and 0.5.6.

Compiled by reading all 27 commits between the 0.5.4 changelog commit (`2ac277c5a`) and the 0.5.6 version bump (`1b37376e4`), keeping only desktop-relevant, user-facing changes (CI, web-only, test, and formatting commits excluded).

## Highlights covered

**Features**
- Mic mute toggle in the recording bar during instant recordings
- Nightly update channel with background auto-update
- 24 / 25 FPS max capture framerate options

**Fixes**
- Recording bar phantom state stopping new instant recordings after seconds
- Lost recording-start clicks from the target picker + surfaced start failures
- Healing of stretched (slow-motion) recordings from high-refresh Windows monitors + WGC capture cadence cap
- Mic sync (input pipeline latency compensation, macOS device resolution by name, mach timestamp conversion)
- Multi-monitor / mixed-DPI window placement, HiDPI overlay sizing, and DPI scale change handling
- Update-ready toast overflowing the main window
- Integrations settings page erroring when signed out

Follows the exact frontmatter and section format of the existing `98.mdx` (0.5.4) entry; verified the frontmatter parses correctly through `apps/web/utils/changelog.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f462b-0119-7e42-8454-10a22f1a09f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f462b-0119-7e42-8454-10a22f1a09f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new Cap Desktop changelog entry.

- Adds `apps/web/content/changelog/99.mdx` for version 0.5.6.
- Documents new recording, update-channel, and FPS features.
- Lists fixes for recording state, audio sync, display scaling, update toast layout, and signed-out integrations.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/content/changelog/99.mdx | Adds a standard MDX changelog entry for the Cap Desktop 0.5.6 release. |

<sub>Reviews (1): Last reviewed commit: ["docs(web): add changelog for 0.5.6 relea..."](https://github.com/capsoftware/cap/commit/3d4deb212f57150a8d9ebd5de73a7807e55c52f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42970242)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))
- Context used - AGENTS.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=27801409-c24c-4476-9c6c-180f1ef0a7f2))

<!-- /greptile_comment -->