### PR TITLE
hotfix: secure cors auth

### DIFF
--- a/apps/web/test.js
+++ b/apps/web/test.js
@@ -1,0 +1,5 @@
+const { mysqlTable, varchar, datetime } = require("drizzle-orm/mysql-core");
+const table = mysqlTable("test", {
+  expires: datetime("expires"),
+});
+console.log(table.expires.config);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ name: cap
 services:
   cap-web:
     container_name: cap-web
-    image: ghcr.io/capsoftware/cap-web:latest
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
     restart: unless-stopped
     depends_on:
       mysql:

--- a/packages/database/auth/auth-options.ts
+++ b/packages/database/auth/auth-options.ts
@@ -132,16 +132,21 @@ export const authOptions = (): NextAuthOptions => {
 
 			return _providers;
 		},
-		cookies: {
-			sessionToken: {
-				name: `next-auth.session-token`,
-				options: {
-					httpOnly: true,
-					sameSite: "none",
-					path: "/",
-					secure: true,
+		get cookies() {
+			const isSecure =
+				serverEnv().NEXTAUTH_URL?.startsWith("https://") ??
+				process.env.NODE_ENV === "production";
+			return {
+				sessionToken: {
+					name: `next-auth.session-token`,
+					options: {
+						httpOnly: true,
+						sameSite: isSecure ? "none" : "lax",
+						path: "/",
+						secure: isSecure,
+					},
 				},
-			},
+			};
 		},
 		callbacks: {
 			async signIn({ user, email, credentials }) {

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -166,7 +166,7 @@ export const sessions = mysqlTable(
 		id: nanoId("id").notNull().primaryKey(),
 		sessionToken: varchar("sessionToken", { length: 255 }).notNull(),
 		userId: nanoId("userId").notNull().$type<User.UserId>(),
-		expires: datetime("expires").notNull(),
+		expires: datetime("expires", { mode: "date" }).notNull(),
 		created_at: timestamp("created_at").notNull().defaultNow(),
 		updated_at: timestamp("updated_at").notNull().defaultNow().onUpdateNow(),
 	},
@@ -179,7 +179,7 @@ export const sessions = mysqlTable(
 export const verificationTokens = mysqlTable("verification_tokens", {
 	identifier: varchar("identifier", { length: 255 }).primaryKey().notNull(),
 	token: varchar("token", { length: 255 }).unique().notNull(),
-	expires: datetime("expires").notNull(),
+	expires: datetime("expires", { mode: "date" }).notNull(),
 	created_at: timestamp("created_at").notNull().defaultNow(),
 	updated_at: timestamp("updated_at").notNull().defaultNow().onUpdateNow(),
 });

--- a/packages/database/test.ts
+++ b/packages/database/test.ts
@@ -1,0 +1,5 @@
+import { mysqlTable, datetime } from "drizzle-orm/mysql-core";
+const table = mysqlTable("test", {
+  expires: datetime("expires"),
+});
+console.log(table.expires);


### PR DESCRIPTION
## Issue
 Users attempting to sign in using the Email OTP on a plain HTTP staging environment (e.g.,
 http://100.82.247.7:3000) were unable to authenticate. After entering the 6-digit code, the
 verification flow would fail silently in the background, redirecting to
 api/auth/error?error=Verification and throwing a 403 (Forbidden) error, leaving the user
 unauthenticated.

 ## Root Causes
 1. Drizzle ORM Date Type Mismatch (error=Verification): The expires column in the
 verificationTokens and sessions tables was defined using datetime("expires"). In
 drizzle-orm/mysql-core, this defaults to returning a string instead of a JavaScript Date object.
 When NextAuth attempted to validate the token's expiration, it executed invite.expires.valueOf().
 This threw a TypeError against the string, which NextAuth caught and surfaced as a
 VerificationTokenError.
 2. Hardcoded Secure Cookies (The 403 / Session Drop): The NextAuth configuration in auth-options.ts
 hardcoded secure: true and sameSite: "none" for the sessionToken to support cross-origin
 authentication for the desktop app. However, modern browsers aggressively reject Secure cookies
 sent over non-HTTPS connections. As a result, the browser dropped the session cookie entirely
 during HTTP staging tests, failing the callback API request with a 403.

 ## Resolution
 - Enforced Date Mode in Schema: Updated packages/database/schema.ts to explicitly use
 datetime("expires", { mode: "date" }) for both verificationTokens and sessions. This guarantees
 Drizzle returns a native Date object, allowing NextAuth's validation logic to execute successfully.
 - Dynamic Cookie Security: Modified packages/database/auth/auth-options.ts to dynamically configure
 the session cookie based on the protocol of the NEXTAUTH_URL environment variable. It now correctly
 applies secure: true and sameSite: "none" for production HTTPS URLs, while gracefully falling back
 to secure: false and sameSite: "lax" for HTTP environments.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates auth cookie handling and Drizzle date typing. The main changes are:

- Dynamic NextAuth session cookie `secure` and `sameSite` settings.
- `Date` mode for session and verification-token expiration columns.
- Two small Drizzle scratch files under the web and database packages.

<h3>Confidence Score: 4/5</h3>

The auth cookie path and new scratch files need fixes before merging.

- HTTPS deployments behind a proxy can get weaker session cookie settings from an internal `http://` auth URL.
- The new scratch files are in lint or typecheck scope but are not configured tests.
- The Drizzle date-mode change looks aligned with the existing auth adapter contract.

packages/database/auth/auth-options.ts, apps/web/test.js, packages/database/test.ts

<details open><summary><h3>Security Review</h3></summary>

The auth cookie logic can downgrade session cookies for HTTPS deployments that use an internal `http://` `NEXTAUTH_URL`, which can break cross-site OAuth or SSO callbacks.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/database/auth/auth-options.ts | Changes session cookie options from fixed secure cross-site settings to a getter based on `NEXTAUTH_URL`. |
| packages/database/schema.ts | Changes NextAuth session and verification-token expiration columns to Drizzle `Date` mode. |
| apps/web/test.js | Adds a top-level Drizzle scratch file under the web app. |
| packages/database/test.ts | Adds a top-level Drizzle scratch file under the database package. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/database/auth/auth-options.ts:137-139
**Proxy HTTPS Cookies Downgrade**

When production runs behind an HTTPS proxy with an internal `NEXTAUTH_URL` such as `http://localhost:3000`, this sets `isSecure` to `false` and changes the session cookie from the previous `Secure`/`SameSite=None` behavior to non-secure `SameSite=Lax`. Cross-site OAuth or SSO callback requests can then miss the auth cookie or CSRF cookie and fail sign-in.

### Issue 2 of 3
apps/web/test.js:1-5
**Scratch File Breaks Lint**

This new file is not matched by the app's Vitest pattern, but it is still in the workspace Biome scope. The unused `varchar` import, `console.log`, and space indentation can make lint or format checks fail while no test runner executes the file.

### Issue 3 of 3
packages/database/test.ts:1-5
**Scratch File Enters Build**

`packages/database` includes `**/*.ts`, so this top-level scratch file is picked up by typecheck/declaration emit and by Biome even though the package has no test runner for it. The top-level `console.log` and non-tab indentation can fail workspace checks or add an unintended build artifact.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["hotfix: secure cors auth"](https://github.com/capsoftware/cap/commit/4a98e11540682ffa30a4efb0b61efc5cec0d2885) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43751098)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=9a906542-f1fe-42c1-89a2-9f252d96d9f0))
- Context used - AGENTS.md ([source](https://app.greptile.com/cap/github/capsoftware/cap/-/custom-context?memory=27801409-c24c-4476-9c6c-180f1ef0a7f2))

<!-- /greptile_comment -->