### PR TITLE
fix(web): gate getVideoAnalytics server action on video access policy

### DIFF
--- a/apps/web/actions/videos/get-analytics.ts
+++ b/apps/web/actions/videos/get-analytics.ts
@@ -60,9 +60,9 @@ export async function getVideoAnalytics(
 		).pipe(Policy.withPublicPolicy(videosPolicy.canView(id)));
 	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
 
-	// An empty result means the video does not exist. Falling through would
-	// query Tinybird with no tenant filter, which both wastes a query and
-	// widens the match beyond a single org.
+	// If the video doesn't exist or isn't viewable, don't query Tinybird.
+	// Otherwise we'd fall through with a null orgId, dropping the tenant
+	// filter, and return analytics for an arbitrary `/s/${videoId}` pathname.
 	if (Exit.isFailure(exit) || exit.value.length === 0) {
 		throw new Error("Video not found");
 	}

--- a/apps/web/actions/videos/get-analytics.ts
+++ b/apps/web/actions/videos/get-analytics.ts
@@ -2,10 +2,11 @@
 
 import { db } from "@cap/database";
 import { videos } from "@cap/database/schema";
-import { Tinybird } from "@cap/web-backend";
-import { Video } from "@cap/web-domain";
+import { provideOptionalAuth, Tinybird, VideosPolicy } from "@cap/web-backend";
+import { Policy, Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
-import { Effect } from "effect";
+import { Effect, Exit } from "effect";
+import * as EffectRuntime from "@/lib/server";
 import { runPromise } from "@/lib/server";
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
@@ -41,11 +42,27 @@ export async function getVideoAnalytics(
 ) {
 	if (!videoId) throw new Error("Video ID is required");
 
-	const [{ orgId } = { orgId: null }] = await db()
-		.select({ orgId: videos.orgId })
-		.from(videos)
-		.where(eq(videos.id, Video.VideoId.make(videoId)))
-		.limit(1);
+	const id = Video.VideoId.make(videoId);
+
+	// This is a server action, so it is directly callable by any client
+	// independently of `/api/analytics` — the gate on that route does not
+	// protect this entry point. Without this check the view count of a private
+	// or password-protected video is readable by anyone who knows its ID.
+	const exit = await Effect.gen(function* () {
+		const videosPolicy = yield* VideosPolicy;
+
+		return yield* Effect.promise(() =>
+			db()
+				.select({ orgId: videos.orgId })
+				.from(videos)
+				.where(eq(videos.id, id))
+				.limit(1),
+		).pipe(Policy.withPublicPolicy(videosPolicy.canView(id)));
+	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+
+	if (Exit.isFailure(exit)) throw new Error("Video not found");
+
+	const orgId = exit.value[0]?.orgId ?? null;
 
 	return runPromise(
 		Effect.gen(function* () {

--- a/apps/web/actions/videos/get-analytics.ts
+++ b/apps/web/actions/videos/get-analytics.ts
@@ -60,7 +60,12 @@ export async function getVideoAnalytics(
 		).pipe(Policy.withPublicPolicy(videosPolicy.canView(id)));
 	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
 
-	if (Exit.isFailure(exit)) throw new Error("Video not found");
+	// An empty result means the video does not exist. Falling through would
+	// query Tinybird with no tenant filter, which both wastes a query and
+	// widens the match beyond a single org.
+	if (Exit.isFailure(exit) || exit.value.length === 0) {
+		throw new Error("Video not found");
+	}
 
 	const orgId = exit.value[0]?.orgId ?? null;
 


### PR DESCRIPTION
## Problem

`/api/analytics/route.ts` correctly gates on `VideosPolicy.canView` before returning view counts — the comment there even says it exists so that *"view counts of private / password-protected videos are not disclosed to unauthorized callers."*

But `getVideoAnalytics` is a `"use server"` action, so it is its own entry point. Any client can invoke it directly with an arbitrary `videoId` and never touch that route. The action itself performed **no authentication at all** — it contains zero calls to `getCurrentUser`, `provideOptionalAuth`, or any policy:

```ts
export async function getVideoAnalytics(videoId: string, options?) {
  if (!videoId) throw new Error("Video ID is required");

  const [{ orgId } = { orgId: null }] = await db()
    .select({ orgId: videos.orgId })
    .from(videos)
    .where(eq(videos.id, Video.VideoId.make(videoId)))
    .limit(1);
  // ...straight to Tinybird
}
```

So the protection on the route is bypassable, and view counts for private and password-protected videos are readable by anyone who knows (or guesses) a video ID. It's the same class of gap as #1982 and the `/api/video/ai` advisory fixed in #1926: the check lives at one caller instead of at the boundary that actually needs it.

The action is already called directly from client code today — `Analytics.tsx` (a `"use client"` component) calls it in a `useEffect` — which is what makes it reachable rather than theoretical.

## Fix

Move the gate into the action, using the same `canView` policy the route uses.

The action already had to query `videos` to fetch `orgId`, so I folded the policy onto that existing query rather than adding a second round-trip:

```ts
const exit = await Effect.gen(function* () {
  const videosPolicy = yield* VideosPolicy;
  return yield* Effect.promise(() =>
    db().select({ orgId: videos.orgId }).from(videos).where(eq(videos.id, id)).limit(1),
  ).pipe(Policy.withPublicPolicy(videosPolicy.canView(id)));
}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);

if (Exit.isFailure(exit)) throw new Error("Video not found");
const orgId = exit.value[0]?.orgId ?? null;
```

Reusing `canView` means public videos, owners, org members, space members, and password-protected videos with a valid cookie all keep working exactly as before — the legitimate paths in `page.tsx` and `Analytics.tsx` are unaffected. Only unauthorized cross-user reads change behaviour.

The redundant check in `/api/analytics` is left in place: it returns a clean `404` there, and defence in depth at the route costs nothing.

## Verification

- `biome check apps/web/actions/videos/get-analytics.ts` — clean.
- `tsc --noEmit` on `apps/web`: the `TS2347` on this file is **pre-existing** — I confirmed by stashing the change and re-running, where it appears identically (at the old line number). The `TS6305`/`TS2488`/`TS18046` diagnostics are project-reference artifacts that the untouched `get-transcript.ts` emits too.
- `@cap/web-domain`, `@cap/web-backend`, `@cap/database` build clean.

**Diff: 1 file, +25/-8.**

Related: #2029 fixes the same class of issue in `newComment` (#1982).
