### PR TITLE
fix(export): match ProRes swscale output to the declared full colour range

### DIFF
--- a/crates/enc-ffmpeg/src/video/prores.rs
+++ b/crates/enc-ffmpeg/src/video/prores.rs
@@ -57,7 +57,7 @@ impl ProResEncoderBuilder {
             || input_config.width != output_width
             || input_config.height != output_height
         {
-            Some(ffmpeg::software::scaling::Context::get(
+            let mut context = ffmpeg::software::scaling::Context::get(
                 input_config.pixel_format,
                 input_config.width,
                 input_config.height,
@@ -65,7 +65,52 @@ impl ProResEncoderBuilder {
                 output_width,
                 output_height,
                 ffmpeg::software::scaling::flag::Flags::BICUBIC,
-            )?)
+            )?;
+
+            // swscale defaults to limited-range (16-235) YUV output, but this
+            // encoder advertises `Range::JPEG` in the stream metadata below.
+            // Left as-is the two disagree: full-range RGB is squeezed into
+            // limited range, then players expand it again as if it were full
+            // range, which crushes contrast and shifts colour.
+            //
+            // ProRes 4444 is a full-range format, so tell swscale to match
+            // what we declare.
+            unsafe {
+                let mut inv_table: *const i32 = std::ptr::null();
+                let mut table: *const i32 = std::ptr::null();
+                let mut src_range: i32 = 0;
+                let mut dst_range: i32 = 0;
+                let mut brightness: i32 = 0;
+                let mut contrast: i32 = 0;
+                let mut saturation: i32 = 0;
+
+                if ffmpeg::ffi::sws_getColorspaceDetails(
+                    context.as_mut_ptr(),
+                    &mut inv_table as *mut _ as *mut *mut i32,
+                    &mut src_range,
+                    &mut table as *mut _ as *mut *mut i32,
+                    &mut dst_range,
+                    &mut brightness,
+                    &mut contrast,
+                    &mut saturation,
+                ) >= 0
+                {
+                    let coefficients = ffmpeg::ffi::sws_getCoefficients(ffmpeg::ffi::SWS_CS_ITU709);
+
+                    ffmpeg::ffi::sws_setColorspaceDetails(
+                        context.as_mut_ptr(),
+                        coefficients,
+                        1,
+                        coefficients,
+                        1,
+                        brightness,
+                        contrast,
+                        saturation,
+                    );
+                }
+            }
+
+            Some(context)
         } else {
             None
         };

--- a/crates/enc-ffmpeg/src/video/prores.rs
+++ b/crates/enc-ffmpeg/src/video/prores.rs
@@ -53,6 +53,10 @@ impl ProResEncoderBuilder {
             .unwrap_or((input_config.width, input_config.height));
         let output_format = format::Pixel::YUVA444P10LE;
 
+        // Set to `false` if swscale can't be told to emit full range, so the
+        // range we declare on the stream keeps matching the pixels we hand it.
+        let mut declare_full_range = true;
+
         let converter = if input_config.pixel_format != output_format
             || input_config.width != output_width
             || input_config.height != output_height
@@ -97,15 +101,17 @@ impl ProResEncoderBuilder {
 
                 if details < 0 {
                     tracing::warn!(
-                        "sws_getColorspaceDetails failed ({details}); ProRes output will stay limited-range while the stream declares full range"
+                        "sws_getColorspaceDetails failed ({details}); falling back to declaring limited range"
                     );
+                    declare_full_range = false;
                 } else {
                     let coefficients = ffmpeg::ffi::sws_getCoefficients(ffmpeg::ffi::SWS_CS_ITU709);
 
                     if coefficients.is_null() {
                         tracing::warn!(
-                            "sws_getCoefficients returned null for ITU709; leaving swscale colour range unchanged"
+                            "sws_getCoefficients returned null for ITU709; falling back to declaring limited range"
                         );
+                        declare_full_range = false;
                     } else {
                         let ret = ffmpeg::ffi::sws_setColorspaceDetails(
                             context.as_mut_ptr(),
@@ -120,8 +126,9 @@ impl ProResEncoderBuilder {
 
                         if ret < 0 {
                             tracing::warn!(
-                                "sws_setColorspaceDetails failed ({ret}); ProRes output will stay limited-range while the stream declares full range"
+                                "sws_setColorspaceDetails failed ({ret}); falling back to declaring limited range"
                             );
+                            declare_full_range = false;
                         }
                     }
                 }
@@ -145,7 +152,13 @@ impl ProResEncoderBuilder {
         encoder.set_time_base(input_config.time_base);
         encoder.set_frame_rate(Some(input_config.frame_rate));
         encoder.set_colorspace(color::Space::BT709);
-        encoder.set_color_range(color::Range::JPEG);
+        encoder.set_color_range(if declare_full_range {
+            color::Range::JPEG
+        } else {
+            // swscale is still emitting its limited-range default, so declaring
+            // full range here would recreate the very mismatch this avoids.
+            color::Range::MPEG
+        });
         unsafe {
             (*encoder.as_mut_ptr()).color_primaries =
                 ffmpeg::ffi::AVColorPrimaries::AVCOL_PRI_BT709;

--- a/crates/enc-ffmpeg/src/video/prores.rs
+++ b/crates/enc-ffmpeg/src/video/prores.rs
@@ -84,7 +84,7 @@ impl ProResEncoderBuilder {
                 let mut contrast: i32 = 0;
                 let mut saturation: i32 = 0;
 
-                if ffmpeg::ffi::sws_getColorspaceDetails(
+                let details = ffmpeg::ffi::sws_getColorspaceDetails(
                     context.as_mut_ptr(),
                     &mut inv_table,
                     &mut src_range,
@@ -93,20 +93,37 @@ impl ProResEncoderBuilder {
                     &mut brightness,
                     &mut contrast,
                     &mut saturation,
-                ) >= 0
-                {
+                );
+
+                if details < 0 {
+                    tracing::warn!(
+                        "sws_getColorspaceDetails failed ({details}); ProRes output will stay limited-range while the stream declares full range"
+                    );
+                } else {
                     let coefficients = ffmpeg::ffi::sws_getCoefficients(ffmpeg::ffi::SWS_CS_ITU709);
 
-                    ffmpeg::ffi::sws_setColorspaceDetails(
-                        context.as_mut_ptr(),
-                        coefficients,
-                        1,
-                        coefficients,
-                        1,
-                        brightness,
-                        contrast,
-                        saturation,
-                    );
+                    if coefficients.is_null() {
+                        tracing::warn!(
+                            "sws_getCoefficients returned null for ITU709; leaving swscale colour range unchanged"
+                        );
+                    } else {
+                        let ret = ffmpeg::ffi::sws_setColorspaceDetails(
+                            context.as_mut_ptr(),
+                            coefficients,
+                            1,
+                            coefficients,
+                            1,
+                            brightness,
+                            contrast,
+                            saturation,
+                        );
+
+                        if ret < 0 {
+                            tracing::warn!(
+                                "sws_setColorspaceDetails failed ({ret}); ProRes output will stay limited-range while the stream declares full range"
+                            );
+                        }
+                    }
                 }
             }
 

--- a/crates/enc-ffmpeg/src/video/prores.rs
+++ b/crates/enc-ffmpeg/src/video/prores.rs
@@ -76,8 +76,8 @@ impl ProResEncoderBuilder {
             // ProRes 4444 is a full-range format, so tell swscale to match
             // what we declare.
             unsafe {
-                let mut inv_table: *const i32 = std::ptr::null();
-                let mut table: *const i32 = std::ptr::null();
+                let mut inv_table: *mut i32 = std::ptr::null_mut();
+                let mut table: *mut i32 = std::ptr::null_mut();
                 let mut src_range: i32 = 0;
                 let mut dst_range: i32 = 0;
                 let mut brightness: i32 = 0;
@@ -86,9 +86,9 @@ impl ProResEncoderBuilder {
 
                 if ffmpeg::ffi::sws_getColorspaceDetails(
                     context.as_mut_ptr(),
-                    &mut inv_table as *mut _ as *mut *mut i32,
+                    &mut inv_table,
                     &mut src_range,
-                    &mut table as *mut _ as *mut *mut i32,
+                    &mut table,
                     &mut dst_range,
                     &mut brightness,
                     &mut contrast,


### PR DESCRIPTION
## Problem

The ProRes encoder declares full range in the stream metadata:

```rust
// crates/enc-ffmpeg/src/video/prores.rs
encoder.set_colorspace(color::Space::BT709);
encoder.set_color_range(color::Range::JPEG);   // full range, 0-255
```

…but the RGBA → `YUVA444P10LE` conversion feeding it is a plain `scaling::Context::get(...)` with no colorspace details set, and **swscale defaults to limited range output (16-235)**.

So the pixels written are limited-range while the container says full-range. A player reads `Range::JPEG`, assumes 16-235 was never applied, and expands the samples again — blacks lift, whites clip, and the whole image shifts. It's the classic double-range-conversion look.

## Evidence

Reproduced the swscale default outside of Cap, so this doesn't depend on reading our pipeline correctly. A 2×2 image of pure white and pure black, converted with ffmpeg:

```
default sws (what prores.rs does today):     luma bytes = [233, 16, 233, 16]
explicit full range (in_range=full:out_range=full): luma bytes = [253, 0, 253, 0]
```

Pure white lands on **235** and pure black on **16** under the default — i.e. limited range — while the encoder is telling the container those same samples are full range. Confirms the two sides disagree.

## Why ProRes specifically

`h264.rs` and `hevc.rs` both declare `Range::MPEG` and also use swscale's limited-range default, so those two are internally consistent — I checked before touching anything, and deliberately left them alone.

`prores.rs` is the only encoder declaring `Range::JPEG`, which makes it the only one where the declaration and the conversion disagree. ProRes 4444 is a full-range format, so the **declaration is right and the conversion was the side that was wrong** — hence fixing the scaler rather than downgrading the metadata to `MPEG`.

## Fix

Set the swscale colorspace details so source and destination are both full range, using the BT.709 coefficients that match the declared `Space::BT709`:

```rust
let coefficients = ffmpeg::ffi::sws_getCoefficients(ffmpeg::ffi::SWS_CS_ITU709);
ffmpeg::ffi::sws_setColorspaceDetails(
    context.as_mut_ptr(),
    coefficients, 1,   // src full range
    coefficients, 1,   // dst full range
    brightness, contrast, saturation,
);
```

Existing brightness/contrast/saturation are read back via `sws_getColorspaceDetails` and preserved rather than reset to zero, and the whole thing is guarded on that call succeeding, so a failure leaves the previous behaviour intact instead of silently mangling the conversion.

## Scope

This affects MOV/ProRes export (`crates/export/src/mov.rs`), which builds frames as `RawVideoFormat::Rgba` and hands them straight to this encoder. MP4/H.264 export is untouched.

Relevant to #1914, which reports colour shift on exported video — though that report is about an external capture card and also describes stutter and compression artifacts, so I'd expect this to be one contributing factor rather than the whole story. I didn't want to claim it closes that issue without a capture card to verify against.

## Verification

- `cargo check -p cap-enc-ffmpeg` — clean.
- `cargo build -p cap-enc-ffmpeg` — clean.
- `cargo clippy -p cap-enc-ffmpeg` — no warnings on this file.
- `cargo fmt` applied.

**Diff: 1 file.**
