### PR TITLE
feat: add desktop teleprompter

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -110,6 +110,7 @@ const DEFAULT_EXCLUDED_WINDOW_TITLES: &[&str] = &[
     "Cap Capture Area",
     "Cap Mode Selection",
     "Cap Recordings Overlay",
+    "Cap Teleprompter",
 ];
 
 pub fn default_excluded_windows() -> Vec<WindowExclusion> {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4911,6 +4911,8 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             clip_thumbnails::get_clip_thumbnail,
             windows::position_traffic_lights,
             windows::set_theme,
+            windows::set_teleprompter_window_level,
+            windows::set_teleprompter_window_opacity,
             windows::apply_macos_liquid_glass_background,
             global_message_dialog,
             show_window,

--- a/apps/desktop/src-tauri/src/platform/macos/mod.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/mod.rs
@@ -26,6 +26,21 @@ pub fn set_window_level(window: tauri::Window, level: objc2_app_kit::NSWindowLev
     });
 }
 
+pub fn set_window_opacity(window: tauri::Window, opacity: f64) {
+    let opacity = opacity.clamp(0.45, 1.0);
+    let c_window = window.clone();
+    _ = window.run_on_main_thread(move || unsafe {
+        use cocoa::base::id;
+        use objc::{msg_send, sel, sel_impl};
+
+        let Ok(ns_win) = c_window.ns_window() else {
+            return;
+        };
+        let ns_win = ns_win as id;
+        let _: () = msg_send![ns_win, setAlphaValue: opacity];
+    });
+}
+
 pub fn apply_squircle_corners(window: &tauri::WebviewWindow, radius: f64) {
     use cocoa::base::{id, nil};
     use cocoa::foundation::NSString;

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -57,6 +57,8 @@ use crate::camera::{CameraPreviewManager, CameraPreviewShape};
 use crate::general_settings;
 use crate::permissions;
 use crate::web_api::AuthedApiError;
+#[cfg(target_os = "macos")]
+use crate::window_exclusion::WindowExclusion;
 use crate::{
     App, CameraWindowOperationLock, CurrentRecordingChanged, EditorRecordingAdded,
     FinalizingRecordings, MutableState, NewStudioRecordingAdded, RecordingStarted, RecordingState,
@@ -1865,6 +1867,16 @@ pub async fn start_recording(
                 } else {
                     window_exclusions
                 };
+
+                let teleprompter_exclusion = WindowExclusion {
+                    bundle_identifier: None,
+                    owner_name: None,
+                    window_title: Some(CapWindowId::Teleprompter.title()),
+                };
+                let mut window_exclusions = window_exclusions;
+                if !window_exclusions.contains(&teleprompter_exclusion) {
+                    window_exclusions.push(teleprompter_exclusion);
+                }
 
                 let mut excluded_window_ids =
                     crate::window_exclusion::resolve_window_ids(&window_exclusions);

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -3255,6 +3255,13 @@ pub fn set_teleprompter_window_level(_window: tauri::Window, _always_on_top: boo
         };
         crate::platform::set_window_level(_window, level);
     }
+
+    #[cfg(not(target_os = "macos"))]
+    if _window.label() == CapWindowId::Teleprompter.to_string()
+        && let Err(error) = _window.set_always_on_top(_always_on_top)
+    {
+        warn!(?error, "Failed to update teleprompter window level");
+    }
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -45,6 +45,12 @@ use cap_recording::{feeds, sources::screen_capture::ScreenCaptureTarget};
 #[cfg(target_os = "macos")]
 const DEFAULT_TRAFFIC_LIGHTS_INSET: LogicalPosition<f64> = LogicalPosition::new(12.0, 12.0);
 
+#[cfg(target_os = "macos")]
+const MAIN_PANEL_LEVEL: i32 = 100;
+
+#[cfg(target_os = "macos")]
+const TELEPROMPTER_PANEL_LEVEL: objc2_app_kit::NSWindowLevel = MAIN_PANEL_LEVEL as isize + 1;
+
 const DEFAULT_FALLBACK_DISPLAY_WIDTH: f64 = 1920.0;
 const DEFAULT_FALLBACK_DISPLAY_HEIGHT: f64 = 1080.0;
 
@@ -937,6 +943,7 @@ pub enum CapWindowId {
     Debug,
     ScreenshotEditor { id: u32 },
     Onboarding,
+    Teleprompter,
 }
 
 impl FromStr for CapWindowId {
@@ -955,6 +962,7 @@ impl FromStr for CapWindowId {
             "mode-select" => Self::ModeSelect,
             "debug" => Self::Debug,
             "onboarding" => Self::Onboarding,
+            "teleprompter" => Self::Teleprompter,
             s if s.starts_with("editor-") => Self::Editor {
                 id: s
                     .replace("editor-", "")
@@ -1005,6 +1013,7 @@ impl std::fmt::Display for CapWindowId {
             Self::Debug => write!(f, "debug"),
             Self::ScreenshotEditor { id } => write!(f, "screenshot-editor-{id}"),
             Self::Onboarding => write!(f, "onboarding"),
+            Self::Teleprompter => write!(f, "teleprompter"),
         }
     }
 }
@@ -1027,6 +1036,7 @@ impl CapWindowId {
             Self::Camera => "Cap Camera".to_string(),
             Self::RecordingsOverlay => "Cap Recordings Overlay".to_string(),
             Self::TargetSelectOverlay { .. } => "Cap Target Select".to_string(),
+            Self::Teleprompter => "Cap Teleprompter".to_string(),
             _ => "Cap".to_string(),
         }
     }
@@ -1087,6 +1097,7 @@ impl CapWindowId {
             | Self::RecordingControls
             | Self::TargetSelectOverlay { .. } => None,
             Self::Settings => Some(Some(LogicalPosition::new(22.0, 22.0))),
+            Self::Teleprompter => Some(Some(LogicalPosition::new(14.0, 14.0))),
             _ => Some(None),
         }
     }
@@ -1619,8 +1630,6 @@ impl ShowCapWindow {
                             use tauri_nspanel::cocoa::appkit::NSWindowCollectionBehavior;
                             use tauri_nspanel::panel_delegate;
                             use crate::panel_manager::try_to_panel;
-
-                            const MAIN_PANEL_LEVEL: i32 = 100;
 
                             let delegate = panel_delegate!(MainPanelDelegate {
                                 window_did_become_key,
@@ -3233,6 +3242,31 @@ pub fn position_traffic_lights(_window: tauri::Window, _controls_inset: Option<(
     );
 }
 
+#[tauri::command]
+#[specta::specta]
+#[instrument(skip(_window))]
+pub fn set_teleprompter_window_level(_window: tauri::Window, _always_on_top: bool) {
+    #[cfg(target_os = "macos")]
+    if _window.label() == CapWindowId::Teleprompter.to_string() {
+        let level = if _always_on_top {
+            TELEPROMPTER_PANEL_LEVEL
+        } else {
+            objc2_app_kit::NSNormalWindowLevel
+        };
+        crate::platform::set_window_level(_window, level);
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+#[instrument(skip(_window))]
+pub fn set_teleprompter_window_opacity(_window: tauri::Window, _opacity: f64) {
+    #[cfg(target_os = "macos")]
+    if _window.label() == CapWindowId::Teleprompter.to_string() {
+        crate::platform::set_window_opacity(_window, _opacity);
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn position_traffic_lights_impl(
     window: &tauri::Window,
@@ -3305,7 +3339,11 @@ fn content_protection_enabled(app: &AppHandle<Wry>) -> bool {
         .unwrap_or(false)
 }
 
-fn window_matches_exclusion_list(app: &AppHandle<Wry>, window_title: &str) -> bool {
+fn window_capture_excluded(app: &AppHandle<Wry>, window_title: &str) -> bool {
+    if window_title == CapWindowId::Teleprompter.title() {
+        return true;
+    }
+
     let matches = |list: &[WindowExclusion]| {
         list.iter()
             .any(|entry| entry.matches(None, None, Some(window_title)))
@@ -3321,7 +3359,7 @@ fn window_matches_exclusion_list(app: &AppHandle<Wry>, window_title: &str) -> bo
 fn should_protect_window(app: &AppHandle<Wry>, window_title: &str) -> bool {
     content_protection_enabled(app)
         && !capture_exclusion_hides_ui()
-        && window_matches_exclusion_list(app, window_title)
+        && window_capture_excluded(app, window_title)
 }
 
 pub fn apply_content_protection(app: &AppHandle<Wry>, enabled: bool) {
@@ -3343,7 +3381,7 @@ pub fn apply_content_protection(app: &AppHandle<Wry>, enabled: bool) {
         }
 
         let title = id.title();
-        let should_protect = enabled && window_matches_exclusion_list(app, &title);
+        let should_protect = enabled && window_capture_excluded(app, &title);
         let _ = window.set_content_protected(should_protect);
 
         #[cfg(target_os = "windows")]

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -95,6 +95,7 @@ const TargetSelectOverlayPage = lazy(
 const WindowCaptureOccluderPage = lazy(
 	() => import("./routes/window-capture-occluder"),
 );
+const TeleprompterPage = lazy(() => import("./routes/teleprompter"));
 
 const queryClient = new QueryClient({
 	defaultOptions: {
@@ -247,6 +248,11 @@ function Inner() {
 					<Route
 						path="/window-capture-occluder"
 						component={WindowCaptureOccluderPage}
+					/>
+					<Route
+						path="/teleprompter"
+						info={{ AUTO_SHOW_WINDOW: false }}
+						component={TeleprompterPage}
 					/>
 				</Router>
 			</CapErrorBoundary>

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -79,6 +79,7 @@ import {
 	type UpdateCheckResult,
 	type UploadProgress,
 } from "~/utils/tauri";
+import { openTeleprompter } from "~/utils/teleprompter";
 import IconCapLogoFull from "~icons/cap/logo-full";
 import IconCapLogoFullDark from "~icons/cap/logo-full-dark";
 import IconLucideAppWindowMac from "~icons/lucide/app-window-mac";
@@ -87,6 +88,7 @@ import IconLucideBug from "~icons/lucide/bug";
 import IconLucideCircleHelp from "~icons/lucide/circle-help";
 import IconLucideImage from "~icons/lucide/image";
 import IconLucideImport from "~icons/lucide/import";
+import IconLucideScanText from "~icons/lucide/scan-text";
 import IconLucideSearch from "~icons/lucide/search";
 import IconLucideSettings from "~icons/lucide/settings";
 import IconLucideSquarePlay from "~icons/lucide/square-play";
@@ -2777,6 +2779,16 @@ function Page() {
 								class="flex justify-center items-center size-5 focus:outline-hidden"
 							>
 								<IconLucideSquarePlay class="transition-colors text-gray-11 size-4 hover:text-gray-12" />
+							</button>
+						</Tooltip>
+						<Tooltip content={<span>Teleprompter</span>}>
+							<button
+								type="button"
+								onClick={() => void openTeleprompter()}
+								class="flex justify-center items-center size-5 focus:outline-hidden"
+								aria-label="Open teleprompter"
+							>
+								<IconLucideScanText class="transition-colors text-gray-11 size-4 hover:text-gray-12" />
 							</button>
 						</Tooltip>
 						<ChangelogButton />

--- a/apps/desktop/src/routes/teleprompter-utils.test.ts
+++ b/apps/desktop/src/routes/teleprompter-utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+	advancePlaybackPosition,
+	calculatePlaybackSpeed,
+	clamp,
+	countWords,
+} from "./teleprompter-utils";
+
+describe("teleprompter utilities", () => {
+	it("counts words in pasted scripts", () => {
+		expect(countWords("  One   two\nthree ")).toBe(3);
+		expect(countWords(" ")).toBe(0);
+	});
+
+	it("clamps a setting to its supported range", () => {
+		expect(clamp(5, 10, 20)).toBe(10);
+		expect(clamp(25, 10, 20)).toBe(20);
+	});
+
+	it("calculates a positive scroll speed from reading duration", () => {
+		expect(calculatePlaybackSpeed(600, 300, 150)).toBe(5);
+		expect(calculatePlaybackSpeed(-10, 300, 150)).toBe(0);
+	});
+
+	it("retains sub-pixel movement across animation frames", () => {
+		let position = 0;
+		for (let frame = 0; frame < 60; frame += 1) {
+			position = advancePlaybackPosition(position, 100, 10, 1 / 60);
+		}
+
+		expect(position).toBeCloseTo(10);
+	});
+});

--- a/apps/desktop/src/routes/teleprompter-utils.ts
+++ b/apps/desktop/src/routes/teleprompter-utils.ts
@@ -1,0 +1,30 @@
+export function countWords(text: string) {
+	return text.trim() ? text.trim().split(/\s+/u).length : 0;
+}
+
+export function clamp(value: number, minimum: number, maximum: number) {
+	return Math.min(Math.max(value, minimum), maximum);
+}
+
+export function calculatePlaybackSpeed(
+	maximumScroll: number,
+	wordCount: number,
+	wordsPerMinute: number,
+) {
+	const durationSeconds =
+		(Math.max(1, wordCount) / Math.max(1, wordsPerMinute)) * 60;
+	return Math.max(0, maximumScroll) / Math.max(1, durationSeconds);
+}
+
+export function advancePlaybackPosition(
+	position: number,
+	maximumScroll: number,
+	pixelsPerSecond: number,
+	elapsedSeconds: number,
+) {
+	return Math.min(
+		Math.max(0, maximumScroll),
+		Math.max(0, position) +
+			Math.max(0, pixelsPerSecond) * Math.max(0, elapsedSeconds),
+	);
+}

--- a/apps/desktop/src/routes/teleprompter.tsx
+++ b/apps/desktop/src/routes/teleprompter.tsx
@@ -125,7 +125,6 @@ export default function Teleprompter() {
 			}),
 		])
 			.then(async () => {
-				await currentWindow.setAlwaysOnTop(true);
 				await commands.setTeleprompterWindowLevel(true);
 				await currentWindow.show();
 				await currentWindow.setFocus();

--- a/apps/desktop/src/routes/teleprompter.tsx
+++ b/apps/desktop/src/routes/teleprompter.tsx
@@ -15,7 +15,11 @@ import {
 import { Toggle } from "~/components/Toggle";
 import CaptionControlsMacOS from "~/components/titlebar/controls/CaptionControlsMacOS";
 import CaptionControlsWindows11 from "~/components/titlebar/controls/CaptionControlsWindows11";
-import { type TeleprompterStore, teleprompterStore } from "~/store";
+import {
+	type TeleprompterStore,
+	teleprompterDefaults,
+	teleprompterStore,
+} from "~/store";
 import { applyMacOSWindowMaterial } from "~/utils/macos-window-material";
 import { commands } from "~/utils/tauri";
 import { initializeTitlebar } from "~/utils/titlebar-state";
@@ -36,16 +40,6 @@ import {
 	clamp,
 	countWords,
 } from "./teleprompter-utils";
-
-const DEFAULT_STATE: TeleprompterStore = {
-	script: "",
-	fontSize: 30,
-	wordsPerMinute: 150,
-	lineHeight: 1.5,
-	showCueMarkers: true,
-	mirror: false,
-	windowOpacityPercent: 92,
-};
 
 function ToolButton(props: {
 	label: string;
@@ -99,7 +93,8 @@ export default function Teleprompter() {
 	const isMacOS = platform === "macos";
 	const isWindows = platform === "windows";
 	const isLinux = platform === "linux";
-	const [state, setState] = createSignal<TeleprompterStore>(DEFAULT_STATE);
+	const [state, setState] =
+		createSignal<TeleprompterStore>(teleprompterDefaults);
 	const [isLoaded, setIsLoaded] = createSignal(false);
 	const [isPlaying, setIsPlaying] = createSignal(false);
 	const [settingsOpen, setSettingsOpen] = createSignal(false);
@@ -142,7 +137,7 @@ export default function Teleprompter() {
 		void teleprompterStore
 			.get()
 			.then((saved) => {
-				if (saved) setState({ ...DEFAULT_STATE, ...saved });
+				if (saved) setState({ ...teleprompterDefaults, ...saved });
 				setIsLoaded(true);
 				requestAnimationFrame(resizeEditor);
 			})

--- a/apps/desktop/src/routes/teleprompter.tsx
+++ b/apps/desktop/src/routes/teleprompter.tsx
@@ -102,12 +102,14 @@ export default function Teleprompter() {
 	let editorElement: HTMLTextAreaElement | undefined;
 	let saveTimer: ReturnType<typeof setTimeout> | undefined;
 	let unlistenTitlebar: UnlistenFn | undefined;
+	let unlistenCloseRequested: UnlistenFn | undefined;
 	let resizeObserver: ResizeObserver | undefined;
 	let playbackFrame = 0;
 	let playbackPosition = 0;
 	let playbackTimestamp: number | undefined;
 	let allowClose = false;
 	let closePending = false;
+	let disposed = false;
 
 	const hasScript = createMemo(() => state().script.trim().length > 0);
 	const wordCount = createMemo(() => countWords(state().script));
@@ -154,25 +156,31 @@ export default function Teleprompter() {
 		}
 	});
 
-	onMount(async () => {
-		const unlisten = await currentWindow.onCloseRequested(async (event) => {
-			if (allowClose) return;
-			event.preventDefault();
-			if (closePending) return;
+	onMount(() => {
+		void currentWindow
+			.onCloseRequested(async (event) => {
+				if (allowClose) return;
+				event.preventDefault();
+				if (closePending) return;
 
-			closePending = true;
-			clearTimeout(saveTimer);
-			try {
-				if (isLoaded()) await teleprompterStore.set(state());
-			} catch (error) {
-				console.error("Failed to save teleprompter before closing:", error);
-			} finally {
-				allowClose = true;
-				await currentWindow.close();
-			}
-		});
-
-		onCleanup(() => unlisten());
+				closePending = true;
+				clearTimeout(saveTimer);
+				try {
+					if (isLoaded()) await teleprompterStore.set(state());
+				} catch (error) {
+					console.error("Failed to save teleprompter before closing:", error);
+				} finally {
+					allowClose = true;
+					await currentWindow.close();
+				}
+			})
+			.then((unlisten) => {
+				if (disposed) unlisten();
+				else unlistenCloseRequested = unlisten;
+			})
+			.catch((error) => {
+				console.error("Failed to register teleprompter close handler:", error);
+			});
 	});
 
 	createEffect(() => {
@@ -193,11 +201,13 @@ export default function Teleprompter() {
 	});
 
 	onCleanup(() => {
-		clearTimeout(saveTimer);
+		disposed = true;
 		if (isLoaded() && !allowClose) void teleprompterStore.set(state());
+		clearTimeout(saveTimer);
 		cancelAnimationFrame(playbackFrame);
 		resizeObserver?.disconnect();
 		unlistenTitlebar?.();
+		unlistenCloseRequested?.();
 	});
 
 	function resizeEditor() {

--- a/apps/desktop/src/routes/teleprompter.tsx
+++ b/apps/desktop/src/routes/teleprompter.tsx
@@ -1,0 +1,473 @@
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { type as ostype } from "@tauri-apps/plugin-os";
+import { cx } from "cva";
+import {
+	createEffect,
+	createMemo,
+	createSignal,
+	type JSX,
+	onCleanup,
+	onMount,
+	Show,
+} from "solid-js";
+
+import { Toggle } from "~/components/Toggle";
+import CaptionControlsMacOS from "~/components/titlebar/controls/CaptionControlsMacOS";
+import CaptionControlsWindows11 from "~/components/titlebar/controls/CaptionControlsWindows11";
+import { type TeleprompterStore, teleprompterStore } from "~/store";
+import { applyMacOSWindowMaterial } from "~/utils/macos-window-material";
+import { commands } from "~/utils/tauri";
+import { initializeTitlebar } from "~/utils/titlebar-state";
+import IconLucideChevronLeft from "~icons/lucide/chevron-left";
+import IconLucideChevronRight from "~icons/lucide/chevron-right";
+import IconLucideEyeOff from "~icons/lucide/eye-off";
+import IconLucideFlipHorizontal2 from "~icons/lucide/flip-horizontal-2";
+import IconLucideGauge from "~icons/lucide/gauge";
+import IconLucideLayers from "~icons/lucide/layers";
+import IconLucideMinus from "~icons/lucide/minus";
+import IconLucidePause from "~icons/lucide/pause";
+import IconLucidePlay from "~icons/lucide/play";
+import IconLucidePlus from "~icons/lucide/plus";
+import IconLucideSettings2 from "~icons/lucide/settings-2";
+import {
+	advancePlaybackPosition,
+	calculatePlaybackSpeed,
+	clamp,
+	countWords,
+} from "./teleprompter-utils";
+
+const DEFAULT_STATE: TeleprompterStore = {
+	script: "",
+	fontSize: 30,
+	wordsPerMinute: 150,
+	lineHeight: 1.5,
+	showCueMarkers: true,
+	mirror: false,
+	windowOpacityPercent: 92,
+};
+
+function ToolButton(props: {
+	label: string;
+	active?: boolean;
+	disabled?: boolean;
+	onClick: () => void;
+	children: JSX.Element;
+}) {
+	return (
+		<button
+			type="button"
+			title={props.label}
+			aria-label={props.label}
+			disabled={props.disabled}
+			onClick={props.onClick}
+			class={cx(
+				"flex size-7 items-center justify-center rounded-full text-gray-9 transition hover:bg-gray-12/7 hover:text-gray-12 disabled:cursor-not-allowed disabled:opacity-30",
+				props.active && "bg-gray-12/8 text-gray-12",
+			)}
+		>
+			{props.children}
+		</button>
+	);
+}
+
+function SettingToggle(props: {
+	label: string;
+	active: boolean;
+	onChange: (active: boolean) => void;
+	children: JSX.Element;
+}) {
+	return (
+		<div class="flex items-center justify-between px-2 py-2 text-xs text-gray-10">
+			<span class="flex items-center gap-2">
+				{props.children}
+				{props.label}
+			</span>
+			<Toggle
+				size="sm"
+				checked={props.active}
+				onChange={props.onChange}
+				aria-label={props.label}
+			/>
+		</div>
+	);
+}
+
+export default function Teleprompter() {
+	const currentWindow = getCurrentWebviewWindow();
+	const platform = ostype();
+	const isMacOS = platform === "macos";
+	const isWindows = platform === "windows";
+	const isLinux = platform === "linux";
+	const [state, setState] = createSignal<TeleprompterStore>(DEFAULT_STATE);
+	const [isLoaded, setIsLoaded] = createSignal(false);
+	const [isPlaying, setIsPlaying] = createSignal(false);
+	const [settingsOpen, setSettingsOpen] = createSignal(false);
+	let scrollElement: HTMLDivElement | undefined;
+	let editorElement: HTMLTextAreaElement | undefined;
+	let saveTimer: ReturnType<typeof setTimeout> | undefined;
+	let unlistenTitlebar: UnlistenFn | undefined;
+	let resizeObserver: ResizeObserver | undefined;
+	let playbackFrame = 0;
+	let playbackPosition = 0;
+	let playbackTimestamp: number | undefined;
+
+	const hasScript = createMemo(() => state().script.trim().length > 0);
+	const wordCount = createMemo(() => countWords(state().script));
+	const spacerHeight = createMemo(
+		() =>
+			`calc((100vh - 5rem) / 2 - ${state().fontSize * state().lineHeight * 0.5}px)`,
+	);
+
+	onMount(() => {
+		document.documentElement.setAttribute("data-transparent-window", "true");
+		document.body.style.background = "transparent";
+
+		void Promise.allSettled([
+			applyMacOSWindowMaterial("teleprompter"),
+			initializeTitlebar().then((unlisten) => {
+				unlistenTitlebar = unlisten;
+			}),
+		])
+			.then(async () => {
+				await currentWindow.setAlwaysOnTop(true);
+				await commands.setTeleprompterWindowLevel(true);
+				await currentWindow.show();
+				await currentWindow.setFocus();
+			})
+			.catch((error) => {
+				console.error("Failed to show teleprompter window:", error);
+			});
+
+		void teleprompterStore
+			.get()
+			.then((saved) => {
+				if (saved) setState({ ...DEFAULT_STATE, ...saved });
+				setIsLoaded(true);
+				requestAnimationFrame(resizeEditor);
+			})
+			.catch((error) => {
+				console.error("Failed to load teleprompter settings:", error);
+				setIsLoaded(true);
+				requestAnimationFrame(resizeEditor);
+			});
+
+		if (scrollElement) {
+			resizeObserver = new ResizeObserver(resizeEditor);
+			resizeObserver.observe(scrollElement);
+		}
+	});
+
+	createEffect(() => {
+		if (!isLoaded()) return;
+		const nextState = state();
+		clearTimeout(saveTimer);
+		saveTimer = setTimeout(() => {
+			void teleprompterStore.set(nextState);
+		}, 250);
+	});
+
+	createEffect(() => {
+		if (!isLoaded() || !isMacOS) return;
+		const opacity = clamp(state().windowOpacityPercent, 45, 100) / 100;
+		void commands.setTeleprompterWindowOpacity(opacity).catch((error) => {
+			console.error("Failed to update teleprompter window opacity:", error);
+		});
+	});
+
+	onCleanup(() => {
+		clearTimeout(saveTimer);
+		cancelAnimationFrame(playbackFrame);
+		resizeObserver?.disconnect();
+		unlistenTitlebar?.();
+	});
+
+	function resizeEditor() {
+		const element = editorElement;
+		if (!element) return;
+		element.style.height = "0px";
+		element.style.height = `${element.scrollHeight}px`;
+	}
+
+	function stopPlayback() {
+		cancelAnimationFrame(playbackFrame);
+		playbackFrame = 0;
+		playbackTimestamp = undefined;
+		setIsPlaying(false);
+	}
+
+	function animatePlayback(timestamp: number) {
+		const element = scrollElement;
+		if (!element) {
+			stopPlayback();
+			return;
+		}
+
+		const maximumScroll = Math.max(
+			0,
+			element.scrollHeight - element.clientHeight,
+		);
+		if (maximumScroll <= 1) {
+			stopPlayback();
+			return;
+		}
+
+		const elapsedSeconds =
+			playbackTimestamp === undefined
+				? 0
+				: Math.min((timestamp - playbackTimestamp) / 1000, 0.05);
+		playbackTimestamp = timestamp;
+		playbackPosition = advancePlaybackPosition(
+			playbackPosition,
+			maximumScroll,
+			calculatePlaybackSpeed(
+				maximumScroll,
+				wordCount(),
+				state().wordsPerMinute,
+			),
+			elapsedSeconds,
+		);
+		element.scrollTop = playbackPosition;
+
+		if (playbackPosition >= maximumScroll - 0.5) {
+			stopPlayback();
+			return;
+		}
+
+		playbackFrame = requestAnimationFrame(animatePlayback);
+	}
+
+	function updateScript(value: string) {
+		setState((current) => ({ ...current, script: value }));
+		if (!value.trim()) stopPlayback();
+		requestAnimationFrame(resizeEditor);
+	}
+
+	function togglePlayback() {
+		if (isPlaying()) {
+			stopPlayback();
+			return;
+		}
+
+		resizeEditor();
+		const element = scrollElement;
+		if (!element || !hasScript()) return;
+		const maximumScroll = Math.max(
+			0,
+			element.scrollHeight - element.clientHeight,
+		);
+		if (maximumScroll <= 1) return;
+		if (element.scrollTop >= maximumScroll - 1) element.scrollTop = 0;
+		playbackPosition = element.scrollTop;
+		setSettingsOpen(false);
+		setIsPlaying(true);
+		playbackTimestamp = undefined;
+		playbackFrame = requestAnimationFrame(animatePlayback);
+	}
+
+	function changeFontSize(delta: number) {
+		setState((current) => ({
+			...current,
+			fontSize: clamp(current.fontSize + delta, 22, 52),
+		}));
+		requestAnimationFrame(resizeEditor);
+	}
+
+	return (
+		<div
+			onKeyDown={(event) => {
+				if (event.key === "Escape") setSettingsOpen(false);
+			}}
+			class={cx(
+				"cap-window-shell relative flex h-screen w-screen flex-col overflow-hidden text-gray-12",
+				!isMacOS &&
+					"rounded-2xl border border-gray-5 bg-gray-1/90 shadow-2xl backdrop-blur-2xl",
+			)}
+			style={{
+				opacity: isMacOS
+					? "1"
+					: `${clamp(state().windowOpacityPercent, 45, 100) / 100}`,
+			}}
+		>
+			<header
+				data-tauri-drag-region
+				class="cap-window-header flex h-9 shrink-0 items-center"
+			>
+				<Show when={isLinux}>
+					<CaptionControlsMacOS
+						class="ml-3"
+						showMinimize={false}
+						showZoom={false}
+					/>
+				</Show>
+				<div
+					data-tauri-drag-region
+					class={cx(
+						"pointer-events-none ml-auto flex items-center gap-1.5 text-[10px] text-gray-9",
+						isWindows ? "mr-1" : "mr-3",
+					)}
+				>
+					<IconLucideEyeOff class="size-3" />
+					<span>
+						{isLinux
+							? "This window may appear in recordings on Linux"
+							: "This window is hidden from Cap recordings"}
+					</span>
+				</div>
+				<Show when={isWindows}>
+					<CaptionControlsWindows11 />
+				</Show>
+			</header>
+
+			<main class="cap-window-body relative min-h-0 flex-1 overflow-hidden">
+				<Show when={state().showCueMarkers}>
+					<div class="pointer-events-none absolute inset-x-3 top-1/2 z-20 flex -translate-y-1/2 items-center justify-between text-blue-10/75 drop-shadow-sm">
+						<IconLucideChevronRight class="size-4" />
+						<IconLucideChevronLeft class="size-4" />
+					</div>
+				</Show>
+				<div
+					ref={scrollElement}
+					onClick={() => editorElement?.focus()}
+					class={cx(
+						"relative z-10 h-full w-full overflow-y-auto overscroll-contain scrollbar-none",
+						state().mirror && "scale-x-[-1]",
+					)}
+					style={{
+						"mask-image":
+							"linear-gradient(to bottom, rgba(0, 0, 0, 0.4) 0%, black 34%, black 66%, rgba(0, 0, 0, 0.4) 100%)",
+						"-webkit-mask-image":
+							"linear-gradient(to bottom, rgba(0, 0, 0, 0.4) 0%, black 34%, black 66%, rgba(0, 0, 0, 0.4) 100%)",
+					}}
+				>
+					<div aria-hidden="true" style={{ height: spacerHeight() }} />
+					<textarea
+						ref={editorElement}
+						autofocus
+						rows={1}
+						spellcheck={true}
+						value={state().script}
+						onInput={(event) => updateScript(event.currentTarget.value)}
+						placeholder="Paste or type your script…"
+						class="block w-full resize-none overflow-hidden bg-transparent px-8 text-center font-medium tracking-[-0.025em] text-gray-12 outline-none placeholder:text-gray-8/70 selection:bg-blue-9/25"
+						style={{
+							"font-size": `${state().fontSize}px`,
+							"line-height": state().lineHeight,
+						}}
+						aria-label="Teleprompter script"
+					/>
+					<div aria-hidden="true" style={{ height: spacerHeight() }} />
+				</div>
+			</main>
+
+			<Show when={settingsOpen()}>
+				<div class="absolute bottom-12 right-2 z-30 w-48 rounded-2xl border border-gray-12/8 bg-gray-1/80 p-2 shadow-xl backdrop-blur-2xl">
+					<div>
+						<SettingToggle
+							label="Cue markers"
+							active={state().showCueMarkers}
+							onChange={(showCueMarkers) =>
+								setState((current) => ({ ...current, showCueMarkers }))
+							}
+						>
+							<IconLucideChevronRight class="size-3.5" />
+						</SettingToggle>
+						<SettingToggle
+							label="Mirror text"
+							active={state().mirror}
+							onChange={(mirror) =>
+								setState((current) => ({ ...current, mirror }))
+							}
+						>
+							<IconLucideFlipHorizontal2 class="size-3.5" />
+						</SettingToggle>
+					</div>
+				</div>
+			</Show>
+
+			<footer class="flex h-11 shrink-0 items-center px-3 pb-2">
+				<button
+					type="button"
+					title={isPlaying() ? "Pause" : "Play"}
+					aria-label={isPlaying() ? "Pause" : "Play"}
+					disabled={!hasScript()}
+					onClick={togglePlayback}
+					class="flex size-8 items-center justify-center rounded-full border border-gray-12/6 bg-gray-12/7 text-gray-12 shadow-sm backdrop-blur-xl transition hover:bg-gray-12/11 disabled:cursor-not-allowed disabled:opacity-30"
+				>
+					<Show
+						when={isPlaying()}
+						fallback={<IconLucidePlay class="size-3.5 fill-current" />}
+					>
+						<IconLucidePause class="size-3.5 fill-current" />
+					</Show>
+				</button>
+				<div
+					title={`Scroll speed: ${state().wordsPerMinute} wpm`}
+					class="ml-1.5 flex h-8 items-center gap-1.5 rounded-full border border-gray-12/6 bg-gray-12/5 px-2 backdrop-blur-xl"
+				>
+					<IconLucideGauge class="size-3.5 shrink-0 text-gray-9" />
+					<input
+						type="range"
+						min="60"
+						max="350"
+						step="5"
+						value={state().wordsPerMinute}
+						onInput={(event) =>
+							setState((current) => ({
+								...current,
+								wordsPerMinute: Number(event.currentTarget.value),
+							}))
+						}
+						class="h-1 w-12 cursor-pointer appearance-none rounded-full bg-gray-12/10 [&::-webkit-slider-thumb]:size-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-blue-9 [&::-webkit-slider-thumb]:shadow-sm"
+						aria-label="Scroll speed"
+					/>
+					<span class="w-12 text-right text-[10px] tabular-nums text-gray-9">
+						{state().wordsPerMinute} wpm
+					</span>
+				</div>
+
+				<div class="ml-auto flex items-center gap-1.5">
+					<div
+						title={`Window opacity: ${state().windowOpacityPercent}%`}
+						class="flex h-8 items-center gap-1.5 rounded-full border border-gray-12/6 bg-gray-12/5 px-2 backdrop-blur-xl"
+					>
+						<IconLucideLayers class="size-3.5 shrink-0 text-gray-9" />
+						<input
+							type="range"
+							min="45"
+							max="100"
+							step="5"
+							value={state().windowOpacityPercent}
+							onInput={(event) =>
+								setState((current) => ({
+									...current,
+									windowOpacityPercent: Number(event.currentTarget.value),
+								}))
+							}
+							class="h-1 w-12 cursor-pointer appearance-none rounded-full bg-gray-12/10 [&::-webkit-slider-thumb]:size-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-gray-11 [&::-webkit-slider-thumb]:shadow-sm"
+							aria-label="Window opacity"
+						/>
+					</div>
+					<div class="flex h-8 items-center rounded-full border border-gray-12/6 bg-gray-12/5 px-0.5 backdrop-blur-xl">
+						<ToolButton label="Smaller text" onClick={() => changeFontSize(-2)}>
+							<IconLucideMinus class="size-3.5" />
+						</ToolButton>
+						<span class="w-6 text-center text-[10px] tabular-nums text-gray-9">
+							{state().fontSize}
+						</span>
+						<ToolButton label="Larger text" onClick={() => changeFontSize(2)}>
+							<IconLucidePlus class="size-3.5" />
+						</ToolButton>
+					</div>
+					<ToolButton
+						label="Settings"
+						active={settingsOpen()}
+						onClick={() => setSettingsOpen((open) => !open)}
+					>
+						<IconLucideSettings2 class="size-3.5" />
+					</ToolButton>
+				</div>
+			</footer>
+		</div>
+	);
+}

--- a/apps/desktop/src/routes/teleprompter.tsx
+++ b/apps/desktop/src/routes/teleprompter.tsx
@@ -106,6 +106,8 @@ export default function Teleprompter() {
 	let playbackFrame = 0;
 	let playbackPosition = 0;
 	let playbackTimestamp: number | undefined;
+	let allowClose = false;
+	let closePending = false;
 
 	const hasScript = createMemo(() => state().script.trim().length > 0);
 	const wordCount = createMemo(() => countWords(state().script));
@@ -152,6 +154,27 @@ export default function Teleprompter() {
 		}
 	});
 
+	onMount(async () => {
+		const unlisten = await currentWindow.onCloseRequested(async (event) => {
+			if (allowClose) return;
+			event.preventDefault();
+			if (closePending) return;
+
+			closePending = true;
+			clearTimeout(saveTimer);
+			try {
+				if (isLoaded()) await teleprompterStore.set(state());
+			} catch (error) {
+				console.error("Failed to save teleprompter before closing:", error);
+			} finally {
+				allowClose = true;
+				await currentWindow.close();
+			}
+		});
+
+		onCleanup(() => unlisten());
+	});
+
 	createEffect(() => {
 		if (!isLoaded()) return;
 		const nextState = state();
@@ -171,6 +194,7 @@ export default function Teleprompter() {
 
 	onCleanup(() => {
 		clearTimeout(saveTimer);
+		if (isLoaded() && !allowClose) void teleprompterStore.set(state());
 		cancelAnimationFrame(playbackFrame);
 		resizeObserver?.disconnect();
 		unlistenTitlebar?.();

--- a/apps/desktop/src/store.ts
+++ b/apps/desktop/src/store.ts
@@ -20,6 +20,16 @@ export type TeleprompterStore = {
 	windowOpacityPercent: number;
 };
 
+export const teleprompterDefaults: TeleprompterStore = {
+	script: "",
+	fontSize: 30,
+	wordsPerMinute: 150,
+	lineHeight: 1.5,
+	showCueMarkers: true,
+	mirror: false,
+	windowOpacityPercent: 92,
+};
+
 export type UserProfileStore = {
 	userId: string | null;
 	profile: {
@@ -104,13 +114,5 @@ export const recordingSettingsStore = declareStore<RecordingSettingsStore>(
 );
 export const teleprompterStore = declareStore<TeleprompterStore>(
 	"teleprompter",
-	{
-		script: "",
-		fontSize: 30,
-		wordsPerMinute: 150,
-		lineHeight: 1.5,
-		showCueMarkers: true,
-		mirror: false,
-		windowOpacityPercent: 92,
-	},
+	teleprompterDefaults,
 );

--- a/apps/desktop/src/store.ts
+++ b/apps/desktop/src/store.ts
@@ -10,6 +10,16 @@ import type {
 	RecordingSettingsStore,
 } from "~/utils/tauri";
 
+export type TeleprompterStore = {
+	script: string;
+	fontSize: number;
+	wordsPerMinute: number;
+	lineHeight: number;
+	showCueMarkers: boolean;
+	mirror: boolean;
+	windowOpacityPercent: number;
+};
+
 export type UserProfileStore = {
 	userId: string | null;
 	profile: {
@@ -90,5 +100,17 @@ export const recordingSettingsStore = declareStore<RecordingSettingsStore>(
 		organizationId: null,
 		cameraDeviceSettings: {},
 		microphoneDeviceSettings: {},
+	},
+);
+export const teleprompterStore = declareStore<TeleprompterStore>(
+	"teleprompter",
+	{
+		script: "",
+		fontSize: 30,
+		wordsPerMinute: 150,
+		lineHeight: 1.5,
+		showCueMarkers: true,
+		mirror: false,
+		windowOpacityPercent: 92,
 	},
 );

--- a/apps/desktop/src/styles/theme.css
+++ b/apps/desktop/src/styles/theme.css
@@ -360,6 +360,15 @@
 	border-radius: 16px;
 }
 
+[data-macos-native-material="teleprompter"] .cap-window-shell {
+	border-radius: 16px;
+}
+
+[data-macos-visual-system="liquid-glass"][data-macos-native-material="teleprompter"]
+	.cap-window-shell {
+	border-radius: 22px;
+}
+
 /* Tone down the see-through on the main panel under Liquid Glass: layer a
    translucent white (or dark in dark mode) wash over the NSGlassEffectView
    backdrop so the window reads as a "more white" surface overall instead of

--- a/apps/desktop/src/utils/macos-window-material.ts
+++ b/apps/desktop/src/utils/macos-window-material.ts
@@ -8,7 +8,7 @@ import {
 } from "@tauri-apps/api/window";
 import { type as osType, version as osVersion } from "@tauri-apps/plugin-os";
 
-type MacOSWindowMaterial = "panel" | "settings";
+type MacOSWindowMaterial = "panel" | "settings" | "teleprompter";
 
 let focusUnlisten: Promise<UnlistenFn> | undefined;
 
@@ -30,7 +30,13 @@ export async function applyMacOSWindowMaterial(material: MacOSWindowMaterial) {
 	const majorVersion = macOSMajorVersion() ?? 0;
 	const visualSystem = majorVersion >= 26 ? "liquid-glass" : "vibrancy";
 	const radius =
-		material === "settings" && visualSystem === "liquid-glass" ? 26 : 16;
+		visualSystem === "liquid-glass"
+			? material === "settings"
+				? 26
+				: material === "teleprompter"
+					? 22
+					: 16
+			: 16;
 	const root = document.documentElement;
 	root.dataset.macosNativeMaterial = material;
 	root.dataset.macosVisualSystem = visualSystem;

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -305,6 +305,12 @@ async positionTrafficLights(controlsInset: [number, number] | null) : Promise<vo
 async setTheme(theme: AppTheme) : Promise<void> {
     await TAURI_INVOKE("set_theme", { theme });
 },
+async setTeleprompterWindowLevel(alwaysOnTop: boolean) : Promise<void> {
+    await TAURI_INVOKE("set_teleprompter_window_level", { alwaysOnTop });
+},
+async setTeleprompterWindowOpacity(opacity: number) : Promise<void> {
+    await TAURI_INVOKE("set_teleprompter_window_opacity", { opacity });
+},
 async applyMacosLiquidGlassBackground(enabled: boolean, radius: number) : Promise<boolean> {
     return await TAURI_INVOKE("apply_macos_liquid_glass_background", { enabled, radius });
 },

--- a/apps/desktop/src/utils/teleprompter.ts
+++ b/apps/desktop/src/utils/teleprompter.ts
@@ -1,0 +1,57 @@
+import { LogicalPosition } from "@tauri-apps/api/dpi";
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { type as ostype } from "@tauri-apps/plugin-os";
+import { commands } from "./tauri";
+
+export const TELEPROMPTER_WINDOW_LABEL = "teleprompter";
+
+let creatingWindow: WebviewWindow | undefined;
+
+export async function openTeleprompter() {
+	const existingWindow = await WebviewWindow.getByLabel(
+		TELEPROMPTER_WINDOW_LABEL,
+	);
+
+	if (existingWindow) {
+		await commands.refreshWindowContentProtection();
+		await existingWindow.unminimize();
+		await existingWindow.show();
+		await existingWindow.setFocus();
+		return;
+	}
+
+	if (creatingWindow) return;
+	const isMacOS = ostype() === "macos";
+
+	const teleprompterWindow = new WebviewWindow(TELEPROMPTER_WINDOW_LABEL, {
+		url: "/teleprompter",
+		title: "Cap Teleprompter",
+		width: 560,
+		height: 320,
+		minWidth: 420,
+		minHeight: 220,
+		center: true,
+		focus: true,
+		visible: false,
+		resizable: true,
+		decorations: isMacOS,
+		titleBarStyle: isMacOS ? "overlay" : undefined,
+		hiddenTitle: isMacOS,
+		trafficLightPosition: isMacOS ? new LogicalPosition(14, 14) : undefined,
+		transparent: true,
+		shadow: true,
+		alwaysOnTop: true,
+		visibleOnAllWorkspaces: true,
+		skipTaskbar: true,
+	});
+	creatingWindow = teleprompterWindow;
+
+	void teleprompterWindow.once("tauri://created", () => {
+		creatingWindow = undefined;
+		void commands.refreshWindowContentProtection();
+	});
+	void teleprompterWindow.once("tauri://error", (event) => {
+		creatingWindow = undefined;
+		console.error("Failed to create teleprompter window:", event.payload);
+	});
+}


### PR DESCRIPTION
## Summary
- add a minimal editable desktop teleprompter with smooth adjustable auto-scroll
- use native macOS Liquid Glass, traffic lights, window opacity, and always-on-top behavior
- exclude the teleprompter from Cap recordings and persist its settings

## Validation
- `pnpm exec biome check <touched files>`
- `pnpm --dir apps/desktop exec tsc --noEmit --project tsconfig.json`
- `pnpm --dir apps/desktop exec vitest run src/routes/teleprompter-utils.test.ts`
- `pnpm --dir apps/desktop build`
- `cargo fmt --all -- --check`
- `cargo check -p cap-desktop`
- `cargo test -p cap-desktop general_settings --lib`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a minimal desktop teleprompter window to Cap with smooth scroll-based playback, native macOS Liquid Glass styling, adjustable opacity and always-on-top behavior, and automatic exclusion from Cap recordings. The previously-noted issue with debounced saves being dropped on window close has been resolved — `onCleanup` now flushes the latest state before clearing the timer, and `onCloseRequested` persists state in a `finally` block guarded by an `allowClose` flag to prevent double-writes.

- **Recording exclusion**: The teleprompter title is excluded at three complementary layers — default settings, a dynamic push at recording start (macOS only), and a hardcoded early-return in `window_capture_excluded` — ensuring content protection is applied reliably.
- **Window lifecycle**: `openTeleprompter` uses a module-level `creatingWindow` sentinel (set synchronously before any further awaits) to prevent duplicate window creation; the async `onCloseRequested` unlisten race is handled with a `disposed` flag.
- **Utility layer**: `teleprompter-utils.ts` extracts pure math (word count, speed calculation, sub-pixel position accumulation) with accompanying unit tests covering edge cases including negative inputs and 60-frame accumulation accuracy.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the feature is well-contained, the previous close-handler data-loss issue has been fixed, and all validation steps in the PR description pass.

The teleprompter window lifecycle, persistence, recording exclusion, and animation loop are all implemented correctly. The previously flagged save-on-close bug is fixed. No logic errors, data races, or broken contracts were found in the changed paths.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/teleprompter.tsx | Main teleprompter UI: correctly guards isLoaded() before saves, flushes state in onCleanup before clearing the debounce timer, and handles the async unlisten race with the disposed flag. |
| apps/desktop/src/utils/teleprompter.ts | openTeleprompter correctly guards against duplicate creation with a module-level creatingWindow sentinel that is cleared on both tauri://created and tauri://error. |
| apps/desktop/src-tauri/src/windows.rs | Adds Teleprompter variant to CapWindowId, moves MAIN_PANEL_LEVEL to module scope, adds two new Tauri commands, renames window_matches_exclusion_list to window_capture_excluded with a hardcoded early-return for the teleprompter — all logically consistent. |
| apps/desktop/src-tauri/src/recording.rs | Dynamically pushes the teleprompter exclusion at recording start inside the existing macOS cfg block; compiles correctly because the new WindowExclusion import is also gated on cfg(target_os="macos"). |
| apps/desktop/src/routes/teleprompter-utils.ts | Pure utility functions (countWords, clamp, calculatePlaybackSpeed, advancePlaybackPosition) with good zero-guard math and accompanying unit tests. |
| apps/desktop/src/store.ts | Adds TeleprompterStore type, teleprompterDefaults, and the teleprompterStore declaration — used as the single source of truth that the component merges against on load. |
| apps/desktop/src-tauri/src/general_settings.rs | Adds Cap Teleprompter to DEFAULT_EXCLUDED_WINDOW_TITLES — a clean one-liner addition. |
| apps/desktop/src-tauri/src/platform/macos/mod.rs | Adds set_window_opacity using setAlphaValue with a 0.45–1.0 clamp; uses the same unsafe objc pattern already present in the file. |
| apps/desktop/src/utils/tauri.ts | Adds setTeleprompterWindowLevel and setTeleprompterWindowOpacity command bindings — straightforward additions matching the new Rust commands. |
| apps/desktop/src/utils/macos-window-material.ts | Extends MacOSWindowMaterial union with teleprompter and adds a 22px Liquid Glass radius — consistent with the CSS rule added in theme.css. |
| apps/desktop/src/routes/(window-chrome)/new-main/index.tsx | Adds the teleprompter toolbar button that calls openTeleprompter() — minimal, correctly async-voided. |
| apps/desktop/src/app.tsx | Registers the /teleprompter route with AUTO_SHOW_WINDOW: false so the window is shown manually after setup. |
| apps/desktop/src/styles/theme.css | Adds border-radius rules for the teleprompter material under both vibrancy (16px) and Liquid Glass (22px) — matches the radius values in macos-window-material.ts. |
| apps/desktop/src/routes/teleprompter-utils.test.ts | Covers countWords edge cases, clamp bounds, speed calculation with negative input, and sub-pixel accumulation across 60 frames — solid coverage for the util layer. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/routes/teleprompter.tsx`, line 513-535 ([link](https://github.com/capsoftware/cap/blob/e298fa98b24b65c37ac1c335366dd3e9e0b3ded8/apps/desktop/src/routes/teleprompter.tsx#L513-L535)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Pending save cancelled on window close**

   `onCleanup` calls `clearTimeout(saveTimer)`, so any state change made within the 250 ms debounce window before the component unmounts is silently dropped — the store write is cancelled before it executes. For a user who edits their script and then immediately closes the window, the last change (including potentially a large paste) won't be persisted.

   The fix is to flush the current state in `onCleanup` before clearing the timer: call `void teleprompterStore.set(state())` before `clearTimeout(saveTimer)` so the latest state is always written on unmount.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/routes/teleprompter.tsx
   Line: 513-535

   Comment:
   **Pending save cancelled on window close**

   `onCleanup` calls `clearTimeout(saveTimer)`, so any state change made within the 250 ms debounce window before the component unmounts is silently dropped — the store write is cancelled before it executes. For a user who edits their script and then immediately closes the window, the last change (including potentially a large paste) won't be persisted.

   The fix is to flush the current state in `onCleanup` before clearing the timer: call `void teleprompterStore.set(state())` before `clearTimeout(saveTimer)` so the latest state is always written on unmount.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix: flush pending teleprompter saves"](https://github.com/capsoftware/cap/commit/42e342fb80c27e94b6f4b1211c52d933602fe825) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44278541)</sub>

<!-- /greptile_comment -->