### PR TITLE
fix: exclude iOS-only mobile dev task from dev:windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"dev:manual": "pnpm run docker:up && trap 'pnpm run docker:stop' EXIT && dotenv -e .env -- turbo run dev --filter=!@cap/storybook --filter=!@cap/chrome-extension --no-cache --concurrency 1",
 		"dev:mobile": "pnpm run docker:up && trap 'pnpm run docker:stop' EXIT && CAP_MOBILE_DISABLE_ASSOCIATED_DOMAINS=1 EXPO_PUBLIC_CAP_WEB_URL=${EXPO_PUBLIC_CAP_WEB_URL:-http://localhost:3000} dotenv -e .env -- turbo run dev --filter=@cap/web --filter=@cap/mobile --env-mode=loose --ui tui",
 		"dev:web": "pnpm dev --filter=!@cap/desktop --filter=!@cap/mobile",
-		"dev:windows": "start /b cmd /c \"pnpm run docker:up > nul\" && timeout /t 5 /nobreak > nul && dotenv -e .env -- turbo run dev --filter=!@cap/chrome-extension --env-mode=loose --ui tui",
+		"dev:windows": "start /b cmd /c \"pnpm run docker:up > nul\" && timeout /t 5 /nobreak > nul && dotenv -e .env -- turbo run dev --filter=!@cap/chrome-extension --filter=!@cap/mobile --env-mode=loose --ui tui",
 		"docker:clean": "turbo run docker:clean",
 		"docker:stop": "turbo run docker:stop",
 		"docker:up": "turbo run docker:up",


### PR DESCRIPTION
dev:windows doesn't work on windows since it currently doesn't exclude the recently added iOS simulator step. For windows development only we should filter this package out.

@cap/mobile#dev boots an iOS simulator and cannot run on Windows; its POSIX env-var prefix also fails to parse under cmd, so the task exits immediately and turbo tears down every sibling dev task, killing dev:windows within seconds of starting. Filter the package out the same way dev:web already does.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the Windows development command to avoid launching the iOS-only mobile task.
- Adds the existing `@cap/mobile` Turbo exclusion filter to `dev:windows`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The focused script change excludes the Windows-incompatible mobile development task without altering other development-task selection or runtime behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | The Windows development script now excludes `@cap/mobile`, matching the established negative-filter pattern and preventing the incompatible iOS simulator task from terminating the run. |

<sub>Reviews (1): Last reviewed commit: ["fix: exclude iOS-only mobile dev task fr..."](https://github.com/capsoftware/cap/commit/80214b8380a26dbfe8c6cd721ee25f48d8f4fb88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46569461)</sub>

<!-- /greptile_comment -->