### PR TITLE
fix(recording): don't false-trip the Windows H264 encoder Timeout after a >5s pause

### DIFF
--- a/crates/enc-mediafoundation/src/video/h264.rs
+++ b/crates/enc-mediafoundation/src/video/h264.rs
@@ -42,6 +42,14 @@ const MAX_CONSECUTIVE_EMPTY_SAMPLES: u8 = 20;
 const MAX_INPUT_WITHOUT_OUTPUT: u32 = 30;
 const MAX_PROCESS_INPUT_FAILURES: u32 = 5;
 const ENCODER_OPERATION_TIMEOUT: Duration = Duration::from_secs(5);
+/// How long `get_frame` may park before we treat the gap as an upstream stall
+/// (recording paused or capture starved) rather than a hung hardware encoder,
+/// and rebase the output-timeout clock. Must stay below
+/// `ENCODER_OPERATION_TIMEOUT` so a pause between this and the timeout is still
+/// absorbed. Live capture always returns a frame within ~one frame interval, so
+/// a block this long only ever means "we had nothing to encode", which is never
+/// the encoder's fault.
+const INPUT_WAIT_HEALTH_RESET: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone)]
 pub struct EncoderHealthStatus {
@@ -94,6 +102,15 @@ impl EncoderHealthMonitor {
 
     fn reset_process_failures(&mut self) {
         self.consecutive_process_failures = 0;
+    }
+
+    /// Rebase the output-timeout clock after `get_frame` parked for a long time
+    /// (recording paused or capture starved). That idle wall-clock time is not
+    /// an encoder stall, so it must not count toward the `Timeout` health check;
+    /// otherwise a pause longer than `ENCODER_OPERATION_TIMEOUT` trips a false
+    /// timeout on the first health check after resume and kills the recording.
+    fn notify_input_stall_recovered(&mut self) {
+        self.last_output_time = Instant::now();
     }
 
     fn check_health(&self) -> EncoderHealthStatus {
@@ -561,9 +578,19 @@ impl H264Encoder {
                     MediaFoundation::METransformNeedInput => {
                         health_monitor.record_input();
                         should_exit = true;
+                        let get_frame_started = Instant::now();
                         if !should_stop.load(Ordering::SeqCst)
                             && let Some((texture, timestamp)) = get_frame()?
                         {
+                            // `get_frame` blocks for the whole pause (frames are
+                            // dropped upstream while paused), so a long park here
+                            // is idle time, not a hardware stall. Rebase the
+                            // timeout clock so the next `check_health` at the top
+                            // of the loop doesn't false-trip `Timeout` on resume.
+                            if get_frame_started.elapsed() > INPUT_WAIT_HEALTH_RESET {
+                                health_monitor.notify_input_stall_recovered();
+                            }
+
                             let process_result = (|| -> windows::core::Result<()> {
                                 self.video_processor.process_texture(&texture)?;
                                 let input_buffer = MFCreateDXGISurfaceBuffer(


### PR DESCRIPTION
## Problem

Pausing an active recording on **Windows** for more than ~5 seconds and then resuming aborts the whole recording. From a real recording log, the failure fires ~60 ms after resume:

```
ERROR ...output_pipeline::win: Hardware encoder failed with recoverable error, marking for
software fallback: Encoder unhealthy: Timeout (inputs_without_output=1, process_failures=0,
frames_encoded=227)
```

Pauses shorter than 5 s do not trip it, and macOS is unaffected.

## Root cause

`enc-mediafoundation`'s `EncoderHealthMonitor` has a wall-clock 5 s "no output" watchdog:

```rust
const ENCODER_OPERATION_TIMEOUT: Duration = Duration::from_secs(5);
// ...
} else if self.last_output_time.elapsed() > ENCODER_OPERATION_TIMEOUT
    && self.total_frames_encoded > 0
{
    failure_reason = Some(EncoderFailureReason::Timeout);
}
```

While paused, `output_pipeline::core`'s `mux-video` task drops frames (`dropped_during_pause`), so the encoder thread's `get_frame` closure parks for the entire pause and produces no output. `H264Encoder::run` is blocked inside `get_frame()` the whole time, so `check_health()` is not evaluated during the pause. On resume, `get_frame` returns, one frame is submitted, and the very next `check_health()` at the top of the loop sees `last_output_time.elapsed() > 5s` → `EncoderUnhealthy { Timeout }`. That fails the `windows-encoder` task and tears down the whole recording (it does **not** transparently fall back to software for the in-flight recording — `force_software_only()` only affects a subsequent one).

The `inputs_without_output=1` in the error is the single frame fed on resume; the timer simply measured the paused wall-clock gap. macOS uses VideoToolbox, which has no equivalent wall-clock output watchdog — hence Windows-only.

## Fix

Time `get_frame()`. If it parked longer than `INPUT_WAIT_HEALTH_RESET` (1 s) — i.e. we simply had nothing to encode (paused or capture-starved), which is never the hardware encoder's fault — rebase `last_output_time` so the next health check does not false-trip.

Safe against real stalls: a genuinely hung encoder keeps live capture flowing, so `get_frame` returns within a frame interval (never > 1 s) and the 5 s `Timeout` still fires, as does the `inputs_without_output > 30` `Stalled` check. The change lives in the shared `H264Encoder::run()`, so it covers the screen and camera muxers and the segmented variants at once.

## Testing

- `cargo fmt --check` clean.
- Diagnosed from a real Windows recording log where the error fires immediately on resume after a 5.3 s pause (a prior 3.0 s pause in the same session did not trip it), matching the 5 s threshold exactly. Would appreciate a maintainer confirming on Windows hardware: record → pause 6–10 s → resume → recording should now continue and the output should play; short pauses remain unaffected.

Refs #393

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the Windows H264 encoder health timer after long upstream frame waits. The main changes are:

- Adds a one-second input-wait threshold for health reset behavior.
- Rebases the encoder output-timeout clock after `get_frame` blocks past that threshold.
- Applies the reset before processing the resumed input frame.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/enc-mediafoundation/src/video/h264.rs | Adds pause-aware timeout rebasing to the H264 MediaFoundation encoder health monitor. |

<sub>Reviews (1): Last reviewed commit: ["fix(recording): don&#39;t false-trip Windows..."](https://github.com/capsoftware/cap/commit/264e81d4e98f10353fcec1da15089bdc516ca0d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42986976)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))
- Context used - AGENTS.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=27801409-c24c-4476-9c6c-180f1ef0a7f2))

<!-- /greptile_comment -->