### PR TITLE
fix(web): verify space membership before listing space and folder videos

### DIFF
--- a/apps/web/actions/folders/get-folder-videos.ts
+++ b/apps/web/actions/folders/get-folder-videos.ts
@@ -4,7 +4,7 @@ import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { sharedVideos, spaceVideos } from "@cap/database/schema";
 import type { Folder, Space, Video } from "@cap/web-domain";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { getSpaceAccess } from "@/actions/organization/space-authorization";
 
 export async function getFolderVideoIds(
@@ -24,9 +24,15 @@ export async function getFolderVideoIds(
 
 		const isAllSpacesEntry = user.activeOrganizationId === spaceId;
 
-		// `spaceId` is caller-supplied. `activeOrganizationId` is read from the
-		// user record so the all-spaces branch is already scoped to them, but the
-		// space branch would otherwise expose folder contents of any space.
+		// `spaceId` is caller-supplied, so the space branch needs a membership
+		// check. The all-spaces branch compares against `activeOrganizationId`,
+		// which is read from the user record, so it is already scoped.
+		//
+		// The membership check alone is not sufficient: `folderId` is also
+		// caller-supplied, so the queries below must be constrained to the space
+		// (or org) we just authorized. Otherwise a caller could pass a space they
+		// legitimately belong to together with a folder from another space and
+		// still read its contents.
 		if (!isAllSpacesEntry) {
 			const access = await getSpaceAccess(user.id, spaceId);
 			if (!access || (!access.organizationRole && !access.spaceRole)) {
@@ -38,11 +44,21 @@ export async function getFolderVideoIds(
 			? await db()
 					.select({ id: sharedVideos.videoId })
 					.from(sharedVideos)
-					.where(eq(sharedVideos.folderId, folderId))
+					.where(
+						and(
+							eq(sharedVideos.folderId, folderId),
+							eq(sharedVideos.organizationId, spaceId),
+						),
+					)
 			: await db()
 					.select({ id: spaceVideos.videoId })
 					.from(spaceVideos)
-					.where(eq(spaceVideos.folderId, folderId));
+					.where(
+						and(
+							eq(spaceVideos.folderId, folderId),
+							eq(spaceVideos.spaceId, spaceId),
+						),
+					);
 
 		return {
 			success: true,

--- a/apps/web/actions/folders/get-folder-videos.ts
+++ b/apps/web/actions/folders/get-folder-videos.ts
@@ -51,7 +51,7 @@ export async function getFolderVideoIds(
 					.where(
 						and(
 							eq(sharedVideos.folderId, folderId),
-							eq(sharedVideos.organizationId, spaceId),
+							eq(sharedVideos.organizationId, user.activeOrganizationId),
 						),
 					)
 			: await db()

--- a/apps/web/actions/folders/get-folder-videos.ts
+++ b/apps/web/actions/folders/get-folder-videos.ts
@@ -22,6 +22,10 @@ export async function getFolderVideoIds(
 			throw new Error("Folder ID is required");
 		}
 
+		if (!spaceId) {
+			throw new Error("Space ID is required");
+		}
+
 		const isAllSpacesEntry = user.activeOrganizationId === spaceId;
 
 		// `spaceId` is caller-supplied, so the space branch needs a membership

--- a/apps/web/actions/folders/get-folder-videos.ts
+++ b/apps/web/actions/folders/get-folder-videos.ts
@@ -5,6 +5,7 @@ import { getCurrentUser } from "@cap/database/auth/session";
 import { sharedVideos, spaceVideos } from "@cap/database/schema";
 import type { Folder, Space, Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
+import { getSpaceAccess } from "@/actions/organization/space-authorization";
 
 export async function getFolderVideoIds(
 	folderId: Folder.FolderId,
@@ -22,6 +23,16 @@ export async function getFolderVideoIds(
 		}
 
 		const isAllSpacesEntry = user.activeOrganizationId === spaceId;
+
+		// `spaceId` is caller-supplied. `activeOrganizationId` is read from the
+		// user record so the all-spaces branch is already scoped to them, but the
+		// space branch would otherwise expose folder contents of any space.
+		if (!isAllSpacesEntry) {
+			const access = await getSpaceAccess(user.id, spaceId);
+			if (!access || (!access.organizationRole && !access.spaceRole)) {
+				throw new Error("Folder not found");
+			}
+		}
 
 		const rows = isAllSpacesEntry
 			? await db()

--- a/apps/web/actions/spaces/get-space-videos.ts
+++ b/apps/web/actions/spaces/get-space-videos.ts
@@ -5,6 +5,7 @@ import { getCurrentUser } from "@cap/database/auth/session";
 import { sharedVideos, spaceVideos } from "@cap/database/schema";
 import type { Space } from "@cap/web-domain";
 import { and, eq, isNull } from "drizzle-orm";
+import { getSpaceAccess } from "@/actions/organization/space-authorization";
 
 export async function getSpaceVideoIds(spaceId: Space.SpaceIdOrOrganisationId) {
 	try {
@@ -19,6 +20,16 @@ export async function getSpaceVideoIds(spaceId: Space.SpaceIdOrOrganisationId) {
 		}
 
 		const isAllSpacesEntry = user.activeOrganizationId === spaceId;
+
+		// `spaceId` comes from the caller, so being signed in is not enough.
+		// Without this, any authenticated user can enumerate the video IDs of a
+		// space in an organization they do not belong to.
+		if (!isAllSpacesEntry) {
+			const access = await getSpaceAccess(user.id, spaceId);
+			if (!access || (!access.organizationRole && !access.spaceRole)) {
+				throw new Error("Space not found");
+			}
+		}
 
 		const videoIds = isAllSpacesEntry
 			? await db()


### PR DESCRIPTION
## Problem

`getSpaceVideoIds` and `getFolderVideoIds` are both `"use server"` actions that authenticate the caller and then trust the `spaceId` argument:

```ts
const user = await getCurrentUser();
if (!user || !user.id) throw new Error("Unauthorized");

const isAllSpacesEntry = user.activeOrganizationId === spaceId;

const videoIds = isAllSpacesEntry
  ? /* scoped to the user's own org */
  : await db().select({ videoId: spaceVideos.videoId })
      .from(spaceVideos)
      .where(and(eq(spaceVideos.spaceId, spaceId), isNull(spaceVideos.folderId)));
```

In the `else` branch there is no membership check at all. Any authenticated user can pass an arbitrary `spaceId` and get back the list of video IDs in a space belonging to an organization they have nothing to do with. `getFolderVideoIds` has the identical shape for folder contents.

Video IDs are the sensitive part here — they're the key into `/s/{videoId}` and into the other video endpoints, so leaking the set of IDs in a private space is a meaningful disclosure even before any per-video check runs.

## Fix

Reuse the existing `getSpaceAccess` helper from `@/actions/organization/space-authorization`, which already resolves both organization-level and space-level roles:

```ts
if (!isAllSpacesEntry) {
  const access = await getSpaceAccess(user.id, spaceId);
  if (!access || (!access.organizationRole && !access.spaceRole)) {
    throw new Error("Space not found");
  }
}
```

Two deliberate choices:

- **`getSpaceAccess`, not `requireSpaceManager`.** These are read paths. `requireSpaceManager` would have rejected ordinary members, breaking legitimate use. Requiring *either* an org role or a space role matches who can actually see a space today.
- **The `isAllSpacesEntry` branch is left untouched.** It keys off `user.activeOrganizationId`, which is read from the user's own DB record rather than supplied by the caller, so that branch is already scoped correctly. Adding a check there would have been noise.

Error text is `"Space not found"` / `"Folder not found"` rather than "forbidden", so this doesn't become a probe for which space IDs exist.

## Verification

- `biome check` on both files — clean.
- `tsc --noEmit` on `apps/web`: the `TS7006` diagnostics on these two files are **pre-existing**. Confirmed by stashing the change and re-running — they appear identically, just at the earlier line numbers (38→49, 46→57). No new diagnostics.
- `@cap/web-domain`, `@cap/web-backend`, `@cap/database` build clean.

**Diff: 2 files, +20/-0.**

Related, same class of missing access check: #2029 (`newComment`, #1982) and #2030 (`getVideoAnalytics`).
