### PR TITLE
Expandable main window with recents and system-managed liquid glass

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3793,10 +3793,11 @@ pub struct RecordingMetaWithMetadata {
     pub status: StudioRecordingStatus,
     // Number of recorded takes (segments) the recording is made up of.
     pub clip_count: u32,
+    pub sort_time_millis: f64,
 }
 
 impl RecordingMetaWithMetadata {
-    fn new(inner: RecordingMeta) -> Self {
+    fn new(inner: RecordingMeta, sort_time_millis: f64) -> Self {
         Self {
             mode: match &inner.inner {
                 RecordingMetaInner::Studio(_) => RecordingMode::Studio,
@@ -3829,9 +3830,17 @@ impl RecordingMetaWithMetadata {
                     StudioRecordingStatus::Complete
                 }
             },
+            sort_time_millis,
             inner,
         }
     }
+}
+
+#[derive(Serialize, specta::Type)]
+pub struct ScreenshotMetaWithMetadata {
+    #[serde(flatten)]
+    pub inner: RecordingMeta,
+    pub sort_time_millis: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
@@ -3848,8 +3857,9 @@ fn get_recording_meta(
     path: PathBuf,
     _file_type: FileType,
 ) -> Result<RecordingMetaWithMetadata, String> {
+    let sort_time_millis = media_sort_time_millis(&path);
     RecordingMeta::load_for_project(&path)
-        .map(RecordingMetaWithMetadata::new)
+        .map(|meta| RecordingMetaWithMetadata::new(meta, sort_time_millis))
         .map_err(|e| format!("Failed to load recording meta: {e}"))
 }
 
@@ -3862,6 +3872,14 @@ fn media_sort_time(path: &Path) -> SystemTime {
         .created()
         .or_else(|_| metadata.modified())
         .unwrap_or(UNIX_EPOCH)
+}
+
+fn media_sort_time_millis(path: &Path) -> f64 {
+    media_sort_time(path)
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+        * 1000.0
 }
 
 #[tauri::command]
@@ -3890,7 +3908,7 @@ fn list_recordings(app: AppHandle) -> Result<Vec<(PathBuf, RecordingMetaWithMeta
         }
     }
 
-    result.sort_by_cached_key(|(path, _)| std::cmp::Reverse(media_sort_time(path)));
+    result.sort_by(|(_, a), (_, b)| b.sort_time_millis.total_cmp(&a.sort_time_millis));
 
     Ok(result)
 }
@@ -3945,7 +3963,7 @@ async fn delete_recording_directory(app: AppHandle, path: PathBuf) -> Result<(),
 #[tauri::command]
 #[specta::specta]
 #[instrument(skip(app))]
-fn list_screenshots(app: AppHandle) -> Result<Vec<(PathBuf, RecordingMeta)>, String> {
+fn list_screenshots(app: AppHandle) -> Result<Vec<(PathBuf, ScreenshotMetaWithMetadata)>, String> {
     let screenshots_dir = screenshots_path(&app);
 
     let mut result = std::fs::read_dir(&screenshots_dir)
@@ -3965,14 +3983,21 @@ fn list_screenshots(app: AppHandle) -> Result<Vec<(PathBuf, RecordingMeta)>, Str
                     .find(|e| e.path().extension().and_then(|s| s.to_str()) == Some("png"))
                     .map(|e| e.path())?;
 
-                Some((png_path, meta))
+                let sort_time_millis = media_sort_time_millis(&png_path);
+                Some((
+                    png_path,
+                    ScreenshotMetaWithMetadata {
+                        inner: meta,
+                        sort_time_millis,
+                    },
+                ))
             } else {
                 None
             }
         })
         .collect::<Vec<_>>();
 
-    result.sort_by_cached_key(|(path, _)| std::cmp::Reverse(media_sort_time(path)));
+    result.sort_by(|(_, a), (_, b)| b.sort_time_millis.total_cmp(&a.sort_time_millis));
 
     Ok(result)
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3853,6 +3853,17 @@ fn get_recording_meta(
         .map_err(|e| format!("Failed to load recording meta: {e}"))
 }
 
+fn media_sort_time(path: &Path) -> SystemTime {
+    let Ok(metadata) = path.metadata() else {
+        return UNIX_EPOCH;
+    };
+
+    metadata
+        .created()
+        .or_else(|_| metadata.modified())
+        .unwrap_or(UNIX_EPOCH)
+}
+
 #[tauri::command]
 #[specta::specta]
 #[instrument(skip(app))]
@@ -3879,19 +3890,7 @@ fn list_recordings(app: AppHandle) -> Result<Vec<(PathBuf, RecordingMetaWithMeta
         }
     }
 
-    result.sort_by(|a, b| {
-        let b_time =
-            b.0.metadata()
-                .and_then(|m| m.created())
-                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-
-        let a_time =
-            a.0.metadata()
-                .and_then(|m| m.created())
-                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-
-        b_time.cmp(&a_time)
-    });
+    result.sort_by_cached_key(|(path, _)| std::cmp::Reverse(media_sort_time(path)));
 
     Ok(result)
 }
@@ -3973,16 +3972,7 @@ fn list_screenshots(app: AppHandle) -> Result<Vec<(PathBuf, RecordingMeta)>, Str
         })
         .collect::<Vec<_>>();
 
-    result.sort_by(|a, b| {
-        b.0.metadata()
-            .and_then(|m| m.created())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
-            .cmp(
-                &a.0.metadata()
-                    .and_then(|m| m.created())
-                    .unwrap_or(std::time::SystemTime::UNIX_EPOCH),
-            )
-    });
+    result.sort_by_cached_key(|(path, _)| std::cmp::Reverse(media_sort_time(path)));
 
     Ok(result)
 }

--- a/apps/desktop/src-tauri/src/platform/macos/mod.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/mod.rs
@@ -71,6 +71,21 @@ pub fn apply_squircle_corners(window: &tauri::WebviewWindow, radius: f64) {
 
 const TAURI_VIBRANCY_VIEW_TAG: isize = 91376254;
 const LIQUID_GLASS_IDENTIFIER: &str = "so.cap.liquid-glass-background";
+const NS_GLASS_EFFECT_VIEW_STYLE_REGULAR: isize = 0;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LiquidGlassActivity {
+    SystemManaged,
+    AlwaysActive,
+}
+
+pub fn apply_main_window_liquid_glass_background(
+    window: &tauri::Window,
+    enabled: bool,
+    radius: f64,
+) -> Result<bool, String> {
+    apply_liquid_glass_background_inner(window, enabled, radius, LiquidGlassActivity::SystemManaged)
+}
 
 unsafe fn remove_tagged_subview(container: cocoa::base::id, tag: isize) {
     use objc::{msg_send, sel, sel_impl};
@@ -146,6 +161,15 @@ pub fn apply_liquid_glass_background(
     enabled: bool,
     radius: f64,
 ) -> Result<bool, String> {
+    apply_liquid_glass_background_inner(window, enabled, radius, LiquidGlassActivity::AlwaysActive)
+}
+
+fn apply_liquid_glass_background_inner(
+    window: &tauri::Window,
+    enabled: bool,
+    radius: f64,
+    activity: LiquidGlassActivity,
+) -> Result<bool, String> {
     use cocoa::{
         base::{id, nil},
         foundation::{NSRect, NSString},
@@ -218,21 +242,27 @@ pub fn apply_liquid_glass_background(
             let _: () = msg_send![glass_view, setCornerRadius: radius];
         }
 
+        if activity == LiquidGlassActivity::SystemManaged {
+            let _: () = msg_send![glass_view, setStyle: NS_GLASS_EFFECT_VIEW_STYLE_REGULAR];
+        }
+
         // Pin the glass to its "always-active" representation so it keeps re-rendering
         // the live backdrop regardless of which window currently has key state. The
         // default for an NSVisualEffectView-derived view is FollowsWindowActiveState,
         // which dims the material whenever another Cap window (camera, settings, etc.)
         // becomes key and masks the backdrop reactivity that's the whole point of
-        // Liquid Glass. NSGlassEffectView is private SPI introduced in macOS 26, so we
-        // probe multiple state knobs (`setState:`, `setActive:`) instead of assuming a
-        // single inheritance path.
+        // Liquid Glass. The always-active state is private SPI, so we probe multiple
+        // state knobs (`setState:`, `setActive:`) instead of assuming one inheritance
+        // path. The main window does not enter this branch and remains system-managed.
         //
         // macOS 26.3 shipped an NSGlassEffectView that responds to neither selector,
         // so the pin silently fails. In that state the material can't be relied on
         // (it dims whenever another window becomes key), so abandon the private SPI
         // entirely and let the caller fall back to NSVisualEffectView vibrancy
         // (Ok(false)).
-        if !force_glass_view_always_active(glass_view) {
+        if activity == LiquidGlassActivity::AlwaysActive
+            && !force_glass_view_always_active(glass_view)
+        {
             // Never entered the view hierarchy; balance the alloc and bail. The
             // content-layer squircle clip applied above is kept (plain Core Animation,
             // not a WindowServer/occlusion mutation) so the vibrancy fallback still gets
@@ -270,10 +300,12 @@ pub fn apply_liquid_glass_background(
             relativeTo: nil
         ];
 
-        // Re-apply after the view enters the hierarchy: some private AppKit views
-        // reset state machine fields on `viewDidMoveToWindow:`, so the post-add pass
-        // is what actually sticks.
-        force_glass_view_always_active(glass_view);
+        if activity == LiquidGlassActivity::AlwaysActive {
+            // Re-apply after the view enters the hierarchy: some private AppKit views
+            // reset state machine fields on `viewDidMoveToWindow:`, so the post-add pass
+            // is what actually sticks.
+            force_glass_view_always_active(glass_view);
+        }
 
         crate::crash_sentinel::set_liquid_glass_outcome("applied");
         Ok(true)
@@ -435,9 +467,8 @@ unsafe fn enable_webview_occlusion_detection(content_view: cocoa::base::id) {
 }
 
 /// Reverse every WindowServer-visible mutation `apply_liquid_glass_background` makes:
-/// remove the private NSGlassEffectView (the load-bearing step — it synchronously
-/// detaches the private compositor relationship), then restore window/WKWebView
-/// occlusion detection and window opacity. MUST run on the AppKit main thread.
+/// remove the NSGlassEffectView, then restore window/WKWebView occlusion detection and
+/// window opacity. MUST run on the AppKit main thread.
 unsafe fn teardown_liquid_glass_ns(ns_window: cocoa::base::id) {
     use cocoa::{
         base::{id, nil},

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -3603,8 +3603,13 @@ pub async fn apply_macos_liquid_glass_background(
 
         _window
             .run_on_main_thread(move || {
-                let result =
-                    crate::platform::apply_liquid_glass_background(&window, _enabled, _radius);
+                let result = if window.label() == CapWindowId::Main.label() {
+                    crate::platform::apply_main_window_liquid_glass_background(
+                        &window, _enabled, _radius,
+                    )
+                } else {
+                    crate::platform::apply_liquid_glass_background(&window, _enabled, _radius)
+                };
                 let _ = tx.send(result);
             })
             .map_err(|error| error.to_string())?;

--- a/apps/desktop/src/components/titlebar/controls/CaptionControlsMacOS.tsx
+++ b/apps/desktop/src/components/titlebar/controls/CaptionControlsMacOS.tsx
@@ -10,12 +10,17 @@ import {
 } from "solid-js";
 
 export default function CaptionControlsMacOS(
-	props: ComponentProps<"div"> & { showMinimize?: boolean; showZoom?: boolean },
+	props: ComponentProps<"div"> & {
+		showMinimize?: boolean;
+		showZoom?: boolean;
+		onZoom?: () => void;
+	},
 ) {
 	const [local, otherProps] = splitProps(props, [
 		"class",
 		"showMinimize",
 		"showZoom",
+		"onZoom",
 	]);
 	const currentWindow = getCurrentWindow();
 	const [focused, setFocus] = createSignal(true);
@@ -65,7 +70,10 @@ export default function CaptionControlsMacOS(
 					type="zoom"
 					focused={focused()}
 					hovered={hovered()}
-					onClick={() => currentWindow.toggleMaximize()}
+					onClick={() => {
+						if (local.onZoom) local.onZoom();
+						else void currentWindow.toggleMaximize();
+					}}
 				/>
 			</Show>
 		</div>

--- a/apps/desktop/src/components/titlebar/controls/CaptionControlsMacOS.tsx
+++ b/apps/desktop/src/components/titlebar/controls/CaptionControlsMacOS.tsx
@@ -44,7 +44,7 @@ export default function CaptionControlsMacOS(
 	return (
 		<div
 			class={cx(
-				"flex flex-row items-center gap-2 h-full cursor-default select-none",
+				"flex flex-row items-center gap-2.5 h-full cursor-default select-none",
 				local.class,
 			)}
 			onMouseEnter={() => setHovered(true)}
@@ -92,17 +92,17 @@ function TrafficLightButton(props: TrafficLightButtonProps) {
 		close: {
 			bg: "#FF5F57",
 			bgHover: "#FF5F57",
-			iconColor: "#4D0000",
+			iconColor: "rgba(0, 0, 0, 0.5)",
 		},
 		minimize: {
 			bg: "#FEBC2E",
 			bgHover: "#FEBC2E",
-			iconColor: "#995700",
+			iconColor: "rgba(0, 0, 0, 0.5)",
 		},
 		zoom: {
 			bg: "#28C840",
 			bgHover: "#28C840",
-			iconColor: "#006500",
+			iconColor: "rgba(0, 0, 0, 0.5)",
 		},
 	};
 
@@ -111,8 +111,15 @@ function TrafficLightButton(props: TrafficLightButtonProps) {
 	return (
 		<button
 			type="button"
+			aria-label={
+				props.type === "close"
+					? "Close window"
+					: props.type === "minimize"
+						? "Minimize window"
+						: "Expand or collapse window"
+			}
 			class={cx(
-				"w-3 h-3 rounded-full flex items-center justify-center transition-colors duration-100",
+				"size-3.5 rounded-full flex items-center justify-center transition-colors duration-100",
 				"hover:brightness-95 active:brightness-90",
 			)}
 			style={{
@@ -138,8 +145,8 @@ interface TrafficLightIconProps {
 function TrafficLightIcon(props: TrafficLightIconProps) {
 	return (
 		<svg
-			width="8"
-			height="8"
+			width={props.type === "zoom" ? "8" : "10"}
+			height={props.type === "zoom" ? "8" : "10"}
 			viewBox="0 0 8 8"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
@@ -158,7 +165,7 @@ function TrafficLightIcon(props: TrafficLightIconProps) {
 			)}
 			{props.type === "zoom" && (
 				<path
-					d="M1.5 1.5a.5.5 0 0 1 .5-.5h4.5a.5.5 0 0 1 .5.5V6a.5.5 0 0 1-.5.5H2a.5.5 0 0 1-.5-.5V1.5Zm1 .5v3.5h3.5V2H2.5Z"
+					d="M.75.75H6.5L.75 6.5V.75ZM7.25 7.25H1.5l5.75-5.75v5.75Z"
 					fill={props.color}
 				/>
 			)}

--- a/apps/desktop/src/components/titlebar/controls/CaptionControlsWindows11.tsx
+++ b/apps/desktop/src/components/titlebar/controls/CaptionControlsWindows11.tsx
@@ -13,11 +13,25 @@ import titlebarState from "~/utils/titlebar-state";
 import { WindowControlButton as ControlButton } from "./WindowControlButton";
 
 export default function (
-	props: ComponentProps<"div"> & { maximizable?: boolean },
+	props: ComponentProps<"div"> & {
+		maximizable?: boolean;
+		maximized?: boolean;
+		onMaximize?: () => void;
+	},
 ) {
-	const [local, otherProps] = splitProps(props, ["class"]);
+	const [local, otherProps] = splitProps(props, [
+		"class",
+		"maximizable",
+		"maximized",
+		"onMaximize",
+	]);
 	const currentWindow = getCurrentWindow();
 	const [focused, setFocus] = createSignal(true);
+	const hasCustomMaximize = () => local.onMaximize !== undefined;
+	const maximizable = () =>
+		local.maximizable !== false &&
+		(hasCustomMaximize() || titlebarState.maximizable);
+	const maximized = () => local.maximized ?? titlebarState.maximized;
 
 	let unlisten: (() => void) | undefined;
 	onMount(async () => {
@@ -54,19 +68,16 @@ export default function (
 				<icons.minimizeWin />
 			</ControlButton>
 			<Show
-				when={
-					titlebarState.maximizable ||
-					!titlebarState.hideMaximize ||
-					props.maximizable
-				}
+				when={maximizable() || !titlebarState.hideMaximize || local.maximizable}
 			>
 				<ControlButton
-					disabled={!titlebarState.maximizable || props.maximizable === false}
+					disabled={!maximizable()}
 					onClick={
-						titlebarState.maximizable
-							? titlebarState.maximized
-								? currentWindow.unmaximize
-								: currentWindow.maximize
+						maximizable()
+							? (local.onMaximize ??
+								(maximized()
+									? currentWindow.unmaximize
+									: currentWindow.maximize))
 							: undefined
 					}
 					class={cx(
@@ -75,11 +86,7 @@ export default function (
 						"disabled:hover:bg-transparent dark:disabled:hover:bg-transparent disabled:text-black-transparent-40",
 					)}
 				>
-					{titlebarState.maximized ? (
-						<icons.maximizeRestoreWin />
-					) : (
-						<icons.maximizeWin />
-					)}
+					{maximized() ? <icons.maximizeRestoreWin /> : <icons.maximizeWin />}
 				</ControlButton>
 			</Show>
 			<ControlButton

--- a/apps/desktop/src/routes/(window-chrome).tsx
+++ b/apps/desktop/src/routes/(window-chrome).tsx
@@ -116,12 +116,20 @@ function Header() {
 			data-tauri-drag-region
 		>
 			{ctx.state()?.items}
-			{isWindows && <CaptionControlsWindows11 class="ml-auto!" />}
+			{isWindows && (
+				<CaptionControlsWindows11
+					class="ml-auto!"
+					maximizable={ctx.state()?.onMaximize ? true : undefined}
+					maximized={ctx.state()?.maximized}
+					onMaximize={ctx.state()?.onMaximize}
+				/>
+			)}
 			{((isMacOS && !isSettings()) || isLinux) && (
 				<CaptionControlsMacOS
 					class="mr-auto! ml-3"
 					showMinimize={false}
-					showZoom={false}
+					showZoom={ctx.state()?.onMaximize !== undefined}
+					onZoom={ctx.state()?.onMaximize}
 				/>
 			)}
 		</header>
@@ -129,15 +137,10 @@ function Header() {
 }
 
 function Inner(props: ParentProps) {
-	onMount(() => {
-		const initialTargetMode = (
-			window as typeof window & {
-				__CAP__?: { initialTargetMode?: unknown };
-			}
-		).__CAP__?.initialTargetMode;
+	const location = useLocation();
 
-		if (location.pathname !== "/" || !initialTargetMode)
-			void getCurrentWindow().show();
+	onMount(() => {
+		if (location.pathname !== "/") void getCurrentWindow().show();
 	});
 
 	return (

--- a/apps/desktop/src/routes/(window-chrome)/Context.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/Context.tsx
@@ -3,6 +3,8 @@ import { createSignal, type JSX, onCleanup } from "solid-js";
 
 interface WindowChromeState {
 	hideMaximize?: boolean;
+	maximized?: boolean;
+	onMaximize?: () => void;
 	items?: JSX.Element;
 }
 
@@ -28,10 +30,20 @@ export function useWindowChrome(state: WindowChromeState) {
 
 export function WindowChromeHeader(props: {
 	hideMaximize?: boolean;
+	maximized?: boolean;
+	onMaximize?: () => void;
 	children?: JSX.Element;
 }) {
 	useWindowChrome({
-		hideMaximize: props.hideMaximize,
+		get hideMaximize() {
+			return props.hideMaximize;
+		},
+		get maximized() {
+			return props.maximized;
+		},
+		get onMaximize() {
+			return props.onMaximize;
+		},
 		get items() {
 			return props.children;
 		},

--- a/apps/desktop/src/routes/(window-chrome)/new-main/Recents.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/Recents.tsx
@@ -1,0 +1,250 @@
+import { convertFileSrc } from "@tauri-apps/api/core";
+import { cx } from "cva";
+import {
+	createEffect,
+	createMemo,
+	createSignal,
+	For,
+	type JSX,
+	onCleanup,
+	onMount,
+	Show,
+} from "solid-js";
+import IconLucideClapperboard from "~icons/lucide/clapperboard";
+import IconLucideHistory from "~icons/lucide/history";
+import IconLucideImage from "~icons/lucide/image";
+import IconLucideSquarePlay from "~icons/lucide/square-play";
+import IconLucideZap from "~icons/lucide/zap";
+import type { RecordingWithPath, ScreenshotWithPath } from "./TargetCard";
+
+export type RecentMediaItem =
+	| {
+			kind: "recording";
+			target: RecordingWithPath;
+			createdAt: number;
+			previewPath?: string;
+			previewVersion?: number;
+	  }
+	| {
+			kind: "screenshot";
+			target: ScreenshotWithPath;
+			createdAt: number;
+			previewPath: string;
+			previewVersion: number;
+	  };
+
+function RecentCarousel(props: { children: JSX.Element; itemCount: number }) {
+	let scrollContainer!: HTMLDivElement;
+	let measureFrame: number | undefined;
+	const [canScrollLeft, setCanScrollLeft] = createSignal(false);
+	const [canScrollRight, setCanScrollRight] = createSignal(false);
+
+	const measure = () => {
+		const maxScrollLeft = Math.max(
+			0,
+			scrollContainer.scrollWidth - scrollContainer.clientWidth,
+		);
+		setCanScrollLeft(scrollContainer.scrollLeft > 1);
+		setCanScrollRight(maxScrollLeft - scrollContainer.scrollLeft > 1);
+	};
+
+	const scheduleMeasure = () => {
+		if (measureFrame !== undefined) cancelAnimationFrame(measureFrame);
+		measureFrame = requestAnimationFrame(() => {
+			measureFrame = undefined;
+			measure();
+		});
+	};
+
+	createEffect(() => {
+		props.itemCount;
+		scheduleMeasure();
+	});
+
+	onMount(() => {
+		const observer = new ResizeObserver(scheduleMeasure);
+		observer.observe(scrollContainer);
+		scheduleMeasure();
+
+		onCleanup(() => {
+			observer.disconnect();
+			if (measureFrame !== undefined) cancelAnimationFrame(measureFrame);
+		});
+	});
+
+	const maskImage = () =>
+		`linear-gradient(to right, transparent, black ${canScrollLeft() ? "22px" : "0px"}, black calc(100% - ${canScrollRight() ? "34px" : "0px"}), transparent)`;
+	const handleWheel: JSX.EventHandler<HTMLDivElement, WheelEvent> = (event) => {
+		if (Math.abs(event.deltaX) >= Math.abs(event.deltaY)) return;
+		const maxScrollLeft = Math.max(
+			0,
+			event.currentTarget.scrollWidth - event.currentTarget.clientWidth,
+		);
+		const nextScrollLeft = Math.min(
+			maxScrollLeft,
+			Math.max(0, event.currentTarget.scrollLeft + event.deltaY),
+		);
+		if (nextScrollLeft === event.currentTarget.scrollLeft) return;
+		event.preventDefault();
+		event.currentTarget.scrollLeft = nextScrollLeft;
+	};
+
+	return (
+		<div
+			ref={scrollContainer}
+			onScroll={scheduleMeasure}
+			onWheel={handleWheel}
+			class="hide-scroll flex snap-x snap-proximity gap-2 overflow-x-auto overscroll-x-contain scroll-smooth pb-1 pr-8"
+			style={{
+				"-webkit-mask-image": maskImage(),
+				"mask-image": maskImage(),
+				"scrollbar-width": "none",
+			}}
+		>
+			{props.children}
+		</div>
+	);
+}
+
+function RecentCard(props: {
+	item: RecentMediaItem;
+	disabled?: boolean;
+	onClick: () => void;
+}) {
+	const [imageAvailable, setImageAvailable] = createSignal(true);
+	const title = () => props.item.target.pretty_name;
+	const typeLabel = () => {
+		if (props.item.kind === "screenshot") return "Screenshot";
+		return props.item.target.mode === "studio" ? "Studio Mode" : "Instant Mode";
+	};
+	const TypeIcon = () => {
+		if (props.item.kind === "screenshot") {
+			return <IconLucideImage class="size-2.5" />;
+		}
+		if (props.item.target.mode === "studio") {
+			return <IconLucideClapperboard class="size-2.5" />;
+		}
+		return <IconLucideZap class="size-2.5" />;
+	};
+	const thumbnailSrc = createMemo(() => {
+		if (!props.item.previewPath || !imageAvailable()) return undefined;
+		return `${convertFileSrc(props.item.previewPath)}?v=${props.item.previewVersion ?? 0}`;
+	});
+
+	return (
+		<button
+			type="button"
+			disabled={props.disabled}
+			onClick={props.onClick}
+			aria-label={`Open ${typeLabel()}: ${title()}`}
+			class={cx(
+				"group relative h-28 w-[196px] shrink-0 snap-start overflow-hidden rounded-xl border border-gray-5 bg-gray-3 text-left shadow-sm outline-hidden transition-[transform,border-color,box-shadow] duration-150 hover:-translate-y-0.5 hover:border-gray-7 hover:shadow-md focus-visible:ring-2 focus-visible:ring-blue-9 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-1",
+				props.disabled && "pointer-events-none opacity-60",
+			)}
+		>
+			<Show
+				when={thumbnailSrc()}
+				fallback={
+					<div class="flex h-full w-full items-center justify-center bg-linear-to-br from-gray-3 to-gray-5 text-gray-9">
+						<Show
+							when={props.item.kind === "screenshot"}
+							fallback={<IconLucideSquarePlay class="size-7" />}
+						>
+							<IconLucideImage class="size-7" />
+						</Show>
+					</div>
+				}
+			>
+				{(src) => (
+					<img
+						src={src()}
+						alt=""
+						loading="lazy"
+						decoding="async"
+						draggable={false}
+						onError={() => setImageAvailable(false)}
+						class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.025]"
+					/>
+				)}
+			</Show>
+			<div class="absolute inset-0 bg-linear-to-t from-black/80 via-black/10 to-black/5" />
+			<div class="absolute left-2 top-2 flex items-center gap-1 rounded-full border border-white/15 bg-black/45 px-2 py-0.5 text-[9px] font-medium text-white/90 backdrop-blur-sm">
+				<TypeIcon />
+				{typeLabel()}
+			</div>
+			<div class="absolute inset-x-0 bottom-0 px-2.5 pb-2 pt-5">
+				<p class="truncate text-[11px] font-medium text-white">{title()}</p>
+				<Show
+					when={
+						props.item.kind === "recording" && props.item.target.clip_count > 1
+					}
+				>
+					<p class="mt-0.5 text-[9px] text-white/65">
+						{props.item.kind === "recording"
+							? `${props.item.target.clip_count} clips`
+							: null}
+					</p>
+				</Show>
+			</div>
+		</button>
+	);
+}
+
+export default function Recents(props: {
+	items?: RecentMediaItem[];
+	isLoading: boolean;
+	errorMessage?: string;
+	disabled?: boolean;
+	onSelect: (item: RecentMediaItem) => void;
+}) {
+	return (
+		<section class="animate-in overflow-hidden fade-in slide-in-from-bottom-1 duration-200">
+			<div class="mb-2 flex items-center px-0.5">
+				<h2 class="text-xs font-semibold text-gray-12">Recents</h2>
+			</div>
+			<Show when={props.errorMessage}>
+				<div class="flex h-28 items-center justify-center rounded-xl border border-dashed border-gray-5 bg-gray-2 px-4 text-center text-xs text-gray-10">
+					{props.errorMessage}
+				</div>
+			</Show>
+			<Show when={!props.errorMessage && props.isLoading}>
+				<RecentCarousel itemCount={3}>
+					<For each={[0, 1, 2]}>
+						{() => (
+							<div class="h-28 w-[196px] shrink-0 snap-start animate-pulse rounded-xl bg-gray-3" />
+						)}
+					</For>
+				</RecentCarousel>
+			</Show>
+			<Show
+				when={
+					!props.errorMessage &&
+					!props.isLoading &&
+					(props.items?.length ?? 0) === 0
+				}
+			>
+				<div class="flex h-28 flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-gray-5 bg-gray-2 text-center">
+					<IconLucideHistory class="size-5 text-gray-9" />
+					<p class="text-xs text-gray-10">
+						Your latest captures will appear here.
+					</p>
+				</div>
+			</Show>
+			<Show
+				when={!props.errorMessage && !props.isLoading && props.items?.length}
+			>
+				<RecentCarousel itemCount={props.items?.length ?? 0}>
+					<For each={props.items}>
+						{(item) => (
+							<RecentCard
+								item={item}
+								disabled={props.disabled}
+								onClick={() => props.onSelect(item)}
+							/>
+						)}
+					</For>
+				</RecentCarousel>
+			</Show>
+		</section>
+	);
+}

--- a/apps/desktop/src/routes/(window-chrome)/new-main/TargetCard.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/TargetCard.tsx
@@ -18,8 +18,8 @@ import {
 	type CaptureDisplayWithThumbnail,
 	type CaptureWindowWithThumbnail,
 	commands,
-	type RecordingMeta,
 	type RecordingMetaWithMetadata,
+	type ScreenshotMetaWithMetadata,
 } from "~/utils/tauri";
 import IconCapLink from "~icons/cap/link";
 import IconCapTrash from "~icons/cap/trash";
@@ -35,7 +35,7 @@ import IconMdiMonitor from "~icons/mdi/monitor";
 import IconPhWarningBold from "~icons/ph/warning-bold";
 
 export type RecordingWithPath = RecordingMetaWithMetadata & { path: string };
-export type ScreenshotWithPath = RecordingMeta & { path: string };
+export type ScreenshotWithPath = ScreenshotMetaWithMetadata & { path: string };
 
 function formatResolution(width?: number, height?: number) {
 	if (!width || !height) return undefined;

--- a/apps/desktop/src/routes/(window-chrome)/new-main/TargetDropdownButton.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/TargetDropdownButton.tsx
@@ -27,8 +27,8 @@ export default function TargetDropdownButton<
 			aria-expanded={local.expanded ? "true" : "false"}
 			data-expanded={local.expanded ? "true" : "false"}
 			class={cx(
-				"flex w-5 shrink-0 items-center justify-center rounded-lg bg-gray-4 text-gray-12 transition-colors duration-150 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-9 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-1 hover:bg-gray-5",
-				local.expanded && "bg-gray-5",
+				"flex w-7 shrink-0 items-center justify-center rounded-lg bg-gray-4 text-gray-12 transition-colors duration-150 hover:bg-gray-6 active:bg-gray-7 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-9 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-1",
+				local.expanded && "bg-blue-4 text-blue-11",
 				local.disabled && "pointer-events-none opacity-60",
 				local.class,
 			)}

--- a/apps/desktop/src/routes/(window-chrome)/new-main/TargetTypeButton.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/TargetTypeButton.tsx
@@ -5,6 +5,7 @@ type TargetTypeButtonProps = {
 	selected: boolean;
 	Component: Component<ComponentProps<"svg">>;
 	name: string;
+	description?: string;
 	disabled?: boolean;
 } & ComponentProps<"button">;
 
@@ -13,6 +14,7 @@ function TargetTypeButton(props: TargetTypeButtonProps) {
 		"selected",
 		"Component",
 		"name",
+		"description",
 		"disabled",
 		"class",
 	]);
@@ -24,19 +26,38 @@ function TargetTypeButton(props: TargetTypeButtonProps) {
 			disabled={local.disabled}
 			aria-pressed={local.selected ? "true" : "false"}
 			class={cx(
-				"flex flex-1 flex-col items-center justify-end gap-1 rounded-lg border border-gray-5 bg-gray-3 py-2 text-center transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-9 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-1",
-				local.selected ? "text-gray-12" : "text-gray-12 hover:bg-gray-4",
+				"flex flex-1 flex-col items-center gap-1 rounded-lg border py-2 text-center transition-[background-color,border-color,color] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-9 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-1",
+				local.description &&
+					"min-h-14 flex-row items-center justify-start gap-2.5 px-3 text-left",
+				!local.description && "justify-end",
+				local.selected
+					? "border-blue-8 bg-blue-3 text-blue-11 hover:border-blue-9 hover:bg-blue-4 active:bg-blue-5 dark:bg-blue-3/30 dark:hover:bg-blue-4/40"
+					: "border-gray-6 bg-gray-2 text-gray-12 hover:border-gray-8 hover:bg-gray-4 active:bg-gray-5",
 				local.disabled && "pointer-events-none opacity-60",
 				local.class,
 			)}
 		>
 			<local.Component
 				class={cx(
-					"size-5 transition-colors",
-					local.selected ? "text-gray-12" : "text-gray-9",
+					"size-5 shrink-0 transition-colors",
+					local.selected ? "text-blue-10" : "text-gray-10",
 				)}
 			/>
-			<p class="text-xs">{local.name}</p>
+			<div class="min-w-0">
+				<p class={cx("text-xs", local.description && "font-medium leading-4")}>
+					{local.name}
+				</p>
+				{local.description && (
+					<p
+						class={cx(
+							"text-[10px] leading-3",
+							local.selected ? "text-blue-10" : "text-gray-10",
+						)}
+					>
+						{local.description}
+					</p>
+				)}
+			</div>
 		</button>
 	);
 }

--- a/apps/desktop/src/routes/(window-chrome)/new-main/deviceRowStyles.ts
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/deviceRowStyles.ts
@@ -1,10 +1,10 @@
 export const DEVICE_ROW_CLASS =
-	"group relative isolate overflow-hidden flex flex-row gap-2.5 items-center pl-3 pr-1.5 w-full h-[42px] rounded-lg border border-gray-5 bg-gray-3 transition-[background-color,border-color,color] cursor-default disabled:opacity-70 disabled:text-gray-11 enabled:hover:bg-gray-4 enabled:hover:border-gray-6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-9 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-1";
+	"group relative isolate overflow-hidden flex flex-row gap-2.5 items-center pl-3 pr-1.5 w-full h-[42px] rounded-lg border border-gray-6 bg-gray-2 transition-[background-color,border-color,color] duration-150 cursor-default disabled:opacity-70 disabled:text-gray-11 enabled:hover:bg-gray-4 enabled:hover:border-gray-8 enabled:active:bg-gray-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-9 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-1";
 
-export const DEVICE_ROW_ICON_CLASS = "text-gray-10 size-4 shrink-0";
+export const DEVICE_ROW_ICON_CLASS = "text-gray-11 size-4 shrink-0";
 
 export const DEVICE_ROW_LABEL_CLASS =
-	"flex-1 min-w-0 text-sm text-left truncate";
+	"flex-1 min-w-0 text-sm font-medium text-left truncate";
 
 export const DEVICE_ROW_TRAILING_CLASS = "flex items-center gap-0.5 shrink-0";
 

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -2443,10 +2443,15 @@ function Page() {
 		};
 		const targetMode = __CAP__?.initialTargetMode ?? null;
 		const currentWindow = getCurrentWindow();
-
-		currentWindow.setSize(
-			new LogicalSize(WINDOW_SIZE.width, WINDOW_SIZE.height),
-		);
+		const storedWindowUI = await mainWindowUIStore.get().catch((error) => {
+			console.error("Failed to load main window size:", error);
+			return undefined;
+		});
+		const expanded = storedWindowUI?.expanded ?? false;
+		setIsExpanded(expanded);
+		await resizeMainWindow(expanded, false).catch((error) => {
+			console.error("Failed to restore main window size:", error);
+		});
 
 		if (targetMode) {
 			await commands.openTargetSelectOverlays(null, null, targetMode);
@@ -2868,20 +2873,25 @@ function Page() {
 						</div>
 						<div
 							class={cx(
-								"flex flex-1 overflow-hidden rounded-lg border border-gray-5 bg-gray-3 ring-1 ring-transparent ring-offset-2 ring-offset-gray-1 transition focus-within:ring-blue-9 focus-within:ring-offset-2 focus-within:ring-offset-gray-1",
-								(rawOptions.targetMode === "window" || windowMenuOpen()) &&
-									"ring-blue-9",
+								"flex flex-1 overflow-hidden rounded-lg border border-gray-6 bg-gray-2 ring-1 ring-transparent ring-offset-1 ring-offset-gray-1 transition-[background-color,border-color] focus-within:ring-blue-9 focus-within:ring-offset-1 focus-within:ring-offset-gray-1",
+								rawOptions.targetMode === "window" || windowMenuOpen()
+									? "border-blue-8 bg-blue-3 ring-blue-8 hover:border-blue-9 hover:bg-blue-4 dark:bg-blue-3/30 dark:hover:bg-blue-4/40"
+									: "hover:border-gray-8 hover:bg-gray-3",
 							)}
 						>
 							<TargetTypeButton
 								selected={rawOptions.targetMode === "window"}
 								Component={IconLucideAppWindowMac}
 								disabled={isRecording()}
+								description={isExpanded() ? "One app" : undefined}
 								onClick={() => {
 									toggleTargetMode("window");
 								}}
 								name="Window"
-								class="flex-1 rounded-none border-0 focus-visible:ring-0 focus-visible:ring-offset-0 pl-5"
+								class={cx(
+									"flex-1 rounded-none border-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0",
+									isExpanded() ? "pl-3" : "pl-5",
+								)}
 							/>
 							<TargetDropdownButton
 								class={cx(
@@ -2910,6 +2920,7 @@ function Page() {
 							selected={rawOptions.targetMode === "area"}
 							Component={IconMaterialSymbolsScreenshotFrame2Rounded}
 							disabled={isRecording()}
+							description={isExpanded() ? "Custom region" : undefined}
 							onClick={() => {
 								toggleTargetMode("area");
 							}}

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -197,21 +197,33 @@ const clamp = (value: number, minimum: number, maximum: number) =>
 
 async function resizeMainWindow(expanded: boolean, animate: boolean) {
 	const currentWindow = getCurrentWindow();
-	const [physicalSize, scaleFactor, physicalPosition, monitor] =
+	const [physicalSize, outerSize, scaleFactor, physicalPosition, monitor] =
 		await Promise.all([
 			currentWindow.innerSize(),
+			currentWindow.outerSize(),
 			currentWindow.scaleFactor(),
 			currentWindow.outerPosition().catch(() => null),
 			currentMonitor().catch(() => null),
 		]);
+	const frameWidth = Math.max(
+		0,
+		(outerSize.width - physicalSize.width) / scaleFactor,
+	);
+	const frameHeight = Math.max(
+		0,
+		(outerSize.height - physicalSize.height) / scaleFactor,
+	);
 	const preferredSize = expanded
 		? MAIN_WINDOW_SIZE.expanded
 		: MAIN_WINDOW_SIZE.compact;
 	const availableWidth = monitor
-		? monitor.workArea.size.width / scaleFactor - MAIN_WINDOW_SCREEN_PADDING * 2
+		? monitor.workArea.size.width / scaleFactor -
+			frameWidth -
+			MAIN_WINDOW_SCREEN_PADDING * 2
 		: preferredSize.width;
 	const availableHeight = monitor
 		? monitor.workArea.size.height / scaleFactor -
+			frameHeight -
 			MAIN_WINDOW_SCREEN_PADDING * 2
 		: preferredSize.height;
 	const targetWidth = Math.max(
@@ -230,10 +242,64 @@ async function resizeMainWindow(expanded: boolean, animate: boolean) {
 		"(prefers-reduced-motion: reduce)",
 	).matches;
 
+	if (monitor && physicalPosition) {
+		const padding = MAIN_WINDOW_SCREEN_PADDING * scaleFactor;
+		const workArea = monitor.workArea;
+		const targetPhysicalWidth = (targetWidth + frameWidth) * scaleFactor;
+		const targetPhysicalHeight = (targetHeight + frameHeight) * scaleFactor;
+		const minimumX = workArea.position.x + padding;
+		const minimumY = workArea.position.y + padding;
+		const maximumX = Math.max(
+			minimumX,
+			workArea.position.x + workArea.size.width - targetPhysicalWidth - padding,
+		);
+		const maximumY = Math.max(
+			minimumY,
+			workArea.position.y +
+				workArea.size.height -
+				targetPhysicalHeight -
+				padding,
+		);
+		const targetX = clamp(physicalPosition.x, minimumX, maximumX);
+		const targetY = clamp(physicalPosition.y, minimumY, maximumY);
+
+		if (targetX !== physicalPosition.x || targetY !== physicalPosition.y) {
+			await currentWindow
+				.setPosition(
+					new PhysicalPosition(Math.round(targetX), Math.round(targetY)),
+				)
+				.catch(() => undefined);
+		}
+	}
+
 	if (Math.abs(widthDelta) > 0.5 || Math.abs(heightDelta) > 0.5) {
 		if (!animate || reduceMotion) {
 			await currentWindow.setSize(new LogicalSize(targetWidth, targetHeight));
 		} else {
+			let pendingSize: LogicalSize | undefined;
+			let resizeWorker: Promise<void> | undefined;
+			let resizeError: unknown;
+			let resizeFailed = false;
+			const scheduleResize = (size: LogicalSize) => {
+				if (resizeFailed) return;
+				pendingSize = size;
+				if (resizeWorker) return;
+				resizeWorker = (async () => {
+					while (pendingSize) {
+						const nextSize = pendingSize;
+						pendingSize = undefined;
+						await currentWindow.setSize(nextSize);
+					}
+				})()
+					.catch((error) => {
+						resizeFailed = true;
+						resizeError = error;
+						pendingSize = undefined;
+					})
+					.finally(() => {
+						resizeWorker = undefined;
+					});
+			};
 			const startedAt = performance.now();
 			let progress = 0;
 			while (progress < 1) {
@@ -243,38 +309,16 @@ async function resizeMainWindow(expanded: boolean, animate: boolean) {
 					(performance.now() - startedAt) / MAIN_WINDOW_RESIZE_DURATION,
 				);
 				const eased = 1 - (1 - progress) ** 3;
-				await currentWindow.setSize(
+				scheduleResize(
 					new LogicalSize(
 						startWidth + widthDelta * eased,
 						startHeight + heightDelta * eased,
 					),
 				);
 			}
+			await resizeWorker;
+			if (resizeFailed) throw resizeError;
 		}
-	}
-
-	if (!monitor || !physicalPosition) return;
-	const padding = MAIN_WINDOW_SCREEN_PADDING * scaleFactor;
-	const workArea = monitor.workArea;
-	const targetPhysicalWidth = targetWidth * scaleFactor;
-	const targetPhysicalHeight = targetHeight * scaleFactor;
-	const targetX = clamp(
-		physicalPosition.x,
-		workArea.position.x + padding,
-		workArea.position.x + workArea.size.width - targetPhysicalWidth - padding,
-	);
-	const targetY = clamp(
-		physicalPosition.y,
-		workArea.position.y + padding,
-		workArea.position.y + workArea.size.height - targetPhysicalHeight - padding,
-	);
-
-	if (targetX !== physicalPosition.x || targetY !== physicalPosition.y) {
-		await currentWindow
-			.setPosition(
-				new PhysicalPosition(Math.round(targetX), Math.round(targetY)),
-			)
-			.catch(() => undefined);
 	}
 }
 

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -2831,8 +2831,13 @@ function Page() {
 			await commands.showWindow({
 				Editor: { project_path: projectPath },
 			});
-		} else if (recording.sharing?.link) {
-			await shell.open(recording.sharing.link);
+		} else {
+			const link = recording.sharing?.link;
+			if (!link) {
+				toast.error("This recording isn't ready to open yet.");
+				return;
+			}
+			await shell.open(link);
 		}
 
 		await getCurrentWindow().hide();

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -2891,25 +2891,35 @@ function Page() {
 			exitClass="scale-100"
 			exitToClass="scale-95"
 		>
-			<div class="flex flex-col gap-2 w-full">
+			<div class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pb-1 w-full">
+				<Show when={isExpanded()}>
+					<div class="px-1 pb-0.5">
+						<h2 class="text-xs font-semibold text-gray-12">Capture</h2>
+					</div>
+				</Show>
 				<div class="flex flex-col gap-2 w-full text-xs text-gray-11">
 					<div class="flex flex-row gap-2 items-stretch w-full">
 						<div
 							class={cx(
-								"flex flex-1 overflow-hidden rounded-lg border border-gray-5 bg-gray-3 ring-1 ring-transparent ring-offset-2 ring-offset-gray-1 transition focus-within:ring-blue-9 focus-within:ring-offset-2 focus-within:ring-offset-gray-1",
-								(rawOptions.targetMode === "display" || displayMenuOpen()) &&
-									"ring-blue-9",
+								"flex flex-1 overflow-hidden rounded-lg border border-gray-6 bg-gray-2 ring-1 ring-transparent ring-offset-1 ring-offset-gray-1 transition-[background-color,border-color] focus-within:ring-blue-9 focus-within:ring-offset-1 focus-within:ring-offset-gray-1",
+								rawOptions.targetMode === "display" || displayMenuOpen()
+									? "border-blue-8 bg-blue-3 ring-blue-8 hover:border-blue-9 hover:bg-blue-4 dark:bg-blue-3/30 dark:hover:bg-blue-4/40"
+									: "hover:border-gray-8 hover:bg-gray-3",
 							)}
 						>
 							<TargetTypeButton
 								selected={rawOptions.targetMode === "display"}
 								Component={IconMdiMonitor}
 								disabled={isRecording()}
+								description={isExpanded() ? "Entire screen" : undefined}
 								onClick={() => {
 									toggleTargetMode("display");
 								}}
 								name="Display"
-								class="flex-1 rounded-none border-0 focus-visible:ring-0 focus-visible:ring-offset-0 pl-5"
+								class={cx(
+									"flex-1 rounded-none border-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0",
+									isExpanded() ? "pl-3" : "pl-5",
+								)}
 							/>
 							<TargetDropdownButton
 								class={cx(
@@ -2992,6 +3002,7 @@ function Page() {
 							selected={rawOptions.targetMode === "camera"}
 							Component={IconLucideVideo}
 							disabled={isRecording()}
+							description={isExpanded() ? "No screen" : undefined}
 							onClick={() => {
 								toggleTargetMode("camera");
 							}}
@@ -3001,6 +3012,25 @@ function Page() {
 					</div>
 				</div>
 				<BaseControls />
+				<Show when={isExpanded()}>
+					<div class="pt-2">
+						<Recents
+							items={recentMedia.data}
+							isLoading={
+								recentMedia.data === undefined &&
+								(recentMedia.status === "pending" ||
+									recentMedia.fetchStatus === "fetching")
+							}
+							errorMessage={
+								recentMedia.error && recentMedia.data === undefined
+									? "Unable to load recent captures"
+									: undefined
+							}
+							disabled={isRecording()}
+							onSelect={(item) => void openRecentMedia(item)}
+						/>
+					</div>
+				</Show>
 			</div>
 		</Transition>
 	);

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -1814,6 +1814,26 @@ function Page() {
 	const compatibilityStudioMode = () =>
 		rawOptions.mode === "studio" &&
 		generalSettings.data?.studioRecordingQuality === "compatibility";
+
+	const toggleMainWindowExpanded = async () => {
+		if (isWindowResizing()) return;
+		const previousExpanded = isExpanded();
+		const expanded = !previousExpanded;
+		setIsWindowResizing(true);
+		if (!expanded) setIsExpanded(false);
+		try {
+			await resizeMainWindow(expanded, true);
+			if (expanded) setIsExpanded(true);
+			void mainWindowUIStore.set({ expanded }).catch((error) => {
+				console.error("Failed to save main window size:", error);
+			});
+		} catch (error) {
+			setIsExpanded(previousExpanded);
+			console.error("Failed to resize main window:", error);
+		} finally {
+			setIsWindowResizing(false);
+		}
+	};
 	let cancelScheduledTargetListPrewarm: (() => void) | undefined;
 	onCleanup(() => cancelScheduledTargetListPrewarm?.());
 
@@ -2091,25 +2111,6 @@ function Page() {
 		}
 	});
 
-	const refetchRecordingsUnlessEditorRecording = () => {
-		if (rawOptions.targetModeSource !== "editorRecording") {
-			void recordings.refetch();
-		}
-	};
-
-	createTauriEventListener(events.recordingDeleted, () => recordings.refetch());
-	createTauriEventListener(events.recordingsMigrationProgress, (payload) => {
-		// Storage-folder migration finished: moved recordings changed paths.
-		if (payload.done === payload.total) void recordings.refetch();
-	});
-	createTauriEventListener(
-		events.recordingStarted,
-		refetchRecordingsUnlessEditorRecording,
-	);
-	createTauriEventListener(
-		events.recordingStopped,
-		refetchRecordingsUnlessEditorRecording,
-	);
 	// Start failures happen before the in-progress window exists, and the picker
 	// overlay that invoked start_recording may already be dismissed — this window
 	// is the only reliable surface for telling the user why nothing started. The
@@ -2472,7 +2473,7 @@ function Page() {
 
 		setCanRevealMainWindow(true);
 		void emit("main-window-ready");
-		scheduleTargetListPrewarm();
+		if (!targetMode) scheduleTargetListPrewarm();
 
 		if (rawOptions.micName) {
 			setMicInput
@@ -2969,7 +2970,10 @@ function Page() {
 			onMouseEnter={handleMouseEnter}
 			class="flex relative flex-col px-[13px] gap-2 pb-[8px] h-full min-h-0 text-(--text-primary)"
 		>
-			<WindowChromeHeader hideMaximize>
+			<WindowChromeHeader
+				maximized={isExpanded()}
+				onMaximize={() => void toggleMainWindowExpanded()}
+			>
 				<div
 					class="flex flex-1 gap-1 items-center mx-2 min-w-0"
 					data-tauri-drag-region
@@ -2977,6 +2981,27 @@ function Page() {
 					<MainWindowHelpButton />
 					<div class="flex-1 min-h-9 min-w-0" data-tauri-drag-region />
 					<div class="flex gap-1 items-center shrink-0" data-tauri-drag-region>
+						<Tooltip
+							content={<span>{isExpanded() ? "Collapse" : "Expand"}</span>}
+						>
+							<button
+								type="button"
+								disabled={isWindowResizing()}
+								onClick={() => void toggleMainWindowExpanded()}
+								aria-label={isExpanded() ? "Collapse window" : "Expand window"}
+								aria-pressed={isExpanded()}
+								class="flex items-center justify-center size-5 focus:outline-hidden disabled:opacity-50"
+							>
+								<Show
+									when={isExpanded()}
+									fallback={
+										<IconLucideMaximize2 class="transition-colors text-gray-11 size-3.5 hover:text-gray-12" />
+									}
+								>
+									<IconLucideMinimize2 class="transition-colors text-gray-11 size-3.5 hover:text-gray-12" />
+								</Show>
+							</button>
+						</Tooltip>
 						<Tooltip content={<span>Settings</span>}>
 							<button
 								type="button"

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -113,6 +113,7 @@ import CameraSelect from "./CameraSelect";
 import ChangelogButton from "./ChangeLogButton";
 import MicrophoneSelect from "./MicrophoneSelect";
 import ModeInfoPanel from "./ModeInfoPanel";
+import Recents, { type RecentMediaItem } from "./Recents";
 import SystemAudio from "./SystemAudio";
 import type { RecordingWithPath, ScreenshotWithPath } from "./TargetCard";
 import TargetDropdownButton from "./TargetDropdownButton";
@@ -2774,50 +2775,109 @@ function Page() {
 		setCameraMenuOpen(false);
 	};
 
+	const openRecording = async (recording: RecordingWithPath) => {
+		if (recording.mode === "studio") {
+			let projectPath = recording.path;
+			const needsRecovery =
+				recording.status.status === "InProgress" ||
+				recording.status.status === "NeedsRemux";
+
+			if (needsRecovery) {
+				try {
+					projectPath = await commands.recoverRecording(projectPath);
+				} catch (error) {
+					console.error("Failed to recover recording:", error);
+				}
+			}
+
+			await commands.showWindow({
+				Editor: { project_path: projectPath },
+			});
+		} else if (recording.sharing?.link) {
+			await shell.open(recording.sharing.link);
+		}
+
+		await getCurrentWindow().hide();
+	};
+
+	const openScreenshot = async (screenshot: ScreenshotWithPath) => {
+		await commands.showWindow({
+			ScreenshotEditor: { path: screenshot.path },
+		});
+	};
+
+	const openRecentMedia = async (item: RecentMediaItem) => {
+		if (item.kind === "recording") {
+			await openRecording(item.target);
+		} else {
+			await openScreenshot(item.target);
+		}
+	};
+
+	const ExpandedControlLabel = (props: { title: string }) => (
+		<Show when={isExpanded()}>
+			<div class="mb-1 px-1">
+				<p class="text-xs font-semibold text-gray-12">{props.title}</p>
+			</div>
+		</Show>
+	);
+
 	const BaseControls = () => (
-		<div class="space-y-2">
-			<CameraSelect
-				disabled={enableDeviceQueries() && devices.isPending}
-				options={devices.cameras}
-				value={options.camera() ?? null}
-				selectedLabel={rawOptions.cameraLabel}
-				isSelected={rawOptions.cameraID != null}
-				onChange={(c) => {
-					if (!c) {
-						setOptions("cameraLabel", null);
-						setCamera.mutate({ model: null });
-					} else if (c.model_id) {
-						setOptions("cameraLabel", c.display_name);
-						setCamera.mutate({ model: { ModelID: c.model_id } });
-					} else {
-						setOptions("cameraLabel", c.display_name);
-						setCamera.mutate({ model: { DeviceID: c.device_id } });
+		<div class={cx("space-y-2", isExpanded() && "space-y-2.5")}>
+			<div>
+				<ExpandedControlLabel title="Camera" />
+				<CameraSelect
+					disabled={enableDeviceQueries() && devices.isPending}
+					options={devices.cameras}
+					value={options.camera() ?? null}
+					selectedLabel={rawOptions.cameraLabel}
+					isSelected={rawOptions.cameraID != null}
+					onChange={(c) => {
+						if (!c) {
+							setOptions("cameraLabel", null);
+							setCamera.mutate({ model: null });
+						} else if (c.model_id) {
+							setOptions("cameraLabel", c.display_name);
+							setCamera.mutate({ model: { ModelID: c.model_id } });
+						} else {
+							setOptions("cameraLabel", c.display_name);
+							setCamera.mutate({ model: { DeviceID: c.device_id } });
+						}
+					}}
+					permissions={currentPermissions()}
+					onOpen={() => openCameraMenu(null)}
+					onOpenSettings={() =>
+						openCameraMenu(
+							options.camera() ?? null,
+							rawOptions.cameraID != null,
+						)
 					}
-				}}
-				permissions={currentPermissions()}
-				onOpen={() => openCameraMenu(null)}
-				onOpenSettings={() =>
-					openCameraMenu(options.camera() ?? null, rawOptions.cameraID != null)
-				}
-			/>
-			<MicrophoneSelect
-				disabled={enableDeviceQueries() && devices.isPending}
-				options={devices.microphones.map((m) => m.name)}
-				value={rawOptions.micName ?? null}
-				onChange={(v) => setMicInput.mutate(v)}
-				permissions={currentPermissions()}
-				onOpen={() => openMicrophoneMenu(null)}
-				onOpenSettings={
-					rawOptions.micName
-						? () =>
-								openMicrophoneMenu(
-									options.micName() ?? null,
-									rawOptions.micName != null,
-								)
-						: undefined
-				}
-			/>
-			<SystemAudio />
+				/>
+			</div>
+			<div>
+				<ExpandedControlLabel title="Microphone" />
+				<MicrophoneSelect
+					disabled={enableDeviceQueries() && devices.isPending}
+					options={devices.microphones.map((m) => m.name)}
+					value={rawOptions.micName ?? null}
+					onChange={(v) => setMicInput.mutate(v)}
+					permissions={currentPermissions()}
+					onOpen={() => openMicrophoneMenu(null)}
+					onOpenSettings={
+						rawOptions.micName
+							? () =>
+									openMicrophoneMenu(
+										options.micName() ?? null,
+										rawOptions.micName != null,
+									)
+							: undefined
+					}
+				/>
+			</div>
+			<div>
+				<ExpandedControlLabel title="System audio" />
+				<SystemAudio />
+			</div>
 		</div>
 	);
 

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -3276,33 +3276,7 @@ function Page() {
 									errorMessage={
 										recordings.error ? "Failed to load recordings" : undefined
 									}
-									onSelect={async (recording) => {
-										if (recording.mode === "studio") {
-											let projectPath = recording.path;
-
-											const needsRecovery =
-												recording.status.status === "InProgress" ||
-												recording.status.status === "NeedsRemux";
-
-											if (needsRecovery) {
-												try {
-													projectPath =
-														await commands.recoverRecording(projectPath);
-												} catch (e) {
-													console.error("Failed to recover recording:", e);
-												}
-											}
-
-											await commands.showWindow({
-												Editor: { project_path: projectPath },
-											});
-										} else {
-											if (recording.sharing?.link) {
-												await shell.open(recording.sharing.link);
-											}
-										}
-										getCurrentWindow().hide();
-									}}
+									onSelect={openRecording}
 									disabled={isRecording()}
 									onBack={() => {
 										setRecordingsMenuOpen(false);
@@ -3316,7 +3290,7 @@ function Page() {
 									uploadProgress={uploadProgress}
 									reuploadingPaths={reuploadingPaths()}
 									onReupload={handleReupload}
-									onRefetch={() => recordings.refetch()}
+									onRefetch={refreshRecordings}
 								/>
 							) : variant === "screenshot" ? (
 								<TargetMenuPanel
@@ -3326,13 +3300,7 @@ function Page() {
 									errorMessage={
 										screenshots.error ? "Failed to load screenshots" : undefined
 									}
-									onSelect={async (screenshot) => {
-										await commands.showWindow({
-											ScreenshotEditor: {
-												path: screenshot.path,
-											},
-										});
-									}}
+									onSelect={openScreenshot}
 									disabled={isRecording()}
 									onBack={() => {
 										setScreenshotsMenuOpen(false);

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -19,7 +19,6 @@ import {
 	PhysicalPosition,
 } from "@tauri-apps/api/window";
 import * as dialog from "@tauri-apps/plugin-dialog";
-import { stat } from "@tauri-apps/plugin-fs";
 import { relaunch } from "@tauri-apps/plugin-process";
 import * as shell from "@tauri-apps/plugin-shell";
 import { cx } from "cva";
@@ -2218,15 +2217,10 @@ function Page() {
 					.slice(0, RECENT_MEDIA_LIMIT)
 					.map((target) => ({ kind: "screenshot" as const, target })),
 			];
-			const datedCandidates = await Promise.all(
-				candidates.map(async (candidate) => {
-					const fileInfo = await stat(candidate.target.path).catch(() => null);
-					return {
-						candidate,
-						createdAt: (fileInfo?.birthtime ?? fileInfo?.mtime)?.getTime() ?? 0,
-					};
-				}),
-			);
+			const datedCandidates = candidates.map((candidate) => ({
+				candidate,
+				createdAt: candidate.target.sort_time_millis,
+			}));
 
 			return datedCandidates
 				.sort((a, b) => b.createdAt - a.createdAt)

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -12,8 +12,14 @@ import {
 	getAllWebviewWindows,
 	WebviewWindow,
 } from "@tauri-apps/api/webviewWindow";
-import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
+import {
+	currentMonitor,
+	getCurrentWindow,
+	LogicalSize,
+	PhysicalPosition,
+} from "@tauri-apps/api/window";
 import * as dialog from "@tauri-apps/plugin-dialog";
+import { stat } from "@tauri-apps/plugin-fs";
 import { relaunch } from "@tauri-apps/plugin-process";
 import * as shell from "@tauri-apps/plugin-shell";
 import { cx } from "cva";
@@ -39,6 +45,7 @@ import { Input } from "~/routes/editor/ui";
 import {
 	authStore,
 	generalSettingsStore,
+	mainWindowUIStore,
 	recordingSettingsStore,
 } from "~/store";
 import { createSignInMutation } from "~/utils/auth";
@@ -88,6 +95,8 @@ import IconLucideBug from "~icons/lucide/bug";
 import IconLucideCircleHelp from "~icons/lucide/circle-help";
 import IconLucideImage from "~icons/lucide/image";
 import IconLucideImport from "~icons/lucide/import";
+import IconLucideMaximize2 from "~icons/lucide/maximize-2";
+import IconLucideMinimize2 from "~icons/lucide/minimize-2";
 import IconLucideScanText from "~icons/lucide/scan-text";
 import IconLucideSearch from "~icons/lucide/search";
 import IconLucideSettings from "~icons/lucide/settings";
@@ -111,7 +120,14 @@ import TargetMenuGrid from "./TargetMenuGrid";
 import TargetTypeButton from "./TargetTypeButton";
 import useRequestPermission from "./useRequestPermission";
 
-const WINDOW_SIZE = { width: 330, height: 395 } as const;
+const MAIN_WINDOW_SIZE = {
+	compact: { width: 330, height: 395 },
+	expanded: { width: 600, height: 660 },
+} as const;
+const MAIN_WINDOW_SCREEN_PADDING = 12;
+const MAIN_WINDOW_RESIZE_DURATION = 180;
+const RECENT_MEDIA_LIMIT = 9;
+const RECENT_MEDIA_QUERY_KEY = ["recent-media"] as const;
 const CAPTURE_LIST_STALE_TIME = 5_000;
 const CAPTURE_LIST_GC_TIME = 60_000;
 const CAPTURE_THUMBNAIL_STALE_TIME = 10_000;
@@ -146,6 +162,120 @@ type RecordingDeviceSettingsStore = {
 	cameraDeviceSettings?: Record<string, CameraDeviceSettings>;
 	microphoneDeviceSettings?: Record<string, MicrophoneDeviceSettings>;
 };
+
+type RecentMediaCandidate =
+	| {
+			kind: "recording";
+			target: RecordingWithPath;
+	  }
+	| {
+			kind: "screenshot";
+			target: ScreenshotWithPath;
+	  };
+
+const listScreenshotsQuery = queryOptions<ScreenshotWithPath[]>({
+	queryKey: ["screenshots"],
+	queryFn: async () => {
+		const result = await commands.listScreenshots().catch(() => [] as const);
+
+		return result.map(
+			([path, meta]) => ({ ...meta, path }) as ScreenshotWithPath,
+		);
+	},
+	staleTime: 5_000,
+	reconcile: (old, next) => reconcile(next)(old),
+	initialData: [],
+	initialDataUpdatedAt: 0,
+});
+
+const nextAnimationFrame = () =>
+	new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+const clamp = (value: number, minimum: number, maximum: number) =>
+	Math.min(Math.max(value, minimum), maximum);
+
+async function resizeMainWindow(expanded: boolean, animate: boolean) {
+	const currentWindow = getCurrentWindow();
+	const [physicalSize, scaleFactor, physicalPosition, monitor] =
+		await Promise.all([
+			currentWindow.innerSize(),
+			currentWindow.scaleFactor(),
+			currentWindow.outerPosition().catch(() => null),
+			currentMonitor().catch(() => null),
+		]);
+	const preferredSize = expanded
+		? MAIN_WINDOW_SIZE.expanded
+		: MAIN_WINDOW_SIZE.compact;
+	const availableWidth = monitor
+		? monitor.workArea.size.width / scaleFactor - MAIN_WINDOW_SCREEN_PADDING * 2
+		: preferredSize.width;
+	const availableHeight = monitor
+		? monitor.workArea.size.height / scaleFactor -
+			MAIN_WINDOW_SCREEN_PADDING * 2
+		: preferredSize.height;
+	const targetWidth = Math.max(
+		MAIN_WINDOW_SIZE.compact.width,
+		Math.min(preferredSize.width, availableWidth),
+	);
+	const targetHeight = Math.max(
+		MAIN_WINDOW_SIZE.compact.height,
+		Math.min(preferredSize.height, availableHeight),
+	);
+	const startWidth = physicalSize.width / scaleFactor;
+	const startHeight = physicalSize.height / scaleFactor;
+	const widthDelta = targetWidth - startWidth;
+	const heightDelta = targetHeight - startHeight;
+	const reduceMotion = window.matchMedia(
+		"(prefers-reduced-motion: reduce)",
+	).matches;
+
+	if (Math.abs(widthDelta) > 0.5 || Math.abs(heightDelta) > 0.5) {
+		if (!animate || reduceMotion) {
+			await currentWindow.setSize(new LogicalSize(targetWidth, targetHeight));
+		} else {
+			const startedAt = performance.now();
+			let progress = 0;
+			while (progress < 1) {
+				await nextAnimationFrame();
+				progress = Math.min(
+					1,
+					(performance.now() - startedAt) / MAIN_WINDOW_RESIZE_DURATION,
+				);
+				const eased = 1 - (1 - progress) ** 3;
+				await currentWindow.setSize(
+					new LogicalSize(
+						startWidth + widthDelta * eased,
+						startHeight + heightDelta * eased,
+					),
+				);
+			}
+		}
+	}
+
+	if (!monitor || !physicalPosition) return;
+	const padding = MAIN_WINDOW_SCREEN_PADDING * scaleFactor;
+	const workArea = monitor.workArea;
+	const targetPhysicalWidth = targetWidth * scaleFactor;
+	const targetPhysicalHeight = targetHeight * scaleFactor;
+	const targetX = clamp(
+		physicalPosition.x,
+		workArea.position.x + padding,
+		workArea.position.x + workArea.size.width - targetPhysicalWidth - padding,
+	);
+	const targetY = clamp(
+		physicalPosition.y,
+		workArea.position.y + padding,
+		workArea.position.y + workArea.size.height - targetPhysicalHeight - padding,
+	);
+
+	if (targetX !== physicalPosition.x || targetY !== physicalPosition.y) {
+		await currentWindow
+			.setPosition(
+				new PhysicalPosition(Math.round(targetX), Math.round(targetY)),
+			)
+			.catch(() => undefined);
+	}
+}
 
 const recordingDeviceSettingsStore = recordingSettingsStore as unknown as {
 	get: () => Promise<RecordingDeviceSettingsStore | undefined>;
@@ -1666,6 +1796,9 @@ function Page() {
 	const queryClient = useQueryClient();
 	const { rawOptions, setOptions } = useRecordingOptions();
 	const currentRecording = createCurrentRecordingQuery();
+	const [isExpanded, setIsExpanded] = createSignal(false);
+	const [isWindowFocused, setIsWindowFocused] = createSignal(false);
+	const [isWindowResizing, setIsWindowResizing] = createSignal(false);
 	const isRecording = () => !!currentRecording.data;
 	const isActivelyRecording = () =>
 		currentRecording.data?.status === "recording";
@@ -2006,30 +2139,135 @@ function Page() {
 				next.delete(path);
 				return next;
 			});
-			recordings.refetch();
+			refreshRecordings();
 		}
 	};
 
-	const screenshots = useQuery(() =>
-		queryOptions<ScreenshotWithPath[]>({
-			queryKey: ["screenshots"],
-			queryFn: async () => {
-				const result = await commands
-					.listScreenshots()
-					.catch(() => [] as const);
+	const screenshots = useQuery(() => ({
+		...listScreenshotsQuery,
+		enabled: screenshotsMenuOpen(),
+		refetchInterval: screenshotsMenuOpen() ? 10_000 : false,
+	}));
 
-				return result.map(
-					([path, meta]) => ({ ...meta, path }) as ScreenshotWithPath,
-				);
-			},
-			enabled: screenshotsMenuOpen(),
-			refetchInterval: screenshotsMenuOpen() ? 10_000 : false,
-			staleTime: 5_000,
-			reconcile: (old, next) => reconcile(next)(old),
-			initialData: [],
-			initialDataUpdatedAt: 0,
-		}),
+	const shouldLoadRecents = () =>
+		isExpanded() &&
+		isWindowFocused() &&
+		rawOptions.targetMode === null &&
+		activeMenu() === null &&
+		!isRecording();
+
+	const recentMedia = useQuery(() => ({
+		queryKey: RECENT_MEDIA_QUERY_KEY,
+		queryFn: async (): Promise<RecentMediaItem[]> => {
+			const [recordingRows, screenshotTargets] = await Promise.all([
+				queryClient.fetchQuery({ ...listRecordings, staleTime: 0 }),
+				queryClient.fetchQuery({ ...listScreenshotsQuery, staleTime: 0 }),
+			]);
+			const candidates: RecentMediaCandidate[] = [
+				...recordingRows.slice(0, RECENT_MEDIA_LIMIT).map(([path, meta]) => ({
+					kind: "recording" as const,
+					target: { ...meta, path } as RecordingWithPath,
+				})),
+				...screenshotTargets
+					.slice(0, RECENT_MEDIA_LIMIT)
+					.map((target) => ({ kind: "screenshot" as const, target })),
+			];
+			const datedCandidates = await Promise.all(
+				candidates.map(async (candidate) => {
+					const fileInfo = await stat(candidate.target.path).catch(() => null);
+					return {
+						candidate,
+						createdAt: (fileInfo?.birthtime ?? fileInfo?.mtime)?.getTime() ?? 0,
+					};
+				}),
+			);
+
+			return datedCandidates
+				.sort((a, b) => b.createdAt - a.createdAt)
+				.slice(0, RECENT_MEDIA_LIMIT)
+				.map(({ candidate, createdAt }): RecentMediaItem => {
+					if (candidate.kind === "screenshot") {
+						return {
+							...candidate,
+							createdAt,
+							previewPath: candidate.target.path,
+							previewVersion: createdAt,
+						};
+					}
+
+					return {
+						...candidate,
+						createdAt,
+						previewPath: `${candidate.target.path}/screenshots/display.jpg`,
+						previewVersion: createdAt,
+					};
+				});
+		},
+		enabled: shouldLoadRecents(),
+		staleTime: Number.POSITIVE_INFINITY,
+		gcTime: CAPTURE_LIST_GC_TIME,
+		refetchOnWindowFocus: false,
+	}));
+
+	const invalidateRecentMedia = () => {
+		void queryClient.invalidateQueries({
+			queryKey: RECENT_MEDIA_QUERY_KEY,
+			refetchType: "none",
+		});
+	};
+
+	const refreshRecentMedia = () => {
+		invalidateRecentMedia();
+		if (shouldLoadRecents()) void recentMedia.refetch();
+	};
+
+	const invalidateRecordings = () => {
+		void queryClient.invalidateQueries({
+			queryKey: listRecordings.queryKey,
+			refetchType: "none",
+		});
+	};
+
+	const refreshRecordings = () => {
+		invalidateRecordings();
+		if (recordingsMenuOpen()) void recordings.refetch();
+		refreshRecentMedia();
+	};
+
+	const refreshScreenshots = () => {
+		void queryClient.invalidateQueries({
+			queryKey: listScreenshotsQuery.queryKey,
+			refetchType: "none",
+		});
+		if (screenshotsMenuOpen()) void screenshots.refetch();
+		refreshRecentMedia();
+	};
+
+	const refreshRecordingsUnlessEditorRecording = () => {
+		if (rawOptions.targetModeSource !== "editorRecording") {
+			refreshRecordings();
+		}
+	};
+	const invalidateRecordingsUnlessEditorRecording = () => {
+		if (rawOptions.targetModeSource !== "editorRecording") {
+			invalidateRecordings();
+			invalidateRecentMedia();
+		}
+	};
+
+	createTauriEventListener(events.recordingDeleted, refreshRecordings);
+	createTauriEventListener(events.recordingsMigrationProgress, (payload) => {
+		if (payload.done === payload.total) refreshRecordings();
+	});
+	createTauriEventListener(
+		events.recordingStarted,
+		invalidateRecordingsUnlessEditorRecording,
 	);
+	createTauriEventListener(
+		events.recordingStopped,
+		refreshRecordingsUnlessEditorRecording,
+	);
+	createTauriEventListener(events.newScreenshotAdded, refreshScreenshots);
 
 	const screens = useQuery(() => ({
 		...listScreens,
@@ -2221,6 +2459,7 @@ function Page() {
 			});
 			await currentWindow.show();
 			await currentWindow.setFocus();
+			setIsWindowFocused(true);
 			void commands.closeTargetSelectOverlays().catch((error) => {
 				console.error("Failed to close target select overlays:", error);
 			});
@@ -2244,20 +2483,17 @@ function Page() {
 
 		const unlistenFocus = currentWindow.onFocusChanged(
 			({ payload: focused }) => {
+				setIsWindowFocused(focused);
 				if (focused) {
-					currentWindow.setSize(
-						new LogicalSize(WINDOW_SIZE.width, WINDOW_SIZE.height),
-					);
+					if (!isWindowResizing()) {
+						void resizeMainWindow(isExpanded(), false).catch((error) => {
+							console.error("Failed to restore main window size:", error);
+						});
+					}
 					scheduleTargetListPrewarm();
 				}
 			},
 		);
-
-		const unlistenResize = currentWindow.onResized(() => {
-			currentWindow.setSize(
-				new LogicalSize(WINDOW_SIZE.width, WINDOW_SIZE.height),
-			);
-		});
 
 		const unlistenSetTargetMode = events.requestSetTargetMode.listen(
 			async (event) => {
@@ -2293,7 +2529,6 @@ function Page() {
 
 		onCleanup(async () => {
 			(await unlistenFocus)?.();
-			(await unlistenResize)?.();
 			(await unlistenSetTargetMode)?.();
 		});
 	});

--- a/apps/desktop/src/store.ts
+++ b/apps/desktop/src/store.ts
@@ -40,6 +40,10 @@ export type UserProfileStore = {
 	updatedAt: number;
 };
 
+export type MainWindowUIStore = {
+	expanded: boolean;
+};
+
 let _store: Promise<Store> | undefined;
 const store = () => {
 	if (!_store) {
@@ -96,6 +100,10 @@ export const presetsStore = declareStore<PresetsStore>("presets");
 export const authStore = declareStore<AuthStore>("auth");
 export const automationsStore = declareStore<AutomationsStore>("automations");
 export const userProfileStore = declareStore<UserProfileStore>("user_profile");
+export const mainWindowUIStore = declareStore<MainWindowUIStore>(
+	"main_window_ui",
+	{ expanded: false },
+);
 export const hotkeysStore = declareStore<HotkeysStore>("hotkeys");
 export const generalSettingsStore =
 	declareStore<GeneralSettingsStore>("general_settings");

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -266,7 +266,7 @@ async saveFileDialog(fileName: string, fileType: string) : Promise<string | null
 async listRecordings() : Promise<([string, RecordingMetaWithMetadata])[]> {
     return await TAURI_INVOKE("list_recordings");
 },
-async listScreenshots() : Promise<([string, RecordingMeta])[]> {
+async listScreenshots() : Promise<([string, ScreenshotMetaWithMetadata])[]> {
     return await TAURI_INVOKE("list_screenshots");
 },
 async checkUpgradedAndUpdate() : Promise<boolean> {
@@ -862,7 +862,7 @@ export type RecordingDeleted = { path: string }
 export type RecordingEvent = { variant: "Countdown"; value: number } | { variant: "Started" } | { variant: "Stopped" } | { variant: "Paused" } | { variant: "Resumed" } | { variant: "Failed"; error: string } | { variant: "StartFailed"; error: string } | { variant: "InputLost"; input: RecordingInputKind } | { variant: "InputRestored"; input: RecordingInputKind } | { variant: "Degraded"; reason: string } | { variant: "Recovered" }
 export type RecordingInputKind = "microphone" | "camera"
 export type RecordingMeta = (StudioRecordingMeta | InstantRecordingMeta) & { platform?: Platform | null; pretty_name: string; sharing?: SharingMeta | null; upload?: UploadMeta | null }
-export type RecordingMetaWithMetadata = ((StudioRecordingMeta | InstantRecordingMeta) & { platform?: Platform | null; pretty_name: string; sharing?: SharingMeta | null; upload?: UploadMeta | null }) & { mode: RecordingMode; status: StudioRecordingStatus; clip_count: number }
+export type RecordingMetaWithMetadata = ((StudioRecordingMeta | InstantRecordingMeta) & { platform?: Platform | null; pretty_name: string; sharing?: SharingMeta | null; upload?: UploadMeta | null }) & { mode: RecordingMode; status: StudioRecordingStatus; clip_count: number; sort_time_millis: number }
 export type RecordingMode = "studio" | "instant" | "screenshot"
 export type RecordingOptionsChanged = null
 export type RecordingSettingsStore = { target: ScreenCaptureTarget | null; micName: string | null; cameraId: DeviceOrModelID | null; mode: RecordingMode | null; systemAudio: boolean; organizationId: string | null; cameraDeviceSettings: { [key in string]: CameraDeviceSettings }; microphoneDeviceSettings: { [key in string]: MicrophoneDeviceSettings } }
@@ -891,6 +891,7 @@ export type SceneMode = "default" | "cameraOnly" | "hideCamera" | "splitScreen" 
 export type SceneSegment = { start: number; end: number; mode?: SceneMode; splitLayout?: SplitLayout | null; transitionIn?: number; transitionOut?: number }
 export type ScreenCaptureTarget = { variant: "window"; id: WindowId } | { variant: "display"; id: DisplayId } | { variant: "area"; screen: DisplayId; bounds: LogicalBounds } | { variant: "cameraOnly" }
 export type ScreenMovementSpring = { stiffness: number; damping: number; mass: number }
+export type ScreenshotMetaWithMetadata = ((StudioRecordingMeta | InstantRecordingMeta) & { platform?: Platform | null; pretty_name: string; sharing?: SharingMeta | null; upload?: UploadMeta | null }) & { sort_time_millis: number }
 export type ScreenshotOcrLine = { text: string; confidence: number | null; bounds: ScreenshotOcrRegion }
 export type ScreenshotOcrRegion = { x: number; y: number; width: number; height: number }
 export type ScreenshotOcrResult = { text: string; lines: ScreenshotOcrLine[]; engine: string }


### PR DESCRIPTION
Adds an expandable main window to the desktop app. Users can toggle between a compact picker (330×395) and a larger layout (600×660) with animated resize, screen-edge clamping, and persisted state via mainWindowUIStore. The expanded view shows richer capture controls (target descriptions, section labels) and a horizontal Recents carousel of the latest recordings and screenshots.

On macOS, the main window now uses system-managed liquid glass instead of the always-active private SPI path used by auxiliary windows (camera, settings, etc.), so the backdrop material behaves correctly when other Cap windows are focused. Titlebar zoom/maximize controls are repurposed for expand/collapse on both macOS and Windows.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an expandable main window (compact 330×395 ↔ expanded 600×660) with an animated resize, screen-edge clamping applied before animation starts, and persisted state via `mainWindowUIStore`. It also introduces a horizontal Recents carousel in the expanded view and switches the main window to system-managed liquid glass on macOS.

- **Resize animation**: A fire-and-forget worker decouples each `setSize` IPC call from the animation frame loop, eliminating per-frame IPC wait time. Position clamping is now applied before the animation begins, so the window never clips off-screen during expansion.
- **Recents carousel**: A new `recentMedia` query feeds unified recording + screenshot items sorted by `sort_time_millis` (now returned from Rust, removing the previous per-item `stat()` round-trips). Instant-mode recordings without a sharing link now show a toast and return early instead of silently hiding the main window.
- **macOS liquid glass**: A new `LiquidGlassActivity` enum routes the main window through `setStyle: NSGlassEffectViewStyleRegular` (system-managed) while auxiliary windows continue to use the always-active private SPI path.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all four issues from the previous review round have been resolved and no new defects were found.

All previously flagged concerns are addressed: instant-mode recordings without a sharing link now show a toast and return early, the animation loop decouples IPC from frame scheduling, stat() calls are eliminated in favour of the Rust-side sort_time_millis, and position clamping runs before animation. The new code paths are well-guarded with error handling and the reactive invalidation/refetch strategy is correct.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/(window-chrome)/new-main/index.tsx | Core of the PR: adds expand/collapse state, animated resize with fire-and-forget IPC, screen-edge clamping applied before animation, persisted state via mainWindowUIStore, and the Recents carousel wired to a unified recentMedia query. |
| apps/desktop/src-tauri/src/lib.rs | Adds sort_time_millis (creation time, falling back to modified) to both RecordingMetaWithMetadata and the new ScreenshotMetaWithMetadata so the frontend no longer needs per-item stat() IPC calls for sorting. |
| apps/desktop/src-tauri/src/platform/macos/mod.rs | Splits liquid glass application into system-managed (main window) and always-active (auxiliary windows) modes via a new LiquidGlassActivity enum, so the main window's backdrop behaves correctly when other Cap windows have focus. |
| apps/desktop/src/routes/(window-chrome)/new-main/Recents.tsx | New component: horizontally scrolling carousel with fade masks, loading skeletons, empty state, and per-item cards that show thumbnail, mode badge, title, and clip count for both recordings and screenshots. |
| apps/desktop/src/components/titlebar/controls/CaptionControlsMacOS.tsx | Adds optional onZoom prop to intercept the zoom/maximize button, repurposing it for expand/collapse in the main window; also tweaks traffic-light icon colors and sizes. |
| apps/desktop/src/components/titlebar/controls/CaptionControlsWindows11.tsx | Adds onMaximize/maximized props and a derived maximizable() accessor that correctly handles both native maximize and the custom expand/collapse handler. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `apps/desktop/src/routes/(window-chrome)/new-main/index.tsx`, line 926-969 ([link](https://github.com/capsoftware/cap/blob/30856d60e441b83b5fb0748abea26b3d97142cff/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx#L926-L969)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Position clamping deferred past animation may clip off-screen**

   `physicalPosition` is captured once before the animation loop runs, but the loop only changes the window's *size* — not its position. When the window is near the right or bottom edge of the monitor, the expanding animation pushes the right/bottom edge off-screen for the full 180 ms before `setPosition` finally corrects it. Users positioned near a screen edge will see the window visibly clip before snapping back.

   Consider calculating and applying the clamped position first (or simultaneously at each animation frame) so the window never extends beyond the work area during expansion.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
   Line: 926-969

   Comment:
   **Position clamping deferred past animation may clip off-screen**

   `physicalPosition` is captured once before the animation loop runs, but the loop only changes the window's *size* — not its position. When the window is near the right or bottom edge of the monitor, the expanding animation pushes the right/bottom edge off-screen for the full 180 ms before `setPosition` finally corrects it. Users positioned near a screen edge will see the window visibly clip before snapping back.

   Consider calculating and applying the clamped position first (or simultaneously at each animation frame) so the window never extends beyond the work area during expansion.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

2. `apps/desktop/src/routes/(window-chrome)/new-main/index.tsx`, line 1094-1102 ([link](https://github.com/capsoftware/cap/blob/30856d60e441b83b5fb0748abea26b3d97142cff/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx#L1094-L1102)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Redundant `stat()` calls when the Rust side already sorted by timestamp**

   The Rust `media_sort_time` helper (added in this PR) already sorts `list_recordings` and `list_screenshots` individually by `created()`/`modified()` timestamps. The frontend then issues up to `RECENT_MEDIA_LIMIT * 2` (18) individual `stat()` IPC calls to re-derive timestamps for cross-list merging. Including the sort timestamp in the Tauri return type (or relying on a single interleaved comparison of the pre-sorted slices using list order as a proxy) would eliminate all 18 round-trips.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
   Line: 1094-1102

   Comment:
   **Redundant `stat()` calls when the Rust side already sorted by timestamp**

   The Rust `media_sort_time` helper (added in this PR) already sorts `list_recordings` and `list_screenshots` individually by `created()`/`modified()` timestamps. The frontend then issues up to `RECENT_MEDIA_LIMIT * 2` (18) individual `stat()` IPC calls to re-derive timestamps for cross-list merging. Including the sort timestamp in the Tauri return type (or relying on a single interleaved comparison of the pre-sorted slices using list order as a proxy) would eliminate all 18 round-trips.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `apps/desktop/src/routes/(window-chrome)/new-main/index.tsx`, line 927-944 ([link](https://github.com/capsoftware/cap/blob/30856d60e441b83b5fb0748abea26b3d97142cff/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx#L927-L944)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Animation loop awaits each IPC `setSize` call before the next frame**

   `await currentWindow.setSize(...)` waits for the full Tauri IPC round-trip before calling `nextAnimationFrame()` again. On machines where IPC latency is a few milliseconds, consecutive frames will be skipped and the animation visibly stutters. Firing `setSize` without awaiting it (fire-and-forget within the loop) would allow the next frame to be scheduled without waiting for the previous resize to acknowledge, producing a smoother result.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
   Line: 927-944

   Comment:
   **Animation loop awaits each IPC `setSize` call before the next frame**

   `await currentWindow.setSize(...)` waits for the full Tauri IPC round-trip before calling `nextAnimationFrame()` again. On machines where IPC latency is a few milliseconds, consecutive frames will be skipped and the animation visibly stutters. Firing `setSize` without awaiting it (fire-and-forget within the loop) would allow the next frame to be scheduled without waiting for the previous resize to acknowledge, producing a smoother result.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

4. `apps/desktop/src/routes/(window-chrome)/new-main/index.tsx`, line 1271-1292 ([link](https://github.com/capsoftware/cap/blob/30856d60e441b83b5fb0748abea26b3d97142cff/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx#L1271-L1292)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Instant-mode recording with no sharing link silently hides the window**

   `openRecording` calls `getCurrentWindow().hide()` unconditionally, but for an instant-mode recording where `sharing?.link` is `undefined`, no content is ever opened. The user clicks a Recents card, the main window disappears, and nothing happens. This code path was already present in the recording-list `onSelect` handler, but it was less reachable; the Recents carousel surfaces it prominently. Consider showing a toast or skipping `hide()` when there is nothing to open.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
   Line: 1271-1292

   Comment:
   **Instant-mode recording with no sharing link silently hides the window**

   `openRecording` calls `getCurrentWindow().hide()` unconditionally, but for an instant-mode recording where `sharing?.link` is `undefined`, no content is ever opened. The user clicks a Recents card, the main window disappears, and nothing happens. This code path was already present in the recording-list `onSelect` handler, but it was less reachable; the Recents carousel surfaces it prominently. Consider showing a toast or skipping `hide()` when there is nothing to open.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: keep unavailable recordings visible"](https://github.com/capsoftware/cap/commit/96894e37d963e24a1b785763aa146b71fd5c4ac4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44769036)</sub>

<!-- /greptile_comment -->