### PR TITLE
fix: preserve loom csv retry quota

### DIFF
--- a/apps/web/__tests__/unit/loom-import.test.ts
+++ b/apps/web/__tests__/unit/loom-import.test.ts
@@ -640,6 +640,99 @@ describe("importFromLoom", () => {
 		expect(valuesMock).not.toHaveBeenCalled();
 	});
 
+	it("skips rate limit checks for csv rows that were already imported", async () => {
+		whereMock.mockImplementation((conditions: unknown) => {
+			const serializedConditions = JSON.stringify(conditions);
+
+			if (serializedConditions.includes("sourceId")) {
+				return Promise.resolve(
+					serializedConditions.includes("loom-existing123")
+						? [{ videoId: "existing-video" }]
+						: [],
+				);
+			}
+
+			return withLimit([{ userId: "member-123", email: "member@example.com" }]);
+		});
+
+		const fetchMock = vi.mocked(fetch);
+		fetchMock.mockImplementation(async (input) => {
+			const url = typeof input === "string" ? input : input.toString();
+
+			if (url.includes("/transcoded-url")) {
+				return {
+					ok: true,
+					status: 200,
+					text: async () =>
+						JSON.stringify({ url: "https://cdn.loom.com/video.mp4" }),
+				} as Response;
+			}
+
+			if (url === "https://www.loom.com/graphql") {
+				return {
+					ok: true,
+					json: async () => ({
+						data: { getVideo: { name: "Imported video" } },
+					}),
+				} as Response;
+			}
+
+			if (url.includes("/v1/oembed")) {
+				return {
+					ok: true,
+					json: async () => ({ duration: 42, width: 1920, height: 1080 }),
+				} as Response;
+			}
+
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+
+		const { importFromLoomCsv } = await import("@/actions/loom");
+
+		const result = await importFromLoomCsv({
+			orgId: "org-1" as never,
+			rows: [
+				{
+					rowNumber: 2,
+					loomUrl: "https://www.loom.com/share/loom-existing123",
+					userEmail: "member@example.com",
+				},
+				{
+					rowNumber: 3,
+					loomUrl: "https://www.loom.com/share/loom-newvideo123",
+					userEmail: "member@example.com",
+				},
+			],
+		});
+
+		expect(result).toEqual({
+			success: true,
+			importedCount: 1,
+			failedCount: 1,
+			results: [
+				{
+					rowNumber: 2,
+					userEmail: "member@example.com",
+					spaceName: undefined,
+					success: false,
+					error: "This Loom video has already been imported.",
+				},
+				{
+					rowNumber: 3,
+					userEmail: "member@example.com",
+					spaceName: undefined,
+					success: true,
+					videoId: "video-123",
+					error: undefined,
+				},
+			],
+			error: undefined,
+		});
+		expect(checkRateLimitMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock).toHaveBeenCalled();
+		expect(startMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("limits CSV imports to 500 rows", async () => {
 		const fetchMock = vi.mocked(fetch);
 		const { importFromLoomCsv } = await import("@/actions/loom");

--- a/apps/web/actions/loom.ts
+++ b/apps/web/actions/loom.ts
@@ -317,10 +317,12 @@ async function importLoomVideoForOwner({
 	loomUrl,
 	orgId,
 	ownerId,
+	isRateLimited,
 }: {
 	loomUrl: string;
 	orgId: Organisation.OrganisationId;
 	ownerId: User.UserId;
+	isRateLimited?: () => Promise<boolean>;
 }): Promise<LoomImportResult> {
 	const loomVideoId = extractLoomVideoId(loomUrl.trim());
 	if (!loomVideoId) {
@@ -355,6 +357,13 @@ async function importLoomVideoForOwner({
 		return {
 			success: false,
 			error: "This Loom video has already been imported.",
+		};
+	}
+
+	if (isRateLimited && (await isRateLimited())) {
+		return {
+			success: false,
+			error: LOOM_IMPORT_RATE_LIMIT_ERROR,
 		};
 	}
 
@@ -791,22 +800,12 @@ export async function importFromLoomCsv({
 			}
 		}
 
-		if (await isRateLimited()) {
-			results.push({
-				rowNumber: row.rowNumber,
-				userEmail: row.userEmail,
-				spaceName: row.spaceName || undefined,
-				success: false,
-				error: LOOM_IMPORT_RATE_LIMIT_ERROR,
-			});
-			continue;
-		}
-
 		try {
 			const result = await importLoomVideoForOwner({
 				loomUrl: row.loomUrl,
 				orgId,
 				ownerId: member.userId,
+				isRateLimited,
 			});
 
 			let spaceName = row.spaceName || undefined;


### PR DESCRIPTION
## what changed

csv retries now run the existing loom duplicate lookup before charging a rate limit token. rows with an existing cap return the same duplicate result, while new and stale rows still go through the limiter.

the limiter moved into `importLoomVideoForOwner` for the csv path. this keeps the lookup and stale row handling in one place and avoids another database query.

the regression test covers a duplicate row followed by a new row and checks that only the new import spends quota.

## why

a retry of a partially imported csv spent its full budget on rows that had already succeeded. large imports could never reach the first unfinished row unless someone edited completed rows out of the csv.

closes #2010

## testing

- `pnpm --filter @cap/web test`
- `pnpm --dir apps/web exec next typegen`
- `pnpm exec tsc -b apps/web/tsconfig.json --pretty false`
- `pnpm exec biome check apps/web/actions/loom.ts apps/web/__tests__/unit/loom-import.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves Loom CSV retry quota by moving per-row rate-limit checks behind the existing duplicate lookup.
- Already-imported Loom rows now return the existing duplicate result without consuming quota.
- New and stale rows continue through the rate limiter before import processing.
- A regression test verifies that a duplicate row followed by a new row charges quota only for the new import.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with duplicate retries bypassing quota consumption while importable rows remain rate-limited.

The changed ordering preserves existing duplicate and stale-record behavior, keeps the single-video path unchanged, and applies the CSV limiter before any new import begins.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/actions/loom.ts | Moves the CSV rate-limit callback into the shared import helper after live-duplicate detection while retaining checks for new and stale imports. |
| apps/web/__tests__/unit/loom-import.test.ts | Adds coverage confirming that duplicate CSV retries preserve quota and a subsequent new row still starts its import. |

<sub>Reviews (1): Last reviewed commit: ["fix: preserve loom csv retry quota"](https://github.com/capsoftware/cap/commit/46fe6434c204995be3df42c39751d22a00ac9dd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46904886)</sub>

<!-- /greptile_comment -->