### PR TITLE
fix(web): gate /api/video/transcribe/status on video access policy

### DIFF
--- a/apps/web/__tests__/unit/transcribe-status-access.test.ts
+++ b/apps/web/__tests__/unit/transcribe-status-access.test.ts
@@ -1,0 +1,136 @@
+import { Exit, Layer } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockDbChain = {
+	select: vi.fn(),
+	from: vi.fn(),
+	where: vi.fn(),
+	limit: vi.fn(),
+};
+
+function resetDbChain() {
+	for (const fn of Object.values(mockDbChain)) fn.mockClear();
+	mockDbChain.select.mockReturnValue(mockDbChain);
+	mockDbChain.from.mockReturnValue(mockDbChain);
+	mockDbChain.where.mockReturnValue(mockDbChain);
+	mockDbChain.limit.mockReturnValue(
+		Promise.resolve([{ id: "video-1", transcriptionStatus: "COMPLETE" }]),
+	);
+}
+
+vi.mock("@cap/database", () => ({ db: () => mockDbChain }));
+
+vi.mock("@cap/database/schema", () => ({
+	videos: { id: "id" },
+}));
+
+const mockGetCurrentUser = vi.fn();
+vi.mock("@cap/database/auth/session", () => ({
+	getCurrentUser: () => mockGetCurrentUser(),
+}));
+
+const mockCanView = vi.fn();
+vi.mock("@cap/web-backend", () => ({
+	makeCurrentUserLayer: () => Layer.empty,
+	VideosPolicy: {
+		key: "VideosPolicy",
+	},
+}));
+
+// The route runs its query through the Effect runtime; the parts under test are
+// which failures reach the handler and how it maps them, so the runtime is
+// replaced with one that returns the exit the policy would have produced.
+vi.mock("@/lib/server", () => ({
+	runPromiseExit: () => mockCanView(),
+}));
+
+vi.mock("@cap/web-domain", async () => {
+	const actual =
+		await vi.importActual<typeof import("@cap/web-domain")>("@cap/web-domain");
+	return {
+		...actual,
+		Policy: {
+			...actual.Policy,
+			withPublicPolicy: () => (self: unknown) => self,
+		},
+	};
+});
+
+const { GET } = await import("@/app/api/video/transcribe/status/route");
+const { DatabaseError, Policy } = await import("@cap/web-domain");
+
+const request = (videoId: string) =>
+	new Request(
+		`https://cap.test/api/video/transcribe/status?videoId=${videoId}`,
+	) as never;
+
+describe("GET /api/video/transcribe/status", () => {
+	beforeEach(() => {
+		resetDbChain();
+		mockGetCurrentUser.mockResolvedValue({ id: "user-1" });
+		mockCanView.mockReset();
+	});
+
+	it("returns 401 when there is no session", async () => {
+		mockGetCurrentUser.mockResolvedValue(null);
+
+		const res = await GET(request("video-1"));
+
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 400 when videoId is missing", async () => {
+		const res = await GET(
+			new Request("https://cap.test/api/video/transcribe/status") as never,
+		);
+
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 404 when the access policy denies the caller", async () => {
+		mockCanView.mockResolvedValue(
+			Exit.fail(new Policy.PolicyDeniedError({ reason: "denied" })),
+		);
+
+		const res = await GET(request("video-1"));
+
+		expect(res.status).toBe(404);
+		await expect(res.json()).resolves.toMatchObject({
+			message: "Video does not exist",
+		});
+	});
+
+	it("returns 500, not 404, when the access check hits a database failure", async () => {
+		mockCanView.mockResolvedValue(
+			Exit.fail(new DatabaseError({ cause: new Error("connection reset") })),
+		);
+
+		const res = await GET(request("video-1"));
+
+		expect(res.status).toBe(500);
+		await expect(res.json()).resolves.toMatchObject({
+			message: "Failed to fetch transcription status",
+		});
+	});
+
+	it("returns the transcription status when access is granted", async () => {
+		mockCanView.mockResolvedValue(
+			Exit.succeed([{ id: "video-1", transcriptionStatus: "COMPLETE" }]),
+		);
+
+		const res = await GET(request("video-1"));
+
+		expect(res.status).toBe(200);
+		await expect(res.json()).resolves.toEqual({
+			transcriptionStatus: "COMPLETE",
+		});
+	});
+
+	it("returns 404 when the video row is missing", async () => {
+		mockCanView.mockResolvedValue(Exit.succeed([]));
+
+		const res = await GET(request("video-1"));
+
+		expect(res.status).toBe(404);
+	});
+});

--- a/apps/web/app/api/video/transcribe/status/route.ts
+++ b/apps/web/app/api/video/transcribe/status/route.ts
@@ -2,9 +2,9 @@ import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { videos } from "@cap/database/schema";
 import { makeCurrentUserLayer, VideosPolicy } from "@cap/web-backend";
-import { Policy, type Video } from "@cap/web-domain";
+import { DatabaseError, Policy, type Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
-import { Effect, Exit } from "effect";
+import { Cause, Effect, Exit, Option, Schema } from "effect";
 import type { NextRequest } from "next/server";
 import * as EffectRuntime from "@/lib/server";
 
@@ -45,6 +45,25 @@ export async function GET(request: NextRequest) {
 	);
 
 	if (Exit.isFailure(exit)) {
+		const failure = Cause.failureOption(exit.cause);
+
+		// The 404-for-denied behaviour below is deliberate, so this endpoint
+		// can't be used to probe which video IDs exist. A database failure is
+		// not a denial though: `canView` reads the video plus its org/space
+		// memberships, so an outage in any of those would otherwise be reported
+		// as "video does not exist" for a video the caller can actually see.
+		if (Option.isSome(failure) && Schema.is(DatabaseError)(failure.value)) {
+			console.error(
+				"[transcribe/status] database error while checking video access:",
+				failure.value.cause,
+			);
+
+			return Response.json(
+				{ error: true, message: "Failed to fetch transcription status" },
+				{ status: 500 },
+			);
+		}
+
 		return Response.json(
 			{ error: true, message: "Video does not exist" },
 			{ status: 404 },

--- a/apps/web/app/api/video/transcribe/status/route.ts
+++ b/apps/web/app/api/video/transcribe/status/route.ts
@@ -1,7 +1,7 @@
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { videos } from "@cap/database/schema";
-import { provideOptionalAuth, VideosPolicy } from "@cap/web-backend";
+import { makeCurrentUserLayer, VideosPolicy } from "@cap/web-backend";
 import { Policy, type Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
 import { Effect, Exit } from "effect";
@@ -36,7 +36,13 @@ export async function GET(request: NextRequest) {
 		return yield* Effect.promise(() =>
 			db().select().from(videos).where(eq(videos.id, videoId)).limit(1),
 		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
-	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+	}).pipe(
+		// The route already required auth above, so provide the user we have
+		// rather than `provideOptionalAuth`, which would re-run
+		// getServerSession() and re-query `users`.
+		Effect.provide(makeCurrentUserLayer(user)),
+		EffectRuntime.runPromiseExit,
+	);
 
 	if (Exit.isFailure(exit)) {
 		return Response.json(

--- a/apps/web/app/api/video/transcribe/status/route.ts
+++ b/apps/web/app/api/video/transcribe/status/route.ts
@@ -34,7 +34,7 @@ export async function GET(request: NextRequest) {
 		const videosPolicy = yield* VideosPolicy;
 
 		return yield* Effect.promise(() =>
-			db().select().from(videos).where(eq(videos.id, videoId)),
+			db().select().from(videos).where(eq(videos.id, videoId)).limit(1),
 		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
 	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
 

--- a/apps/web/app/api/video/transcribe/status/route.ts
+++ b/apps/web/app/api/video/transcribe/status/route.ts
@@ -1,9 +1,12 @@
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { videos } from "@cap/database/schema";
-import type { Video } from "@cap/web-domain";
+import { provideOptionalAuth, VideosPolicy } from "@cap/web-backend";
+import { Policy, type Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
+import { Effect, Exit } from "effect";
 import type { NextRequest } from "next/server";
+import * as EffectRuntime from "@/lib/server";
 
 export const dynamic = "force-dynamic";
 
@@ -23,7 +26,26 @@ export async function GET(request: NextRequest) {
 		);
 	}
 
-	const video = await db().select().from(videos).where(eq(videos.id, videoId));
+	// `videoId` is caller-supplied, so an authenticated session is not enough:
+	// without this any signed-in user could read the transcription status of
+	// someone else's private recording. The `getVideoStatus` server action,
+	// which returns this same field, already gates on `canView`.
+	const exit = await Effect.gen(function* () {
+		const videosPolicy = yield* VideosPolicy;
+
+		return yield* Effect.promise(() =>
+			db().select().from(videos).where(eq(videos.id, videoId)),
+		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
+	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+
+	if (Exit.isFailure(exit)) {
+		return Response.json(
+			{ error: true, message: "Video does not exist" },
+			{ status: 404 },
+		);
+	}
+
+	const video = exit.value;
 
 	if (video.length === 0 || !video[0]) {
 		return Response.json(


### PR DESCRIPTION
## Problem

`/api/video/transcribe/status` authenticates the caller and then trusts the `videoId` query parameter:

```ts
const user = await getCurrentUser();
const videoId = url.searchParams.get("videoId") as Video.VideoId;

if (!user) return Response.json({ auth: false }, { status: 401 });

const video = await db().select().from(videos).where(eq(videos.id, videoId));
// ...returns video[0].transcriptionStatus
```

Being signed in is the only barrier, so any authenticated user can read the transcription status of any video by ID — including private recordings belonging to someone else. It also doubles as an existence oracle, since a missing video returns 404 while an existing one returns a status.

The clearest evidence that this is a gap rather than intentional: **the `getVideoStatus` server action returns this exact same field and already gates on `VideosPolicy.canView`** (`apps/web/actions/videos/get-status.ts`). Two entry points to the same data, only one of them checked.

## Fix

Apply the same policy the server action uses, folded onto the query that was already being made — no extra round-trip:

```ts
const exit = await Effect.gen(function* () {
  const videosPolicy = yield* VideosPolicy;
  return yield* Effect.promise(() =>
    db().select().from(videos).where(eq(videos.id, videoId)),
  ).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);

if (Exit.isFailure(exit)) {
  return Response.json({ error: true, message: "Video does not exist" }, { status: 404 });
}
```

Reusing `canView` keeps every legitimate caller working — owners, org members, space members, public videos, and password-protected videos with a valid cookie.

The denial response deliberately reuses the existing `"Video does not exist"` 404 rather than a distinct 403, so an unauthorized caller cannot distinguish "exists but private" from "does not exist".

## Verification

- `biome check` — clean.
- `tsc --noEmit` on `apps/web`: the `TS2488` / `TS18046` diagnostics on this file are artifacts of the Effect generator pattern under an unbuilt workspace, not regressions — the **untouched** `actions/videos/get-status.ts`, which uses the identical pattern, emits the same pair. Verified by diffing the two files' diagnostics.
- `@cap/web-domain`, `@cap/web-backend`, `@cap/database` build clean.

**Diff: 1 file, +21/-2.**

Same class of missing access check as #2029 (`newComment`, closes #1982), #2030 (`getVideoAnalytics`), and #2031 (space/folder video listing). This one is the last `videoId`-taking endpoint I found without a check.
