### PR TITLE
fix(web): require an explicit share to download, matching the view policy

### DIFF
--- a/apps/web/__tests__/unit/video-download-permissions.test.ts
+++ b/apps/web/__tests__/unit/video-download-permissions.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `canUserDownloadVideo` issues its queries in a fixed order, so each test
+ * declares the rows every query returns, in order:
+ *
+ *   1. sharedVideos    - orgs this video was explicitly shared with
+ *   2. organizationMembers - the user's membership in one of those orgs (only when 1 is non-empty)
+ *   3. spaceVideos     - spaces this video sits in
+ *   4. spaceMembers    - the user's membership in one of those spaces (only when 3 is non-empty)
+ */
+const mocks = vi.hoisted(() => {
+	const queue: unknown[][] = [];
+	let selectCalls = 0;
+
+	const db = () => ({
+		select: () => {
+			selectCalls += 1;
+			const rows = queue.shift() ?? [];
+			// The production code awaits some chains directly and calls .limit()
+			// on others, so the tail satisfies both shapes.
+			const tail = {
+				limit: async () => rows,
+				then: (resolve: (value: unknown[]) => unknown) => resolve(rows),
+			};
+			return { from: () => ({ where: () => tail }) };
+		},
+	});
+
+	return {
+		db,
+		queue,
+		reset() {
+			queue.length = 0;
+			selectCalls = 0;
+		},
+		get selectCalls() {
+			return selectCalls;
+		},
+	};
+});
+
+vi.mock("@cap/database", () => ({ db: mocks.db }));
+
+vi.mock("@cap/database/schema", () => ({
+	organizationMembers: {
+		id: "organizationMembers.id",
+		userId: "organizationMembers.userId",
+		organizationId: "organizationMembers.organizationId",
+	},
+	sharedVideos: {
+		videoId: "sharedVideos.videoId",
+		organizationId: "sharedVideos.organizationId",
+	},
+	spaceMembers: {
+		id: "spaceMembers.id",
+		userId: "spaceMembers.userId",
+		spaceId: "spaceMembers.spaceId",
+	},
+	spaceVideos: {
+		videoId: "spaceVideos.videoId",
+		spaceId: "spaceVideos.spaceId",
+	},
+}));
+
+import { canUserDownloadVideo } from "@/lib/video-download-permissions";
+
+const request = (overrides: Record<string, string> = {}) =>
+	({
+		userId: "user-b",
+		ownerId: "user-a",
+		videoId: "video-1",
+		...overrides,
+	}) as Parameters<typeof canUserDownloadVideo>[0];
+
+beforeEach(() => {
+	mocks.reset();
+});
+
+describe("canUserDownloadVideo", () => {
+	it("allows the owner without querying anything", async () => {
+		await expect(
+			canUserDownloadVideo(request({ userId: "user-a" })),
+		).resolves.toBe(true);
+
+		expect(mocks.selectCalls).toBe(0);
+	});
+
+	it("refuses a colleague when the video was never shared", async () => {
+		// The video belongs to the owner's org, but no sharedVideos or
+		// spaceVideos row exists. Membership of the owner's org is not a grant:
+		// buildCanView requires an explicit share, and download must match it.
+		mocks.queue.push([], []);
+
+		await expect(canUserDownloadVideo(request())).resolves.toBe(false);
+
+		// With no share rows there is nothing to match a membership against, so
+		// neither membership lookup should run: 2 queries, not 4.
+		expect(mocks.selectCalls).toBe(2);
+	});
+
+	it("allows a member of an org the video was explicitly shared with", async () => {
+		mocks.queue.push(
+			[{ organizationId: "org-shared" }],
+			[{ id: "org-membership-1" }],
+		);
+
+		await expect(canUserDownloadVideo(request())).resolves.toBe(true);
+	});
+
+	it("refuses when shared to an org the user does not belong to", async () => {
+		mocks.queue.push([{ organizationId: "org-shared" }], [], []);
+
+		await expect(canUserDownloadVideo(request())).resolves.toBe(false);
+	});
+
+	it("allows a member of a space the video was shared into", async () => {
+		mocks.queue.push([], [{ spaceId: "space-1" }], [{ id: "space-membership-1" }]);
+
+		await expect(canUserDownloadVideo(request())).resolves.toBe(true);
+	});
+
+	it("refuses when the space is one the user does not belong to", async () => {
+		mocks.queue.push([], [{ spaceId: "space-1" }], []);
+
+		await expect(canUserDownloadVideo(request())).resolves.toBe(false);
+	});
+});

--- a/apps/web/actions/videos/download.ts
+++ b/apps/web/actions/videos/download.ts
@@ -90,7 +90,6 @@ export async function getVideoDownloadInfo(
 		userId: user.id,
 		ownerId: video.ownerId,
 		videoId,
-		orgId: video.orgId,
 	});
 
 	if (!allowed) {

--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -862,7 +862,6 @@ async function AuthorizedContent({
 					userId,
 					ownerId: video.owner.id,
 					videoId,
-					orgId: video.orgId,
 				})
 			: false;
 

--- a/apps/web/lib/video-download-permissions.ts
+++ b/apps/web/lib/video-download-permissions.ts
@@ -5,19 +5,17 @@ import {
 	spaceMembers,
 	spaceVideos,
 } from "@cap/database/schema";
-import type { Organisation, User, Video } from "@cap/web-domain";
+import type { User, Video } from "@cap/web-domain";
 import { and, eq, inArray } from "drizzle-orm";
 
 export async function canUserDownloadVideo({
 	userId,
 	ownerId,
 	videoId,
-	orgId,
 }: {
 	userId: User.UserId;
 	ownerId: User.UserId;
 	videoId: Video.VideoId;
-	orgId: Organisation.OrganisationId;
 }): Promise<boolean> {
 	if (userId === ownerId) return true;
 
@@ -26,20 +24,27 @@ export async function canUserDownloadVideo({
 		.from(sharedVideos)
 		.where(eq(sharedVideos.videoId, videoId));
 
-	const orgIds = [orgId, ...sharedOrgs.map((org) => org.organizationId)];
+	// Only orgs this video was explicitly shared with count. The video's own
+	// orgId is where it lives, not a grant: including it would let any member of
+	// the owner's org download a video they cannot even view, since buildCanView
+	// requires a sharedVideos row for the org (VideosPolicy.ts).
+	if (sharedOrgs.length > 0) {
+		const [orgMembership] = await db()
+			.select({ id: organizationMembers.id })
+			.from(organizationMembers)
+			.where(
+				and(
+					eq(organizationMembers.userId, userId),
+					inArray(
+						organizationMembers.organizationId,
+						sharedOrgs.map((org) => org.organizationId),
+					),
+				),
+			)
+			.limit(1);
 
-	const [orgMembership] = await db()
-		.select({ id: organizationMembers.id })
-		.from(organizationMembers)
-		.where(
-			and(
-				eq(organizationMembers.userId, userId),
-				inArray(organizationMembers.organizationId, orgIds),
-			),
-		)
-		.limit(1);
-
-	if (orgMembership) return true;
+		if (orgMembership) return true;
+	}
 
 	const sharedSpaces = await db()
 		.select({ spaceId: spaceVideos.spaceId })


### PR DESCRIPTION
## What

`canUserDownloadVideo` no longer treats the video's own organization as a share target. Download permission now requires the same thing view permission requires: ownership, an explicit `sharedVideos` row for an org the user belongs to, or an explicit `spaceVideos` row for a space they belong to.

Closes #2037.

## The problem

```ts
const orgIds = [orgId, ...sharedOrgs.map((org) => org.organizationId)];
//              ^^^^^ video.orgId, unconditionally
```

`orgId` is passed from `video.orgId` at the call site in `actions/videos/download.ts`. That is the org the video *belongs to*, not one it was shared with — so membership of the owner's org was enough to download anything that org owns, and the `sharedVideos` lookup above it was redundant for that org.

The view policy next door is stricter. `buildCanView` in `packages/web-backend/src/Videos/VideosPolicy.ts` goes through `orgsRepo.membershipForVideo`, which joins through `sharedVideos` and requires the share row to exist:

```ts
.where(Dz.and(
  Dz.eq(Db.organizationMembers.userId, userId),
  Dz.eq(Db.sharedVideos.videoId, videoId),   // the share must exist
))
```

There, `video.orgId` is used only to look up the allowed email *domain*, never as a grant.

So the two paths disagreed: a colleague in the owner's org who cannot **view** an unshared private video could still **download** it. The space branch of the same function was already written the stricter way — it derives space ids purely from `spaceVideos` rows and returns `false` when there are none — which is part of why the org branch reads as an oversight.

## The change

The org membership lookup now runs only when `sharedVideos` returned rows, and only against those org ids. As a side effect it skips a query entirely when the video has no org shares, which is the common case for a personal recording.

`orgId` becomes unused, so it is dropped from the signature and from the single call site.

## Verification

I want to be precise about what I did and did not run.

**What I ran.** I could not install the full monorepo toolchain, so I ran the committed test file, unmodified, against the real `video-download-permissions.ts` in an isolated vitest project with the same `@/lib` alias this repo's `vitest.config.ts` defines. Six tests, all passing:

- the owner is allowed without any query at all
- **a colleague in the owner's org is refused when the video was never shared** — the regression, and it also asserts only 2 queries run, not 4
- a member of an org the video *was* shared with is allowed
- shared to an org the user is not in is refused
- a member of a space the video was shared into is allowed
- a space the user is not in is refused

**Revert check.** I restored the original implementation (with `orgId` and the unconditional `orgIds`) and re-ran the same tests: exactly 2 fail. The other 4 pass under both implementations, so they confirm the change did not simply make the function refuse more things.

**Direct proof of the old behaviour.** With the original code, an unshared private video plus a colleague who is a member of the owner's org returns:

```text
CURRENT code, unshared private video, colleague in owner org -> download allowed? true
```

**What I did not do.** I have not run this against a live Cap instance with a seeded database, so the query-shape reasoning is from reading the drizzle chains rather than from observed SQL. `video-download-permissions.ts` had no test file before this, so nothing pinned either interpretation.

If `video.orgId` was meant to be a grant and the view policy is deliberately the stricter of the two, then this is a docs gap rather than a bug, and I would much rather be told that than have it merged. The test file is written so it documents whichever rule you land on.
