### PR TITLE
Add speed audio modes for retimed clip segments

### DIFF
--- a/apps/cli/src/selftest/playback.rs
+++ b/apps/cli/src/selftest/playback.rs
@@ -901,6 +901,7 @@ mod fixture {
                     end: display_duration,
                     timescale: 1.0,
                     name: None,
+                    speed_audio_mode: None,
                 }],
                 transitions: Vec::new(),
                 zoom_segments: Vec::new(),

--- a/apps/desktop/src-tauri/examples/desktop-display-transport-benchmark.rs
+++ b/apps/desktop/src-tauri/examples/desktop-display-transport-benchmark.rs
@@ -7,8 +7,8 @@ use std::{
 
 use cap_desktop_lib::frame_ws::{WSFrame, WSFrameFormat, create_watch_frame_ws};
 use cap_editor::{
-    EditorFrameOutput, Playback, PlaybackRenderOutputFormat, PlaybackSkipReason, PlaybackTelemetry,
-    PlaybackTelemetryEvent, Renderer, finish_renderer_layers_creation,
+    EditorFrameOutput, FrameLayout, Playback, PlaybackRenderOutputFormat, PlaybackSkipReason,
+    PlaybackTelemetry, PlaybackTelemetryEvent, Renderer, finish_renderer_layers_creation,
     start_renderer_layers_creation,
 };
 use cap_project::{
@@ -132,6 +132,7 @@ async fn load_recording(
                     end: duration,
                     timescale: 1.0,
                     name: None,
+                    speed_audio_mode: None,
                 }]
             }
             StudioRecordingMeta::MultipleSegments { inner } => inner
@@ -150,6 +151,7 @@ async fn load_recording(
                         end: duration,
                         timescale: 1.0,
                         name: None,
+                        speed_audio_mode: None,
                     })
                 })
                 .collect(),
@@ -252,7 +254,7 @@ async fn main() {
     let (telemetry, mut telemetry_rx) = PlaybackTelemetry::channel();
     let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<usize>();
 
-    let frame_cb = Box::new(move |output: EditorFrameOutput| {
+    let frame_cb = Box::new(move |output: EditorFrameOutput, _: FrameLayout| {
         let ws_frame = match output {
             EditorFrameOutput::Nv12(frame) => {
                 let ws_format = match frame.format {

--- a/apps/desktop/src-tauri/src/import.rs
+++ b/apps/desktop/src-tauri/src/import.rs
@@ -322,6 +322,7 @@ fn full_timeline_for_segments(
                 start: 0.0,
                 end: duration,
                 name: None,
+                speed_audio_mode: None,
             })
         })
         .collect()
@@ -355,6 +356,7 @@ fn full_timeline_for_source_segments(
                 start: 0.0,
                 end: duration,
                 name: None,
+                speed_audio_mode: None,
             })
         })
         .collect()
@@ -914,6 +916,7 @@ fn source_timeline_segments_for_import(
             start,
             end,
             name: None,
+            speed_audio_mode: None,
         });
     }
 
@@ -1707,6 +1710,7 @@ async fn append_mp4_to_editor_project(
             start: 0.0,
             end: duration,
             name: None,
+            speed_audio_mode: None,
         });
     add_clip_configs(
         &mut config,
@@ -1837,6 +1841,7 @@ async fn append_cap_project_to_editor_project(
                 start: source_segment.start,
                 end: source_segment.end,
                 name: None,
+                speed_audio_mode: source_segment.speed_audio_mode,
             });
         }
     }

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -3840,6 +3840,7 @@ fn project_config_from_recording(
             end: segment.duration(),
             timescale: 1.0,
             name: None,
+            speed_audio_mode: None,
         })
         .collect::<Vec<_>>();
 

--- a/apps/desktop/src/routes/editor/ConfigSidebar.tsx
+++ b/apps/desktop/src/routes/editor/ConfigSidebar.tsx
@@ -61,6 +61,7 @@ import {
 	type CameraYPosition,
 	type CaptionTrackSegment,
 	type ClipOffsets,
+	type ClipSpeedAudioMode,
 	type CursorAnimationStyle,
 	type CursorType,
 	commands,
@@ -4418,6 +4419,19 @@ function ClipSegmentConfig(props: {
 		);
 	}
 
+	function setSpeedAudioMode(value: string) {
+		if (
+			value === "mute" ||
+			value === "maintainPitch" ||
+			value === "matchSpeed"
+		) {
+			projectActions.setClipSegmentSpeedAudioMode(
+				props.segmentIndex,
+				value satisfies ClipSpeedAudioMode,
+			);
+		}
+	}
+
 	return (
 		<>
 			<div class="flex flex-row justify-between items-center">
@@ -4449,10 +4463,6 @@ function ClipSegmentConfig(props: {
 			</div>
 
 			<Field name="Speed" icon={<IconLucideFastForward class="size-4" />}>
-				<p class="text-gray-11 -mt-3">
-					Modifying speed will mute this segment's audio.
-				</p>
-
 				<KRadioGroup
 					class="flex flex-row gap-1.5 -mt-1"
 					value={props.segment.timescale.toString()}
@@ -4473,6 +4483,36 @@ function ClipSegmentConfig(props: {
 						)}
 					</For>
 				</KRadioGroup>
+
+				<Show when={props.segment.timescale !== 1}>
+					<div class="space-y-2 pt-2">
+						<p class="text-gray-11">
+							Mute is fastest. Maintain pitch keeps voices natural, while Match
+							speed raises or lowers pitch with playback speed.
+						</p>
+						<KRadioGroup
+							class="grid grid-cols-3 gap-1.5"
+							value={props.segment.speedAudioMode ?? "mute"}
+							onChange={setSpeedAudioMode}
+						>
+							<For
+								each={[
+									{ value: "mute", label: "Mute" },
+									{ value: "maintainPitch", label: "Maintain pitch" },
+									{ value: "matchSpeed", label: "Match speed" },
+								]}
+							>
+								{(option) => (
+									<KRadioGroup.Item value={option.value}>
+										<KRadioGroup.ItemControl class="w-full px-2 py-1.5 text-xs text-gray-11 hover:text-gray-12 bg-gray-1 border border-gray-3 rounded-md data-checked:bg-gray-3 data-checked:border-gray-4 data-checked:text-gray-12">
+											{option.label}
+										</KRadioGroup.ItemControl>
+									</KRadioGroup.Item>
+								)}
+							</For>
+						</KRadioGroup>
+					</div>
+				</Show>
 			</Field>
 
 			<div class="space-y-0.5 pt-2">

--- a/apps/desktop/src/routes/editor/context.ts
+++ b/apps/desktop/src/routes/editor/context.ts
@@ -37,6 +37,7 @@ import {
 	type FrameData,
 } from "~/utils/socket";
 import {
+	type ClipSpeedAudioMode,
 	commands,
 	type EditorPreviewQuality,
 	events,
@@ -957,6 +958,18 @@ export const [EditorContextProvider, useEditorContext] = createContextProvider(
 							keyboardSegment.end += diff(keyboardSegment.end);
 						}
 					}),
+				);
+			},
+			setClipSegmentSpeedAudioMode: (
+				index: number,
+				speedAudioMode: ClipSpeedAudioMode,
+			) => {
+				setProject(
+					"timeline",
+					"segments",
+					index,
+					"speedAudioMode",
+					speedAudioMode,
 				);
 			},
 		};

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -691,6 +691,7 @@ export type ClipConfiguration = { index: number; offsets: ClipOffsets;
  */
 offsetsAutoCalculated?: boolean }
 export type ClipOffsets = { camera?: number; mic?: number; system_audio?: number }
+export type ClipSpeedAudioMode = "mute" | "maintainPitch" | "matchSpeed"
 export type ClipTransition = { segmentIndex: number; type: ClipTransitionType; duration: number }
 export type ClipTransitionType = "cross-fade" | "fade-through-black"
 export type ClipboardSource = "raw" | "rendered"
@@ -918,7 +919,7 @@ export type SystemDiagnostics = { macosVersion: MacOSVersionInfo | null; availab
 export type TargetUnderCursor = { display_id: DisplayId | null; window: WindowUnderCursor | null }
 export type TextSegment = { start: number; end: number; track?: number; enabled?: boolean; content?: string; center?: XY<number>; size?: XY<number>; fontFamily?: string; fontSize?: number; fontWeight?: number; italic?: boolean; color?: string; fadeDuration?: number }
 export type TimelineConfiguration = { segments: TimelineSegment[]; transitions: ClipTransition[]; zoomSegments: ZoomSegment[]; sceneSegments?: SceneSegment[]; maskSegments?: MaskSegment[]; textSegments?: TextSegment[]; captionSegments?: CaptionTrackSegment[]; keyboardSegments?: KeyboardTrackSegment[]; audioSegments?: AudioTrackSegment[] }
-export type TimelineSegment = { recordingSegment?: number; timescale: number; start: number; end: number; name?: string | null }
+export type TimelineSegment = { recordingSegment?: number; timescale: number; start: number; end: number; name?: string | null; speedAudioMode?: ClipSpeedAudioMode | null }
 export type TranscriptionEngine = "Whisper" | "Parakeet"
 export type Trigger = "screenshotTaken" | "studioRecordingFinished" | "instantRecordingFinished" | "recordingStarted" | "uploadCompleted" | "videoImported" | "recordingDeleted"
 export type UpdateChannel = "stable" | "nightly"

--- a/crates/editor/examples/editor-playback-benchmark.rs
+++ b/crates/editor/examples/editor-playback-benchmark.rs
@@ -352,6 +352,7 @@ async fn load_recording(
                     end: duration,
                     timescale: 1.0,
                     name: None,
+                    speed_audio_mode: None,
                 }]
             }
             StudioRecordingMeta::MultipleSegments { inner } => inner
@@ -370,6 +371,7 @@ async fn load_recording(
                         end: duration,
                         timescale: 1.0,
                         name: None,
+                        speed_audio_mode: None,
                     })
                 })
                 .collect(),

--- a/crates/editor/examples/playback-pipeline-benchmark.rs
+++ b/crates/editor/examples/playback-pipeline-benchmark.rs
@@ -275,6 +275,7 @@ async fn load_recording(
                     end: duration,
                     timescale: 1.0,
                     name: None,
+                    speed_audio_mode: None,
                 }]
             }
             StudioRecordingMeta::MultipleSegments { inner } => inner
@@ -296,6 +297,7 @@ async fn load_recording(
                         end: duration,
                         timescale: 1.0,
                         name: None,
+                        speed_audio_mode: None,
                     })
                 })
                 .collect(),

--- a/crates/editor/src/audio.rs
+++ b/crates/editor/src/audio.rs
@@ -1,27 +1,29 @@
 use cap_audio::{
-    AudioData, AudioRendererTrack, FromSampleBytes, StereoMode, cast_f32_slice_to_bytes,
+    AudioData, AudioRendererTrack, FromSampleBytes, StereoMode, cast_bytes_to_f32_slice,
+    cast_f32_slice_to_bytes,
 };
 use cap_media::MediaError;
 use cap_media_info::AudioInfo;
 use cap_project::{
-    AudioConfiguration, ClipOffsets, ClipTransitionType, ProjectConfiguration,
+    AudioConfiguration, ClipOffsets, ClipSpeedAudioMode, ClipTransitionType, ProjectConfiguration,
     TimelineConfiguration, TimelineFrameMapping, TimelineSource,
 };
 use ffmpeg::{
-    ChannelLayout, Dictionary, format as avformat, frame::Audio as FFAudio, software::resampling,
+    ChannelLayout, Dictionary, filter, format as avformat, frame::Audio as FFAudio,
+    software::resampling,
 };
 use ringbuf::{
     HeapRb,
     traits::{Consumer, Observer, Producer},
 };
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering},
     },
 };
-use tracing::info;
+use tracing::{info, warn};
 
 /// Decoded music/imported-audio tracks, keyed by the path string stored in the
 /// project config's `timeline.audio_segments`. The renderer mixes these on top
@@ -37,6 +39,8 @@ pub struct AudioRenderer {
     music: MusicTracks,
     transition_outgoing: Vec<f32>,
     transition_incoming: Vec<f32>,
+    speed_audio_processors: [Option<SpeedAudioProcessorSlot>; 2],
+    speed_audio_use_counter: u64,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -103,7 +107,47 @@ impl AudioSegmentTrack {
 struct TimelineCursor<'a> {
     segment_end_samples: usize,
     segment_time: f64,
+    segment_index: usize,
     segment: &'a cap_project::TimelineSegment,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct SpeedAudioProcessorKey {
+    segment_index: usize,
+    recording_clip: u32,
+    timescale_bits: u64,
+    mode: ClipSpeedAudioMode,
+    segment_start_samples: usize,
+    segment_end_samples: usize,
+    mic_volume_bits: u32,
+    system_volume_bits: u32,
+    mic_stereo_mode: u8,
+    mic_offset_bits: u32,
+    system_offset_bits: u32,
+}
+
+struct SpeedAudioProcessorSlot {
+    key: SpeedAudioProcessorKey,
+    last_used: u64,
+    state: SpeedAudioProcessorState,
+}
+
+enum SpeedAudioProcessorState {
+    Ready(SpeedAudioProcessor),
+    Failed,
+}
+
+struct SpeedAudioProcessor {
+    graph: filter::Graph,
+    pending: VecDeque<f32>,
+    input_data: Vec<f32>,
+    recording_clip: u32,
+    input_samples: usize,
+    segment_end_samples: usize,
+    discard_output_samples: usize,
+    expected_source_sample: f64,
+    timescale: f64,
+    flushed: bool,
 }
 
 impl AudioRenderer {
@@ -127,6 +171,8 @@ impl AudioRenderer {
             music: MusicTracks::new(),
             transition_outgoing: Vec::new(),
             transition_incoming: Vec::new(),
+            speed_audio_processors: [None, None],
+            speed_audio_use_counter: 0,
         }
     }
 
@@ -137,6 +183,7 @@ impl AudioRenderer {
 
     pub fn set_playhead(&mut self, playhead: f64, project: &ProjectConfiguration) {
         self.elapsed_samples = self.playhead_to_samples(playhead);
+        self.speed_audio_processors = [None, None];
 
         self.cursor = match project.get_segment_time(playhead) {
             Some((segment_time, segment)) => AudioRendererCursor {
@@ -235,6 +282,18 @@ impl AudioRenderer {
             if cursor.segment.timescale == 1.0 {
                 self.render_current_chunk(project, chunk_samples, written * 2, &mut ret);
                 self.cursor.samples += chunk_samples;
+            } else {
+                self.render_speed_audio_chunk(
+                    project,
+                    TimelineSource {
+                        source_time: cursor.segment_time,
+                        segment_index: cursor.segment_index,
+                        segment: cursor.segment,
+                    },
+                    chunk_samples,
+                    written * 2,
+                    &mut ret,
+                );
             }
 
             self.elapsed_samples += chunk_samples;
@@ -389,7 +448,7 @@ impl AudioRenderer {
         let mut segment_start_samples = 0usize;
         let mut accumulated_duration = 0.0;
 
-        for segment in &timeline.segments {
+        for (segment_index, segment) in timeline.segments.iter().enumerate() {
             accumulated_duration += segment.duration();
             let segment_end_samples = self.playhead_to_samples(accumulated_duration);
 
@@ -399,6 +458,7 @@ impl AudioRenderer {
                 return Some(TimelineCursor {
                     segment_end_samples,
                     segment_time: segment.start + local_time * segment.timescale,
+                    segment_index,
                     segment,
                 });
             }
@@ -420,19 +480,128 @@ impl AudioRenderer {
     }
 
     fn render_segment_chunk(
-        &self,
+        &mut self,
         project: &ProjectConfiguration,
         source: TimelineSource<'_>,
         samples: usize,
         out_offset: usize,
         out: &mut [f32],
     ) -> usize {
-        if source.segment.timescale != 1.0 {
-            // Keep the inherited silent behavior until per-segment retiming can supply this chunk.
+        if source.segment.timescale == 1.0 {
+            let cursor = source_cursor(source, self.playhead_to_samples(source.source_time));
+            return self.render_chunk_at_cursor(project, cursor, samples, out_offset, out);
+        }
+
+        self.render_speed_audio_chunk(project, source, samples, out_offset, out)
+    }
+
+    fn render_speed_audio_chunk(
+        &mut self,
+        project: &ProjectConfiguration,
+        source: TimelineSource<'_>,
+        samples: usize,
+        out_offset: usize,
+        out: &mut [f32],
+    ) -> usize {
+        if samples == 0
+            || project.audio.mute
+            || source.segment.speed_audio_mode.unwrap_or_default() == ClipSpeedAudioMode::Mute
+            || !source.segment.timescale.is_finite()
+            || !(0.25..=8.0).contains(&source.segment.timescale)
+        {
             return 0;
         }
-        let cursor = source_cursor(source, self.playhead_to_samples(source.source_time));
-        self.render_chunk_at_cursor(project, cursor, samples, out_offset, out)
+
+        let Some(audio_segment) = self.data.get(source.segment.recording_clip as usize) else {
+            return 0;
+        };
+        if audio_segment.tracks.is_empty() {
+            return 0;
+        }
+
+        let offsets = project
+            .clips
+            .iter()
+            .find(|clip| clip.index == source.segment.recording_clip)
+            .map(|clip| clip.offsets)
+            .unwrap_or_default();
+        let key = SpeedAudioProcessorKey {
+            segment_index: source.segment_index,
+            recording_clip: source.segment.recording_clip,
+            timescale_bits: source.segment.timescale.to_bits(),
+            mode: source.segment.speed_audio_mode.unwrap_or_default(),
+            segment_start_samples: self.playhead_to_samples(source.segment.start),
+            segment_end_samples: self.playhead_to_samples(source.segment.end),
+            mic_volume_bits: project.audio.mic_volume_db.to_bits(),
+            system_volume_bits: project.audio.system_volume_db.to_bits(),
+            mic_stereo_mode: project_stereo_mode_key(&project.audio.mic_stereo_mode),
+            mic_offset_bits: offsets.mic.to_bits(),
+            system_offset_bits: offsets.system_audio.to_bits(),
+        };
+        let requested_source_sample = source.source_time * Self::SAMPLE_RATE as f64;
+        self.speed_audio_use_counter = self.speed_audio_use_counter.saturating_add(1);
+
+        let existing = self
+            .speed_audio_processors
+            .iter()
+            .position(|slot| slot.as_ref().is_some_and(|slot| slot.key == key));
+        let slot_index = existing.unwrap_or_else(|| {
+            self.speed_audio_processors
+                .iter()
+                .position(Option::is_none)
+                .unwrap_or_else(|| {
+                    self.speed_audio_processors
+                        .iter()
+                        .enumerate()
+                        .min_by_key(|(_, slot)| {
+                            slot.as_ref().map_or(u64::MIN, |slot| slot.last_used)
+                        })
+                        .map_or(0, |(index, _)| index)
+                })
+        });
+
+        if existing.is_none() {
+            self.speed_audio_processors[slot_index] = Some(SpeedAudioProcessorSlot {
+                key,
+                last_used: self.speed_audio_use_counter,
+                state: speed_audio_processor_state(key, requested_source_sample),
+            });
+        }
+
+        let slot = self.speed_audio_processors[slot_index].as_mut().unwrap();
+        slot.last_used = self.speed_audio_use_counter;
+        if matches!(
+            &slot.state,
+            SpeedAudioProcessorState::Ready(processor)
+                if !processor.is_contiguous(requested_source_sample)
+        ) {
+            slot.state = speed_audio_processor_state(key, requested_source_sample);
+        }
+
+        let result = match &mut slot.state {
+            SpeedAudioProcessorState::Ready(processor) => processor.render(
+                &self.data,
+                project,
+                requested_source_sample,
+                samples,
+                out_offset,
+                out,
+            ),
+            SpeedAudioProcessorState::Failed => return 0,
+        };
+
+        match result {
+            Ok(written) => written,
+            Err(error) => {
+                warn!(
+                    ?error,
+                    segment_index = source.segment_index,
+                    "Speed audio processing failed"
+                );
+                slot.state = SpeedAudioProcessorState::Failed;
+                0
+            }
+        }
     }
 
     fn render_chunk_at_cursor(
@@ -443,55 +612,7 @@ impl AudioRenderer {
         out_offset: usize,
         out: &mut [f32],
     ) -> usize {
-        let Some(segment) = self.data.get(cursor.clip_index as usize) else {
-            return 0;
-        };
-        let tracks = &segment.tracks;
-
-        if tracks.is_empty() {
-            return 0;
-        }
-
-        let offsets = project
-            .clips
-            .iter()
-            .find(|c| c.index == cursor.clip_index)
-            .map(|c| c.offsets)
-            .unwrap_or_default();
-
-        let max_samples = tracks
-            .iter()
-            .map(|t| {
-                let track_offset_samples =
-                    (t.offset(&offsets) * Self::SAMPLE_RATE as f32).round() as isize;
-                let available = t.data().sample_count() as isize - track_offset_samples;
-                available.max(0) as usize
-            })
-            .max()
-            .unwrap_or(0);
-
-        if cursor.samples >= max_samples {
-            return 0;
-        }
-
-        let samples = samples.min(max_samples - cursor.samples);
-
-        let track_datas = tracks
-            .iter()
-            .map(|t| AudioRendererTrack {
-                data: t.data().as_ref(),
-                gain: if project.audio.mute {
-                    f32::NEG_INFINITY
-                } else {
-                    let g = t.gain(&project.audio);
-                    if g < -30.0 { f32::NEG_INFINITY } else { g }
-                },
-                stereo_mode: t.stereo_mode(&project.audio),
-                offset: (t.offset(&offsets) * Self::SAMPLE_RATE as f32).round() as isize,
-            })
-            .collect::<Vec<_>>();
-
-        cap_audio::render_audio(&track_datas, cursor.samples, samples, out_offset, out)
+        render_audio_data_chunk(&self.data, project, cursor, samples, out_offset, out)
     }
 }
 
@@ -501,6 +622,277 @@ fn source_cursor(source: TimelineSource<'_>, samples: usize) -> AudioRendererCur
         timescale: source.segment.timescale,
         samples,
     }
+}
+
+fn render_audio_data_chunk(
+    data: &[AudioSegment],
+    project: &ProjectConfiguration,
+    cursor: AudioRendererCursor,
+    samples: usize,
+    out_offset: usize,
+    out: &mut [f32],
+) -> usize {
+    let Some(segment) = data.get(cursor.clip_index as usize) else {
+        return 0;
+    };
+    let tracks = &segment.tracks;
+
+    if tracks.is_empty() {
+        return 0;
+    }
+
+    let offsets = project
+        .clips
+        .iter()
+        .find(|clip| clip.index == cursor.clip_index)
+        .map(|clip| clip.offsets)
+        .unwrap_or_default();
+    let max_samples = tracks
+        .iter()
+        .map(|track| {
+            let track_offset_samples =
+                (track.offset(&offsets) * AudioRenderer::SAMPLE_RATE as f32).round() as isize;
+            let available = track.data().sample_count() as isize - track_offset_samples;
+            available.max(0) as usize
+        })
+        .max()
+        .unwrap_or(0);
+
+    if cursor.samples >= max_samples {
+        return 0;
+    }
+
+    let samples = samples.min(max_samples - cursor.samples);
+    let track_datas = tracks
+        .iter()
+        .map(|track| AudioRendererTrack {
+            data: track.data().as_ref(),
+            gain: if project.audio.mute {
+                f32::NEG_INFINITY
+            } else {
+                let gain = track.gain(&project.audio);
+                if gain < -30.0 {
+                    f32::NEG_INFINITY
+                } else {
+                    gain
+                }
+            },
+            stereo_mode: track.stereo_mode(&project.audio),
+            offset: (track.offset(&offsets) * AudioRenderer::SAMPLE_RATE as f32).round() as isize,
+        })
+        .collect::<Vec<_>>();
+
+    cap_audio::render_audio(&track_datas, cursor.samples, samples, out_offset, out)
+}
+
+const SPEED_AUDIO_INPUT_BLOCK_SAMPLES: usize = 4_096;
+const SPEED_AUDIO_PREROLL_SAMPLES: usize = 2_400;
+
+fn project_stereo_mode_key(mode: &cap_project::StereoMode) -> u8 {
+    match mode {
+        cap_project::StereoMode::Stereo => 0,
+        cap_project::StereoMode::MonoL => 1,
+        cap_project::StereoMode::MonoR => 2,
+    }
+}
+
+fn speed_audio_processor_state(
+    key: SpeedAudioProcessorKey,
+    requested_source_sample: f64,
+) -> SpeedAudioProcessorState {
+    match SpeedAudioProcessor::new(key, requested_source_sample) {
+        Ok(processor) => SpeedAudioProcessorState::Ready(processor),
+        Err(error) => {
+            warn!(
+                ?error,
+                segment_index = key.segment_index,
+                "Unable to initialize speed audio processor"
+            );
+            SpeedAudioProcessorState::Failed
+        }
+    }
+}
+
+impl SpeedAudioProcessor {
+    fn new(
+        key: SpeedAudioProcessorKey,
+        requested_source_sample: f64,
+    ) -> Result<Self, ffmpeg::Error> {
+        let timescale = f64::from_bits(key.timescale_bits);
+        let mut graph = filter::Graph::new();
+        let input_args = format!(
+            "time_base=1/{rate}:sample_rate={rate}:sample_fmt={format}:channel_layout=0x{layout:x}",
+            rate = AudioRenderer::SAMPLE_RATE,
+            format = AudioRenderer::SAMPLE_FORMAT.name(),
+            layout = ChannelLayout::STEREO.bits(),
+        );
+        graph.add(
+            &filter::find("abuffer").ok_or(ffmpeg::Error::FilterNotFound)?,
+            "in",
+            &input_args,
+        )?;
+        graph.add(
+            &filter::find("abuffersink").ok_or(ffmpeg::Error::FilterNotFound)?,
+            "out",
+            "",
+        )?;
+        graph
+            .output("in", 0)?
+            .input("out", 0)?
+            .parse(&speed_audio_filter(key.mode, timescale))?;
+        graph.validate()?;
+
+        let requested_source_sample = requested_source_sample.clamp(
+            key.segment_start_samples as f64,
+            key.segment_end_samples as f64,
+        );
+        let preroll_source_samples = (SPEED_AUDIO_PREROLL_SAMPLES as f64 * timescale).ceil();
+        let input_samples = (requested_source_sample - preroll_source_samples)
+            .floor()
+            .max(key.segment_start_samples as f64) as usize;
+        let discard_output_samples =
+            ((requested_source_sample - input_samples as f64) / timescale).round() as usize;
+
+        Ok(Self {
+            graph,
+            pending: VecDeque::with_capacity(SPEED_AUDIO_INPUT_BLOCK_SAMPLES * 2),
+            input_data: Vec::with_capacity(SPEED_AUDIO_INPUT_BLOCK_SAMPLES * 2),
+            recording_clip: key.recording_clip,
+            input_samples,
+            segment_end_samples: key.segment_end_samples,
+            discard_output_samples,
+            expected_source_sample: requested_source_sample,
+            timescale,
+            flushed: false,
+        })
+    }
+
+    fn is_contiguous(&self, requested_source_sample: f64) -> bool {
+        (requested_source_sample - self.expected_source_sample).abs() <= 2.0
+    }
+
+    fn render(
+        &mut self,
+        data: &[AudioSegment],
+        project: &ProjectConfiguration,
+        requested_source_sample: f64,
+        samples: usize,
+        out_offset: usize,
+        out: &mut [f32],
+    ) -> Result<usize, ffmpeg::Error> {
+        let target_samples = samples.saturating_add(self.discard_output_samples);
+        while self.pending.len() / 2 < target_samples {
+            if self.input_samples < self.segment_end_samples {
+                self.feed_input(data, project)?;
+            } else if !self.flushed {
+                let mut source = self.graph.get("in").ok_or(ffmpeg::Error::InvalidData)?;
+                source.source().flush()?;
+                self.flushed = true;
+            } else {
+                break;
+            }
+            self.drain_output()?;
+        }
+
+        let discard = self.discard_output_samples.min(self.pending.len() / 2);
+        for _ in 0..discard * 2 {
+            self.pending.pop_front();
+        }
+        self.discard_output_samples -= discard;
+
+        let available_output = out.len().saturating_sub(out_offset) / 2;
+        let written = samples.min(available_output).min(self.pending.len() / 2);
+        for target in &mut out[out_offset..out_offset + written * 2] {
+            *target = self.pending.pop_front().unwrap();
+        }
+        self.expected_source_sample = requested_source_sample + samples as f64 * self.timescale;
+
+        Ok(written)
+    }
+
+    fn feed_input(
+        &mut self,
+        data: &[AudioSegment],
+        project: &ProjectConfiguration,
+    ) -> Result<(), ffmpeg::Error> {
+        let samples = SPEED_AUDIO_INPUT_BLOCK_SAMPLES
+            .min(self.segment_end_samples.saturating_sub(self.input_samples));
+        self.input_data.resize(samples * 2, 0.0);
+        self.input_data.fill(0.0);
+        render_audio_data_chunk(
+            data,
+            project,
+            AudioRendererCursor {
+                clip_index: self.recording_clip,
+                timescale: self.timescale,
+                samples: self.input_samples,
+            },
+            samples,
+            0,
+            &mut self.input_data,
+        );
+
+        let mut frame = FFAudio::new(AudioRenderer::SAMPLE_FORMAT, samples, ChannelLayout::STEREO);
+        frame.set_rate(AudioRenderer::SAMPLE_RATE);
+        frame.set_pts(Some(self.input_samples as i64));
+        let byte_len = self.input_data.len() * f32::BYTE_SIZE;
+        frame.data_mut(0)[..byte_len]
+            .copy_from_slice(unsafe { cast_f32_slice_to_bytes(&self.input_data) });
+        let mut source = self.graph.get("in").ok_or(ffmpeg::Error::InvalidData)?;
+        source.source().add(&frame)?;
+        self.input_samples += samples;
+
+        Ok(())
+    }
+
+    fn drain_output(&mut self) -> Result<(), ffmpeg::Error> {
+        let mut sink = self.graph.get("out").ok_or(ffmpeg::Error::InvalidData)?;
+        let mut frame = FFAudio::empty();
+        while sink.sink().frame(&mut frame).is_ok() {
+            if frame.channels() != AudioRenderer::CHANNELS {
+                return Err(ffmpeg::Error::InvalidData);
+            }
+            let value_count = frame.samples() * usize::from(frame.channels());
+            let byte_len = value_count * f32::BYTE_SIZE;
+            let values = unsafe { cast_bytes_to_f32_slice(&frame.data(0)[..byte_len]) };
+            self.pending.extend(values.iter().copied());
+        }
+
+        Ok(())
+    }
+}
+
+fn speed_audio_filter(mode: ClipSpeedAudioMode, timescale: f64) -> String {
+    let retiming = match mode {
+        ClipSpeedAudioMode::Mute => "anull".to_string(),
+        ClipSpeedAudioMode::MaintainPitch => {
+            let mut remaining = timescale;
+            let mut filters = Vec::new();
+            while remaining < 0.5 {
+                filters.push("atempo=0.5".to_string());
+                remaining /= 0.5;
+            }
+            while remaining > 2.0 {
+                filters.push("atempo=2.0".to_string());
+                remaining /= 2.0;
+            }
+            if (remaining - 1.0).abs() > f64::EPSILON || filters.is_empty() {
+                filters.push(format!("atempo={remaining:.10}"));
+            }
+            filters.join(",")
+        }
+        ClipSpeedAudioMode::MatchSpeed => {
+            let rate = (AudioRenderer::SAMPLE_RATE as f64 * timescale).round() as u32;
+            format!("asetrate={rate},aresample={}", AudioRenderer::SAMPLE_RATE)
+        }
+    };
+
+    format!(
+        "{retiming},aformat=sample_fmts={}:sample_rates={}:channel_layouts=0x{:x}",
+        AudioRenderer::SAMPLE_FORMAT.name(),
+        AudioRenderer::SAMPLE_RATE,
+        ChannelLayout::STEREO.bits(),
+    )
 }
 
 fn mix_transition_audio(
@@ -1407,8 +1799,57 @@ mod tests {
         std::fs::write(path, bytes).unwrap();
     }
 
+    fn write_sine_wav(path: &Path, frequency: f64, duration: f64) {
+        let sample_rate = AudioData::SAMPLE_RATE;
+        let channels = 2u16;
+        let bits_per_sample = 16u16;
+        let total_frames = (duration * sample_rate as f64).round() as usize;
+        let bytes_per_frame = usize::from(channels) * usize::from(bits_per_sample / 8);
+        let data_size = total_frames * bytes_per_frame;
+        let mut bytes = Vec::with_capacity(44 + data_size);
+
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&(36 + data_size as u32).to_le_bytes());
+        bytes.extend_from_slice(b"WAVE");
+        bytes.extend_from_slice(b"fmt ");
+        bytes.extend_from_slice(&16u32.to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&channels.to_le_bytes());
+        bytes.extend_from_slice(&sample_rate.to_le_bytes());
+        bytes.extend_from_slice(&(sample_rate * bytes_per_frame as u32).to_le_bytes());
+        bytes.extend_from_slice(&(bytes_per_frame as u16).to_le_bytes());
+        bytes.extend_from_slice(&bits_per_sample.to_le_bytes());
+        bytes.extend_from_slice(b"data");
+        bytes.extend_from_slice(&(data_size as u32).to_le_bytes());
+
+        for frame in 0..total_frames {
+            let phase = std::f64::consts::TAU * frequency * frame as f64 / sample_rate as f64;
+            let value = (phase.sin() * 16_000.0).round() as i16;
+            bytes.extend_from_slice(&value.to_le_bytes());
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+
+        std::fs::write(path, bytes).unwrap();
+    }
+
     fn mean_abs(samples: &[f32]) -> f32 {
         samples.iter().map(|sample| sample.abs()).sum::<f32>() / samples.len() as f32
+    }
+
+    fn estimate_left_frequency(samples: &[f32], start: f64, end: f64) -> f64 {
+        let sample_rate = AudioData::SAMPLE_RATE as f64;
+        let start = (start * sample_rate).round() as usize;
+        let end = (end * sample_rate).round() as usize;
+        let mut crossings = 0usize;
+        let mut previous = samples[start * 2];
+        for frame in start + 1..end {
+            let current = samples[frame * 2];
+            if previous <= 0.0 && current > 0.0 {
+                crossings += 1;
+            }
+            previous = current;
+        }
+        crossings as f64 / ((end - start) as f64 / sample_rate)
     }
 
     fn build_renderer_fixture() -> (TempDir, AudioRenderer, ProjectConfiguration) {
@@ -1449,6 +1890,7 @@ mod tests {
                         start: 0.0,
                         end: 1.0,
                         name: None,
+                        speed_audio_mode: None,
                     },
                     TimelineSegment {
                         recording_clip: 0,
@@ -1456,6 +1898,7 @@ mod tests {
                         start: 1.0,
                         end: 2.0,
                         name: None,
+                        speed_audio_mode: None,
                     },
                     TimelineSegment {
                         recording_clip: 0,
@@ -1463,6 +1906,7 @@ mod tests {
                         start: 2.0,
                         end: 3.0,
                         name: None,
+                        speed_audio_mode: None,
                     },
                     TimelineSegment {
                         recording_clip: 1,
@@ -1470,6 +1914,7 @@ mod tests {
                         start: 0.0,
                         end: 1.0,
                         name: None,
+                        speed_audio_mode: None,
                     },
                     TimelineSegment {
                         recording_clip: 1,
@@ -1477,6 +1922,7 @@ mod tests {
                         start: 1.0,
                         end: 2.0,
                         name: None,
+                        speed_audio_mode: None,
                     },
                     TimelineSegment {
                         recording_clip: 1,
@@ -1484,6 +1930,7 @@ mod tests {
                         start: 2.0,
                         end: 3.0,
                         name: None,
+                        speed_audio_mode: None,
                     },
                 ],
                 transitions: Vec::new(),
@@ -1572,6 +2019,7 @@ mod tests {
 
         assert!(before > 0.1);
         assert!(after < 0.0001);
+        assert!(renderer.speed_audio_processors.iter().all(Option::is_none));
     }
 
     #[test]
@@ -1590,6 +2038,86 @@ mod tests {
 
         assert!(before < 0.0001);
         assert!(after > 0.15);
+    }
+
+    #[test]
+    fn speed_audio_modes_preserve_or_shift_pitch() {
+        for (timescale, mode, expected_frequency) in [
+            (0.25, ClipSpeedAudioMode::MaintainPitch, 440.0),
+            (0.25, ClipSpeedAudioMode::MatchSpeed, 110.0),
+            (8.0, ClipSpeedAudioMode::MaintainPitch, 440.0),
+            (8.0, ClipSpeedAudioMode::MatchSpeed, 3_520.0),
+        ] {
+            let dir = TempDir::new().unwrap();
+            let path = dir.path().join("tone.wav");
+            write_sine_wav(&path, 440.0, 8.0);
+            let audio_segments = vec![AudioSegment {
+                tracks: vec![AudioSegmentTrack::new(
+                    Arc::new(AudioData::from_file(&path).unwrap()),
+                    gain,
+                    stereo,
+                    no_offset,
+                )],
+            }];
+            let segment_end = if timescale < 1.0 { 1.0 } else { timescale };
+            let output_duration = segment_end / timescale;
+            let mut speed_segment = segment(0, 0.0, segment_end, timescale);
+            speed_segment.speed_audio_mode = Some(mode);
+            let project = ProjectConfiguration {
+                timeline: Some(TimelineConfiguration {
+                    segments: vec![speed_segment],
+                    transitions: Vec::new(),
+                    zoom_segments: Vec::new(),
+                    scene_segments: Vec::new(),
+                    mask_segments: Vec::new(),
+                    text_segments: Vec::new(),
+                    caption_segments: Vec::new(),
+                    keyboard_segments: Vec::new(),
+                    audio_segments: Vec::new(),
+                }),
+                clips: vec![ClipConfiguration {
+                    index: 0,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+            let mut renderer = AudioRenderer::new(audio_segments);
+            let stream = render_export_audio(
+                &mut renderer,
+                &project,
+                30,
+                (output_duration * 30.0).round() as u64,
+            );
+            let frequency =
+                estimate_left_frequency(&stream, output_duration * 0.2, output_duration * 0.8);
+            let tolerance = expected_frequency * 0.01 + 5.0;
+
+            assert!(mean_abs(&stream) > 0.1);
+            assert!(
+                (frequency - expected_frequency).abs() < tolerance,
+                "{timescale}x {mode:?}: expected {expected_frequency} Hz, measured {frequency} Hz"
+            );
+            assert!(renderer.speed_audio_processors.iter().flatten().count() <= 2);
+
+            if timescale == 0.25 && mode == ClipSpeedAudioMode::MaintainPitch {
+                renderer.set_playhead(1.0, &project);
+                let (_, seek_samples) = renderer.render_frame_raw(4_800, &project).unwrap();
+                assert!(mean_abs(&seek_samples) > 0.1);
+            }
+        }
+    }
+
+    #[test]
+    fn one_x_audio_bypasses_speed_processing() {
+        let (_dir, mut renderer, mut project) = build_renderer_fixture();
+        project.timeline.as_mut().unwrap().segments[0].speed_audio_mode =
+            Some(ClipSpeedAudioMode::MaintainPitch);
+
+        renderer.set_playhead(0.0, &project);
+        let (_, samples) = renderer.render_frame_raw(4_800, &project).unwrap();
+
+        assert!(mean_abs(&samples) > 0.01);
+        assert!(renderer.speed_audio_processors.iter().all(Option::is_none));
     }
 
     /// One clip per second `section_values`, on a timeline made of `segments`.
@@ -1641,6 +2169,7 @@ mod tests {
             start,
             end,
             name: None,
+            speed_audio_mode: None,
         }
     }
 
@@ -1788,6 +2317,22 @@ mod tests {
 
         assert_eq!(written, expected);
         assert_eq!(samples.len(), expected * 2);
+    }
+
+    #[test]
+    fn transition_audio_retimes_each_segment_before_mixing() {
+        let (_dir, mut renderer, mut project) = transition_fixture(ClipTransitionType::CrossFade);
+        let timeline = project.timeline.as_mut().unwrap();
+        timeline.segments[0].timescale = 2.0;
+        timeline.segments[0].speed_audio_mode = Some(ClipSpeedAudioMode::MaintainPitch);
+        timeline.segments[1].timescale = 2.0;
+        timeline.segments[1].speed_audio_mode = Some(ClipSpeedAudioMode::MatchSpeed);
+        let frames = (timeline.duration() * 30.0).ceil() as u64;
+
+        let stream = render_export_audio(&mut renderer, &project, 30, frames);
+
+        assert!(mean_abs(&stream) > 0.1);
+        assert_eq!(renderer.speed_audio_processors.iter().flatten().count(), 2);
     }
 
     #[test]
@@ -2026,6 +2571,29 @@ mod tests {
                 "second {second}: music not mixed",
             );
         }
+    }
+
+    #[test]
+    fn speed_audio_mode_does_not_retime_timeline_music() {
+        let _ = ffmpeg::init();
+        let dir = tempfile::tempdir().unwrap();
+        let music_path = dir.path().join("music.wav");
+        write_step_wav(&music_path, &[8000, 8000]);
+        let mut music = MusicTracks::new();
+        music.insert(
+            "music.wav".to_string(),
+            Arc::new(AudioData::from_file(&music_path).unwrap()),
+        );
+        let mut project = music_project(vec![music_track_segment("music.wav", 0.0, 1.0, 0.0, 0.0)]);
+        let segment = &mut project.timeline.as_mut().unwrap().segments[0];
+        segment.end = 2.0;
+        segment.timescale = 2.0;
+        segment.speed_audio_mode = Some(ClipSpeedAudioMode::MaintainPitch);
+        let mut renderer = AudioRenderer::new(vec![]).with_music(music);
+
+        let stream = render_export_audio(&mut renderer, &project, 30, 30);
+
+        assert!((left_at_time(&stream, 0.5) - expected(8000)).abs() < 0.02);
     }
 
     // A timeline-positioned music clip only sounds inside its [start, end) window.

--- a/crates/editor/src/audio.rs
+++ b/crates/editor/src/audio.rs
@@ -739,7 +739,7 @@ impl SpeedAudioProcessor {
         graph
             .output("in", 0)?
             .input("out", 0)?
-            .parse(&speed_audio_filter(key.mode, timescale))?;
+            .parse(&speed_audio_filter(key.mode, timescale)?)?;
         graph.validate()?;
 
         let requested_source_sample = requested_source_sample.clamp(
@@ -862,9 +862,9 @@ impl SpeedAudioProcessor {
     }
 }
 
-fn speed_audio_filter(mode: ClipSpeedAudioMode, timescale: f64) -> String {
+fn speed_audio_filter(mode: ClipSpeedAudioMode, timescale: f64) -> Result<String, ffmpeg::Error> {
     let retiming = match mode {
-        ClipSpeedAudioMode::Mute => "anull".to_string(),
+        ClipSpeedAudioMode::Mute => return Err(ffmpeg::Error::InvalidData),
         ClipSpeedAudioMode::MaintainPitch => {
             let mut remaining = timescale;
             let mut filters = Vec::new();
@@ -876,7 +876,7 @@ fn speed_audio_filter(mode: ClipSpeedAudioMode, timescale: f64) -> String {
                 filters.push("atempo=2.0".to_string());
                 remaining /= 2.0;
             }
-            if (remaining - 1.0).abs() > f64::EPSILON || filters.is_empty() {
+            if (remaining - 1.0).abs() > 1e-9 || filters.is_empty() {
                 filters.push(format!("atempo={remaining:.10}"));
             }
             filters.join(",")
@@ -887,12 +887,12 @@ fn speed_audio_filter(mode: ClipSpeedAudioMode, timescale: f64) -> String {
         }
     };
 
-    format!(
+    Ok(format!(
         "{retiming},aformat=sample_fmts={}:sample_rates={}:channel_layouts=0x{:x}",
         AudioRenderer::SAMPLE_FORMAT.name(),
         AudioRenderer::SAMPLE_RATE,
         ChannelLayout::STEREO.bits(),
-    )
+    ))
 }
 
 fn mix_transition_audio(
@@ -2105,6 +2105,14 @@ mod tests {
                 assert!(mean_abs(&seek_samples) > 0.1);
             }
         }
+    }
+
+    #[test]
+    fn speed_audio_filter_rejects_mute_and_omits_near_unit_stage() {
+        assert!(speed_audio_filter(ClipSpeedAudioMode::Mute, 2.0).is_err());
+
+        let filter = speed_audio_filter(ClipSpeedAudioMode::MaintainPitch, 4.0 + 1e-10).unwrap();
+        assert_eq!(filter.matches("atempo=").count(), 2);
     }
 
     #[test]

--- a/crates/editor/src/editor_instance.rs
+++ b/crates/editor/src/editor_instance.rs
@@ -171,6 +171,7 @@ impl EditorInstance {
                             end: duration,
                             timescale: 1.0,
                             name: None,
+                            speed_audio_mode: None,
                         }],
                         _ => {
                             warn!(
@@ -203,6 +204,7 @@ impl EditorInstance {
                             end: duration,
                             timescale: 1.0,
                             name: None,
+                            speed_audio_mode: None,
                         })
                     })
                     .collect(),

--- a/crates/export/src/lib.rs
+++ b/crates/export/src/lib.rs
@@ -117,6 +117,7 @@ impl ExporterBuilder {
                         end: duration,
                         timescale: 1.0,
                         name: None,
+                        speed_audio_mode: None,
                     })
                 })
                 .collect();

--- a/crates/project/src/configuration.rs
+++ b/crates/project/src/configuration.rs
@@ -691,6 +691,17 @@ pub struct TimelineSegment {
     pub end: f64,
     #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub speed_audio_mode: Option<ClipSpeedAudioMode>,
+}
+
+#[derive(Type, Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ClipSpeedAudioMode {
+    #[default]
+    Mute,
+    MaintainPitch,
+    MatchSpeed,
 }
 
 impl TimelineSegment {
@@ -1817,6 +1828,7 @@ mod tests {
                     start: 0.0,
                     end: 4.0,
                     name: None,
+                    speed_audio_mode: None,
                 },
                 TimelineSegment {
                     recording_clip: 1,
@@ -1824,6 +1836,7 @@ mod tests {
                     start: 10.0,
                     end: 16.0,
                     name: None,
+                    speed_audio_mode: None,
                 },
             ],
             transitions,
@@ -1886,6 +1899,34 @@ mod tests {
                 && incoming.source_time == 10.5
                 && progress == 0.5
         ));
+    }
+
+    #[test]
+    fn timeline_segment_speed_audio_mode_is_backward_compatible() {
+        let legacy: TimelineSegment = serde_json::from_value(serde_json::json!({
+            "recordingSegment": 0,
+            "timescale": 2.0,
+            "start": 0.0,
+            "end": 4.0
+        }))
+        .unwrap();
+        assert_eq!(legacy.speed_audio_mode, None);
+
+        let serialized = serde_json::to_value(&legacy).unwrap();
+        assert!(serialized.get("speedAudioMode").is_none());
+
+        let maintain_pitch: TimelineSegment = serde_json::from_value(serde_json::json!({
+            "recordingSegment": 0,
+            "timescale": 2.0,
+            "start": 0.0,
+            "end": 4.0,
+            "speedAudioMode": "maintainPitch"
+        }))
+        .unwrap();
+        assert_eq!(
+            maintain_pitch.speed_audio_mode,
+            Some(ClipSpeedAudioMode::MaintainPitch)
+        );
     }
 
     #[test]

--- a/crates/recording/src/recovery.rs
+++ b/crates/recording/src/recovery.rs
@@ -1496,6 +1496,7 @@ impl RecoveryManager {
                     end: duration,
                     timescale: 1.0,
                     name: None,
+                    speed_audio_mode: None,
                 })
             })
             .collect();

--- a/crates/recording/src/studio_recording.rs
+++ b/crates/recording/src/studio_recording.rs
@@ -1112,6 +1112,7 @@ async fn stop_recording(
                 end: segment.duration,
                 timescale: 1.0,
                 name: None,
+                speed_audio_mode: None,
             })
         })
         .collect();

--- a/crates/recording/src/track_heal.rs
+++ b/crates/recording/src/track_heal.rs
@@ -1033,14 +1033,14 @@ mod tests {
         };
 
         let dir = tempfile::tempdir().unwrap();
-        let mut config = ProjectConfiguration::default();
-        config.timeline = Some(TimelineConfiguration {
+        let timeline = TimelineConfiguration {
             segments: vec![TimelineSegment {
                 recording_clip: 0,
                 timescale: 1.0,
                 start: 0.0,
                 end: 202.220711,
                 name: None,
+                speed_audio_mode: None,
             }],
             transitions: Vec::new(),
             zoom_segments: vec![ZoomSegment {
@@ -1059,7 +1059,11 @@ mod tests {
             caption_segments: vec![],
             keyboard_segments: vec![],
             audio_segments: vec![],
-        });
+        };
+        let config = ProjectConfiguration {
+            timeline: Some(timeline),
+            ..Default::default()
+        };
         config.write(dir.path()).unwrap();
 
         let scale = 0.4468;
@@ -1081,8 +1085,7 @@ mod tests {
         };
 
         let dir = tempfile::tempdir().unwrap();
-        let mut config = ProjectConfiguration::default();
-        config.timeline = Some(TimelineConfiguration {
+        let timeline = TimelineConfiguration {
             segments: vec![
                 TimelineSegment {
                     recording_clip: 0,
@@ -1090,6 +1093,7 @@ mod tests {
                     start: 0.0,
                     end: 100.0,
                     name: None,
+                    speed_audio_mode: None,
                 },
                 TimelineSegment {
                     recording_clip: 1,
@@ -1097,6 +1101,7 @@ mod tests {
                     start: 0.0,
                     end: 50.0,
                     name: None,
+                    speed_audio_mode: None,
                 },
             ],
             transitions: Vec::new(),
@@ -1116,7 +1121,11 @@ mod tests {
             caption_segments: vec![],
             keyboard_segments: vec![],
             audio_segments: vec![],
-        });
+        };
+        let config = ProjectConfiguration {
+            timeline: Some(timeline),
+            ..Default::default()
+        };
         config.write(dir.path()).unwrap();
 
         let mut scales = HashMap::new();

--- a/crates/rendering/src/zoom_spring.rs
+++ b/crates/rendering/src/zoom_spring.rs
@@ -1491,6 +1491,7 @@ mod tests {
                 start: 10.0,
                 end: 20.0,
                 name: None,
+                speed_audio_mode: None,
             }],
             transitions: vec![],
             zoom_segments: vec![],
@@ -1546,6 +1547,7 @@ mod tests {
                     start: 0.0,
                     end: 4.0,
                     name: None,
+                    speed_audio_mode: None,
                 },
                 TimelineSegment {
                     recording_clip: 0,
@@ -1553,6 +1555,7 @@ mod tests {
                     start: 10.0,
                     end: 14.0,
                     name: None,
+                    speed_audio_mode: None,
                 },
             ],
             transitions: vec![ClipTransition {


### PR DESCRIPTION
Clip segments with non-1x speed no longer always mute audio. Each segment can use **Mute** (default), **Maintain pitch**, or **Match speed** (pitch follows playback speed).

- Adds `ClipSpeedAudioMode` to the project schema with backward-compatible serde defaults
- Implements FFmpeg-based retiming in the editor audio renderer (atempo / asetrate)
- Adds a speed audio picker in the clip config sidebar when speed ≠ 1x
- Wires the setting through import, recording, export, and playback benchmarks

Legacy projects default to mute, preserving existing behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lifts the blanket audio mute for retimed clip segments and replaces it with three user-selectable modes — **Mute** (default, preserves existing behavior), **Maintain pitch** (pitch-corrected via an FFmpeg `atempo` chain), and **Match speed** (pitch follows rate via `asetrate+aresample`). The schema change is fully backward-compatible (`None` serialises as absent; legacy files default to Mute). A 2-slot LRU `SpeedAudioProcessor` cache wraps per-segment FFmpeg filter graphs with preroll/discard seek support and a contiguity check for gapless playback.

- **Schema & Tauri bindings** (`configuration.rs`, `tauri.ts`): adds `ClipSpeedAudioMode` enum and optional `speed_audio_mode` field to `TimelineSegment`; all new literal sites across recording, import, export, and benchmark code are initialised to `None`.
- **Audio renderer** (`audio.rs`): `render_speed_audio_chunk` replaces the old silent-bypass; the `SpeedAudioProcessor` feeds raw audio data into an FFmpeg filter graph and drains output into a `VecDeque`, with preroll to reduce seek latency; `set_playhead` clears both slots.
- **Sidebar UI** (`ConfigSidebar.tsx`, `context.ts`): adds the audio-mode radio group below the speed picker, gated on `timescale !== 1`; the mode is persisted to the project store without requiring a seek.

<h3>Confidence Score: 5/5</h3>

Safe to merge; new speed-audio paths are additive and isolated, legacy projects default to silent behavior, and the schema change is backward-compatible.

FFmpeg filter dispatch, LRU processor cache, preroll/discard seek logic, and serialization round-trip are all covered by new tests. No existing audio rendering path is broken.

No files require special attention; the two suggestions in audio.rs are minor quality improvements, not blockers.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/editor/src/audio.rs | Core change: adds SpeedAudioProcessor with 2-slot LRU cache, FFmpeg filter-graph dispatch (atempo chain for MaintainPitch, asetrate+aresample for MatchSpeed), preroll/discard for seek, and contiguity check. Logic is sound and well-tested. |
| crates/project/src/configuration.rs | Adds ClipSpeedAudioMode enum and speed_audio_mode field to TimelineSegment with serde defaults; serialization round-trip test verifies backward compatibility. |
| apps/desktop/src/routes/editor/ConfigSidebar.tsx | Adds speed audio picker behind a Show guard for timescale !== 1; removes the old static mute warning. |
| apps/desktop/src/routes/editor/context.ts | Adds setClipSegmentSpeedAudioMode action writing speedAudioMode into the SolidJS store. |
| apps/desktop/src/utils/tauri.ts | Exports ClipSpeedAudioMode union type and extends TimelineSegment with the optional speedAudioMode field. |
| apps/desktop/src-tauri/src/import.rs | Adds speed_audio_mode: None to import-path literals; append_cap_project correctly propagates source_segment.speed_audio_mode. |
| crates/export/src/lib.rs | Adds speed_audio_mode: None when constructing export segments. |
| crates/recording/src/studio_recording.rs | Adds speed_audio_mode: None to new recording segments. |
| crates/recording/src/track_heal.rs | Adds speed_audio_mode: None to test fixtures and refactors config init to use struct update syntax. |
| crates/recording/src/recovery.rs | Adds speed_audio_mode: None to recovery-path segment construction. |
| crates/editor/src/editor_instance.rs | Adds speed_audio_mode: None when synthesising timeline segments from recording metadata. |
| crates/rendering/src/zoom_spring.rs | Adds speed_audio_mode: None to zoom-spring test fixtures only. |

<sub>Reviews (2): Last reviewed commit: ["fix: harden speed audio filter construct..."](https://github.com/capsoftware/cap/commit/46c90dd2796ac40669db73c23607b5ffc682b2fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44923725)</sub>

<!-- /greptile_comment -->