### PR TITLE
improve: add blur and pixelation mask effects

### DIFF
--- a/apps/desktop/src/routes/editor/ConfigSidebar.tsx
+++ b/apps/desktop/src/routes/editor/ConfigSidebar.tsx
@@ -76,7 +76,6 @@ import {
 import IconLucideBoxSelect from "~icons/lucide/box-select";
 import IconLucideColumns2 from "~icons/lucide/columns-2";
 import IconLucideEyeOff from "~icons/lucide/eye-off";
-import IconLucideGauge from "~icons/lucide/gauge";
 import IconLucideGrid from "~icons/lucide/grid";
 import IconLucideImageOff from "~icons/lucide/image-off";
 import IconLucideKeyboard from "~icons/lucide/keyboard";
@@ -104,7 +103,14 @@ import { getColorPreviewBorderColor, hexToRgb, RgbInput } from "./color-utils";
 import { type CornerRoundingType, useEditorContext } from "./context";
 import { GradientEditor } from "./GradientEditor";
 import { KeyboardTab } from "./KeyboardTab";
-import { evaluateMask, type MaskKind, type MaskSegment } from "./masks";
+import {
+	encodeMaskEffect,
+	getMaskEffect,
+	getMaskEffectAmount,
+	type MaskEffect,
+	type MaskKind,
+	type MaskSegment,
+} from "./masks";
 import {
 	DEFAULT_BACKGROUND_PADDING,
 	DEFAULT_BACKGROUND_ROUNDING,
@@ -3780,7 +3786,7 @@ function MaskSegmentConfig(props: {
 	segmentIndex: number;
 	segment: MaskSegment;
 }) {
-	const { setProject, editorState } = useEditorContext();
+	const { setProject } = useEditorContext();
 
 	const updateSegment = (fn: (segment: MaskSegment) => void) => {
 		setProject(
@@ -3809,32 +3815,24 @@ function MaskSegmentConfig(props: {
 		});
 	});
 
-	const currentAbsoluteTime = () =>
-		editorState.previewTime ?? editorState.playbackTime ?? props.segment.start;
-	const _maskState = () => evaluateMask(props.segment, currentAbsoluteTime());
+	const maskEffect = () => getMaskEffect(props.segment);
+	const maskEffectAmount = () => getMaskEffectAmount(props.segment);
 
-	const clearKeyframes = (segment: MaskSegment) => {
-		segment.keyframes.position = [];
-		segment.keyframes.size = [];
-		segment.keyframes.intensity = [];
-	};
-
-	const _setPosition = (value: { x: number; y: number }) =>
+	const setMaskEffect = (effect: MaskEffect) =>
 		updateSegment((segment) => {
-			segment.center = value;
-			clearKeyframes(segment);
+			segment.pixelation = encodeMaskEffect(
+				effect,
+				getMaskEffectAmount(segment),
+			);
+			segment.opacity = 1;
+			segment.keyframes.intensity = [];
 		});
 
-	const _setSize = (value: { x: number; y: number }) =>
+	const setMaskEffectAmount = (amount: number) =>
 		updateSegment((segment) => {
-			segment.size = value;
-			clearKeyframes(segment);
-		});
-
-	const setIntensity = (value: number) =>
-		updateSegment((segment) => {
-			segment.opacity = value;
-			clearKeyframes(segment);
+			segment.pixelation = encodeMaskEffect(getMaskEffect(segment), amount);
+			segment.opacity = 1;
+			segment.keyframes.intensity = [];
 		});
 
 	return (
@@ -3890,29 +3888,48 @@ function MaskSegmentConfig(props: {
 				</div>
 			</Field>
 			<Show when={props.segment.maskType === "sensitive"}>
-				<Field name="Intensity" icon={<IconLucideGauge class="size-4" />}>
-					<Slider
-						value={[props.segment.opacity]}
-						onChange={([v]) => setIntensity(v)}
-						minValue={0}
-						maxValue={1}
-						step={0.01}
-						formatTooltip="%"
-					/>
+				<Field name="Effect" icon={<IconLucideEyeOff class="size-4" />}>
+					<RadioGroup
+						class="grid grid-cols-2 gap-2"
+						value={maskEffect()}
+						onChange={(value) => setMaskEffect(value as MaskEffect)}
+					>
+						{[
+							{ value: "blur", label: "Blur" },
+							{ value: "pixelate", label: "Pixelate" },
+						].map((option) => (
+							<RadioGroup.Item
+								value={option.value}
+								class="rounded-lg border border-gray-3 transition-colors data-checked:border-blue-8 data-checked:bg-blue-3/40"
+							>
+								<RadioGroup.ItemInput class="sr-only" />
+								<RadioGroup.ItemLabel class="flex items-center gap-2 p-2 text-sm text-gray-12">
+									<RadioGroup.ItemControl class="size-4 rounded-full border border-gray-7 data-checked:border-blue-9 data-checked:bg-blue-9" />
+									{option.label}
+								</RadioGroup.ItemLabel>
+							</RadioGroup.Item>
+						))}
+					</RadioGroup>
 				</Field>
 			</Show>
 			<Show when={props.segment.maskType === "sensitive"}>
-				<Field name="Pixelation" icon={<IconLucideGrid class="size-4" />}>
+				<Field
+					name={maskEffect() === "blur" ? "Blur" : "Pixel Size"}
+					icon={
+						maskEffect() === "blur" ? (
+							<IconLucideWind class="size-4" />
+						) : (
+							<IconLucideGrid class="size-4" />
+						)
+					}
+				>
 					<Slider
-						value={[props.segment.pixelation]}
-						onChange={([v]) =>
-							updateSegment((segment) => {
-								segment.pixelation = v;
-							})
-						}
-						minValue={1}
+						value={[maskEffectAmount()]}
+						onChange={([v]) => setMaskEffectAmount(v)}
+						minValue={4}
 						maxValue={80}
 						step={1}
+						formatTooltip="px"
 					/>
 				</Field>
 			</Show>

--- a/apps/desktop/src/routes/editor/masks.test.ts
+++ b/apps/desktop/src/routes/editor/masks.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	defaultMaskSegment,
+	encodeMaskEffect,
+	getMaskEffect,
+	getMaskEffectAmount,
+} from "./masks";
+
+describe("mask effects", () => {
+	it("defaults new sensitive masks to a fully obscuring blur", () => {
+		const segment = defaultMaskSegment(0, 1);
+
+		expect(getMaskEffect(segment)).toBe("blur");
+		expect(getMaskEffectAmount(segment)).toBe(16);
+		expect(segment.opacity).toBe(1);
+	});
+
+	it("preserves legacy pixelation values", () => {
+		const segment = defaultMaskSegment(0, 1);
+		segment.pixelation = 18;
+
+		expect(getMaskEffect(segment)).toBe("pixelate");
+		expect(getMaskEffectAmount(segment)).toBe(18);
+	});
+
+	it("encodes blur as a privacy-safe legacy pixelation fallback", () => {
+		const segment = defaultMaskSegment(0, 1);
+		segment.pixelation = encodeMaskEffect("blur", 24);
+
+		expect(segment.pixelation).toBe(1024);
+		expect(getMaskEffect(segment)).toBe("blur");
+		expect(getMaskEffectAmount(segment)).toBe(24);
+	});
+
+	it("keeps effect amounts within the supported range", () => {
+		const segment = defaultMaskSegment(0, 1);
+		segment.pixelation = encodeMaskEffect("pixelate", Number.NaN);
+
+		expect(getMaskEffectAmount(segment)).toBe(16);
+		expect(encodeMaskEffect("pixelate", 1)).toBe(4);
+		expect(encodeMaskEffect("blur", 100)).toBe(1080);
+	});
+});

--- a/apps/desktop/src/routes/editor/masks.ts
+++ b/apps/desktop/src/routes/editor/masks.ts
@@ -1,13 +1,16 @@
 import type { XY } from "~/utils/tauri";
+import maskEffectContract from "../../../../../crates/project/mask-effects.json";
 
 export type MaskKind = "sensitive" | "highlight";
 export type MaskEffect = "blur" | "pixelate";
 
 // Older versions interpret encoded blur as strong pixelation, keeping masked content private.
-const MASK_BLUR_ENCODING_OFFSET = 1000;
-const DEFAULT_MASK_EFFECT_AMOUNT = 16;
-const MIN_MASK_EFFECT_AMOUNT = 4;
-const MAX_MASK_EFFECT_AMOUNT = 80;
+const {
+	blurEncodingOffset: MASK_BLUR_ENCODING_OFFSET,
+	defaultAmount: DEFAULT_MASK_EFFECT_AMOUNT,
+	minAmount: MIN_MASK_EFFECT_AMOUNT,
+	maxAmount: MAX_MASK_EFFECT_AMOUNT,
+} = maskEffectContract;
 
 export type MaskScalarKeyframe = {
 	time: number;

--- a/apps/desktop/src/routes/editor/masks.ts
+++ b/apps/desktop/src/routes/editor/masks.ts
@@ -1,6 +1,13 @@
 import type { XY } from "~/utils/tauri";
 
 export type MaskKind = "sensitive" | "highlight";
+export type MaskEffect = "blur" | "pixelate";
+
+// Older versions interpret encoded blur as strong pixelation, keeping masked content private.
+const MASK_BLUR_ENCODING_OFFSET = 1000;
+const DEFAULT_MASK_EFFECT_AMOUNT = 16;
+const MIN_MASK_EFFECT_AMOUNT = 4;
+const MAX_MASK_EFFECT_AMOUNT = 80;
 
 export type MaskScalarKeyframe = {
 	time: number;
@@ -38,7 +45,37 @@ export type MaskSegment = {
 export type MaskState = {
 	position: XY<number>;
 	size: XY<number>;
-	intensity: number;
+};
+
+const normalizeMaskEffectAmount = (amount: number) => {
+	if (!Number.isFinite(amount) || amount <= 0) {
+		return DEFAULT_MASK_EFFECT_AMOUNT;
+	}
+	return Math.min(
+		Math.max(amount, MIN_MASK_EFFECT_AMOUNT),
+		MAX_MASK_EFFECT_AMOUNT,
+	);
+};
+
+export const encodeMaskEffect = (effect: MaskEffect, amount: number) => {
+	const normalizedAmount = normalizeMaskEffectAmount(amount);
+	return effect === "blur"
+		? MASK_BLUR_ENCODING_OFFSET + normalizedAmount
+		: normalizedAmount;
+};
+
+export const getMaskEffect = (segment: MaskSegment): MaskEffect =>
+	segment.pixelation >= MASK_BLUR_ENCODING_OFFSET ? "blur" : "pixelate";
+
+export const getMaskEffectAmount = (segment: MaskSegment) => {
+	const storedAmount = Number.isFinite(segment.pixelation)
+		? segment.pixelation
+		: DEFAULT_MASK_EFFECT_AMOUNT;
+	const decodedAmount =
+		getMaskEffect(segment) === "blur"
+			? storedAmount - MASK_BLUR_ENCODING_OFFSET
+			: storedAmount;
+	return normalizeMaskEffectAmount(decodedAmount);
 };
 
 export const defaultMaskSegment = (
@@ -54,7 +91,7 @@ export const defaultMaskSegment = (
 	size: { x: 0.35, y: 0.35 },
 	feather: 0.1,
 	opacity: 1,
-	pixelation: 18,
+	pixelation: encodeMaskEffect("blur", DEFAULT_MASK_EFFECT_AMOUNT),
 	darkness: 0.5,
 	fadeDuration: 0,
 	keyframes: { position: [], size: [], intensity: [] },
@@ -72,9 +109,7 @@ export const evaluateMask = (
 		x: Math.min(Math.max(segment.size.x, 0.01), 2),
 		y: Math.min(Math.max(segment.size.y, 0.01), 2),
 	};
-	const intensity = Math.min(Math.max(segment.opacity, 0), 1);
-
-	return { position, size, intensity };
+	return { position, size };
 };
 
 const sortByTime = <T extends { time: number }>(items: T[]) =>

--- a/crates/project/mask-effects.json
+++ b/crates/project/mask-effects.json
@@ -1,0 +1,6 @@
+{
+	"blurEncodingOffset": 1000,
+	"defaultAmount": 16,
+	"minAmount": 4,
+	"maxAmount": 80
+}

--- a/crates/project/src/configuration.rs
+++ b/crates/project/src/configuration.rs
@@ -2,6 +2,7 @@ use std::{
     fmt,
     ops::{Add, Div, Mul, Sub, SubAssign},
     path::Path,
+    sync::LazyLock,
 };
 
 use serde::{Deserialize, Serialize};
@@ -758,6 +759,24 @@ pub enum MaskKind {
     Highlight,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MaskEffectContract {
+    pub blur_encoding_offset: f64,
+    pub default_amount: f64,
+    pub min_amount: f64,
+    pub max_amount: f64,
+}
+
+static MASK_EFFECT_CONTRACT: LazyLock<MaskEffectContract> = LazyLock::new(|| {
+    serde_json::from_str(include_str!("../mask-effects.json"))
+        .expect("embedded mask effect contract must be valid JSON")
+});
+
+pub fn mask_effect_contract() -> &'static MaskEffectContract {
+    &MASK_EFFECT_CONTRACT
+}
+
 #[derive(Type, Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct MaskScalarKeyframe {
@@ -820,7 +839,7 @@ impl MaskSegment {
     }
 
     fn default_pixelation() -> f64 {
-        16.0
+        mask_effect_contract().default_amount
     }
 
     fn default_fade_duration() -> f64 {

--- a/crates/project/src/configuration.rs
+++ b/crates/project/src/configuration.rs
@@ -800,7 +800,7 @@ pub struct MaskSegment {
     pub feather: f64,
     #[serde(default = "MaskSegment::default_opacity")]
     pub opacity: f64,
-    #[serde(default)]
+    #[serde(default = "MaskSegment::default_pixelation")]
     pub pixelation: f64,
     #[serde(default)]
     pub darkness: f64,
@@ -817,6 +817,10 @@ impl MaskSegment {
 
     fn default_opacity() -> f64 {
         1.0
+    }
+
+    fn default_pixelation() -> f64 {
+        16.0
     }
 
     fn default_fade_duration() -> f64 {
@@ -1617,6 +1621,20 @@ mod tests {
 
         assert_eq!(config.cursor.motion_blur, 1.0);
         assert_eq!(config.screen_motion_blur, 1.0);
+    }
+
+    #[test]
+    fn mask_without_pixelation_uses_a_visible_safe_default() {
+        let segment: MaskSegment = serde_json::from_value(serde_json::json!({
+            "start": 0.0,
+            "end": 1.0,
+            "maskType": "sensitive",
+            "center": { "x": 0.5, "y": 0.5 },
+            "size": { "x": 0.25, "y": 0.25 }
+        }))
+        .unwrap();
+
+        assert_eq!(segment.pixelation, 16.0);
     }
 
     #[test]

--- a/crates/rendering/src/layers/mask.rs
+++ b/crates/rendering/src/layers/mask.rs
@@ -3,6 +3,9 @@ use wgpu::util::DeviceExt;
 
 use crate::{PreparedMask, RenderSession};
 
+const BLUR_HORIZONTAL_MODE: u32 = 2;
+const BLUR_VERTICAL_MODE: u32 = 3;
+
 pub struct MaskLayer {
     sampler: wgpu::Sampler,
     pipeline: MaskPipeline,
@@ -49,7 +52,7 @@ impl MaskLayer {
                     target_texture_view: session.other_texture_view(),
                     render_pipeline: &self.pipeline.render_pipeline,
                     load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                    uniforms: MaskUniforms::from_mask_with_mode(mask, 2),
+                    uniforms: MaskUniforms::from_mask_with_mode(mask, BLUR_HORIZONTAL_MODE),
                 },
             );
             self.render_pass(
@@ -60,7 +63,7 @@ impl MaskLayer {
                     target_texture_view: session.current_texture_view(),
                     render_pipeline: &self.pipeline.blur_composite_pipeline,
                     load: wgpu::LoadOp::Load,
-                    uniforms: MaskUniforms::from_mask_with_mode(mask, 3),
+                    uniforms: MaskUniforms::from_mask_with_mode(mask, BLUR_VERTICAL_MODE),
                 },
             );
         } else {

--- a/crates/rendering/src/layers/mask.rs
+++ b/crates/rendering/src/layers/mask.rs
@@ -15,8 +15,8 @@ impl MaskLayer {
                 address_mode_u: wgpu::AddressMode::ClampToEdge,
                 address_mode_v: wgpu::AddressMode::ClampToEdge,
                 address_mode_w: wgpu::AddressMode::ClampToEdge,
-                mag_filter: wgpu::FilterMode::Nearest,
-                min_filter: wgpu::FilterMode::Nearest,
+                mag_filter: wgpu::FilterMode::Linear,
+                min_filter: wgpu::FilterMode::Linear,
                 mipmap_filter: wgpu::FilterMode::Nearest,
                 ..Default::default()
             }),
@@ -32,7 +32,34 @@ impl MaskLayer {
         encoder: &mut wgpu::CommandEncoder,
         mask: &PreparedMask,
     ) {
-        let uniforms = MaskUniforms::from_mask(mask);
+        if mask.mode == crate::MaskRenderMode::Blur {
+            self.render_pass(
+                device,
+                session,
+                encoder,
+                MaskUniforms::from_mask_with_mode(mask, 2),
+            );
+            session.swap_textures();
+            self.render_pass(
+                device,
+                session,
+                encoder,
+                MaskUniforms::from_mask_with_mode(mask, 3),
+            );
+            session.swap_textures();
+        } else {
+            self.render_pass(device, session, encoder, MaskUniforms::from_mask(mask));
+            session.swap_textures();
+        }
+    }
+
+    fn render_pass(
+        &self,
+        device: &wgpu::Device,
+        session: &RenderSession,
+        encoder: &mut wgpu::CommandEncoder,
+        uniforms: MaskUniforms,
+    ) {
         let uniforms_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Mask Uniform Buffer"),
             contents: bytemuck::cast_slice(&[uniforms]),
@@ -66,7 +93,6 @@ impl MaskLayer {
         pass.draw(0..3, 0..1);
 
         drop(pass);
-        session.swap_textures();
     }
 }
 
@@ -77,7 +103,7 @@ struct MaskUniforms {
     rect_size: [f32; 2],
     feather: f32,
     opacity: f32,
-    pixel_size: f32,
+    effect_size: f32,
     darkness: f32,
     mode: u32,
     padding0: u32,
@@ -93,14 +119,18 @@ impl Default for MaskUniforms {
 
 impl MaskUniforms {
     fn from_mask(mask: &PreparedMask) -> Self {
+        Self::from_mask_with_mode(mask, mask.mode_value())
+    }
+
+    fn from_mask_with_mode(mask: &PreparedMask, mode: u32) -> Self {
         Self {
             rect_center: [mask.center.x, mask.center.y],
             rect_size: [mask.size.x, mask.size.y],
             feather: mask.feather,
             opacity: mask.opacity,
-            pixel_size: mask.pixel_size,
+            effect_size: mask.effect_size,
             darkness: mask.darkness,
-            mode: mask.mode_value(),
+            mode,
             padding0: 0,
             output_size: [mask.output_size.x as f32, mask.output_size.y as f32],
             padding1: [0.0; 2],

--- a/crates/rendering/src/layers/mask.rs
+++ b/crates/rendering/src/layers/mask.rs
@@ -8,6 +8,14 @@ pub struct MaskLayer {
     pipeline: MaskPipeline,
 }
 
+struct MaskPass<'a> {
+    source_texture_view: &'a wgpu::TextureView,
+    target_texture_view: &'a wgpu::TextureView,
+    render_pipeline: &'a wgpu::RenderPipeline,
+    load: wgpu::LoadOp<wgpu::Color>,
+    uniforms: MaskUniforms,
+}
+
 impl MaskLayer {
     pub fn new(device: &wgpu::Device) -> Self {
         Self {
@@ -35,20 +43,38 @@ impl MaskLayer {
         if mask.mode == crate::MaskRenderMode::Blur {
             self.render_pass(
                 device,
-                session,
                 encoder,
-                MaskUniforms::from_mask_with_mode(mask, 2),
+                MaskPass {
+                    source_texture_view: session.current_texture_view(),
+                    target_texture_view: session.other_texture_view(),
+                    render_pipeline: &self.pipeline.render_pipeline,
+                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    uniforms: MaskUniforms::from_mask_with_mode(mask, 2),
+                },
             );
-            session.swap_textures();
             self.render_pass(
                 device,
-                session,
                 encoder,
-                MaskUniforms::from_mask_with_mode(mask, 3),
+                MaskPass {
+                    source_texture_view: session.other_texture_view(),
+                    target_texture_view: session.current_texture_view(),
+                    render_pipeline: &self.pipeline.blur_composite_pipeline,
+                    load: wgpu::LoadOp::Load,
+                    uniforms: MaskUniforms::from_mask_with_mode(mask, 3),
+                },
             );
-            session.swap_textures();
         } else {
-            self.render_pass(device, session, encoder, MaskUniforms::from_mask(mask));
+            self.render_pass(
+                device,
+                encoder,
+                MaskPass {
+                    source_texture_view: session.current_texture_view(),
+                    target_texture_view: session.other_texture_view(),
+                    render_pipeline: &self.pipeline.render_pipeline,
+                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    uniforms: MaskUniforms::from_mask(mask),
+                },
+            );
             session.swap_textures();
         }
     }
@@ -56,30 +82,29 @@ impl MaskLayer {
     fn render_pass(
         &self,
         device: &wgpu::Device,
-        session: &RenderSession,
         encoder: &mut wgpu::CommandEncoder,
-        uniforms: MaskUniforms,
+        config: MaskPass<'_>,
     ) {
         let uniforms_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Mask Uniform Buffer"),
-            contents: bytemuck::cast_slice(&[uniforms]),
+            contents: bytemuck::cast_slice(&[config.uniforms]),
             usage: wgpu::BufferUsages::UNIFORM,
         });
 
         let bind_group = self.pipeline.bind_group(
             device,
             &uniforms_buffer,
-            session.current_texture_view(),
+            config.source_texture_view,
             &self.sampler,
         );
 
         let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: Some("Mask Pass"),
             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                view: session.other_texture_view(),
+                view: config.target_texture_view,
                 resolve_target: None,
                 ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    load: config.load,
                     store: wgpu::StoreOp::Store,
                 },
             })],
@@ -88,7 +113,7 @@ impl MaskLayer {
             occlusion_query_set: None,
         });
 
-        pass.set_pipeline(&self.pipeline.render_pipeline);
+        pass.set_pipeline(config.render_pipeline);
         pass.set_bind_group(0, &bind_group, &[]);
         pass.draw(0..3, 0..1);
 
@@ -141,6 +166,7 @@ impl MaskUniforms {
 pub struct MaskPipeline {
     bind_group_layout: wgpu::BindGroupLayout,
     render_pipeline: wgpu::RenderPipeline,
+    blur_composite_pipeline: wgpu::RenderPipeline,
 }
 
 impl MaskPipeline {
@@ -188,49 +214,68 @@ impl MaskPipeline {
             push_constant_ranges: &[],
         });
 
-        let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("Mask Pipeline"),
-            layout: Some(&pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &shader,
-                entry_point: Some("vs_main"),
-                buffers: &[],
-                compilation_options: wgpu::PipelineCompilationOptions {
-                    constants: &[],
-                    zero_initialize_workgroup_memory: false,
+        let create_render_pipeline = |label, blend| {
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some(label),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    buffers: &[],
+                    compilation_options: wgpu::PipelineCompilationOptions {
+                        constants: &[],
+                        zero_initialize_workgroup_memory: false,
+                    },
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: wgpu::TextureFormat::Rgba8Unorm,
+                        blend: Some(blend),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: wgpu::PipelineCompilationOptions {
+                        constants: &[],
+                        zero_initialize_workgroup_memory: false,
+                    },
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    strip_index_format: None,
+                    front_face: wgpu::FrontFace::Ccw,
+                    cull_mode: Some(wgpu::Face::Back),
+                    polygon_mode: wgpu::PolygonMode::Fill,
+                    unclipped_depth: false,
+                    conservative: false,
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            })
+        };
+        let render_pipeline = create_render_pipeline("Mask Pipeline", wgpu::BlendState::REPLACE);
+        let blur_composite_pipeline = create_render_pipeline(
+            "Mask Blur Composite Pipeline",
+            wgpu::BlendState {
+                color: wgpu::BlendComponent {
+                    src_factor: wgpu::BlendFactor::SrcAlpha,
+                    dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                    operation: wgpu::BlendOperation::Add,
+                },
+                alpha: wgpu::BlendComponent {
+                    src_factor: wgpu::BlendFactor::Zero,
+                    dst_factor: wgpu::BlendFactor::One,
+                    operation: wgpu::BlendOperation::Add,
                 },
             },
-            fragment: Some(wgpu::FragmentState {
-                module: &shader,
-                entry_point: Some("fs_main"),
-                targets: &[Some(wgpu::ColorTargetState {
-                    format: wgpu::TextureFormat::Rgba8Unorm,
-                    blend: Some(wgpu::BlendState::REPLACE),
-                    write_mask: wgpu::ColorWrites::ALL,
-                })],
-                compilation_options: wgpu::PipelineCompilationOptions {
-                    constants: &[],
-                    zero_initialize_workgroup_memory: false,
-                },
-            }),
-            primitive: wgpu::PrimitiveState {
-                topology: wgpu::PrimitiveTopology::TriangleList,
-                strip_index_format: None,
-                front_face: wgpu::FrontFace::Ccw,
-                cull_mode: Some(wgpu::Face::Back),
-                polygon_mode: wgpu::PolygonMode::Fill,
-                unclipped_depth: false,
-                conservative: false,
-            },
-            depth_stencil: None,
-            multisample: wgpu::MultisampleState::default(),
-            multiview: None,
-            cache: None,
-        });
+        );
 
         Self {
             bind_group_layout,
             render_pipeline,
+            blur_composite_pipeline,
         }
     }
 

--- a/crates/rendering/src/layers/mask.rs
+++ b/crates/rendering/src/layers/mask.rs
@@ -1,8 +1,10 @@
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
 
-use crate::{PreparedMask, RenderSession};
+use crate::{MaskRenderMode, PreparedMask, RenderSession};
 
+const PIXELATE_MODE: u32 = 0;
+const HIGHLIGHT_MODE: u32 = 1;
 const BLUR_HORIZONTAL_MODE: u32 = 2;
 const BLUR_VERTICAL_MODE: u32 = 3;
 
@@ -43,43 +45,60 @@ impl MaskLayer {
         encoder: &mut wgpu::CommandEncoder,
         mask: &PreparedMask,
     ) {
-        if mask.mode == crate::MaskRenderMode::Blur {
-            self.render_pass(
-                device,
-                encoder,
-                MaskPass {
-                    source_texture_view: session.current_texture_view(),
-                    target_texture_view: session.other_texture_view(),
-                    render_pipeline: &self.pipeline.render_pipeline,
-                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                    uniforms: MaskUniforms::from_mask_with_mode(mask, BLUR_HORIZONTAL_MODE),
-                },
-            );
-            self.render_pass(
-                device,
-                encoder,
-                MaskPass {
-                    source_texture_view: session.other_texture_view(),
-                    target_texture_view: session.current_texture_view(),
-                    render_pipeline: &self.pipeline.blur_composite_pipeline,
-                    load: wgpu::LoadOp::Load,
-                    uniforms: MaskUniforms::from_mask_with_mode(mask, BLUR_VERTICAL_MODE),
-                },
-            );
-        } else {
-            self.render_pass(
-                device,
-                encoder,
-                MaskPass {
-                    source_texture_view: session.current_texture_view(),
-                    target_texture_view: session.other_texture_view(),
-                    render_pipeline: &self.pipeline.render_pipeline,
-                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                    uniforms: MaskUniforms::from_mask(mask),
-                },
-            );
-            session.swap_textures();
+        match mask.mode {
+            MaskRenderMode::Blur => {
+                self.render_pass(
+                    device,
+                    encoder,
+                    MaskPass {
+                        source_texture_view: session.current_texture_view(),
+                        target_texture_view: session.other_texture_view(),
+                        render_pipeline: &self.pipeline.render_pipeline,
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        uniforms: MaskUniforms::from_mask(mask, BLUR_HORIZONTAL_MODE),
+                    },
+                );
+                self.render_pass(
+                    device,
+                    encoder,
+                    MaskPass {
+                        source_texture_view: session.other_texture_view(),
+                        target_texture_view: session.current_texture_view(),
+                        render_pipeline: &self.pipeline.blur_composite_pipeline,
+                        load: wgpu::LoadOp::Load,
+                        uniforms: MaskUniforms::from_mask(mask, BLUR_VERTICAL_MODE),
+                    },
+                );
+            }
+            MaskRenderMode::Pixelate => {
+                self.render_single_pass(device, session, encoder, mask, PIXELATE_MODE);
+            }
+            MaskRenderMode::Highlight => {
+                self.render_single_pass(device, session, encoder, mask, HIGHLIGHT_MODE);
+            }
         }
+    }
+
+    fn render_single_pass(
+        &self,
+        device: &wgpu::Device,
+        session: &mut RenderSession,
+        encoder: &mut wgpu::CommandEncoder,
+        mask: &PreparedMask,
+        mode: u32,
+    ) {
+        self.render_pass(
+            device,
+            encoder,
+            MaskPass {
+                source_texture_view: session.current_texture_view(),
+                target_texture_view: session.other_texture_view(),
+                render_pipeline: &self.pipeline.render_pipeline,
+                load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                uniforms: MaskUniforms::from_mask(mask, mode),
+            },
+        );
+        session.swap_textures();
     }
 
     fn render_pass(
@@ -146,11 +165,7 @@ impl Default for MaskUniforms {
 }
 
 impl MaskUniforms {
-    fn from_mask(mask: &PreparedMask) -> Self {
-        Self::from_mask_with_mode(mask, mask.mode_value())
-    }
-
-    fn from_mask_with_mode(mask: &PreparedMask, mode: u32) -> Self {
+    fn from_mask(mask: &PreparedMask, mode: u32) -> Self {
         Self {
             rect_center: [mask.center.x, mask.center.y],
             rect_size: [mask.size.x, mask.size.y],

--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use cap_project::{
     AspectRatio, Camera, CameraShape, CameraXPosition, CameraYPosition, ClipOffsets, CornerStyle,
-    Crop, CursorEvents, CursorType, FrameConfiguration, FrameStyle, MaskKind, ProjectConfiguration,
+    Crop, CursorEvents, CursorType, FrameConfiguration, FrameStyle, ProjectConfiguration,
     RecordingMeta, SceneMode, StudioRecordingMeta, XY,
 };
 use composite_frame::CompositeVideoFrameUniforms;
@@ -216,19 +216,11 @@ pub struct RenderOptions {
     pub preserve_screen_alpha: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MaskRenderMode {
-    Sensitive,
+    Pixelate,
     Highlight,
-}
-
-impl MaskRenderMode {
-    fn from_kind(kind: MaskKind) -> Self {
-        match kind {
-            MaskKind::Sensitive => MaskRenderMode::Sensitive,
-            MaskKind::Highlight => MaskRenderMode::Highlight,
-        }
-    }
+    Blur,
 }
 
 #[derive(Debug, Clone)]
@@ -237,7 +229,7 @@ pub struct PreparedMask {
     pub size: XY<f32>,
     pub feather: f32,
     pub opacity: f32,
-    pub pixel_size: f32,
+    pub effect_size: f32,
     pub darkness: f32,
     pub mode: MaskRenderMode,
     pub output_size: XY<u32>,
@@ -246,8 +238,9 @@ pub struct PreparedMask {
 impl PreparedMask {
     fn mode_value(&self) -> u32 {
         match self.mode {
-            MaskRenderMode::Sensitive => 0,
+            MaskRenderMode::Pixelate => 0,
             MaskRenderMode::Highlight => 1,
+            MaskRenderMode::Blur => 2,
         }
     }
 }

--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -235,16 +235,6 @@ pub struct PreparedMask {
     pub output_size: XY<u32>,
 }
 
-impl PreparedMask {
-    fn mode_value(&self) -> u32 {
-        match self.mode {
-            MaskRenderMode::Pixelate => 0,
-            MaskRenderMode::Highlight => 1,
-            MaskRenderMode::Blur => 2,
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct RecordingSegmentDecoders {
     screen: AsyncVideoDecoderHandle,

--- a/crates/rendering/src/mask.rs
+++ b/crates/rendering/src/mask.rs
@@ -1,13 +1,10 @@
-use cap_project::{MaskKind, MaskScalarKeyframe, MaskSegment, MaskVectorKeyframe, XY};
+use cap_project::{
+    MaskKind, MaskScalarKeyframe, MaskSegment, MaskVectorKeyframe, XY, mask_effect_contract,
+};
 
 use crate::{MaskRenderMode, PreparedMask};
 
 const MASK_EFFECT_BASE_HEIGHT: f32 = 1080.0;
-// Older versions interpret encoded blur as strong pixelation, keeping masked content private.
-const MASK_BLUR_ENCODING_OFFSET: f64 = 1000.0;
-const DEFAULT_MASK_EFFECT_AMOUNT: f64 = 16.0;
-const MIN_MASK_EFFECT_AMOUNT: f64 = 4.0;
-const MAX_MASK_EFFECT_AMOUNT: f64 = 80.0;
 
 fn interpolate_vector(base: XY<f64>, keys: &[MaskVectorKeyframe], time: f64) -> XY<f64> {
     if keys.is_empty() {
@@ -142,15 +139,16 @@ pub fn interpolate_masks(
 }
 
 fn sensitive_effect(stored_effect: f64) -> (MaskRenderMode, f64) {
+    let contract = mask_effect_contract();
     let stored_effect = if stored_effect.is_finite() {
         stored_effect
     } else {
-        DEFAULT_MASK_EFFECT_AMOUNT
+        contract.default_amount
     };
-    if stored_effect >= MASK_BLUR_ENCODING_OFFSET {
+    if stored_effect >= contract.blur_encoding_offset {
         (
             MaskRenderMode::Blur,
-            normalize_effect_amount(stored_effect - MASK_BLUR_ENCODING_OFFSET),
+            normalize_effect_amount(stored_effect - contract.blur_encoding_offset),
         )
     } else {
         (
@@ -161,10 +159,11 @@ fn sensitive_effect(stored_effect: f64) -> (MaskRenderMode, f64) {
 }
 
 fn normalize_effect_amount(amount: f64) -> f64 {
+    let contract = mask_effect_contract();
     if amount <= 0.0 {
-        DEFAULT_MASK_EFFECT_AMOUNT
+        contract.default_amount
     } else {
-        amount.clamp(MIN_MASK_EFFECT_AMOUNT, MAX_MASK_EFFECT_AMOUNT)
+        amount.clamp(contract.min_amount, contract.max_amount)
     }
 }
 

--- a/crates/rendering/src/mask.rs
+++ b/crates/rendering/src/mask.rs
@@ -2,7 +2,12 @@ use cap_project::{MaskKind, MaskScalarKeyframe, MaskSegment, MaskVectorKeyframe,
 
 use crate::{MaskRenderMode, PreparedMask};
 
-const MASK_PIXELATION_BASE_HEIGHT: f32 = 1080.0;
+const MASK_EFFECT_BASE_HEIGHT: f32 = 1080.0;
+// Older versions interpret encoded blur as strong pixelation, keeping masked content private.
+const MASK_BLUR_ENCODING_OFFSET: f64 = 1000.0;
+const DEFAULT_MASK_EFFECT_AMOUNT: f64 = 16.0;
+const MIN_MASK_EFFECT_AMOUNT: f64 = 4.0;
+const MAX_MASK_EFFECT_AMOUNT: f64 = 80.0;
 
 fn interpolate_vector(base: XY<f64>, keys: &[MaskVectorKeyframe], time: f64) -> XY<f64> {
     if keys.is_empty() {
@@ -82,22 +87,28 @@ pub fn interpolate_masks(
         let position =
             interpolate_vector(segment.center, &segment.keyframes.position, relative_time);
         let size = interpolate_vector(segment.size, &segment.keyframes.size, relative_time);
-        let mut intensity =
-            interpolate_scalar(segment.opacity, &segment.keyframes.intensity, relative_time);
-
-        let fade_duration = match segment.mask_type {
-            MaskKind::Sensitive => 0.0,
-            MaskKind::Highlight => segment.fade_duration.max(0.0),
+        let (mode, opacity, effect_amount) = match segment.mask_type {
+            MaskKind::Sensitive => {
+                let (mode, effect_amount) = sensitive_effect(segment.pixelation);
+                (mode, 1.0, effect_amount)
+            }
+            MaskKind::Highlight => {
+                let mut intensity = interpolate_scalar(
+                    segment.opacity,
+                    &segment.keyframes.intensity,
+                    relative_time,
+                );
+                let fade_duration = segment.fade_duration.max(0.0);
+                if fade_duration > 0.0 {
+                    let time_since_start = (frame_time - segment.start).max(0.0);
+                    let time_until_end = (segment.end - frame_time).max(0.0);
+                    let fade_in = (time_since_start / fade_duration).min(1.0);
+                    let fade_out = (time_until_end / fade_duration).min(1.0);
+                    intensity *= fade_in * fade_out;
+                }
+                (MaskRenderMode::Highlight, intensity.clamp(0.0, 1.0), 0.0)
+            }
         };
-        if fade_duration > 0.0 {
-            let time_since_start = (frame_time - segment.start).max(0.0);
-            let time_until_end = (segment.end - frame_time).max(0.0);
-
-            let fade_in = (time_since_start / fade_duration).min(1.0);
-            let fade_out = (time_until_end / fade_duration).min(1.0);
-
-            intensity *= fade_in * fade_out;
-        }
 
         let clamped_size = XY::new(size.x.clamp(0.01, 2.0), size.y.clamp(0.01, 2.0));
 
@@ -119,10 +130,10 @@ pub fn interpolate_masks(
                 clamped_size.y.clamp(0.0, 2.0) as f32,
             ),
             feather,
-            opacity: intensity.clamp(0.0, 1.0) as f32,
-            pixel_size: scaled_pixel_size(output_size, segment.pixelation),
+            opacity: opacity as f32,
+            effect_size: scaled_effect_size(output_size, effect_amount),
             darkness: segment.darkness.clamp(0.0, 1.0) as f32,
-            mode: MaskRenderMode::from_kind(segment.mask_type),
+            mode,
             output_size,
         });
     }
@@ -130,9 +141,36 @@ pub fn interpolate_masks(
     prepared
 }
 
-fn scaled_pixel_size(output_size: XY<u32>, pixelation: f64) -> f32 {
-    let resolution_scale = output_size.y as f32 / MASK_PIXELATION_BASE_HEIGHT;
-    (pixelation.max(1.0) as f32) * resolution_scale
+fn sensitive_effect(stored_effect: f64) -> (MaskRenderMode, f64) {
+    let stored_effect = if stored_effect.is_finite() {
+        stored_effect
+    } else {
+        DEFAULT_MASK_EFFECT_AMOUNT
+    };
+    if stored_effect >= MASK_BLUR_ENCODING_OFFSET {
+        (
+            MaskRenderMode::Blur,
+            normalize_effect_amount(stored_effect - MASK_BLUR_ENCODING_OFFSET),
+        )
+    } else {
+        (
+            MaskRenderMode::Pixelate,
+            normalize_effect_amount(stored_effect),
+        )
+    }
+}
+
+fn normalize_effect_amount(amount: f64) -> f64 {
+    if amount <= 0.0 {
+        DEFAULT_MASK_EFFECT_AMOUNT
+    } else {
+        amount.clamp(MIN_MASK_EFFECT_AMOUNT, MAX_MASK_EFFECT_AMOUNT)
+    }
+}
+
+fn scaled_effect_size(output_size: XY<u32>, amount: f64) -> f32 {
+    let resolution_scale = output_size.y as f32 / MASK_EFFECT_BASE_HEIGHT;
+    amount as f32 * resolution_scale
 }
 
 #[cfg(test)]
@@ -158,7 +196,7 @@ mod tests {
     }
 
     #[test]
-    fn sensitive_mask_pixelation_scales_with_output_height() {
+    fn sensitive_mask_effect_scales_with_output_height() {
         let segment = sample_segment();
         let smaller = interpolate_masks(XY::new(872, 720), 1.0, std::slice::from_ref(&segment));
         let low = interpolate_masks(XY::new(1308, 1080), 1.0, std::slice::from_ref(&segment));
@@ -167,8 +205,46 @@ mod tests {
         assert_eq!(smaller.len(), 1);
         assert_eq!(low.len(), 1);
         assert_eq!(high.len(), 1);
-        assert_eq!(smaller[0].pixel_size, 12.0);
-        assert_eq!(low[0].pixel_size, 18.0);
-        assert_eq!(high[0].pixel_size, 36.0);
+        assert_eq!(smaller[0].effect_size, 12.0);
+        assert_eq!(low[0].effect_size, 18.0);
+        assert_eq!(high[0].effect_size, 36.0);
+    }
+
+    #[test]
+    fn sensitive_mask_never_blends_with_source_content() {
+        let mut segment = sample_segment();
+        segment.opacity = 0.01;
+        segment.keyframes.intensity.push(MaskScalarKeyframe {
+            time: 1.0,
+            value: 0.01,
+        });
+
+        let masks = interpolate_masks(XY::new(1920, 1080), 1.0, &[segment]);
+
+        assert_eq!(masks[0].opacity, 1.0);
+        assert_eq!(masks[0].mode, MaskRenderMode::Pixelate);
+    }
+
+    #[test]
+    fn encoded_blur_uses_its_decoded_radius() {
+        let mut segment = sample_segment();
+        segment.pixelation = MASK_BLUR_ENCODING_OFFSET + 24.0;
+
+        let masks = interpolate_masks(XY::new(1920, 1080), 1.0, &[segment]);
+
+        assert_eq!(masks[0].mode, MaskRenderMode::Blur);
+        assert_eq!(masks[0].effect_size, 24.0);
+        assert_eq!(masks[0].opacity, 1.0);
+    }
+
+    #[test]
+    fn missing_legacy_pixelation_uses_a_visible_safe_default() {
+        let mut segment = sample_segment();
+        segment.pixelation = 0.0;
+
+        let masks = interpolate_masks(XY::new(1920, 1080), 1.0, &[segment]);
+
+        assert_eq!(masks[0].mode, MaskRenderMode::Pixelate);
+        assert_eq!(masks[0].effect_size, 16.0);
     }
 }

--- a/crates/rendering/src/mask.rs
+++ b/crates/rendering/src/mask.rs
@@ -226,15 +226,22 @@ mod tests {
     }
 
     #[test]
-    fn encoded_blur_uses_its_decoded_radius() {
-        let mut segment = sample_segment();
-        segment.pixelation = MASK_BLUR_ENCODING_OFFSET + 24.0;
+    fn persisted_effect_encoding_matches_the_desktop_contract() {
+        for (stored_effect, expected_mode, expected_size) in [
+            (18.0, MaskRenderMode::Pixelate, 18.0),
+            (1001.0, MaskRenderMode::Blur, 4.0),
+            (1024.0, MaskRenderMode::Blur, 24.0),
+            (1080.0, MaskRenderMode::Blur, 80.0),
+        ] {
+            let mut segment = sample_segment();
+            segment.pixelation = stored_effect;
 
-        let masks = interpolate_masks(XY::new(1920, 1080), 1.0, &[segment]);
+            let masks = interpolate_masks(XY::new(1920, 1080), 1.0, &[segment]);
 
-        assert_eq!(masks[0].mode, MaskRenderMode::Blur);
-        assert_eq!(masks[0].effect_size, 24.0);
-        assert_eq!(masks[0].opacity, 1.0);
+            assert_eq!(masks[0].mode, expected_mode);
+            assert_eq!(masks[0].effect_size, expected_size);
+            assert_eq!(masks[0].opacity, 1.0);
+        }
     }
 
     #[test]

--- a/crates/rendering/src/shaders/mask.wgsl
+++ b/crates/rendering/src/shaders/mask.wgsl
@@ -3,7 +3,7 @@ struct Uniforms {
     rect_size: vec2<f32>,
     feather: f32,
     opacity: f32,
-    pixel_size: f32,
+    effect_size: f32,
     darkness: f32,
     mode: u32,
     padding0: u32,
@@ -47,10 +47,38 @@ fn rect_mask(uv: vec2<f32>) -> f32 {
 }
 
 fn pixelate_sample(uv: vec2<f32>) -> vec4<f32> {
-    let px_size = max(uniforms.pixel_size, 1.0);
+    let px_size = max(uniforms.effect_size, 1.0);
     let cell = px_size / uniforms.output_size;
     let snapped = floor(uv / cell) * cell + cell * 0.5;
-    return textureSample(source_texture, source_sampler, snapped);
+    let texture_size = textureDimensions(source_texture);
+    let max_coord = vec2<i32>(texture_size) - vec2<i32>(1);
+    let coord = clamp(
+        vec2<i32>(snapped * vec2<f32>(texture_size)),
+        vec2<i32>(0),
+        max_coord,
+    );
+    return textureLoad(source_texture, coord, 0);
+}
+
+fn blur_sample(uv: vec2<f32>, direction: vec2<f32>) -> vec4<f32> {
+    let radius = max(uniforms.effect_size, 1.0);
+    let sample_step = direction * radius / (uniforms.output_size * 12.0);
+    var color = vec4<f32>(0.0);
+    var weight_sum = 0.0;
+
+    for (var index = -12; index <= 12; index++) {
+        let distance = f32(index) / 4.0;
+        let weight = exp(-0.5 * distance * distance);
+        color += textureSampleLevel(
+            source_texture,
+            source_sampler,
+            uv + f32(index) * sample_step,
+            0.0,
+        ) * weight;
+        weight_sum += weight;
+    }
+
+    return color / weight_sum;
 }
 
 @fragment
@@ -60,9 +88,26 @@ fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
 
     if uniforms.mode == 0u {
         let pixelated = pixelate_sample(uv);
-        let mix_amount = clamp(uniforms.opacity, 0.0, 1.0);
-        let effect = mix(base, pixelated, mix_amount);
-        return mix(base, effect, mask * mix_amount);
+        let effect = vec4<f32>(pixelated.rgb, base.a);
+        return mix(base, effect, mask);
+    }
+
+    if uniforms.mode == 2u {
+        if mask <= 0.0 {
+            return base;
+        }
+        let blurred = blur_sample(uv, vec2<f32>(1.0, 0.0));
+        let effect = vec4<f32>(blurred.rgb, base.a);
+        return mix(base, effect, mask);
+    }
+
+    if uniforms.mode == 3u {
+        if mask <= 0.0 {
+            return base;
+        }
+        let blurred = blur_sample(uv, vec2<f32>(0.0, 1.0));
+        let effect = vec4<f32>(blurred.rgb, base.a);
+        return mix(base, effect, mask);
     }
 
     let darkness = clamp(uniforms.darkness * uniforms.opacity, 0.0, 1.0);

--- a/crates/rendering/src/shaders/mask.wgsl
+++ b/crates/rendering/src/shaders/mask.wgsl
@@ -15,6 +15,11 @@ struct Uniforms {
 @group(0) @binding(1) var source_texture: texture_2d<f32>;
 @group(0) @binding(2) var source_sampler: sampler;
 
+const MODE_PIXELATE: u32 = 0u;
+const MODE_HIGHLIGHT: u32 = 1u;
+const MODE_BLUR_HORIZONTAL: u32 = 2u;
+const MODE_BLUR_VERTICAL: u32 = 3u;
+
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) uv: vec2<f32>,
@@ -93,13 +98,13 @@ fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
     let base = textureSample(source_texture, source_sampler, uv);
     let mask = rect_mask(uv);
 
-    if uniforms.mode == 0u {
+    if uniforms.mode == MODE_PIXELATE {
         let pixelated = pixelate_sample(uv);
         let effect = vec4<f32>(pixelated.rgb, base.a);
         return mix(base, effect, mask);
     }
 
-    if uniforms.mode == 2u {
+    if uniforms.mode == MODE_BLUR_HORIZONTAL {
         if !horizontal_blur_support(uv) {
             return base;
         }
@@ -107,7 +112,7 @@ fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
         return vec4<f32>(blurred.rgb, base.a);
     }
 
-    if uniforms.mode == 3u {
+    if uniforms.mode == MODE_BLUR_VERTICAL {
         if mask <= 0.0 {
             discard;
         }
@@ -115,7 +120,11 @@ fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
         return vec4<f32>(blurred.rgb, mask);
     }
 
-    let darkness = clamp(uniforms.darkness * uniforms.opacity, 0.0, 1.0);
-    let outside = vec4<f32>(base.rgb * (1.0 - darkness), base.a);
-    return mix(outside, base, mask);
+    if uniforms.mode == MODE_HIGHLIGHT {
+        let darkness = clamp(uniforms.darkness * uniforms.opacity, 0.0, 1.0);
+        let outside = vec4<f32>(base.rgb * (1.0 - darkness), base.a);
+        return mix(outside, base, mask);
+    }
+
+    return base;
 }

--- a/crates/rendering/src/shaders/mask.wgsl
+++ b/crates/rendering/src/shaders/mask.wgsl
@@ -81,6 +81,13 @@ fn blur_sample(uv: vec2<f32>, direction: vec2<f32>) -> vec4<f32> {
     return color / weight_sum;
 }
 
+fn horizontal_blur_support(uv: vec2<f32>) -> bool {
+    let half_size = uniforms.rect_size * 0.5;
+    let delta = abs(uv - uniforms.rect_center);
+    let vertical_radius = uniforms.effect_size / uniforms.output_size.y;
+    return delta.x <= half_size.x && delta.y <= half_size.y + vertical_radius;
+}
+
 @fragment
 fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
     let base = textureSample(source_texture, source_sampler, uv);
@@ -93,21 +100,19 @@ fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
     }
 
     if uniforms.mode == 2u {
-        if mask <= 0.0 {
+        if !horizontal_blur_support(uv) {
             return base;
         }
         let blurred = blur_sample(uv, vec2<f32>(1.0, 0.0));
-        let effect = vec4<f32>(blurred.rgb, base.a);
-        return mix(base, effect, mask);
+        return vec4<f32>(blurred.rgb, base.a);
     }
 
     if uniforms.mode == 3u {
         if mask <= 0.0 {
-            return base;
+            discard;
         }
         let blurred = blur_sample(uv, vec2<f32>(0.0, 1.0));
-        let effect = vec4<f32>(blurred.rgb, base.a);
-        return mix(base, effect, mask);
+        return vec4<f32>(blurred.rgb, mask);
     }
 
     let darkness = clamp(uniforms.darkness * uniforms.opacity, 0.0, 1.0);


### PR DESCRIPTION
## Summary
- replace opacity-based sensitive-mask intensity with blur and pixelation controls
- keep sensitive masks fully opaque while preserving highlight intensity behavior
- render smooth separable Gaussian blur and stable pixelation in previews and exports
- preserve existing projects with privacy-safe effect defaults

## Validation
- pnpm exec biome check --write on the touched desktop files
- pnpm --filter @cap/desktop exec vitest run src/routes/editor/masks.test.ts
- pnpm --dir apps/desktop exec tsc --noEmit --pretty false -p tsconfig.json
- cargo fmt --all -- --check
- cargo test -p cap-project mask_without_pixelation_uses_a_visible_safe_default
- cargo test -p cap-rendering mask::tests
- cargo check -p cap-project -p cap-rendering
- naga --validate 7 crates/rendering/src/shaders/mask.wgsl
- native macOS blur and pixelation frame renders with mask opacity set to 0.01

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the opacity-based sensitive mask intensity control with dedicated blur and pixelation effect modes. A shared `mask-effects.json` contract file is introduced as the single source of truth for encoding constants, consumed by both TypeScript (via `import`) and Rust (via `include_str!` + `serde_json`), directly addressing the constants-duplication concern raised in previous review threads.

- **Encoding scheme**: blur is encoded as `pixelation = 1000 + amount`; legacy pixelation values stay as raw amounts. Both TS and Rust decode this identically from the JSON contract.
- **Two-pass Gaussian blur**: horizontal pass writes to the intermediate buffer using `REPLACE` blend; vertical pass reads from that buffer and composites back with `SrcAlpha/OneMinusSrcAlpha` blend, correctly feathering the result over the original frame.
- **Sensitive mask opacity is hard-coded to `1.0`** in `interpolate_masks`, so old projects with low-opacity sensitive masks are upgraded to fully opaque effects.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is well-tested on both the TypeScript and Rust sides, and the JSON contract file cleanly eliminates the encoding drift risk that was the main concern in previous review rounds.

The encoding scheme is sound: the blur offset (1000) is far above any pixelation value the old UI could have produced (max 80), so legacy projects deserialize cleanly. The two-pass blur correctly avoids a texture swap by writing the composite result back to current_texture_view() in pass 2, while render_single_pass still swaps for pixelate/highlight. Switching pixelation to textureLoad sidesteps linear filtering artifacts. All behavior is backed by dedicated Rust and TypeScript tests.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/project/mask-effects.json | New contract file that acts as the single source of truth for blur encoding constants, read by both TypeScript and Rust to eliminate the previously flagged duplication. |
| apps/desktop/src/routes/editor/masks.ts | Adds encoding/decoding helpers sourced from the JSON contract; normalizeMaskEffectAmount correctly handles NaN, infinity, and out-of-range inputs consistently with the Rust side. |
| apps/desktop/src/routes/editor/masks.test.ts | New test file with good coverage of default values, legacy pixelation round-trip, blur encoding, and NaN/boundary clamping. |
| apps/desktop/src/routes/editor/ConfigSidebar.tsx | Replaces opacity/intensity slider with a blur/pixelate radio group and a unified effect-amount slider; correctly forces segment.opacity to 1 and clears intensity keyframes when switching modes. |
| crates/project/src/configuration.rs | Adds MaskEffectContract and a LazyLock for the embedded JSON; serde default for pixelation returns default_amount (16.0 = pixelate mode) for old projects missing the field. |
| crates/rendering/src/mask.rs | sensitive_effect() correctly guards against non-finite pixelation before calling normalize_effect_amount; new tests cover encoding round-trip, opacity override, and zero-pixelation fallback. |
| crates/rendering/src/layers/mask.rs | Two-pass blur architecture is correct: pass 1 clears other_texture and writes horizontal blur; pass 2 alpha-composites back to current_texture with LoadOp::Load, so no swap is needed. |
| crates/rendering/src/shaders/mask.wgsl | blur_sample uses a 25-tap separable Gaussian with correct per-axis UV normalization. pixelate_sample switched to textureLoad for stable cell boundaries. horizontal_blur_support extends the horizontal pass vertically by one blur radius. |
| crates/rendering/src/lib.rs | MaskRenderMode updated from Sensitive/Highlight to Pixelate/Blur/Highlight; PreparedMask.pixel_size renamed to effect_size; mode_value() helper removed. |

<sub>Reviews (4): Last reviewed commit: ["fix: make mask render dispatch explicit"](https://github.com/capsoftware/cap/commit/81afd5bf3c7ad33e699ebb8c71829dc93da82ae7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44785419)</sub>

<!-- /greptile_comment -->