### PR TITLE
fix(recording): keep Windows screen frames in sync

### DIFF
--- a/crates/recording/src/output_pipeline/oop_fragmented_m4s_win.rs
+++ b/crates/recording/src/output_pipeline/oop_fragmented_m4s_win.rs
@@ -20,7 +20,7 @@ use std::{
     sync::{
         Arc,
         atomic::AtomicBool,
-        mpsc::{RecvTimeoutError, SyncSender, sync_channel},
+        mpsc::{RecvTimeoutError, SyncSender, TryRecvError, TrySendError, sync_channel},
     },
     thread::JoinHandle,
     time::Duration,
@@ -28,13 +28,56 @@ use std::{
 use tracing::*;
 
 const DEFAULT_MAX_RESPAWNS: u32 = 3;
-const DEFAULT_MUXER_BUFFER_SIZE: usize = 240;
+const DEFAULT_MUXER_BUFFER_SIZE: usize = 8;
 
 fn get_muxer_buffer_size() -> usize {
     std::env::var("CAP_MUXER_BUFFER_SIZE")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(DEFAULT_MUXER_BUFFER_SIZE)
+}
+
+type ScreenFrameItem = Option<(screen_capture::ScreenFrame, Duration)>;
+
+struct LatestScreenFrame {
+    frame: screen_capture::ScreenFrame,
+    timestamp: Duration,
+    stale_frames: u64,
+    end_after_frame: bool,
+}
+
+fn recv_latest_screen_frame(
+    video_rx: &std::sync::mpsc::Receiver<ScreenFrameItem>,
+    timeout: Duration,
+) -> Result<Option<LatestScreenFrame>, RecvTimeoutError> {
+    let Some((mut frame, mut timestamp)) = video_rx.recv_timeout(timeout)? else {
+        return Ok(None);
+    };
+
+    let mut stale_frames = 0;
+    let mut end_after_frame = false;
+    loop {
+        match video_rx.try_recv() {
+            Ok(Some((next_frame, next_timestamp))) => {
+                frame = next_frame;
+                timestamp = next_timestamp;
+                stale_frames += 1;
+            }
+            Ok(None) => {
+                end_after_frame = true;
+                break;
+            }
+            Err(TryRecvError::Empty) => break,
+            Err(TryRecvError::Disconnected) => return Err(RecvTimeoutError::Disconnected),
+        }
+    }
+
+    Ok(Some(LatestScreenFrame {
+        frame,
+        timestamp,
+        stale_frames,
+        end_after_frame,
+    }))
 }
 
 struct FrameDropTracker {
@@ -106,8 +149,6 @@ impl FrameDropTracker {
         }
     }
 }
-
-type ScreenFrameItem = Option<(screen_capture::ScreenFrame, Duration)>;
 
 struct EncoderState {
     video_tx: SyncSender<ScreenFrameItem>,
@@ -371,6 +412,8 @@ impl WindowsOOPFragmentedM4SMuxer {
                 let mut first_timestamp: Option<Duration> = None;
                 let mut total_frames = 0u64;
                 let mut duplicated_frames = 0u64;
+                let mut stale_frames_dropped = 0u64;
+                let mut pending_end_after_frame = false;
                 let mut slow_convert_count = 0u32;
                 let mut slow_encode_count = 0u32;
                 const SLOW_THRESHOLD_MS: u128 = 5;
@@ -446,6 +489,10 @@ impl WindowsOOPFragmentedM4SMuxer {
                     };
 
                 loop {
+                    if pending_end_after_frame {
+                        break;
+                    }
+
                     match disk_monitor.poll(&base_path, &health_tx) {
                         super::core::DiskSpacePollResult::Exhausted { .. }
                         | super::core::DiskSpacePollResult::Stopped => {
@@ -462,26 +509,39 @@ impl WindowsOOPFragmentedM4SMuxer {
 
                     let convert_start = std::time::Instant::now();
 
-                    let (ffmpeg_frame, timestamp) = match video_rx.recv_timeout(frame_interval) {
-                        Ok(Some((frame, ts))) => match frame.as_ffmpeg() {
-                            Ok(f) => {
-                                last_ffmpeg_frame = Some(f.clone());
-                                last_timestamp = Some(ts);
-                                (Some(f), ts)
-                            }
-                            Err(e) => {
-                                warn!("Windows OOP failed to convert D3D11 frame: {e:?}");
-                                match (&last_ffmpeg_frame, last_timestamp) {
-                                    (Some(f), Some(last_ts)) => {
-                                        let new_ts = last_ts.saturating_add(frame_interval);
-                                        last_timestamp = Some(new_ts);
-                                        duplicated_frames += 1;
-                                        (Some(f.clone()), new_ts)
-                                    }
-                                    _ => (None, Duration::ZERO),
+                    let (ffmpeg_frame, timestamp) = match recv_latest_screen_frame(&video_rx, frame_interval) {
+                        Ok(Some(latest)) => {
+                            if latest.stale_frames > 0 {
+                                stale_frames_dropped += latest.stale_frames;
+                                if stale_frames_dropped <= 5 || stale_frames_dropped.is_multiple_of(120) {
+                                    debug!(
+                                        stale_frames = latest.stale_frames,
+                                        total_stale_frames = stale_frames_dropped,
+                                        "Dropped stale queued screen frames before OOP encoding latest"
+                                    );
                                 }
                             }
-                        },
+                            pending_end_after_frame = latest.end_after_frame;
+                            match latest.frame.as_ffmpeg() {
+                                Ok(f) => {
+                                    last_ffmpeg_frame = Some(f.clone());
+                                    last_timestamp = Some(latest.timestamp);
+                                    (Some(f), latest.timestamp)
+                                }
+                                Err(e) => {
+                                    warn!("Windows OOP failed to convert D3D11 frame: {e:?}");
+                                    match (&last_ffmpeg_frame, last_timestamp) {
+                                        (Some(f), Some(last_ts)) => {
+                                            let new_ts = last_ts.saturating_add(frame_interval);
+                                            last_timestamp = Some(new_ts);
+                                            duplicated_frames += 1;
+                                            (Some(f.clone()), new_ts)
+                                        }
+                                        _ => (None, Duration::ZERO),
+                                    }
+                                }
+                            }
+                        }
                         Ok(None) | Err(RecvTimeoutError::Disconnected) => {
                             let drain_start = std::time::Instant::now();
                             let drain_timeout = Duration::from_millis(500);
@@ -593,6 +653,7 @@ impl WindowsOOPFragmentedM4SMuxer {
                     debug!(
                         total_frames = total_frames,
                         duplicated_frames = duplicated_frames,
+                        stale_frames_dropped = stale_frames_dropped,
                         slow_converts = slow_convert_count,
                         slow_encodes = slow_encode_count,
                         slow_convert_pct = format!(
@@ -695,11 +756,17 @@ impl VideoMuxer for WindowsOOPFragmentedM4SMuxer {
         };
 
         if let Some(state) = &self.state {
-            match state.video_tx.send(Some((frame.frame, adjusted_timestamp))) {
+            match state
+                .video_tx
+                .try_send(Some((frame.frame, adjusted_timestamp)))
+            {
                 Ok(()) => {
                     self.frame_drops.record_frame();
                 }
-                Err(_) => {
+                Err(TrySendError::Full(_)) => {
+                    self.frame_drops.record_drop();
+                }
+                Err(TrySendError::Disconnected(_)) => {
                     return Err(anyhow!("Windows OOP M4S encoder channel disconnected"));
                 }
             }

--- a/crates/recording/src/output_pipeline/win.rs
+++ b/crates/recording/src/output_pipeline/win.rs
@@ -13,19 +13,62 @@ use std::{
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
-        mpsc::{RecvTimeoutError, SyncSender, TrySendError, sync_channel},
+        mpsc::{RecvTimeoutError, SyncSender, TryRecvError, TrySendError, sync_channel},
     },
     time::Duration,
 };
 use tracing::*;
 
-const DEFAULT_MUXER_BUFFER_SIZE: usize = 240;
+const DEFAULT_MUXER_BUFFER_SIZE: usize = 8;
 
 fn get_muxer_buffer_size() -> usize {
     std::env::var("CAP_MUXER_BUFFER_SIZE")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(DEFAULT_MUXER_BUFFER_SIZE)
+}
+
+type ScreenFrameItem = Option<(screen_capture::ScreenFrame, Duration)>;
+
+struct LatestScreenFrame {
+    frame: screen_capture::ScreenFrame,
+    timestamp: Duration,
+    stale_frames: u64,
+    end_after_frame: bool,
+}
+
+fn recv_latest_screen_frame(
+    video_rx: &std::sync::mpsc::Receiver<ScreenFrameItem>,
+    timeout: Duration,
+) -> Result<Option<LatestScreenFrame>, RecvTimeoutError> {
+    let Some((mut frame, mut timestamp)) = video_rx.recv_timeout(timeout)? else {
+        return Ok(None);
+    };
+
+    let mut stale_frames = 0;
+    let mut end_after_frame = false;
+    loop {
+        match video_rx.try_recv() {
+            Ok(Some((next_frame, next_timestamp))) => {
+                frame = next_frame;
+                timestamp = next_timestamp;
+                stale_frames += 1;
+            }
+            Ok(None) => {
+                end_after_frame = true;
+                break;
+            }
+            Err(TryRecvError::Empty) => break,
+            Err(TryRecvError::Disconnected) => return Err(RecvTimeoutError::Disconnected),
+        }
+    }
+
+    Ok(Some(LatestScreenFrame {
+        frame,
+        timestamp,
+        stale_frames,
+        end_after_frame,
+    }))
 }
 
 struct FrameDropTracker {
@@ -327,15 +370,28 @@ impl Muxer for WindowsMuxer {
                         let mut last_timestamp: Option<Duration> = None;
                         let mut frame_count: u64 = 0;
                         let mut frames_reused: u64 = 0;
+                        let mut pending_end_after_frame = false;
 
                         let result = encoder.run(
                             Arc::new(AtomicBool::default()),
                             || {
+                                if pending_end_after_frame {
+                                    trace!("End of stream signal received after latest queued frame");
+                                    return Ok(None);
+                                }
+
                                 loop {
-                                    match video_rx.recv_timeout(frame_interval) {
-                                        Ok(Some((frame, timestamp))) => {
-                                            last_texture = Some(frame.texture().clone());
-                                            last_timestamp = Some(timestamp);
+                                    match recv_latest_screen_frame(&video_rx, frame_interval) {
+                                        Ok(Some(latest)) => {
+                                            if latest.stale_frames > 0 {
+                                                debug!(
+                                                    stale_frames = latest.stale_frames,
+                                                    "Dropped stale queued screen frames before encoding latest"
+                                                );
+                                            }
+                                            pending_end_after_frame = latest.end_after_frame;
+                                            last_texture = Some(latest.frame.texture().clone());
+                                            last_timestamp = Some(latest.timestamp);
                                         }
                                         Ok(None) => {
                                             trace!("End of stream signal received");
@@ -426,19 +482,31 @@ impl Muxer for WindowsMuxer {
                         let mut last_ffmpeg_frame: Option<ffmpeg::frame::Video> = None;
                         let mut first_timestamp: Option<Duration> = None;
                         let mut last_timestamp: Option<Duration> = None;
+                        let mut pending_end_after_frame = false;
 
                         loop {
-                            let (ffmpeg_frame, ts) = match video_rx.recv_timeout(frame_interval) {
-                                Ok(Some((frame, timestamp))) => {
-                                    last_timestamp = Some(timestamp);
-                                    match frame.as_ffmpeg() {
+                            if pending_end_after_frame {
+                                break;
+                            }
+
+                            let (ffmpeg_frame, ts) = match recv_latest_screen_frame(&video_rx, frame_interval) {
+                                Ok(Some(latest)) => {
+                                    if latest.stale_frames > 0 {
+                                        debug!(
+                                            stale_frames = latest.stale_frames,
+                                            "Dropped stale queued screen frames before encoding latest"
+                                        );
+                                    }
+                                    pending_end_after_frame = latest.end_after_frame;
+                                    last_timestamp = Some(latest.timestamp);
+                                    match latest.frame.as_ffmpeg() {
                                         Ok(f) => {
                                             last_ffmpeg_frame = Some(f.clone());
-                                            (Some(f), timestamp)
+                                            (Some(f), latest.timestamp)
                                         }
                                         Err(e) => {
                                             warn!("Failed to convert frame: {e:?}");
-                                            (last_ffmpeg_frame.clone(), timestamp)
+                                            (last_ffmpeg_frame.clone(), latest.timestamp)
                                         }
                                     }
                                 }

--- a/crates/recording/src/output_pipeline/win_fragmented_m4s.rs
+++ b/crates/recording/src/output_pipeline/win_fragmented_m4s.rs
@@ -18,20 +18,63 @@ use std::{
     sync::{
         Arc, Mutex,
         atomic::AtomicBool,
-        mpsc::{RecvTimeoutError, SyncSender, sync_channel},
+        mpsc::{RecvTimeoutError, SyncSender, TryRecvError, TrySendError, sync_channel},
     },
     thread::JoinHandle,
     time::Duration,
 };
 use tracing::*;
 
-const DEFAULT_MUXER_BUFFER_SIZE: usize = 240;
+const DEFAULT_MUXER_BUFFER_SIZE: usize = 8;
 
 fn get_muxer_buffer_size() -> usize {
     std::env::var("CAP_MUXER_BUFFER_SIZE")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(DEFAULT_MUXER_BUFFER_SIZE)
+}
+
+type ScreenFrameItem = Option<(screen_capture::ScreenFrame, Duration)>;
+
+struct LatestScreenFrame {
+    frame: screen_capture::ScreenFrame,
+    timestamp: Duration,
+    stale_frames: u64,
+    end_after_frame: bool,
+}
+
+fn recv_latest_screen_frame(
+    video_rx: &std::sync::mpsc::Receiver<ScreenFrameItem>,
+    timeout: Duration,
+) -> Result<Option<LatestScreenFrame>, RecvTimeoutError> {
+    let Some((mut frame, mut timestamp)) = video_rx.recv_timeout(timeout)? else {
+        return Ok(None);
+    };
+
+    let mut stale_frames = 0;
+    let mut end_after_frame = false;
+    loop {
+        match video_rx.try_recv() {
+            Ok(Some((next_frame, next_timestamp))) => {
+                frame = next_frame;
+                timestamp = next_timestamp;
+                stale_frames += 1;
+            }
+            Ok(None) => {
+                end_after_frame = true;
+                break;
+            }
+            Err(TryRecvError::Empty) => break,
+            Err(TryRecvError::Disconnected) => return Err(RecvTimeoutError::Disconnected),
+        }
+    }
+
+    Ok(Some(LatestScreenFrame {
+        frame,
+        timestamp,
+        stale_frames,
+        end_after_frame,
+    }))
 }
 
 struct FrameDropTracker {
@@ -367,6 +410,8 @@ impl WindowsFragmentedM4SMuxer {
                 let mut slow_encode_count = 0u32;
                 let mut total_frames = 0u64;
                 let mut duplicated_frames = 0u64;
+                let mut stale_frames_dropped = 0u64;
+                let mut pending_end_after_frame = false;
                 let mut disk_monitor = DiskSpaceMonitor::new();
                 let mut disk_exhausted = false;
                 const SLOW_THRESHOLD_MS: u128 = 5;
@@ -421,6 +466,10 @@ impl WindowsFragmentedM4SMuxer {
                 };
 
                 loop {
+                    if pending_end_after_frame {
+                        break;
+                    }
+
                     if matches!(
                         disk_monitor.poll(&base_path, &health_tx),
                         super::core::DiskSpacePollResult::Exhausted { .. }
@@ -434,26 +483,44 @@ impl WindowsFragmentedM4SMuxer {
 
                     let convert_start = std::time::Instant::now();
 
-                    let (ffmpeg_frame, timestamp) = match video_rx.recv_timeout(frame_interval) {
-                        Ok(Some((frame, ts))) => match frame.as_ffmpeg() {
-                            Ok(f) => {
-                                last_ffmpeg_frame = Some(f.clone());
-                                last_timestamp = Some(ts);
-                                (Some(f), ts)
-                            }
-                            Err(e) => {
-                                warn!("Failed to convert D3D11 frame: {e:?}");
-                                match (&last_ffmpeg_frame, last_timestamp) {
-                                    (Some(f), Some(last_ts)) => {
-                                        let new_ts = last_ts.saturating_add(frame_interval);
-                                        last_timestamp = Some(new_ts);
-                                        duplicated_frames += 1;
-                                        (Some(f.clone()), new_ts)
-                                    }
-                                    _ => (None, Duration::ZERO),
+                    let (ffmpeg_frame, timestamp) = match recv_latest_screen_frame(
+                        &video_rx,
+                        frame_interval,
+                    ) {
+                        Ok(Some(latest)) => {
+                            if latest.stale_frames > 0 {
+                                stale_frames_dropped += latest.stale_frames;
+                                if stale_frames_dropped <= 5
+                                    || stale_frames_dropped.is_multiple_of(120)
+                                {
+                                    debug!(
+                                        stale_frames = latest.stale_frames,
+                                        total_stale_frames = stale_frames_dropped,
+                                        "Dropped stale queued screen frames before encoding latest"
+                                    );
                                 }
                             }
-                        },
+                            pending_end_after_frame = latest.end_after_frame;
+                            match latest.frame.as_ffmpeg() {
+                                Ok(f) => {
+                                    last_ffmpeg_frame = Some(f.clone());
+                                    last_timestamp = Some(latest.timestamp);
+                                    (Some(f), latest.timestamp)
+                                }
+                                Err(e) => {
+                                    warn!("Failed to convert D3D11 frame: {e:?}");
+                                    match (&last_ffmpeg_frame, last_timestamp) {
+                                        (Some(f), Some(last_ts)) => {
+                                            let new_ts = last_ts.saturating_add(frame_interval);
+                                            last_timestamp = Some(new_ts);
+                                            duplicated_frames += 1;
+                                            (Some(f.clone()), new_ts)
+                                        }
+                                        _ => (None, Duration::ZERO),
+                                    }
+                                }
+                            }
+                        }
                         Ok(None) | Err(RecvTimeoutError::Disconnected) => {
                             let mut drained = 0u64;
                             let drain_start = std::time::Instant::now();
@@ -550,6 +617,7 @@ impl WindowsFragmentedM4SMuxer {
                     debug!(
                         total_frames = total_frames,
                         duplicated_frames = duplicated_frames,
+                        stale_frames_dropped = stale_frames_dropped,
                         slow_converts = slow_convert_count,
                         slow_encodes = slow_encode_count,
                         slow_convert_pct = format!(
@@ -601,11 +669,17 @@ impl VideoMuxer for WindowsFragmentedM4SMuxer {
         };
 
         if let Some(state) = &self.state {
-            match state.video_tx.send(Some((frame.frame, adjusted_timestamp))) {
+            match state
+                .video_tx
+                .try_send(Some((frame.frame, adjusted_timestamp)))
+            {
                 Ok(()) => {
                     self.frame_drops.record_frame();
                 }
-                Err(_) => {
+                Err(TrySendError::Full(_)) => {
+                    self.frame_drops.record_drop();
+                }
+                Err(TrySendError::Disconnected(_)) => {
                     return Err(anyhow!("Windows M4S encoder channel disconnected"));
                 }
             }

--- a/crates/recording/src/output_pipeline/win_segmented.rs
+++ b/crates/recording/src/output_pipeline/win_segmented.rs
@@ -8,7 +8,7 @@ use std::{
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
-        mpsc::{SyncSender, sync_channel},
+        mpsc::{RecvError, SyncSender, TryRecvError, sync_channel},
     },
     thread::JoinHandle,
     time::Duration,
@@ -53,6 +53,46 @@ struct SegmentState {
     video_tx: SyncSender<Option<(screen_capture::ScreenFrame, Duration)>>,
     output: Arc<Mutex<ffmpeg::format::context::Output>>,
     encoder_handle: Option<JoinHandle<anyhow::Result<()>>>,
+}
+
+struct LatestScreenFrame {
+    frame: screen_capture::ScreenFrame,
+    timestamp: Duration,
+    stale_frames: u64,
+    end_after_frame: bool,
+}
+
+fn recv_latest_screen_frame(
+    video_rx: &std::sync::mpsc::Receiver<Option<(screen_capture::ScreenFrame, Duration)>>,
+) -> Result<Option<LatestScreenFrame>, RecvError> {
+    let Some((mut frame, mut timestamp)) = video_rx.recv()? else {
+        return Ok(None);
+    };
+
+    let mut stale_frames = 0;
+    let mut end_after_frame = false;
+    loop {
+        match video_rx.try_recv() {
+            Ok(Some((next_frame, next_timestamp))) => {
+                frame = next_frame;
+                timestamp = next_timestamp;
+                stale_frames += 1;
+            }
+            Ok(None) => {
+                end_after_frame = true;
+                break;
+            }
+            Err(TryRecvError::Empty) => break,
+            Err(TryRecvError::Disconnected) => return Err(RecvError),
+        }
+    }
+
+    Ok(Some(LatestScreenFrame {
+        frame,
+        timestamp,
+        stale_frames,
+        end_after_frame,
+    }))
 }
 
 struct PauseTracker {
@@ -531,23 +571,36 @@ impl WindowsSegmentedMuxer {
                     either::Left((mut encoder, mut muxer)) => {
                         trace!("Running native encoder for segment");
                         let mut first_timestamp: Option<Duration> = None;
+                        let mut pending_end_after_frame = false;
                         let result = encoder.run(
                             Arc::new(AtomicBool::default()),
                             || {
-                                let Ok(Some((frame, timestamp))) = video_rx.recv() else {
+                                if pending_end_after_frame {
+                                    return Ok(None);
+                                }
+
+                                let Ok(Some(latest)) = recv_latest_screen_frame(&video_rx) else {
                                     trace!("No more frames available for segment");
                                     return Ok(None);
                                 };
 
+                                if latest.stale_frames > 0 {
+                                    debug!(
+                                        stale_frames = latest.stale_frames,
+                                        "Dropped stale queued segment screen frames before encoding latest"
+                                    );
+                                }
+                                pending_end_after_frame = latest.end_after_frame;
+
                                 let relative = if let Some(first) = first_timestamp {
-                                    timestamp.checked_sub(first).unwrap_or(Duration::ZERO)
+                                    latest.timestamp.checked_sub(first).unwrap_or(Duration::ZERO)
                                 } else {
-                                    first_timestamp = Some(timestamp);
+                                    first_timestamp = Some(latest.timestamp);
                                     Duration::ZERO
                                 };
                                 let frame_time = duration_to_timespan(relative);
 
-                                Ok(Some((frame.texture().clone(), frame_time)))
+                                Ok(Some((latest.frame.texture().clone(), frame_time)))
                             },
                             |output_sample| {
                                 let mut output = match output_clone.lock() {
@@ -590,19 +643,29 @@ impl WindowsSegmentedMuxer {
                         }
                     }
                     either::Right(mut encoder) => {
-                        while let Ok(Some((frame, time))) = video_rx.recv() {
+                        while let Ok(Some(latest)) = recv_latest_screen_frame(&video_rx) {
+                            if latest.stale_frames > 0 {
+                                debug!(
+                                    stale_frames = latest.stale_frames,
+                                    "Dropped stale queued segment screen frames before encoding latest"
+                                );
+                            }
                             let Ok(mut output) = output_clone.lock() else {
                                 continue;
                             };
 
-                            frame
+                            latest
+                                .frame
                                 .as_ffmpeg()
                                 .context("frame as_ffmpeg")
                                 .and_then(|frame| {
                                     encoder
-                                        .queue_frame(frame, time, &mut output)
+                                        .queue_frame(frame, latest.timestamp, &mut output)
                                         .context("queue_frame")
                                 })?;
+                            if latest.end_after_frame {
+                                break;
+                            }
                         }
 
                         Ok(())

--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -280,8 +280,18 @@ impl RecordingSegmentDecoders {
             camera: camera_path,
         } = segment;
 
+        // Windows studio recordings write video packets with recording-epoch timestamps,
+        // so the finalized tracks already share one timeline that starts at the epoch.
+        // Applying `latest_start_time` on top (which assumes first-frame-rebased tracks,
+        // as produced on macOS) double-counts the capture startup delay and makes the
+        // rendered cursor run ahead of the screen content by that delay.
+        let recorded_on_windows = matches!(
+            _recording_meta.platform,
+            Some(cap_project::Platform::Windows)
+        );
         let latest_start_time = match &meta {
             StudioRecordingMeta::SingleSegment { .. } => None,
+            StudioRecordingMeta::MultipleSegments { .. } if recorded_on_windows => None,
             StudioRecordingMeta::MultipleSegments { inner, .. } => {
                 inner.segments[segment_i].latest_start_time()
             }

--- a/scripts/build-desktop-binaries.mjs
+++ b/scripts/build-desktop-binaries.mjs
@@ -92,6 +92,7 @@ async function main() {
 				path.join(repoRoot, "crates", "media"),
 				path.join(repoRoot, "crates", "media-info"),
 				path.join(repoRoot, "crates", "project"),
+				path.join(repoRoot, "crates", "recording"),
 				path.join(repoRoot, "crates", "rendering"),
 				path.join(repoRoot, "Cargo.lock"),
 			],


### PR DESCRIPTION
## Summary

This PR stabilizes Windows screen recordings by keeping encoded screen frames close to the latest captured frame instead of preserving a stale backlog.

## Root cause

On Windows, the screen-frame channel could buffer several seconds of frames under encoder or muxer backpressure. Cursor events continued to follow wall-clock recording time, while the video encoder could still be consuming older screen frames. That made exported recordings look like the cursor was ahead of the screen content, and it also made recordings feel laggy under load.

Windows multi-segment studio recordings also already use recording-epoch timestamps for video packets. Applying `latest_start_time` again during rendering double-counted capture startup delay and could push the rendered cursor ahead of the screen.

## What changed

- Reduce the default Windows muxer buffer size from 240 frames to 8 frames.
- Drain stale queued screen frames and encode the latest available frame in Windows output pipelines.
- Make fragmented/OOP video frame handoff use non-blocking sends so backpressure drops stale frames instead of blocking capture.
- Skip macOS-style `latest_start_time` offset for Windows multi-segment studio recordings.
- Include `crates/recording` in the desktop sidecar rebuild dependency list so recording pipeline changes rebuild the binary.

## Validation

- `cargo fmt --all --check`
- `cargo check -p cap-recording --lib`
- `cargo test --lib -p cap-rendering -p cap-project -p cap-recording`

