### PR TITLE
fix(comments): require canView access before posting a comment

### DIFF
--- a/apps/web/actions/videos/new-comment.ts
+++ b/apps/web/actions/videos/new-comment.ts
@@ -55,7 +55,12 @@ export async function newComment(data: {
 		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
 	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
 
-	if (Exit.isFailure(accessExit) || accessExit.value.length === 0) {
+	if (Exit.isFailure(accessExit)) {
+		console.error("Video access check failed:", accessExit);
+		throw new Error("Video not found");
+	}
+
+	if (accessExit.value.length === 0) {
 		throw new Error("Video not found");
 	}
 

--- a/apps/web/actions/videos/new-comment.ts
+++ b/apps/web/actions/videos/new-comment.ts
@@ -51,7 +51,11 @@ export async function newComment(data: {
 	const accessExit = await Effect.gen(function* () {
 		const videosPolicy = yield* VideosPolicy;
 		return yield* Effect.promise(() =>
-			db().select({ id: videos.id }).from(videos).where(eq(videos.id, videoId)),
+			db()
+				.select({ id: videos.id })
+				.from(videos)
+				.where(eq(videos.id, videoId))
+				.limit(1),
 		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
 	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
 

--- a/apps/web/actions/videos/new-comment.ts
+++ b/apps/web/actions/videos/new-comment.ts
@@ -3,10 +3,11 @@
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { nanoId } from "@cap/database/helpers";
-import { comments } from "@cap/database/schema";
+import { comments, videos } from "@cap/database/schema";
 import { provideOptionalAuth, VideosPolicy } from "@cap/web-backend";
 import type { ImageUpload } from "@cap/web-domain";
 import { Comment, Policy, type Video } from "@cap/web-domain";
+import { eq } from "drizzle-orm";
 import { Effect, Exit } from "effect";
 import { revalidatePath } from "next/cache";
 import { createNotification } from "@/lib/Notification";
@@ -41,16 +42,20 @@ export async function newComment(data: {
 		throw new Error("Content and videoId are required");
 	}
 
-	// Authentication alone isn't authorization: without this, any logged-in
-	// user could comment on someone else's private video (CVE-worthy IDOR).
+	// Authentication alone isn't authorization: without this, any logged-in user could
+	// comment on someone else's private video by guessing its id.
+	//
+	// This also fetches the video row (rather than gating a no-op) because
+	// canView returns true for a nonexistent videoId by design, so a bogus id
+	// would otherwise reach the insert below.
 	const accessExit = await Effect.gen(function* () {
 		const videosPolicy = yield* VideosPolicy;
-		return yield* Effect.void.pipe(
-			Policy.withPublicPolicy(videosPolicy.canView(videoId)),
-		);
+		return yield* Effect.promise(() =>
+			db().select({ id: videos.id }).from(videos).where(eq(videos.id, videoId)),
+		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
 	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
 
-	if (Exit.isFailure(accessExit)) {
+	if (Exit.isFailure(accessExit) || accessExit.value.length === 0) {
 		throw new Error("Video not found");
 	}
 

--- a/apps/web/actions/videos/new-comment.ts
+++ b/apps/web/actions/videos/new-comment.ts
@@ -4,10 +4,13 @@ import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { nanoId } from "@cap/database/helpers";
 import { comments } from "@cap/database/schema";
+import { provideOptionalAuth, VideosPolicy } from "@cap/web-backend";
 import type { ImageUpload } from "@cap/web-domain";
-import { Comment, type Video } from "@cap/web-domain";
+import { Comment, Policy, type Video } from "@cap/web-domain";
+import { Effect, Exit } from "effect";
 import { revalidatePath } from "next/cache";
 import { createNotification } from "@/lib/Notification";
+import * as EffectRuntime from "@/lib/server";
 
 export async function newComment(data: {
 	content: string;
@@ -37,6 +40,20 @@ export async function newComment(data: {
 	if (!content || !videoId) {
 		throw new Error("Content and videoId are required");
 	}
+
+	// Authentication alone isn't authorization: without this, any logged-in
+	// user could comment on someone else's private video (CVE-worthy IDOR).
+	const accessExit = await Effect.gen(function* () {
+		const videosPolicy = yield* VideosPolicy;
+		return yield* Effect.void.pipe(
+			Policy.withPublicPolicy(videosPolicy.canView(videoId)),
+		);
+	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+
+	if (Exit.isFailure(accessExit)) {
+		throw new Error("Video not found");
+	}
+
 	const id = Comment.CommentId.make(nanoId());
 
 	const newComment = {


### PR DESCRIPTION
## Problem

Fixes #1982.

`newComment` (in `apps/web/actions/videos/new-comment.ts`) only checked that the requester was authenticated (`getCurrentUser()`), not that they actually had access to the target video. Since the action inserts directly into the `comments` table keyed only by a client-supplied `videoId`, any authenticated user could post a comment (or reply/reaction) onto someone else's **private** video just by knowing/guessing its id — an IDOR.

## Fix

Adds a `VideosPolicy.canView` guard before the insert, following the exact pattern already used in `get-transcript.ts` (`provideOptionalAuth` + `Policy.withPublicPolicy(videosPolicy.canView(videoId))`), and the same approach used to close the equivalent gaps in #1926, #1927, and #1936 for other video endpoints. On denial the action throws "Video not found" (not "Forbidden"), so the error doesn't leak whether a private video exists to someone who can't view it.

## Testing

- `pnpm typecheck` — clean (scoped to `packages/web-backend` + `apps/web` project references; ran with `--max-old-space-size=8192` since the default heap OOMs the full monorepo `tsc -b` on this machine).
- `pnpm exec biome lint` on the changed file — clean.
- `vitest run __tests__/unit/videos-policy.test.ts` — all 40 existing cases pass, including the exact scenario this fix relies on ("denies logged-in user without membership" on a private video).

**Limitation:** I don't have Docker available in this environment, so I could not run the full dev stack (MySQL/MinIO) to exercise `newComment` end-to-end against a real private video + second account. The change itself is a minimal, mechanical application of the same already-tested `canView` policy used elsewhere in the codebase, but flagging this so a maintainer can do a quick manual pass if desired.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an authorization guard to `newComment` so that posting a comment (or reply/reaction) now requires `canView` access on the target video, not just authentication. Without this check, any logged-in user could post to a private video by knowing its ID.

- Inserts a `VideosPolicy.canView` check using the same `provideOptionalAuth` + `Policy.withPublicPolicy` + `EffectRuntime.runPromiseExit` pattern already present in `get-transcript.ts` and several other actions.
- On authorization failure, throws `\"Video not found\"` rather than `\"Forbidden\"` to avoid leaking the existence of private videos to callers who lack access.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is a focused, minimal addition of a well-established access-control pattern that closes a real vulnerability without touching any other logic.

The authorization gate is a direct mechanical copy of the pattern used in get-transcript.ts and several other actions — same provideOptionalAuth, same Policy.withPublicPolicy, same runPromiseExit/Exit.isFailure check. The error message deliberately obscures private-video existence. No existing logic was modified; the insert, notification, and return path are unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/actions/videos/new-comment.ts | Adds a VideosPolicy.canView authorization gate before inserting a comment, closing an IDOR that let any authenticated user post to private videos. Pattern is mechanically identical to get-transcript.ts. |

<sub>Reviews (1): Last reviewed commit: ["fix(comments): require canView access be..."](https://github.com/capsoftware/cap/commit/330379bfc1a59e7a6117b79e90434d578f44f0a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45731668)</sub>

<!-- /greptile_comment -->