### PR TITLE
fix(setup): locate libclang on VS Build Tools-only Windows installs

### DIFF
--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -201,7 +201,7 @@ async function main() {
 
 		const { stdout: vcInstallDir } = await exec(
 			// biome-ignore lint/suspicious/noTemplateCurlyInString: PowerShell syntax, not JS template literal
-			'$(& "${env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe" -latest -property installationPath)',
+			'$(& "${env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath)',
 			{ shell: "powershell.exe" },
 		);
 

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -201,7 +201,7 @@ async function main() {
 
 		const { stdout: vcInstallDir } = await exec(
 			// biome-ignore lint/suspicious/noTemplateCurlyInString: PowerShell syntax, not JS template literal
-			'$(& "${env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath)',
+			'$(& "${env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe" -latest -products "*" -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath)',
 			{ shell: "powershell.exe" },
 		);
 


### PR DESCRIPTION
This change allows people to build the project even if they don't have a full install of Visual Studio, so long as they have the right Visual Studio Build Tools 2022 installed.

vswhere excludes the standalone Build Tools product unless -products * is passed, so on machines without a full Visual Studio IDE the installationPath query returns nothing and LIBCLANG_PATH is written as a dangling relative path, breaking bindgen. Query with the same -products/-requires filters that ensureMsvcVersion() already uses, so any install that passes the MSVC version gate is also found here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a one-line `vswhere.exe` invocation on Windows so that the `LIBCLANG_PATH` lookup works on machines that only have VS Build Tools installed (no full IDE). Without `-products *`, `vswhere` silently skips standalone Build Tool installs, producing an empty `installationPath` and a broken path written into `.cargo/config.toml`.

- The added `-products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64` flags exactly mirror those already used in `ensureMsvcVersion()`, making the two `vswhere` calls consistent: any install that passes the MSVC version gate will also be found by the `LIBCLANG_PATH` query.
- Because `ensureMsvcVersion()` runs first and throws on an empty result, the absence of an explicit empty-string guard on `vcInstallDir` is safe — no silent partial failure is possible.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one-line targeted fix to a PowerShell vswhere query with no new logic, no risk of regression on full VS IDE installs.

The change adds two well-understood vswhere flags that match the existing ensureMsvcVersion() call exactly. Full VS IDE installs are unaffected (they still satisfy the requires filter), and the fix only makes Build Tools-only machines work correctly. No error-handling paths are altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/setup.js | Adds `-products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64` to the vswhere query that resolves LIBCLANG_PATH, matching the identical flags already used in ensureMsvcVersion(); correctly fixes the empty-path bug on Build Tools-only installs. |

<sub>Reviews (1): Last reviewed commit: ["fix(setup): locate libclang on VS Build ..."](https://github.com/capsoftware/cap/commit/e9053566a77196f27ed9abfed27ae7a9fe03c67b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46569087)</sub>

<!-- /greptile_comment -->