### PR TITLE
feat(extension-auth): accept Firefox identity redirect hosts for extension auth

### DIFF
--- a/packages/env/server.ts
+++ b/packages/env/server.ts
@@ -83,6 +83,12 @@ function createServerEnv() {
 				.string()
 				.optional()
 				.describe("Chrome Web Store extension id allowed to receive auth keys"),
+			CAP_FIREFOX_EXTENSION_ID: z
+				.string()
+				.optional()
+				.describe(
+					"Firefox identity redirect subdomain (the <id> in https://<id>.extensions.allizom.org, derived from the gecko extension id) allowed to receive auth keys",
+				),
 			CAP_ALLOWED_SIGNUP_DOMAINS: z
 				.string()
 				.optional()

--- a/packages/web-backend/src/Extension/Http.ts
+++ b/packages/web-backend/src/Extension/Http.ts
@@ -19,7 +19,18 @@ import { handleDomainError } from "../Http/Errors.ts";
 import { Videos } from "../Videos/index.ts";
 import { Extensions } from "./Extensions.ts";
 
-const CHROMIUM_IDENTITY_HOST_SUFFIX = ".chromiumapp.org";
+// Each browser's identity.launchWebAuthFlow intercepts redirects to its own
+// synthetic host; the leading label identifies the extension installation.
+const IDENTITY_REDIRECT_HOSTS = [
+	{
+		suffix: ".chromiumapp.org",
+		getConfiguredExtensionId: () => serverEnv().CAP_CHROME_EXTENSION_ID,
+	},
+	{
+		suffix: ".extensions.allizom.org",
+		getConfiguredExtensionId: () => serverEnv().CAP_FIREFOX_EXTENSION_ID,
+	},
+] as const;
 
 const validateExtensionRedirectUri = (redirectUri: string) =>
 	Effect.gen(function* () {
@@ -28,18 +39,15 @@ const validateExtensionRedirectUri = (redirectUri: string) =>
 			catch: () => new HttpApiError.BadRequest(),
 		});
 
-		if (
-			url.protocol !== "https:" ||
-			!url.hostname.endsWith(CHROMIUM_IDENTITY_HOST_SUFFIX)
-		) {
+		const identityHost = IDENTITY_REDIRECT_HOSTS.find(({ suffix }) =>
+			url.hostname.endsWith(suffix),
+		);
+		if (url.protocol !== "https:" || !identityHost) {
 			return yield* new HttpApiError.BadRequest();
 		}
 
-		const extensionId = url.hostname.slice(
-			0,
-			-CHROMIUM_IDENTITY_HOST_SUFFIX.length,
-		);
-		const configuredExtensionId = serverEnv().CAP_CHROME_EXTENSION_ID;
+		const extensionId = url.hostname.slice(0, -identityHost.suffix.length);
+		const configuredExtensionId = identityHost.getConfiguredExtensionId();
 
 		if (configuredExtensionId) {
 			if (extensionId !== configuredExtensionId) {
@@ -52,7 +60,8 @@ const validateExtensionRedirectUri = (redirectUri: string) =>
 		// signed-in user's auth key through this flow. The only deployment
 		// where accepting an arbitrary id is safe is localhost development;
 		// every reachable deployment (staging, previews, self-hosted) must set
-		// CAP_CHROME_EXTENSION_ID regardless of NODE_ENV.
+		// CAP_CHROME_EXTENSION_ID / CAP_FIREFOX_EXTENSION_ID regardless of
+		// NODE_ENV.
 		const webHostname = new URL(serverEnv().WEB_URL).hostname;
 		const isLocalDevelopment =
 			serverEnv().NODE_ENV !== "production" &&
@@ -150,7 +159,7 @@ const renderConsentPage = ({
 	</head>
 	<body>
 		<main class="card">
-			<h1>Connect the Cap Chrome extension</h1>
+			<h1>Connect the Cap browser extension</h1>
 			<p>The Cap extension is asking for access to your Cap account <span class="email">${escapeHtml(email)}</span> to create and upload recordings on your behalf.</p>
 			<p>Only continue if you opened this page from the Cap extension.</p>
 			<form method="post" action="approve" class="actions">

--- a/packages/web-backend/src/Extension/Http.ts
+++ b/packages/web-backend/src/Extension/Http.ts
@@ -47,7 +47,7 @@ const validateExtensionRedirectUri = (redirectUri: string) =>
 		}
 
 		const extensionId = url.hostname.slice(0, -identityHost.suffix.length);
-		const configuredExtensionId = identityHost.getConfiguredExtensionId();
+		const configuredExtensionId = identityHost.getConfiguredExtensionId()?.toLowerCase();
 
 		if (configuredExtensionId) {
 			if (extensionId !== configuredExtensionId) {


### PR DESCRIPTION
Firefox's identity.launchWebAuthFlow redirects to https://<hash>.extensions.allizom.org/. 

Generalizes validateExtensionRedirectUri to a host-suffix table and adds optional CAP_FIREFOX_EXTENSION_ID (packages/env). 

Chrome pinning and the localhost-dev escape hatch unchanged. Independent of the other PRs. 
(For production later: the hash for gecko id extension@cap.so is 324e9362f26688ae2eb9a75d1beae53ef6b8d0d2.)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Firefox redirect host support to extension auth. The main changes are:

- Adds optional `CAP_FIREFOX_EXTENSION_ID` server configuration.
- Generalizes identity redirect validation across Chromium and Firefox host suffixes.
- Normalizes the configured extension id before comparing it with the redirect host.
- Updates the consent page heading to use browser-neutral wording.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.
- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/env/server.ts | Adds the optional Firefox extension redirect id to the server env schema. |
| packages/web-backend/src/Extension/Http.ts | Validates extension auth redirects through a browser suffix table and compares against the normalized configured id. |

<sub>Reviews (2): Last reviewed commit: ["fix(extension-auth): normalize configure..."](https://github.com/capsoftware/cap/commit/f6d875cbc1e093ae1fa24d779f2139ee8b43194c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43536513)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))
- Context used - AGENTS.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=27801409-c24c-4476-9c6c-180f1ef0a7f2))

<!-- /greptile_comment -->