### PR TITLE
fix(infra): remove broken wget healthcheck override for media-server

### DIFF
--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -46,12 +46,6 @@ services:
     environment:
       PORT: 3456
       MEDIA_SERVER_WEBHOOK_SECRET: ${MEDIA_SERVER_WEBHOOK_SECRET}
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3456/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
     networks:
       - cap-network
 

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -60,12 +60,6 @@ services:
       MEDIA_SERVER_WEBHOOK_SECRET: fe337b52749070bb7b5d2c78cff9948439ea73cbc1869ba39d350e6c24db53b1
     ports:
       - "3456:3456"
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3456/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
 
   # Local S3 Strorage
   minio:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,12 +48,6 @@ services:
     environment:
       PORT: 3456
       MEDIA_SERVER_WEBHOOK_SECRET: ${MEDIA_SERVER_WEBHOOK_SECRET:-fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210}
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3456/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
     networks:
       - cap-network
 


### PR DESCRIPTION
## Problem

`cap-media-server` reports **unhealthy** in every docker-compose based deployment (`docker-compose.yml`, `docker-compose.coolify.yml`, `docker-compose.template.yml`), even though the service itself is fully functional. Querying `/health` directly (e.g. from another container on the same network) returns:

```json
{"status":"ok","mediaEngine":{"available":true,...},"ffmpeg":{"available":true,...}}
```

## Root cause

The compose `healthcheck:` for `media-server` shells out to `wget`:

```yaml
healthcheck:
  test: ["CMD", "wget", "-qO-", "http://localhost:3456/health"]
```

but `apps/media-server/Dockerfile` is `FROM oven/bun:1`, which never installs `wget`. Every healthcheck invocation fails immediately:

```
OCI runtime exec failed: exec: "wget": executable file not found in $PATH
```

This permanently marks the container unhealthy regardless of actual application state — including for anything downstream that keys off container health (`depends_on: condition: service_healthy`, monitoring/alerting, etc.).

The Dockerfile already defines a correct healthcheck:

```dockerfile
HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
	CMD ["bun", "-e", "const response = await fetch(`http://localhost:${process.env.PORT || 3456}/health`); process.exit(response.ok ? 0 : 1)"]
```

but Compose's `healthcheck:` stanza overrides the image's built-in `HEALTHCHECK` rather than falling back to it, so this correct check never runs for anyone deploying via any of the three compose files.

## Fix

Remove the redundant, broken `healthcheck:` override for `media-server` from all three compose files, so each deployment inherits the image's own correct `HEALTHCHECK` instead of duplicating (and silently breaking) the same logic in three places.

## Testing

Applied this change against a running self-hosted instance and recreated the `media-server` container:

```
$ docker inspect cap-media-server --format '{{json .Config.Healthcheck}}'
{"Test":["CMD","bun","-e","...fetch(...)..."],...}

$ docker ps --filter name=cap-media-server
cap-media-server   Up 55 seconds (healthy)
```

Confirmed healthy and stable over multiple check intervals (`FailingStreak: 0`), with no other Cap services affected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lets the media server use its image-defined healthcheck. The main changes are:

- Removed the `wget` healthcheck override from `docker-compose.yml`.
- Removed the same override from `docker-compose.coolify.yml`.
- Removed the same override from `docker-compose.template.yml`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The inherited media-server healthcheck exists on the relevant image build path and uses the configured port.
- No compose service currently waits on media-server health for startup ordering.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docker-compose.yml | Removes the local media-server healthcheck override so the standalone Dockerfile healthcheck is used. |
| docker-compose.coolify.yml | Removes the Coolify media-server healthcheck override so the prebuilt image healthcheck is used. |
| docker-compose.template.yml | Removes the template media-server healthcheck override so deployments avoid the missing `wget` check. |

<sub>Reviews (1): Last reviewed commit: ["fix(infra): remove broken wget healthche..."](https://github.com/capsoftware/cap/commit/fc1a142223223ec988c6cde689bdd28157946e32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43712252)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))
- Context used - AGENTS.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=27801409-c24c-4476-9c6c-180f1ef0a7f2))

<!-- /greptile_comment -->