### PR TITLE
Optimize playback prefetch and decoder scheduling

### DIFF
--- a/crates/editor/PLAYBACK-FINDINGS.md
+++ b/crates/editor/PLAYBACK-FINDINGS.md
@@ -695,6 +695,41 @@ The CPU RGBA→NV12 conversion was taking 15-25ms per frame for 3024x1964 resolu
 
 ---
 
+### Session 2026-07-16 (Scrub and Transition Decoder Scheduling)
+
+**Goal**: Reduce decoder work during rapid preview requests and keep 60fps playback stable through scrubbing, jumps, timeline restarts, and transitions without changing export behavior.
+
+**What was done**:
+1. Traced preview, playback prefetch, renderer, and AVAssetReader pool activity during repeated scrubs, transition restarts, forward jumps, and a return to frame zero.
+2. Replaced 15 concurrent preview-prefetch tasks with one sequential, cancellable task that begins only after the requested preview frame renders.
+3. Removed playback prefetch work behind the playhead after runtime traces showed it caused unnecessary decode traffic and false scrub behavior.
+4. Split discontinuous AVAssetReader request batches into contiguous clusters and kept deferred clusters for the next decoder selection.
+5. Changed reset selection to use an untouched decoder first, then the least-recently-used decoder once every pool member has been used.
+
+**Changes Made**:
+- `crates/editor/src/editor_instance.rs`: Preview prefetch is sequential, cancellable, and starts after confirmed rendering.
+- `crates/editor/src/playback.rs`: Removed behind-playhead prefetch.
+- `crates/rendering/src/decoder/avassetreader.rs`: Discontinuous request batches are processed as separate contiguous clusters.
+- `crates/rendering/src/decoder/multi_position.rs`: Repositioning preserves active decoder work when an unused pool member is available.
+
+**Results**:
+- Transition playback sustained 60.38fps with 119 rendered frames and zero skipped frames.
+- Two additional sustained samples measured 60.47fps and 60.19fps with zero skipped frames.
+- Decoder traces showed transition source ranges separated into clusters and assigned to stable decoder positions instead of repeatedly resetting one active decoder.
+- Repeated scrubbing, forward jumps, timeline restarts, and returning to frame zero were visually smooth.
+- Debug instrumentation was removed after the successful verification run.
+
+**Validation**:
+- `cargo fmt --all`
+- `cargo test -p cap-rendering decoder::multi_position::tests::test_reposition_preserves_accessed_decoder_when_unused_decoder_is_available`
+- `cargo test -p cap-rendering` (118 passed, 1 ignored)
+- `cargo check -p cap-rendering -p cap-editor`
+- `cargo check -p cap-export`
+
+**Stopping point**: The reproduced transition and seek workload is smooth at 60fps with zero measured playback skips. The final implementation retains only the measured scheduling changes and their decoder-pool regression test.
+
+---
+
 ## References
 
 - `PLAYBACK-BENCHMARKS.md` - Raw performance test data (auto-updated by test runner)

--- a/crates/editor/src/editor_instance.rs
+++ b/crates/editor/src/editor_instance.rs
@@ -752,7 +752,7 @@ impl EditorInstance {
                             }
 
                             if rendered
-                                && !preview_rx.has_changed().unwrap_or(false)
+                                && !preview_rx.has_changed().unwrap_or(true)
                                 && !*self.playback_active_rx.borrow()
                                 && !self.export_preview_active.load(Ordering::Acquire)
                                 && !self.export_active.load(Ordering::Acquire)

--- a/crates/editor/src/editor_instance.rs
+++ b/crates/editor/src/editor_instance.rs
@@ -778,13 +778,13 @@ impl EditorInstance {
                                                 prefetch_frame as f64 / fps as f64,
                                             )
                                         else {
-                                            break;
+                                            continue;
                                         };
                                         let Some(prefetch_segment_media) = this
                                             .segment_medias
                                             .get(prefetch_segment.recording_clip as usize)
                                         else {
-                                            break;
+                                            continue;
                                         };
                                         let prefetch_clip_offsets = project
                                             .clips

--- a/crates/editor/src/editor_instance.rs
+++ b/crates/editor/src/editor_instance.rs
@@ -557,48 +557,6 @@ impl EditorInstance {
                     let new_cancel_token = CancellationToken::new();
                     prefetch_cancel_token = Some(new_cancel_token.clone());
 
-                    let playback_is_active = *self.playback_active_rx.borrow();
-                    let export_preview_is_active =
-                        self.export_preview_active.load(Ordering::Acquire);
-                    let export_is_active = self.export_active.load(Ordering::Acquire);
-                    if !playback_is_active && !export_preview_is_active && !export_is_active {
-                        let prefetch_frames_count = 15u32;
-                        let hide_camera = project.camera.hide;
-                        let playback_rx = self.playback_active_rx.clone();
-                        for offset in 1..=prefetch_frames_count {
-                            let prefetch_frame = frame_number + offset;
-                            if let Some((prefetch_segment_time, prefetch_segment)) =
-                                project.get_segment_time(prefetch_frame as f64 / fps as f64)
-                                && let Some(prefetch_segment_media) = self
-                                    .segment_medias
-                                    .get(prefetch_segment.recording_clip as usize)
-                            {
-                                let prefetch_clip_offsets = project
-                                    .clips
-                                    .iter()
-                                    .find(|v| v.index == prefetch_segment.recording_clip)
-                                    .map(|v| v.offsets)
-                                    .unwrap_or_default();
-                                let decoders = prefetch_segment_media.decoders.clone();
-                                let cancel_token = new_cancel_token.clone();
-                                let playback_rx = playback_rx.clone();
-                                tokio::spawn(async move {
-                                    if cancel_token.is_cancelled() || *playback_rx.borrow() {
-                                        return;
-                                    }
-                                    let _ = decoders
-                                        .get_frames(
-                                            prefetch_segment_time as f32,
-                                            !hide_camera,
-                                            true,
-                                            prefetch_clip_offsets,
-                                        )
-                                        .await;
-                                });
-                            }
-                        }
-                    }
-
                     tokio::select! {
                         biased;
 
@@ -791,6 +749,66 @@ impl EditorInstance {
                                     attempts = PREVIEW_RENDER_MAX_ATTEMPTS,
                                     "Preview renderer: frame render failed"
                                 );
+                            }
+
+                            if rendered
+                                && !preview_rx.has_changed().unwrap_or(false)
+                                && !*self.playback_active_rx.borrow()
+                                && !self.export_preview_active.load(Ordering::Acquire)
+                                && !self.export_active.load(Ordering::Acquire)
+                            {
+                                let this = self.clone();
+                                let project = project.clone();
+                                let cancel_token = new_cancel_token.clone();
+                                let playback_rx = self.playback_active_rx.clone();
+                                tokio::spawn(async move {
+                                    for offset in 1..=15u32 {
+                                        if cancel_token.is_cancelled()
+                                            || *playback_rx.borrow()
+                                            || this.export_preview_active.load(Ordering::Acquire)
+                                            || this.export_active.load(Ordering::Acquire)
+                                        {
+                                            break;
+                                        }
+
+                                        let prefetch_frame =
+                                            frame_number.saturating_add(offset);
+                                        let Some((prefetch_segment_time, prefetch_segment)) =
+                                            project.get_segment_time(
+                                                prefetch_frame as f64 / fps as f64,
+                                            )
+                                        else {
+                                            break;
+                                        };
+                                        let Some(prefetch_segment_media) = this
+                                            .segment_medias
+                                            .get(prefetch_segment.recording_clip as usize)
+                                        else {
+                                            break;
+                                        };
+                                        let prefetch_clip_offsets = project
+                                            .clips
+                                            .iter()
+                                            .find(|v| {
+                                                v.index == prefetch_segment.recording_clip
+                                            })
+                                            .map(|v| v.offsets)
+                                            .unwrap_or_default();
+                                        prefetch_segment_media
+                                            .decoders
+                                            .get_frames(
+                                                prefetch_segment_time as f32,
+                                                !project.camera.hide,
+                                                true,
+                                                prefetch_clip_offsets,
+                                            )
+                                            .await;
+
+                                        if cancel_token.is_cancelled() {
+                                            break;
+                                        }
+                                    }
+                                });
                             }
                         }
                     }

--- a/crates/editor/src/editor_instance.rs
+++ b/crates/editor/src/editor_instance.rs
@@ -794,15 +794,16 @@ impl EditorInstance {
                                             })
                                             .map(|v| v.offsets)
                                             .unwrap_or_default();
-                                        prefetch_segment_media
-                                            .decoders
-                                            .get_frames(
+                                        tokio::select! {
+                                            biased;
+                                            _ = cancel_token.cancelled() => break,
+                                            _ = prefetch_segment_media.decoders.get_frames(
                                                 prefetch_segment_time as f32,
                                                 !project.camera.hide,
                                                 true,
                                                 prefetch_clip_offsets,
-                                            )
-                                            .await;
+                                            ) => {}
+                                        }
 
                                         if cancel_token.is_cancelled() {
                                             break;

--- a/crates/editor/src/playback.rs
+++ b/crates/editor/src/playback.rs
@@ -31,8 +31,6 @@ const PREFETCH_BUFFER_SIZE: usize = 90;
 const PARALLEL_DECODE_TASKS: usize = 4;
 const INITIAL_PARALLEL_DECODE_TASKS: usize = 4;
 const MAX_PREFETCH_AHEAD: u32 = 90;
-#[cfg(not(target_os = "windows"))]
-const PREFETCH_BEHIND: u32 = 10;
 const FRAME_CACHE_SIZE: usize = 90;
 const RAMP_UP_FRAME_COUNT: u32 = 15;
 
@@ -398,11 +396,6 @@ impl Playback {
             let mut next_prefetch_frame = *frame_request_rx.borrow();
             let mut in_flight: FuturesUnordered<PrefetchFuture> = FuturesUnordered::new();
             let mut frames_decoded: u32 = 0;
-            let mut prefetched_behind: HashSet<u32> = HashSet::new();
-            #[cfg(target_os = "windows")]
-            let prefetch_behind = 0u32;
-            #[cfg(not(target_os = "windows"))]
-            let prefetch_behind = PREFETCH_BEHIND;
             let mut cached_project = prefetch_project.borrow().clone();
 
             loop {
@@ -427,7 +420,6 @@ impl Playback {
 
                         next_prefetch_frame = requested;
                         frames_decoded = 0;
-                        prefetched_behind.clear();
 
                         if let Ok(mut in_flight_guard) = prefetch_in_flight.write() {
                             in_flight_guard.clear();
@@ -514,71 +506,6 @@ impl Playback {
                     }
 
                     next_prefetch_frame += 1;
-                }
-
-                if in_flight.len() < effective_parallel {
-                    for behind_offset in 1..=prefetch_behind {
-                        if in_flight.len() >= effective_parallel {
-                            break;
-                        }
-                        let behind_frame = current_playback_frame.saturating_sub(behind_offset);
-                        if behind_frame == 0 || prefetched_behind.contains(&behind_frame) {
-                            continue;
-                        }
-
-                        let prefetch_time = behind_frame as f64 / fps_f64;
-                        if prefetch_time >= prefetch_duration || prefetch_time < 0.0 {
-                            continue;
-                        }
-
-                        let already_in_flight = prefetch_in_flight
-                            .read()
-                            .map(|guard| guard.contains(&behind_frame))
-                            .unwrap_or(false);
-                        if already_in_flight {
-                            continue;
-                        }
-
-                        if let Some((segment_time, segment)) =
-                            cached_project.get_segment_time(prefetch_time)
-                            && let Some(segment_media) =
-                                prefetch_segment_medias.get(segment.recording_clip as usize)
-                        {
-                            let clip_offsets = cached_project
-                                .clips
-                                .iter()
-                                .find(|v| v.index == segment.recording_clip)
-                                .map(|v| v.offsets)
-                                .unwrap_or_default();
-
-                            let decoders = segment_media.decoders.clone();
-                            let hide_camera = cached_project.camera.hide;
-                            let segment_index = segment.recording_clip;
-                            let transition = transition_decode_request(
-                                &cached_project,
-                                &prefetch_segment_medias,
-                                prefetch_time,
-                            );
-
-                            if let Ok(mut in_flight_guard) = prefetch_in_flight.write() {
-                                in_flight_guard.insert(behind_frame);
-                            }
-
-                            prefetched_behind.insert(behind_frame);
-                            in_flight.push(Box::pin(decode_prefetched_frame(
-                                PrefetchDecodeRequest {
-                                    frame_number: behind_frame,
-                                    decoders,
-                                    segment_time,
-                                    segment_index,
-                                    offsets: clip_offsets,
-                                    hide_camera,
-                                    is_initial: false,
-                                    transition,
-                                },
-                            )));
-                        }
-                    }
                 }
 
                 tokio::select! {

--- a/crates/rendering/src/decoder/avassetreader.rs
+++ b/crates/rendering/src/decoder/avassetreader.rs
@@ -608,12 +608,18 @@ impl AVAssetReaderDecoder {
             let processing_deferred = !deferred_requests.is_empty();
 
             if let Some(request) = deferred_requests.pop_front() {
+                if request.sender.is_closed() {
+                    continue;
+                }
                 let mut last_frame = request.frame;
                 pending_requests.push(request);
                 while deferred_requests.front().is_some_and(|next| {
                     next.frame.saturating_sub(last_frame) <= DECODER_REQUEST_CLUSTER_GAP_FRAMES
                 }) {
                     if let Some(request) = deferred_requests.pop_front() {
+                        if request.sender.is_closed() {
+                            continue;
+                        }
                         last_frame = request.frame;
                         pending_requests.push(request);
                     }

--- a/crates/rendering/src/decoder/avassetreader.rs
+++ b/crates/rendering/src/decoder/avassetreader.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::BTreeMap,
+    collections::{BTreeMap, VecDeque},
     path::PathBuf,
     rc::Rc,
     sync::{Arc, mpsc},
@@ -24,6 +24,7 @@ use super::{
 
 const MAX_RELAXED_FALLBACK_DISTANCE: u32 = 8;
 const SCRUB_REUSE_THRESHOLD_SECS: f32 = 0.5;
+const DECODER_REQUEST_CLUSTER_GAP_FRAMES: u32 = FRAME_CACHE_SIZE as u32 / 2;
 
 #[derive(Clone)]
 struct FrameData {
@@ -600,24 +601,28 @@ impl AVAssetReaderDecoder {
             sender: oneshot::Sender<DecodedFrame>,
         }
 
-        while let Ok(r) = rx.recv() {
-            let mut pending_requests: Vec<PendingRequest> = Vec::with_capacity(8);
+        let mut deferred_requests = VecDeque::<PendingRequest>::new();
 
-            match r {
-                VideoDecoderMessage::GetFrame(requested_time, max_fallback_distance, sender) => {
-                    let frame = (requested_time * fps as f32).floor() as u32;
-                    if !sender.is_closed() {
-                        pending_requests.push(PendingRequest {
-                            frame,
-                            max_fallback_distance,
-                            sender,
-                        });
+        loop {
+            let mut pending_requests: Vec<PendingRequest> = Vec::with_capacity(8);
+            let processing_deferred = !deferred_requests.is_empty();
+
+            if let Some(request) = deferred_requests.pop_front() {
+                let mut last_frame = request.frame;
+                pending_requests.push(request);
+                while deferred_requests.front().is_some_and(|next| {
+                    next.frame.saturating_sub(last_frame) <= DECODER_REQUEST_CLUSTER_GAP_FRAMES
+                }) {
+                    if let Some(request) = deferred_requests.pop_front() {
+                        last_frame = request.frame;
+                        pending_requests.push(request);
                     }
                 }
-            }
-
-            while let Ok(msg) = rx.try_recv() {
-                match msg {
+            } else {
+                let Ok(message) = rx.recv() else {
+                    break;
+                };
+                match message {
                     VideoDecoderMessage::GetFrame(
                         requested_time,
                         max_fallback_distance,
@@ -633,9 +638,40 @@ impl AVAssetReaderDecoder {
                         }
                     }
                 }
+
+                while let Ok(message) = rx.try_recv() {
+                    match message {
+                        VideoDecoderMessage::GetFrame(
+                            requested_time,
+                            max_fallback_distance,
+                            sender,
+                        ) => {
+                            let frame = (requested_time * fps as f32).floor() as u32;
+                            if !sender.is_closed() {
+                                pending_requests.push(PendingRequest {
+                                    frame,
+                                    max_fallback_distance,
+                                    sender,
+                                });
+                            }
+                        }
+                    }
+                }
             }
 
             pending_requests.sort_by_key(|r| r.frame);
+
+            if !processing_deferred
+                && let Some(split_index) = pending_requests
+                    .windows(2)
+                    .position(|requests| {
+                        requests[1].frame.saturating_sub(requests[0].frame)
+                            > DECODER_REQUEST_CLUSTER_GAP_FRAMES
+                    })
+                    .map(|index| index + 1)
+            {
+                deferred_requests.extend(pending_requests.drain(split_index..));
+            }
 
             let is_scrubbing = if let Some(first_req) = pending_requests.first() {
                 this.scrub_detector.record_request(first_req.frame)

--- a/crates/rendering/src/decoder/multi_position.rs
+++ b/crates/rendering/src/decoder/multi_position.rs
@@ -182,12 +182,31 @@ impl DecoderPoolManager {
         }
 
         if needs_reset {
-            for position in self.positions.iter().filter(|p| p.id < decoder_count) {
-                let distance = (position.position_secs - requested_time).abs();
-                if distance < best_distance {
-                    best_distance = distance;
-                    best_decoder_id = position.id;
+            let has_unused_decoder = self
+                .positions
+                .iter()
+                .any(|position| position.id < decoder_count && position.access_count == 0);
+
+            if has_unused_decoder {
+                for position in self
+                    .positions
+                    .iter()
+                    .filter(|position| position.id < decoder_count && position.access_count == 0)
+                {
+                    let distance = (position.position_secs - requested_time).abs();
+                    if distance < best_distance {
+                        best_distance = distance;
+                        best_decoder_id = position.id;
+                    }
                 }
+            } else if let Some(position) = self
+                .positions
+                .iter()
+                .filter(|position| position.id < decoder_count)
+                .min_by_key(|position| position.last_access_time)
+            {
+                best_distance = (position.position_secs - requested_time).abs();
+                best_decoder_id = position.id;
             }
         }
 
@@ -417,5 +436,29 @@ mod tests {
 
         assert_eq!(decoder_id, 1);
         assert!(needs_reset);
+    }
+
+    #[test]
+    fn test_reposition_preserves_accessed_decoder_when_unused_decoder_is_available() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let config = MultiPositionDecoderConfig {
+            path: PathBuf::from("fixture.mp4"),
+            tokio_handle: runtime.handle().clone(),
+            keyframe_index: None,
+            fps: 60,
+            duration_secs: 200.0,
+        };
+        let mut manager = DecoderPoolManager::new(config);
+
+        let (first_decoder_id, _, first_needs_reset) =
+            manager.find_best_decoder_for_time_with_reuse_threshold(15.0, 5, 0.5);
+        manager.update_decoder_position(first_decoder_id, 17.0);
+        let (second_decoder_id, _, second_needs_reset) =
+            manager.find_best_decoder_for_time_with_reuse_threshold(15.0, 5, 0.5);
+
+        assert_eq!(first_decoder_id, 0);
+        assert!(first_needs_reset);
+        assert_eq!(second_decoder_id, 1);
+        assert!(second_needs_reset);
     }
 }


### PR DESCRIPTION
Reduces redundant decode work during scrubbing and transitions by serializing preview prefetch, removing behind-playhead prefetch, and improving decoder allocation. Verified at 60fps with zero playback skips; rendering tests and export checks pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces redundant decoder work during scrubbing and transitions through three complementary changes: serializing preview prefetch into a single cancellable sequential task (started only after confirmed rendering), removing behind-playhead prefetch that traces showed caused false scrub behavior, and splitting discontinuous AVAssetReader request batches into contiguous clusters decoded separately.

- **`editor_instance.rs`**: Replaces 15 eagerly-spawned concurrent prefetch tasks with one sequential `tokio::spawn` that is properly guarded with `tokio::select!` for cancellation. Missing segments and media now use `continue` so a gap does not abort the remainder of the prefetch window.
- **`avassetreader.rs`**: Adds a `VecDeque<PendingRequest>` deferred queue; when sorted pending requests span a gap larger than `DECODER_REQUEST_CLUSTER_GAP_FRAMES` (45 frames), the tail cluster is saved for the next loop iteration rather than processed in one seek.
- **`multi_position.rs`**: When a decoder reset is required, the pool selection now prefers the nearest untouched decoder so active decoders keep their position. Backs off to LRU selection once all pool members have been accessed. A dedicated regression test is included.

<h3>Confidence Score: 5/5</h3>

The changes are safe to merge; the core decode-scheduling logic is well-structured and the 60fps validation with zero skipped frames is a strong signal.

No new defects were found in this pass. The previous review flagged two issues in `avassetreader.rs` (new channel messages stalling behind the deferred queue, and `last_frame` not being updated when a closed-sender request is skipped inside the cluster-drain loop) that remain open; those were already surfaced and are tracked in prior review threads. All other previously flagged items — the `break` vs `continue` for missing segments, and the missing `tokio::select!` cancellation guard in the prefetch loop — have been addressed.

The deferred-request cluster logic in `crates/rendering/src/decoder/avassetreader.rs` has two open items from the prior review worth revisiting in a follow-up: high-frequency scrub scenarios where new requests pile up behind a large deferred batch, and the `last_frame` tracking when closed-sender requests appear mid-cluster.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/editor/PLAYBACK-FINDINGS.md | Adds a new session entry documenting the scrub/transition decoder scheduling changes, validation steps, and performance results. Documentation only. |
| crates/editor/src/editor_instance.rs | Replaces 15 concurrent preview-prefetch spawns (launched before render) with a single sequential, cancellation-aware task launched only after confirmed rendering. Uses `continue` (not `break`) for missing segments so gaps don't abort the full prefetch run. |
| crates/editor/src/playback.rs | Removes behind-playhead prefetch (`PREFETCH_BEHIND`, `prefetched_behind` HashSet, and the behind-offset decode loop). Clean removal with no logical residue left behind. |
| crates/rendering/src/decoder/avassetreader.rs | Introduces a `deferred_requests` VecDeque and cluster-gap splitting so discontinuous request batches are processed as separate contiguous runs. Two issues from the previous review thread remain in this file: new channel messages can stall behind the deferred queue, and `last_frame` is not updated when a closed-sender request is skipped inside the inner cluster-drain loop. |
| crates/rendering/src/decoder/multi_position.rs | When a decoder reset is required, the selection now prefers the closest untouched decoder over any active one. Falls back to LRU selection only once every pool member has been accessed. New regression test validates the core invariant. |

<sub>Reviews (6): Last reviewed commit: ["fix(editor): preserve prefetch across mi..."](https://github.com/capsoftware/cap/commit/0132884926a05bd77a5ff538867fae0baa7d9ee1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44887989)</sub>

<!-- /greptile_comment -->