### PR TITLE
fix(chrome-extension): keep camera preview alive across tab hand-offs and retry failed connects

### DIFF
--- a/apps/chrome-extension/src/offscreen/recorder.ts
+++ b/apps/chrome-extension/src/offscreen/recorder.ts
@@ -150,7 +150,21 @@ let retryInProgress = false;
 let lastProgressBroadcastAt = 0;
 let cameraPreviewStream: MediaStream | null = null;
 let cameraPreviewDeviceId: string | null = null;
+// A single getUserMedia may be awaited by several connecting sessions at
+// once; keying the in-flight promise by device stops concurrent connects
+// from opening the camera twice and leaking whichever stream loses the race.
+let cameraPreviewAcquisition: {
+	deviceId: string | null;
+	promise: Promise<MediaStream>;
+} | null = null;
+let cameraPreviewReleaseTimer: number | null = null;
 const cameraPreviewSessions = new Map<string, RTCPeerConnection>();
+// A tab hand-off disconnects the old tab's session before the new tab's
+// connect arrives. Releasing the camera the instant the session count hits
+// zero closes and reopens the physical device on every tab switch — and a
+// reopen that lands too soon after the close fails with NotReadableError on
+// exclusive-access platforms. Keep the stream warm across that gap instead.
+const CAMERA_PREVIEW_RELEASE_GRACE_MS = 2000;
 const activeRecordingSounds = new Set<HTMLAudioElement>();
 
 const playRecordingSound = (
@@ -265,7 +279,15 @@ const stopTracks = (stream: MediaStream) => {
 	}
 };
 
+const cancelCameraPreviewRelease = () => {
+	if (cameraPreviewReleaseTimer !== null) {
+		window.clearTimeout(cameraPreviewReleaseTimer);
+		cameraPreviewReleaseTimer = null;
+	}
+};
+
 const stopCameraPreviewStream = () => {
+	cancelCameraPreviewRelease();
 	if (!cameraPreviewStream) return;
 	stopTracks(cameraPreviewStream);
 	cameraPreviewStream = null;
@@ -278,18 +300,32 @@ const disconnectCameraPreview = (sessionId: string) => {
 	cameraPreviewSessions.delete(sessionId);
 	peer.close();
 	if (cameraPreviewSessions.size === 0) {
-		stopCameraPreviewStream();
+		cancelCameraPreviewRelease();
+		cameraPreviewReleaseTimer = window.setTimeout(() => {
+			cameraPreviewReleaseTimer = null;
+			if (cameraPreviewSessions.size === 0) {
+				stopCameraPreviewStream();
+			}
+		}, CAMERA_PREVIEW_RELEASE_GRACE_MS);
 	}
 };
 
-const disconnectCameraPreviews = () => {
+const disconnectCameraPreviewsExcept = (keepSessionId?: string) => {
 	for (const sessionId of Array.from(cameraPreviewSessions.keys())) {
+		if (sessionId === keepSessionId) continue;
 		disconnectCameraPreview(sessionId);
 	}
 	stopCameraPreviewStream();
 };
 
-const getCameraPreviewStream = async (settings: WebcamSettings) => {
+const disconnectCameraPreviews = () => {
+	disconnectCameraPreviewsExcept();
+};
+
+const getCameraPreviewStream = async (
+	settings: WebcamSettings,
+	keepSessionId?: string,
+) => {
 	if (
 		cameraPreviewStream?.active &&
 		cameraPreviewDeviceId === settings.deviceId
@@ -297,10 +333,36 @@ const getCameraPreviewStream = async (settings: WebcamSettings) => {
 		return cameraPreviewStream;
 	}
 
-	disconnectCameraPreviews();
-	cameraPreviewStream = await getCameraMediaStream(settings, false);
-	cameraPreviewDeviceId = settings.deviceId;
-	return cameraPreviewStream;
+	if (cameraPreviewAcquisition?.deviceId === settings.deviceId) {
+		return cameraPreviewAcquisition.promise;
+	}
+
+	disconnectCameraPreviewsExcept(keepSessionId);
+
+	const promise = getCameraMediaStream(settings, false).then((stream) => {
+		// The camera can take long enough to open that every waiting session
+		// may have disconnected (or moved to another device) in the meantime;
+		// adopting the stream then would leave the camera lit with no consumer.
+		if (
+			cameraPreviewAcquisition?.promise !== promise ||
+			cameraPreviewSessions.size === 0
+		) {
+			stopTracks(stream);
+			throw new Error("Camera preview was disconnected while opening.");
+		}
+		cameraPreviewStream = stream;
+		cameraPreviewDeviceId = settings.deviceId;
+		return stream;
+	});
+	cameraPreviewAcquisition = { deviceId: settings.deviceId, promise };
+	void promise
+		.catch(() => undefined)
+		.finally(() => {
+			if (cameraPreviewAcquisition?.promise === promise) {
+				cameraPreviewAcquisition = null;
+			}
+		});
+	return promise;
 };
 
 const getStreamSize = (stream: MediaStream) => {
@@ -1588,11 +1650,17 @@ const queryMediaPermissions = async (): Promise<MediaPermissionSnapshot> => {
 
 const connectCameraPreview = async (request: ConnectCameraPreviewRequest) => {
 	disconnectCameraPreview(request.sessionId);
-	const stream = await getCameraPreviewStream(request.settings);
 	const peer = new RTCPeerConnection();
+	// Register before the first await: once the previous tab's session
+	// disconnects, only a registered successor keeps the shared camera
+	// stream from being released mid-connect.
 	cameraPreviewSessions.set(request.sessionId, peer);
 
 	try {
+		const stream = await getCameraPreviewStream(
+			request.settings,
+			request.sessionId,
+		);
 		peer.addEventListener("connectionstatechange", () => {
 			if (
 				peer.connectionState === "closed" ||

--- a/apps/chrome-extension/src/preview/camera-preview.tsx
+++ b/apps/chrome-extension/src/preview/camera-preview.tsx
@@ -17,6 +17,14 @@ import "./styles.css";
 
 const FRAME_CAPTURE_INTERVAL_MS = 700;
 const FRAME_CAPTURE_MAX_WIDTH = 320;
+// A failed connect used to leave the tile dead until the user changed camera
+// settings. Most failures self-resolve (camera briefly held by another app or
+// by the previous tab's hand-off, offscreen document mid-restart), so keep
+// retrying with capped backoff while the preview is supposed to be visible.
+const CONNECT_RETRY_DELAYS_MS = [500, 1000, 2000, 4000, 8000];
+// Remote tracks mute briefly during renegotiation; only a sustained mute
+// means the sender's camera stream is gone.
+const REMOTE_TRACK_MUTE_GRACE_MS = 2000;
 
 type ParentMessage =
 	| {
@@ -438,8 +446,74 @@ function App() {
 		}
 
 		let disposed = false;
+		let retryTimer: number | null = null;
+		let muteTimer: number | null = null;
 
-		const startPreview = async () => {
+		const clearRetryTimer = () => {
+			if (retryTimer !== null) {
+				window.clearTimeout(retryTimer);
+				retryTimer = null;
+			}
+		};
+
+		const clearMuteTimer = () => {
+			if (muteTimer !== null) {
+				window.clearTimeout(muteTimer);
+				muteTimer = null;
+			}
+		};
+
+		const scheduleReconnect = (attempt: number) => {
+			if (disposed) return;
+			clearRetryTimer();
+			const delay =
+				CONNECT_RETRY_DELAYS_MS[
+					Math.min(attempt, CONNECT_RETRY_DELAYS_MS.length - 1)
+				];
+			retryTimer = window.setTimeout(() => {
+				retryTimer = null;
+				void startPreview(attempt + 1);
+			}, delay);
+		};
+
+		// The offscreen document stops the shared camera stream when it believes
+		// no tab is watching; when that guess is wrong (a tab hand-off race) this
+		// side sees its remote track die while the peer connection itself stays
+		// "connected" — so the track, not the connection, is the liveness signal.
+		const watchRemoteStream = (
+			peer: RTCPeerConnection,
+			stream: MediaStream,
+		) => {
+			const reconnect = () => {
+				if (disposed || peerRef.current !== peer) return;
+				stopPreview();
+				void startPreview(0);
+			};
+			const [track] = stream.getVideoTracks();
+			if (track) {
+				track.addEventListener("ended", reconnect);
+				track.addEventListener("mute", () => {
+					clearMuteTimer();
+					muteTimer = window.setTimeout(() => {
+						muteTimer = null;
+						if (track.muted) reconnect();
+					}, REMOTE_TRACK_MUTE_GRACE_MS);
+				});
+				track.addEventListener("unmute", clearMuteTimer);
+			}
+			peer.addEventListener("connectionstatechange", () => {
+				if (
+					peer.connectionState === "failed" ||
+					peer.connectionState === "disconnected" ||
+					peer.connectionState === "closed"
+				) {
+					reconnect();
+				}
+			});
+		};
+
+		const startPreview = async (attempt = 0) => {
+			if (disposed) return;
 			const peerActive =
 				peerRef.current &&
 				peerRef.current.connectionState !== "closed" &&
@@ -485,6 +559,7 @@ function App() {
 				peerRef.current = peer;
 				streamRef.current = stream;
 				activeDeviceRef.current = settings.deviceId;
+				watchRemoteStream(peer, stream);
 
 				if (videoRef.current) {
 					videoRef.current.srcObject = stream;
@@ -504,6 +579,11 @@ function App() {
 						reason: details.reason,
 						message: details.message,
 					});
+					// Permission errors need user action; everything else heals on
+					// its own once the camera frees up, so keep trying.
+					if (details.reason !== "permission") {
+						scheduleReconnect(attempt);
+					}
 				}
 			}
 		};
@@ -512,6 +592,8 @@ function App() {
 
 		return () => {
 			disposed = true;
+			clearRetryTimer();
+			clearMuteTimer();
 		};
 	}, [
 		previewEnabled,

--- a/apps/chrome-extension/src/preview/camera-preview.tsx
+++ b/apps/chrome-extension/src/preview/camera-preview.tsx
@@ -25,6 +25,9 @@ const CONNECT_RETRY_DELAYS_MS = [500, 1000, 2000, 4000, 8000];
 // Remote tracks mute briefly during renegotiation; only a sustained mute
 // means the sender's camera stream is gone.
 const REMOTE_TRACK_MUTE_GRACE_MS = 2000;
+// "disconnected" can be a transient blip that recovers to "connected" on its
+// own; only a sustained loss warrants tearing the session down to reconnect.
+const PEER_DISCONNECT_GRACE_MS = 2000;
 
 type ParentMessage =
 	| {
@@ -448,6 +451,7 @@ function App() {
 		let disposed = false;
 		let retryTimer: number | null = null;
 		let muteTimer: number | null = null;
+		let disconnectTimer: number | null = null;
 
 		const clearRetryTimer = () => {
 			if (retryTimer !== null) {
@@ -460,6 +464,13 @@ function App() {
 			if (muteTimer !== null) {
 				window.clearTimeout(muteTimer);
 				muteTimer = null;
+			}
+		};
+
+		const clearDisconnectTimer = () => {
+			if (disconnectTimer !== null) {
+				window.clearTimeout(disconnectTimer);
+				disconnectTimer = null;
 			}
 		};
 
@@ -486,6 +497,9 @@ function App() {
 		) => {
 			const reconnect = () => {
 				if (disposed || peerRef.current !== peer) return;
+				clearRetryTimer();
+				clearMuteTimer();
+				clearDisconnectTimer();
 				stopPreview();
 				void startPreview(0);
 			};
@@ -502,12 +516,25 @@ function App() {
 				track.addEventListener("unmute", clearMuteTimer);
 			}
 			peer.addEventListener("connectionstatechange", () => {
+				if (peer.connectionState === "connected") {
+					clearDisconnectTimer();
+					return;
+				}
 				if (
 					peer.connectionState === "failed" ||
-					peer.connectionState === "disconnected" ||
 					peer.connectionState === "closed"
 				) {
 					reconnect();
+					return;
+				}
+				if (peer.connectionState === "disconnected") {
+					clearDisconnectTimer();
+					disconnectTimer = window.setTimeout(() => {
+						disconnectTimer = null;
+						if (peer.connectionState === "disconnected") {
+							reconnect();
+						}
+					}, PEER_DISCONNECT_GRACE_MS);
 				}
 			});
 		};
@@ -594,6 +621,7 @@ function App() {
 			disposed = true;
 			clearRetryTimer();
 			clearMuteTimer();
+			clearDisconnectTimer();
 		};
 	}, [
 		previewEnabled,

--- a/apps/chrome-extension/src/preview/camera-preview.tsx
+++ b/apps/chrome-extension/src/preview/camera-preview.tsx
@@ -518,6 +518,7 @@ function App() {
 			peer.addEventListener("connectionstatechange", () => {
 				if (peer.connectionState === "connected") {
 					clearDisconnectTimer();
+					clearMuteTimer();
 					return;
 				}
 				if (


### PR DESCRIPTION
Fixes the "front camera never loads again after switching tabs" report from Discord.

Two problems combined: switching tabs stopped and reopened the physical camera with no synchronization, and the preview iframe had no retry, one failure left the tile dead until camera settings changed, which is why deselect/reselect fixed it.

- Offscreen doc keeps the shared camera stream warm for 2s across hand-offs, registers new sessions before the stream await, and dedups concurrent getUserMedia calls
- Preview iframe retries failed connects with capped backoff (skipping permission errors) and reconnects when the remote track ends, stays muted, or the peer fails

Repro: with the preview live, seize the camera with another app and switch tabs, previously the tile stayed dead after freeing the camera; now it recovers on its own.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves camera-preview recovery across tab hand-offs.
- Keeps the shared camera stream warm briefly and deduplicates concurrent camera acquisition.
- Registers preview sessions before awaiting camera access.
- Retries recoverable connection failures with capped backoff.
- Reconnects after sustained peer disconnection, track mute, or track termination.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previous transient-disconnection issue is addressed by waiting through a bounded grace period, cancelling reconnection when the peer recovers, and reconnecting only when disconnection persists.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/chrome-extension/src/offscreen/recorder.ts | Adds synchronized camera acquisition and delayed stream release to preserve the shared preview during tab hand-offs. |
| apps/chrome-extension/src/preview/camera-preview.tsx | Adds retry and liveness handling, including the grace period that resolves the previously reported transient-disconnection teardown. |

<sub>Reviews (2): Last reviewed commit: ["fix(chrome-extension): cancel pending mu..."](https://github.com/capsoftware/cap/commit/13421c8ab5bb2e24395e6c24212c71bc0f06020a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46023913)</sub>

<!-- /greptile_comment -->