### PR TITLE
feat(chrome-extension): add i18n foundation

### DIFF
--- a/apps/chrome-extension/e2e/overlay-ui.spec.ts
+++ b/apps/chrome-extension/e2e/overlay-ui.spec.ts
@@ -346,9 +346,7 @@ test("clicking X in the panel closes the panel and the camera preview", async ()
 
 		const panelFrame = frameWithUrl(targetPage, "popup.html");
 		if (!panelFrame) throw new Error("panel frame missing");
-		await panelFrame
-			.locator('button[aria-label="Close Cap and hide all recorder UI"]')
-			.click();
+		await panelFrame.getByTestId("close-recorder-ui").click();
 
 		// The panel and the camera preview should both tear down.
 		await expect
@@ -419,7 +417,7 @@ test("a failed recording start reopens the panel with the error", async () => {
 			.toBe(true);
 		const panelFrame = frameWithUrl(targetPage, "popup.html");
 		if (!panelFrame) throw new Error("panel frame missing");
-		await expect(panelFrame.getByText("Recording failed.")).toBeVisible({
+		await expect(panelFrame.getByTestId("recording-start-error")).toBeVisible({
 			timeout: 10_000,
 		});
 		await targetPage.screenshot({

--- a/apps/chrome-extension/public/_locales/en/messages.json
+++ b/apps/chrome-extension/public/_locales/en/messages.json
@@ -1,0 +1,17 @@
+{
+	"actionDefaultTitle": {
+		"message": "Record your screen with Cap"
+	},
+	"extensionDescription": {
+		"message": "Free, open source screen recorder. Capture your screen, tab, camera & mic in Chrome and share a video link the moment you stop."
+	},
+	"extensionName": {
+		"message": "Cap - Screen Recorder & Screen Capture"
+	},
+	"extensionShortName": {
+		"message": "Cap"
+	},
+	"offscreenJustification": {
+		"message": "Record and upload Cap videos from an extension page."
+	}
+}

--- a/apps/chrome-extension/public/_locales/zh_CN/messages.json
+++ b/apps/chrome-extension/public/_locales/zh_CN/messages.json
@@ -1,0 +1,17 @@
+{
+	"actionDefaultTitle": {
+		"message": "使用 Cap 录制屏幕"
+	},
+	"extensionDescription": {
+		"message": "免费开源的屏幕录制工具。在 Chrome 中录制屏幕、标签页、摄像头和麦克风，停止录制后即可分享视频链接。"
+	},
+	"extensionName": {
+		"message": "Cap - 屏幕录制与截图"
+	},
+	"extensionShortName": {
+		"message": "Cap"
+	},
+	"offscreenJustification": {
+		"message": "从扩展页面录制并上传 Cap 视频。"
+	}
+}

--- a/apps/chrome-extension/public/manifest.json
+++ b/apps/chrome-extension/public/manifest.json
@@ -1,8 +1,9 @@
 {
 	"manifest_version": 3,
-	"name": "Cap - Screen Recorder & Screen Capture",
-	"short_name": "Cap",
-	"description": "Free, open source screen recorder. Capture your screen, tab, camera & mic in Chrome and share a video link the moment you stop.",
+	"name": "__MSG_extensionName__",
+	"short_name": "__MSG_extensionShortName__",
+	"description": "__MSG_extensionDescription__",
+	"default_locale": "en",
 	"version": "1.0.2",
 	"homepage_url": "https://cap.so",
 	"minimum_chrome_version": "116",
@@ -13,7 +14,7 @@
 		"128": "icons/icon-128.png"
 	},
 	"action": {
-		"default_title": "Record your screen with Cap",
+		"default_title": "__MSG_actionDefaultTitle__",
 		"default_icon": {
 			"16": "icons/icon-16.png",
 			"32": "icons/icon-32.png",

--- a/apps/chrome-extension/src/background/service-worker.ts
+++ b/apps/chrome-extension/src/background/service-worker.ts
@@ -5,6 +5,7 @@ import {
 	parseAuthResponse,
 	revokeAuth,
 } from "../shared/api";
+import { msg } from "../shared/i18n";
 import {
 	isRecordingStatusBroadcast,
 	isServiceWorkerRequest,
@@ -219,7 +220,7 @@ const createOffscreenDocument = () =>
 			{
 				url: OFFSCREEN_URL,
 				reasons: ["USER_MEDIA", "DISPLAY_MEDIA", "BLOBS", "AUDIO_PLAYBACK"],
-				justification: "Record and upload Cap videos from an extension page.",
+				justification: msg("offscreenJustification"),
 			},
 			() => {
 				const error = chrome.runtime.lastError;

--- a/apps/chrome-extension/src/popup/components/recorder-header.tsx
+++ b/apps/chrome-extension/src/popup/components/recorder-header.tsx
@@ -42,6 +42,7 @@ export const RecorderHeader = ({
 							: "cursor-pointer transition-transform hover:scale-110",
 					)}
 					aria-label="Close Cap and hide all recorder UI"
+					data-testid="close-recorder-ui"
 				>
 					<X
 						size={10}

--- a/apps/chrome-extension/src/popup/main.tsx
+++ b/apps/chrome-extension/src/popup/main.tsx
@@ -699,7 +699,10 @@ function App() {
 							</div>
 						)}
 						{status.phase === "error" && (
-							<div className="cap-fade-up rounded-md border border-red-6 bg-red-3/70 px-3 py-2 text-xs leading-snug text-red-12">
+							<div
+								className="cap-fade-up rounded-md border border-red-6 bg-red-3/70 px-3 py-2 text-xs leading-snug text-red-12"
+								data-testid="recording-start-error"
+							>
 								<span className="font-medium">Recording failed.</span>{" "}
 								{status.message}
 							</div>

--- a/apps/chrome-extension/src/shared/i18n.test.ts
+++ b/apps/chrome-extension/src/shared/i18n.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import englishMessages from "../../public/_locales/en/messages.json";
+import chineseMessages from "../../public/_locales/zh_CN/messages.json";
+import { msg } from "./i18n";
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("extension messages", () => {
+	it("keeps locale catalogs aligned", () => {
+		expect(Object.keys(chineseMessages).sort()).toEqual(
+			Object.keys(englishMessages).sort(),
+		);
+	});
+
+	it("uses the browser locale when a translation is available", () => {
+		const getMessage = vi.fn(() => "使用 Cap 录制屏幕");
+		vi.stubGlobal("chrome", { i18n: { getMessage } });
+
+		expect(msg("actionDefaultTitle")).toBe("使用 Cap 录制屏幕");
+		expect(getMessage).toHaveBeenCalledWith("actionDefaultTitle", undefined);
+	});
+
+	it("falls back to English outside an extension context", () => {
+		vi.stubGlobal("chrome", undefined);
+
+		expect(msg("actionDefaultTitle")).toBe("Record your screen with Cap");
+	});
+
+	it("falls back to English when Chrome cannot resolve a message", () => {
+		vi.stubGlobal("chrome", {
+			i18n: { getMessage: vi.fn(() => "") },
+		});
+
+		expect(msg("offscreenJustification")).toBe(
+			"Record and upload Cap videos from an extension page.",
+		);
+	});
+});

--- a/apps/chrome-extension/src/shared/i18n.test.ts
+++ b/apps/chrome-extension/src/shared/i18n.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import englishMessages from "../../public/_locales/en/messages.json";
 import chineseMessages from "../../public/_locales/zh_CN/messages.json";
-import { msg } from "./i18n";
+import { type MessageKey, msg } from "./i18n";
 
 afterEach(() => {
 	vi.unstubAllGlobals();
@@ -28,6 +28,12 @@ describe("extension messages", () => {
 		expect(msg("actionDefaultTitle")).toBe("Record your screen with Cap");
 	});
 
+	it("falls back to English when Chrome i18n is unavailable", () => {
+		vi.stubGlobal("chrome", {});
+
+		expect(msg("actionDefaultTitle")).toBe("Record your screen with Cap");
+	});
+
 	it("falls back to English when Chrome cannot resolve a message", () => {
 		vi.stubGlobal("chrome", {
 			i18n: { getMessage: vi.fn(() => "") },
@@ -36,5 +42,30 @@ describe("extension messages", () => {
 		expect(msg("offscreenJustification")).toBe(
 			"Record and upload Cap videos from an extension page.",
 		);
+	});
+
+	it("applies substitutions to the English fallback", () => {
+		const originalMessage = englishMessages.actionDefaultTitle.message;
+		vi.stubGlobal("chrome", undefined);
+
+		try {
+			englishMessages.actionDefaultTitle.message = "Record $1";
+			expect(msg("actionDefaultTitle", "your screen")).toBe(
+				"Record your screen",
+			);
+
+			englishMessages.actionDefaultTitle.message = "Record $1 with $2";
+			expect(msg("actionDefaultTitle", ["your screen", "Cap"])).toBe(
+				"Record your screen with Cap",
+			);
+		} finally {
+			englishMessages.actionDefaultTitle.message = originalMessage;
+		}
+	});
+
+	it("returns the key when the English fallback is missing", () => {
+		vi.stubGlobal("chrome", undefined);
+
+		expect(msg("missingMessage" as MessageKey)).toBe("missingMessage");
 	});
 });

--- a/apps/chrome-extension/src/shared/i18n.ts
+++ b/apps/chrome-extension/src/shared/i18n.ts
@@ -1,0 +1,12 @@
+import englishMessages from "../../public/_locales/en/messages.json";
+
+export type MessageKey = keyof typeof englishMessages;
+
+export const msg = (key: MessageKey, substitutions?: string | string[]) => {
+	const localizedMessage =
+		typeof chrome === "undefined"
+			? ""
+			: chrome.i18n.getMessage(key, substitutions);
+
+	return localizedMessage || englishMessages[key].message;
+};

--- a/apps/chrome-extension/src/shared/i18n.ts
+++ b/apps/chrome-extension/src/shared/i18n.ts
@@ -1,12 +1,22 @@
 import englishMessages from "../../public/_locales/en/messages.json";
 
-export type MessageKey = keyof typeof englishMessages;
+export type MessageKey = keyof typeof englishMessages & string;
 
 export const msg = (key: MessageKey, substitutions?: string | string[]) => {
 	const localizedMessage =
-		typeof chrome === "undefined"
+		typeof chrome === "undefined" ||
+		typeof chrome.i18n?.getMessage !== "function"
 			? ""
 			: chrome.i18n.getMessage(key, substitutions);
 
-	return localizedMessage || englishMessages[key].message;
+	if (localizedMessage) return localizedMessage;
+
+	const fallback = englishMessages[key]?.message || key;
+	if (!substitutions) return fallback;
+
+	const values = Array.isArray(substitutions) ? substitutions : [substitutions];
+	return fallback.replace(
+		/\$(\d+)/g,
+		(_match, index: string) => values[Number(index) - 1] ?? "",
+	);
 };


### PR DESCRIPTION
## Summary

- add Chrome extension locale catalogs with English as the default and Simplified Chinese support
- localize manifest metadata through Chrome i18n and provide a typed runtime helper with an English fallback
- keep thrown and logged runtime errors stable while localizing the offscreen document justification
- replace copy-dependent E2E selectors with stable test IDs

## Review context

This is the first focused split from #2008, which changed 426 files and exceeded the automated review limit. It addresses the four inline review comments without coupling tests or runtime diagnostics to translated copy. Follow-up PRs can migrate the remaining Chrome extension UI in smaller, reviewable groups.

## Validation

- Biome check on all touched files
- Chrome extension TypeScript check
- 14 unit tests passed
- main, content bootstrap, and content overlay production builds passed
- close-panel Playwright scenario passed with the new stable selector
- two existing screen-capture Playwright scenarios time out while waiting on the capture API in headless Chromium before reaching the changed assertions

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR establishes the i18n foundation for the Chrome extension: it adds English and Simplified Chinese locale catalogs, updates `manifest.json` to use `__MSG_*__` placeholders, and introduces a typed `msg()` helper that wraps `chrome.i18n.getMessage` with an English JSON fallback. It also decouples two E2E selectors from copy by adding stable `data-testid` attributes to the close button and recording-error element.

- `msg()` in `i18n.ts` correctly guards against an undefined `chrome` global and falls back to the English catalog, with unit tests covering locale key alignment, locale resolution, and both fallback paths.
- The manifest i18n wiring and locale catalogs follow Chrome's documented conventions; the `default_locale: \"en\"` setting is correct.
- E2E selector changes are a clean improvement: `data-testid` attributes survive copy changes, and the existing `aria-label` on the close button is preserved for accessibility.

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are additive and well-tested with no impact on existing runtime paths beyond the offscreen justification string

The msg() helper's English fallback branch discards caller-supplied substitution arguments when Chrome returns an empty string. No current messages use placeholders, so nothing breaks today, but the helper would silently mis-render any future message that does.

apps/chrome-extension/src/shared/i18n.ts — the English fallback branch ignores the substitutions argument

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/chrome-extension/src/shared/i18n.ts | New i18n helper that wraps chrome.i18n.getMessage with an English JSON fallback; logic is sound but the English fallback silently drops substitution arguments when the Chrome API returns an empty string |
| apps/chrome-extension/src/shared/i18n.test.ts | Good unit tests covering locale key alignment, locale resolution, and both fallback paths; no issues found |
| apps/chrome-extension/public/_locales/en/messages.json | New English locale catalog with all 5 keys correctly defined; no issues |
| apps/chrome-extension/public/_locales/zh_CN/messages.json | New Simplified Chinese locale catalog with keys aligned to English; translations look correct |
| apps/chrome-extension/public/manifest.json | Updated to use __MSG_*__ i18n placeholders and added default_locale; no issues |
| apps/chrome-extension/src/background/service-worker.ts | Changed offscreen document justification to use msg() helper; minimal and correct change |
| apps/chrome-extension/src/popup/components/recorder-header.tsx | Adds data-testid to close button while retaining the aria-label for accessibility; clean change |
| apps/chrome-extension/src/popup/main.tsx | Adds data-testid to the recording-error div; straightforward and correct |
| apps/chrome-extension/e2e/overlay-ui.spec.ts | E2E selectors migrated from text/aria-label to stable data-testid attributes; improvement in test robustness |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/chrome-extension/src/shared/i18n.ts:11
When `chrome` is available but `getMessage` returns `""` (e.g., key missing in a locale), the function falls back to the English message string — but the caller-supplied `substitutions` are silently discarded. This means any future message that uses `$1`/`$2` placeholders would render raw placeholder syntax in the fallback path instead of the substituted value. In the Chrome extension context this is unlikely (English is the default locale, so the API should always resolve), but a non-extension caller (test or Node script) using `msg("someKey", someValue)` would always get unsubstituted English text back.

```suggestion
	if (localizedMessage) return localizedMessage;

	const fallback = englishMessages[key].message;
	if (!substitutions) return fallback;
	const subs = Array.isArray(substitutions) ? substitutions : [substitutions];
	return fallback.replace(/\$(\d+)/g, (_, i) => subs[Number(i) - 1] ?? "");
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(chrome-extension): add localization..."](https://github.com/capsoftware/cap/commit/6cc67f21691d8bc9e4c291ac15abb689862918da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44566389)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->