### PR TITLE
fix(web): enforce video access policy before creating comments (#1982)

### DIFF
--- a/apps/web/actions/videos/new-comment.ts
+++ b/apps/web/actions/videos/new-comment.ts
@@ -4,7 +4,7 @@ import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { nanoId } from "@cap/database/helpers";
 import { comments, videos } from "@cap/database/schema";
-import { provideOptionalAuth, VideosPolicy } from "@cap/web-backend";
+import { makeCurrentUserLayer, VideosPolicy } from "@cap/web-backend";
 import type { ImageUpload } from "@cap/web-domain";
 import { Comment, Policy, type Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
@@ -55,7 +55,13 @@ export async function newComment(data: {
 				.where(eq(videos.id, videoId))
 				.limit(1),
 		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
-	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+	}).pipe(
+		// This action already required auth above, so provide the user we have
+		// rather than `provideOptionalAuth`, which would re-run getServerSession()
+		// and re-query `users`.
+		Effect.provide(makeCurrentUserLayer(user)),
+		EffectRuntime.runPromiseExit,
+	);
 
 	if (Exit.isFailure(accessExit)) {
 		throw new Error("Video not found");

--- a/apps/web/actions/videos/new-comment.ts
+++ b/apps/web/actions/videos/new-comment.ts
@@ -3,11 +3,15 @@
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { nanoId } from "@cap/database/helpers";
-import { comments } from "@cap/database/schema";
+import { comments, videos } from "@cap/database/schema";
+import { provideOptionalAuth, VideosPolicy } from "@cap/web-backend";
 import type { ImageUpload } from "@cap/web-domain";
-import { Comment, type Video } from "@cap/web-domain";
+import { Comment, Policy, type Video } from "@cap/web-domain";
+import { eq } from "drizzle-orm";
+import { Effect, Exit } from "effect";
 import { revalidatePath } from "next/cache";
 import { createNotification } from "@/lib/Notification";
+import * as EffectRuntime from "@/lib/server";
 
 export async function newComment(data: {
 	content: string;
@@ -37,6 +41,22 @@ export async function newComment(data: {
 	if (!content || !videoId) {
 		throw new Error("Content and videoId are required");
 	}
+
+	// The caller controls `videoId`, so being signed in is not enough — without
+	// this check any authenticated user can insert comments into a video they
+	// cannot view, including someone else's private recording.
+	const accessExit = await Effect.gen(function* () {
+		const videosPolicy = yield* VideosPolicy;
+
+		return yield* Effect.promise(() =>
+			db().select({ id: videos.id }).from(videos).where(eq(videos.id, videoId)),
+		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
+	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+
+	if (Exit.isFailure(accessExit) || accessExit.value.length === 0) {
+		throw new Error("Video not found");
+	}
+
 	const id = Comment.CommentId.make(nanoId());
 
 	const newComment = {

--- a/apps/web/actions/videos/new-comment.ts
+++ b/apps/web/actions/videos/new-comment.ts
@@ -49,11 +49,19 @@ export async function newComment(data: {
 		const videosPolicy = yield* VideosPolicy;
 
 		return yield* Effect.promise(() =>
-			db().select({ id: videos.id }).from(videos).where(eq(videos.id, videoId)),
+			db()
+				.select({ id: videos.id })
+				.from(videos)
+				.where(eq(videos.id, videoId))
+				.limit(1),
 		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
 	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
 
-	if (Exit.isFailure(accessExit) || accessExit.value.length === 0) {
+	if (Exit.isFailure(accessExit)) {
+		throw new Error("Video not found");
+	}
+
+	if (accessExit.value.length === 0) {
 		throw new Error("Video not found");
 	}
 


### PR DESCRIPTION
Fixes #1982 (GHSA-5r3r-v2f5-wqwh).

## Problem

The `newComment` server action authenticates the caller, then inserts the comment without ever checking whether that user is allowed to access the target video:

```ts
const user = await getCurrentUser();
if (!user) throw new Error("User not authenticated");
// ...no video access check...
await db().insert(comments).values(newComment);
```

`videoId` is a client-supplied argument to a server action, so being signed in is the only barrier. Any authenticated user can post comments — or emoji reactions, or threaded replies — into **any** video by ID, including another user's private recording. The comment then shows up in the owner's activity feed and triggers a notification to them via `createNotification`.

Worth noting the same file already treats deletion correctly: `deleteComment` verifies `authorId` before removing anything. Creation was the gap.

## Fix

Gate the insert behind the existing `VideosPolicy.canView` policy before any write happens.

I deliberately did not invent a new access-check shape — this mirrors the pattern already used in this exact directory by `getTranscript` (`apps/web/actions/videos/get-transcript.ts`), and it is the same policy the `/api/video/ai` fix in #1926 used to close the sibling advisory #1981:

```ts
const accessExit = await Effect.gen(function* () {
  const videosPolicy = yield* VideosPolicy;
  return yield* Effect.promise(() =>
    db().select({ id: videos.id }).from(videos).where(eq(videos.id, videoId)),
  ).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);

if (Exit.isFailure(accessExit) || accessExit.value.length === 0) {
  throw new Error("Video not found");
}
```

Because it reuses `canView`, it inherits the full existing access model for free — owner, org membership, space membership, public videos, password-protected videos, and email-domain restrictions — rather than approximating it with an ownership check that would have broken legitimate commenting on shared videos.

The error message is deliberately `"Video not found"` rather than `"Access denied"`, so this does not become an oracle for probing which video IDs exist.

## Verification

- `biome check apps/web/actions/videos/new-comment.ts` — clean.
- `tsc --noEmit` on `apps/web`: the remaining diagnostics on this file (TS6305, plus TS2488/TS18046 on the Effect generator) are **not introduced by this change** — the untouched `get-transcript.ts` emits the identical set, since it uses the same pattern and the workspace `tsconfig` project references aren't built in a plain `tsc` run. Verified by diffing the two files' diagnostics.
- `@cap/web-domain`, `@cap/web-backend` and `@cap/database` build clean via turbo.

**Diff: 1 file, +22/-2.**
