### PR TITLE
Add Chinese-first short form captions

### DIFF
--- a/NEOCAP.md
+++ b/NEOCAP.md
@@ -1,0 +1,36 @@
+# NeoCap
+
+## Metadata
+
+| Field | Value |
+| --- | --- |
+| Project | NeoCap |
+| Document Type | Project Overview |
+| Status | Active development |
+| Version | v0.1 |
+| Created | 2026-07-17 |
+| Last Updated | 2026-07-17 |
+| Owner | Haowu |
+| Upstream | CapSoftware/Cap at `976681e9eab9ea201eaab6b4aad56a5114bac20c` |
+
+## Change Log
+
+| Date | Version | Change | Author |
+| --- | --- | --- |
+| 2026-07-17 | v0.1 | Creates public fork overview and records the initial product direction. | Codex |
+
+## Purpose
+
+NeoCap is a macOS-first, local-first screen recorder for Chinese product demos and creator explainers. It builds on Cap's capture, editor, and export foundation, with product work focused on Chinese short-form captions, cursor-driven presentation, and privacy-preserving local processing.
+
+## Current Scope
+
+The first implementation slice makes multilingual Whisper small the default local caption model and splits word-timed captions into short display phrases using Chinese character count, pauses, and punctuation. It preserves original word timestamps so existing trimming and timeline projection continue to work.
+
+## License Boundary
+
+This repository retains Cap's upstream licensing. `cap-camera*` and `scap-*` crates are MIT; other upstream content is AGPLv3. NeoCap is therefore developed as an AGPL-compatible public fork. A closed-source product or hosted derivative is not an approved path unless its licensing basis is re-evaluated.
+
+## Distribution Baseline
+
+Initial target: macOS 14+, Apple Silicon M1+, 16 GB RAM. Distribution will be a direct Apple-notarized download, not a Mac App Store release.

--- a/apps/desktop/src/routes/editor/CaptionsTab.tsx
+++ b/apps/desktop/src/routes/editor/CaptionsTab.tsx
@@ -42,6 +42,7 @@ import {
 	mapEditedTimeToSource,
 	PARAKEET_DIR_MODELS,
 	resolveCaptionModel,
+	segmentCaptionsForShortForm,
 	sourceCaptionId,
 	supportsParakeetTranscription,
 	syncCaptionWordsWithText,
@@ -86,32 +87,32 @@ const MODEL_DOWNLOAD_STATUS_POLL_MS = 1000;
 
 const MODEL_OPTIONS: ModelOption[] = [
 	{
-		name: "best",
-		label: "Recommended",
-		modelName: "parakeet-tdt-0.6b-v3 int8",
-		size: "~640MB",
-		description: "Best balance for most recordings",
-	},
-	{
-		name: "best-max",
-		label: "High Accuracy",
-		modelName: "parakeet-tdt-0.6b-v3",
-		size: "~2.4GB",
-		description: "Larger download, higher accuracy",
-	},
-	{
 		name: "small",
 		modelName: "whisper.cpp small",
-		label: "Small",
+		label: "Chinese / Multilingual",
 		size: "466MB",
-		description: "Smallest download",
+		description: "Recommended local model for Chinese captions",
 	},
 	{
 		name: "medium",
 		modelName: "whisper.cpp medium",
-		label: "Medium",
+		label: "Chinese High Accuracy",
 		size: "1.5GB",
-		description: "Slower, more accurate",
+		description: "Slower, more accurate local Chinese transcription",
+	},
+	{
+		name: "best",
+		label: "Fast (Experimental)",
+		modelName: "parakeet-tdt-0.6b-v3 int8",
+		size: "~640MB",
+		description: "Fast local transcription; not the default for Chinese",
+	},
+	{
+		name: "best-max",
+		label: "Fast High Accuracy (Experimental)",
+		modelName: "parakeet-tdt-0.6b-v3",
+		size: "~2.4GB",
+		description: "Larger Parakeet model; not the default for Chinese",
 	},
 ];
 
@@ -723,7 +724,7 @@ export function CaptionsTab(props: {
 					produce((p) => {
 						applyCaptionResultToProject(
 							p,
-							result.segments,
+							segmentCaptionsForShortForm(result.segments),
 							editorInstance.recordings.segments,
 							editorInstance.recordingDuration,
 						);

--- a/apps/desktop/src/routes/editor/Timeline/index.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/index.tsx
@@ -30,6 +30,7 @@ import {
 	applyCaptionResultToProject,
 	getCaptionGenerationErrorMessage,
 	getSelectedTranscriptionSettings,
+	segmentCaptionsForShortForm,
 	transcribeEditorCaptions,
 } from "../captions";
 import { FPS, type TimelineTrackType, useEditorContext } from "../context";
@@ -898,7 +899,7 @@ export function Timeline(props: {
 				produce((p) => {
 					applyCaptionResultToProject(
 						p,
-						result.segments,
+						segmentCaptionsForShortForm(result.segments),
 						editorInstance.recordings.segments,
 						duration(),
 					);

--- a/apps/desktop/src/routes/editor/captions.short-form.test.ts
+++ b/apps/desktop/src/routes/editor/captions.short-form.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { segmentCaptionsForShortForm } from "./short-form-captions";
+
+describe("segmentCaptionsForShortForm", () => {
+	it("creates short Chinese phrases at the configured character limit", () => {
+		const words = "这是一个中文短视频字幕示例".split("").map((text, index) => ({
+			text,
+			start: index * 0.1,
+			end: (index + 1) * 0.1,
+		}));
+
+		const result = segmentCaptionsForShortForm([
+			{
+				id: "zh",
+				start: 0,
+				end: 1.2,
+				text: words.map((word) => word.text).join(""),
+				words,
+			},
+		]);
+
+		expect(result.map((segment) => segment.text)).toEqual([
+			"这是一个中文短视",
+			"频字幕示例",
+		]);
+		expect(result[0]?.end).toBeCloseTo(0.8);
+		expect(result[1]?.start).toBeCloseTo(0.8);
+	});
+
+	it("prefers a meaningful pause once a phrase is long enough", () => {
+		const result = segmentCaptionsForShortForm([
+			{
+				id: "pause",
+				start: 0,
+				end: 1.1,
+				text: "这个功能现在可以录屏了",
+				words: [
+					{ text: "这个", start: 0, end: 0.1 },
+					{ text: "功能", start: 0.1, end: 0.2 },
+					{ text: "现在", start: 0.2, end: 0.3 },
+					{ text: "可以", start: 0.55, end: 0.65 },
+					{ text: "录屏", start: 0.65, end: 0.75 },
+					{ text: "了", start: 0.75, end: 0.85 },
+				],
+			},
+		]);
+
+		expect(result.map((segment) => segment.text)).toEqual([
+			"这个功能现在",
+			"可以录屏了",
+		]);
+	});
+
+	it("keeps English words readable and starts a new phrase after four words", () => {
+		const words = ["Build", "better", "product", "demos", "today"].map(
+			(text, index) => ({
+				text,
+				start: index * 0.2,
+				end: (index + 1) * 0.2,
+			}),
+		);
+
+		const result = segmentCaptionsForShortForm([
+			{
+				id: "en",
+				start: 0,
+				end: 1,
+				text: "Build better product demos today",
+				words,
+			},
+		]);
+
+		expect(result.map((segment) => segment.text)).toEqual([
+			"Build better product demos",
+			"today",
+		]);
+	});
+
+	it("preserves segments without word timing", () => {
+		const source = {
+			id: "legacy",
+			start: 1,
+			end: 2,
+			text: "legacy caption",
+			words: [],
+		};
+
+		expect(segmentCaptionsForShortForm([source])).toEqual([source]);
+	});
+});

--- a/apps/desktop/src/routes/editor/captions.ts
+++ b/apps/desktop/src/routes/editor/captions.ts
@@ -11,8 +11,12 @@ import {
 	type SegmentRecordings,
 	type TimelineSegment,
 } from "~/utils/tauri";
-export const DEFAULT_CAPTION_MODEL = "best";
+
+export { segmentCaptionsForShortForm } from "./short-form-captions";
 export const DEFAULT_WHISPER_CAPTION_MODEL = "small";
+// This product is local-first and Chinese-first. Whisper small is multilingual,
+// while Cap's Parakeet default is retained as an opt-in fast path.
+export const DEFAULT_CAPTION_MODEL = DEFAULT_WHISPER_CAPTION_MODEL;
 export const DEFAULT_CAPTION_LANGUAGE = "auto";
 export const CAPTION_MODEL_FOLDER = "transcription_models";
 export const PARAKEET_DIR_MODELS = new Set(["best", "best-max"]);

--- a/apps/desktop/src/routes/editor/short-form-captions.ts
+++ b/apps/desktop/src/routes/editor/short-form-captions.ts
@@ -1,0 +1,132 @@
+import type { CaptionSegment, CaptionWord } from "~/utils/tauri";
+
+const SHORT_FORM_PAUSE_SECONDS = 0.18;
+const SHORT_FORM_MAX_HAN_CHARACTERS = 8;
+const SHORT_FORM_MIN_HAN_CHARACTERS = 4;
+const SHORT_FORM_MAX_LATIN_WORDS = 4;
+const SHORT_FORM_MIN_LATIN_WORDS = 2;
+const SHORT_FORM_BOUNDARY_PUNCTUATION = /[。！？；!?;.]/u;
+const CAPTION_ATTACHING_PUNCTUATION = new Set([
+	",",
+	".",
+	"!",
+	"?",
+	";",
+	":",
+	"%",
+	")",
+	"]",
+	"}",
+	"'",
+	"’",
+	"、",
+	"。",
+	"！",
+	"？",
+	"；",
+	"：",
+	"，",
+]);
+const HAN_CHARACTER = /\p{Script=Han}/gu;
+
+function countHanCharacters(text: string) {
+	return text.match(HAN_CHARACTER)?.length ?? 0;
+}
+
+function formatPhraseText(words: CaptionWord[]) {
+	let text = "";
+
+	for (const word of words) {
+		const wordText = word.text.trim();
+		if (wordText.length === 0) continue;
+
+		const joinsChineseText =
+			countHanCharacters(text) > 0 && countHanCharacters(wordText) > 0;
+		if (
+			text.length > 0 &&
+			!CAPTION_ATTACHING_PUNCTUATION.has(wordText.charAt(0)) &&
+			!joinsChineseText
+		) {
+			text += " ";
+		}
+		text += wordText;
+	}
+
+	return text;
+}
+
+function isShortFormBoundary(
+	word: CaptionWord,
+	nextWord: CaptionWord | undefined,
+) {
+	if (SHORT_FORM_BOUNDARY_PUNCTUATION.test(word.text)) return true;
+	return (
+		nextWord !== undefined &&
+		nextWord.start - word.end >= SHORT_FORM_PAUSE_SECONDS
+	);
+}
+
+/**
+ * Splits word-timed transcription segments into short, display-ready phrases.
+ * It deliberately preserves the ASR words and timestamps: the editor can still
+ * re-project captions after trim/reorder without another transcription pass.
+ */
+export function segmentCaptionsForShortForm(
+	segments: CaptionSegment[],
+): CaptionSegment[] {
+	return segments.flatMap((segment) => {
+		if (!segment.words || segment.words.length === 0) return [segment];
+
+		const result: CaptionSegment[] = [];
+		let phraseWords: CaptionWord[] = [];
+		let phraseHanCharacters = 0;
+		let phraseHasHan = false;
+
+		const flush = () => {
+			if (phraseWords.length === 0) return;
+			const first = phraseWords[0];
+			const last = phraseWords[phraseWords.length - 1];
+			if (!first || !last) return;
+
+			result.push({
+				...segment,
+				id: `${segment.id}:short:${result.length}`,
+				start: first.start,
+				end: last.end,
+				text: formatPhraseText(phraseWords),
+				words: phraseWords,
+			});
+			phraseWords = [];
+			phraseHanCharacters = 0;
+			phraseHasHan = false;
+		};
+
+		for (let index = 0; index < segment.words.length; index += 1) {
+			const word = segment.words[index];
+			if (!word) continue;
+			const nextWord = segment.words[index + 1];
+			const hanCharacters = countHanCharacters(word.text);
+			phraseWords.push(word);
+			phraseHanCharacters += hanCharacters;
+			phraseHasHan ||= hanCharacters > 0;
+
+			const unitCount = phraseHasHan ? phraseHanCharacters : phraseWords.length;
+			const minUnits = phraseHasHan
+				? SHORT_FORM_MIN_HAN_CHARACTERS
+				: SHORT_FORM_MIN_LATIN_WORDS;
+			const maxUnits = phraseHasHan
+				? SHORT_FORM_MAX_HAN_CHARACTERS
+				: SHORT_FORM_MAX_LATIN_WORDS;
+
+			if (
+				unitCount >= maxUnits ||
+				(unitCount >= minUnits && isShortFormBoundary(word, nextWord))
+			) {
+				flush();
+			}
+		}
+
+		flush();
+		return result;
+	});
+}

--- a/docs/NEOCAP_PRODUCT_OVERVIEW.md
+++ b/docs/NEOCAP_PRODUCT_OVERVIEW.md
@@ -1,0 +1,35 @@
+# NeoCap Product Overview
+
+## Metadata
+
+| Field | Value |
+| --- | --- |
+| Product | NeoCap |
+| Document Type | Product Overview |
+| Status | Draft |
+| Version | v0.1 |
+| Created | 2026-07-17 |
+| Last Updated | 2026-07-17 |
+| Owner | Haowu |
+
+## Change Log
+
+| Date | Version | Change | Author |
+| --- | --- | --- |
+| 2026-07-17 | v0.1 | Publishes the concise public product scope for the initial fork. | Codex |
+
+## Product Promise
+
+Record a screen, camera, audio, and interaction once; locally turn it into a publishable Chinese product demo with short animated captions and editable click-driven presentation effects.
+
+## P0 Scope
+
+1. Local screen, camera, microphone, system-audio, and cursor recording.
+2. Editable click-driven zoom, cursor following, and click emphasis.
+3. Local Chinese transcription with word timing and short phrase segmentation.
+4. Animated caption presets, caption editing, and SRT / MP4 export.
+5. Camera layout, static sensitive-content masks, 16:9 / 9:16 / 1:1 canvases, and local-first project storage.
+
+## Explicit Non-goals
+
+NeoCap is not a full CapCut-style editor, AI avatar tool, mandatory cloud service, or mobile product in its first release.


### PR DESCRIPTION
Adds a Chinese-first local Whisper default and short-form caption segmentation. The shared segmenter preserves word timestamps, is used by both editor transcription flows, and includes focused tests for Chinese length, pauses, English fallback, and legacy captions.\n\nValidated with: Vitest (4 tests), Biome, and desktop TypeScript type checking.