### PR TITLE
fix(web): wire three unused rate-limit ids and guard against new ones

### DIFF
--- a/apps/web/__tests__/unit/rate-limit-ids.test.ts
+++ b/apps/web/__tests__/unit/rate-limit-ids.test.ts
@@ -25,9 +25,14 @@ const KNOWN_UNWIRED: Record<string, string> = {
  * Every key referenced somewhere other than its own declaration.
  *
  * Uses git's own file list so the search sees exactly the tracked sources and
- * never walks node_modules or .next.
+ * never walks node_modules or .next. Memoized: the scan reads every tracked
+ * TS/TSX file, and each test in this suite needs the same answer.
  */
+let referencedCache: Set<string> | undefined;
+
 function referencedKeys(): Set<string> {
+	if (referencedCache) return referencedCache;
+
 	const tracked = execFileSync(
 		"git",
 		["ls-files", "-z", "*.ts", "*.tsx"],
@@ -43,8 +48,13 @@ function referencedKeys(): Set<string> {
 		let source: string;
 		try {
 			source = readFileSync(join(WEB_ROOT, file), "utf8");
-		} catch {
-			continue; // deleted from the worktree but still in the index
+		} catch (error) {
+			// A tracked file missing from the worktree is expected (deleted but
+			// still in the index). Anything else - a permission problem, an I/O
+			// error - would silently shrink the scan and turn this guard into a
+			// no-op, so it has to surface.
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+			throw error;
 		}
 
 		for (const key of keys) {
@@ -52,6 +62,7 @@ function referencedKeys(): Set<string> {
 		}
 	}
 
+	referencedCache = found;
 	return found;
 }
 

--- a/apps/web/__tests__/unit/rate-limit-ids.test.ts
+++ b/apps/web/__tests__/unit/rate-limit-ids.test.ts
@@ -7,6 +7,7 @@ import { RATE_LIMIT_IDS } from "@/lib/rate-limit";
 
 const WEB_ROOT = join(__dirname, "..", "..");
 const DECLARATION_FILE = "lib/rate-limit.ts";
+const TEST_DIR = "__tests__/";
 
 /**
  * Ids that are intentionally declared ahead of being wired. Each entry needs a
@@ -39,7 +40,16 @@ function referencedKeys(): Set<string> {
 		{ cwd: WEB_ROOT, encoding: "utf8", maxBuffer: 32 * 1024 * 1024 },
 	)
 		.split("\0")
-		.filter((file) => file && file !== DECLARATION_FILE);
+		.filter(
+			(file) =>
+				file &&
+				file !== DECLARATION_FILE &&
+				// Only runtime call sites count. A test that merely names an id
+				// would otherwise make an unwired endpoint look protected — and
+				// this file itself references every key, which would make the
+				// guard vacuous.
+				!file.startsWith(TEST_DIR),
+		);
 
 	const found = new Set<string>();
 	const keys = Object.keys(RATE_LIMIT_IDS);

--- a/apps/web/__tests__/unit/rate-limit-ids.test.ts
+++ b/apps/web/__tests__/unit/rate-limit-ids.test.ts
@@ -1,0 +1,96 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { RATE_LIMIT_IDS } from "@/lib/rate-limit";
+
+const WEB_ROOT = join(__dirname, "..", "..");
+const DECLARATION_FILE = "lib/rate-limit.ts";
+
+/**
+ * Ids that are intentionally declared ahead of being wired. Each entry needs a
+ * reason; removing one from this list and wiring the endpoint is the goal.
+ * Keeping it explicit means a NEW unwired id fails the test instead of quietly
+ * joining an already-failing count.
+ */
+const KNOWN_UNWIRED: Record<string, string> = {
+	AUTH_OTP_VERIFY: "no OTP verification route located yet (see #2039)",
+	AUTH_OTP_SEND: "no OTP send route located yet (see #2039)",
+	MESSENGER_MESSAGE: "anonymous support chat route not located yet (see #2039)",
+	DESKTOP_LOGS: "desktop log forwarding route not located yet (see #2039)",
+};
+
+/**
+ * Every key referenced somewhere other than its own declaration.
+ *
+ * Uses git's own file list so the search sees exactly the tracked sources and
+ * never walks node_modules or .next.
+ */
+function referencedKeys(): Set<string> {
+	const tracked = execFileSync(
+		"git",
+		["ls-files", "-z", "*.ts", "*.tsx"],
+		{ cwd: WEB_ROOT, encoding: "utf8", maxBuffer: 32 * 1024 * 1024 },
+	)
+		.split("\0")
+		.filter((file) => file && file !== DECLARATION_FILE);
+
+	const found = new Set<string>();
+	const keys = Object.keys(RATE_LIMIT_IDS);
+
+	for (const file of tracked) {
+		let source: string;
+		try {
+			source = readFileSync(join(WEB_ROOT, file), "utf8");
+		} catch {
+			continue; // deleted from the worktree but still in the index
+		}
+
+		for (const key of keys) {
+			if (source.includes(`RATE_LIMIT_IDS.${key}`)) found.add(key);
+		}
+	}
+
+	return found;
+}
+
+describe("RATE_LIMIT_IDS", () => {
+	it("has a unique rule id per key", () => {
+		const ids = Object.values(RATE_LIMIT_IDS);
+
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	it("every declared id is actually called somewhere", () => {
+		// A declared-but-uncalled id looks like protection in code review and in
+		// the Vercel Firewall dashboard while the endpoint runs unlimited. The
+		// helper already fails open when a dashboard rule is missing, so an
+		// unreferenced constant is a second, quieter way to have no limit.
+		const referenced = referencedKeys();
+		const unused = Object.keys(RATE_LIMIT_IDS).filter(
+			(key) => !referenced.has(key) && !(key in KNOWN_UNWIRED),
+		);
+
+		expect(unused).toEqual([]);
+	});
+
+	it("does not carry a stale allowance for an id that is now wired", () => {
+		// Keeps the allow-list honest: once an endpoint is wired, its entry has
+		// to be deleted rather than lingering and masking a future regression.
+		const referenced = referencedKeys();
+		const staleAllowances = Object.keys(KNOWN_UNWIRED).filter((key) =>
+			referenced.has(key),
+		);
+
+		expect(staleAllowances).toEqual([]);
+	});
+
+	it("only allows ids that actually exist", () => {
+		const unknown = Object.keys(KNOWN_UNWIRED).filter(
+			(key) => !(key in RATE_LIMIT_IDS),
+		);
+
+		expect(unknown).toEqual([]);
+	});
+});

--- a/apps/web/app/api/analytics/track/route.ts
+++ b/apps/web/app/api/analytics/track/route.ts
@@ -12,6 +12,7 @@ import {
 	createAnonymousViewNotification,
 	sendFirstViewEmail,
 } from "@/lib/Notification";
+import { isRateLimited, RATE_LIMIT_IDS } from "@/lib/rate-limit";
 import { runPromise } from "@/lib/server";
 
 interface TrackPayload {
@@ -42,6 +43,15 @@ const decodeUrlEncodedHeaderValue = (value?: string | null) => {
 };
 
 export async function POST(request: NextRequest) {
+	// Unauthenticated by design (provideOptionalAuth), and every accepted call
+	// costs a Tinybird ingest and can fan out into view notifications and a
+	// first-view email.
+	if (await isRateLimited(RATE_LIMIT_IDS.ANALYTICS_TRACK, {
+		headers: request.headers,
+	})) {
+		return Response.json({ error: "Too many requests" }, { status: 429 });
+	}
+
 	let body: TrackPayload;
 	try {
 		body = (await request.json()) as TrackPayload;

--- a/apps/web/app/api/settings/billing/guest-checkout/route.ts
+++ b/apps/web/app/api/settings/billing/guest-checkout/route.ts
@@ -3,8 +3,17 @@ import { stripe } from "@cap/utils";
 import type { NextRequest } from "next/server";
 import { PostHog } from "posthog-node";
 import { getCheckoutRedirectUrls } from "@/lib/mobile-checkout";
+import { isRateLimited, RATE_LIMIT_IDS } from "@/lib/rate-limit";
 
 export async function POST(request: NextRequest) {
+	// Unauthenticated: every accepted call creates a real Stripe checkout
+	// session, so this is rate limited before anything is read from the body.
+	if (await isRateLimited(RATE_LIMIT_IDS.GUEST_CHECKOUT, {
+		headers: request.headers,
+	})) {
+		return Response.json({ error: "Too many requests" }, { status: 429 });
+	}
+
 	console.log("Starting guest checkout process");
 	const { priceId, quantity, platform } = await request.json();
 	const checkoutPlatform = platform === "mobile" ? "mobile" : "web";

--- a/apps/web/app/api/tools/loom-download/route.ts
+++ b/apps/web/app/api/tools/loom-download/route.ts
@@ -5,6 +5,7 @@ import {
 	isMediaServerConfigured,
 } from "@/lib/media-client";
 import { convertRemoteVideoToMp4Buffer } from "@/lib/video-convert";
+import { isRateLimited, RATE_LIMIT_IDS } from "@/lib/rate-limit";
 
 function isHlsUrl(url: string): boolean {
 	return (url.split("?")[0] ?? "").toLowerCase().endsWith(".m3u8");
@@ -160,6 +161,14 @@ async function tryMp4CandidateDownload(
 }
 
 export async function GET(request: NextRequest) {
+	// Unauthenticated, and an accepted call downloads a remote video and can run
+	// it through ffmpeg, so it is bounded before any fetching starts.
+	if (await isRateLimited(RATE_LIMIT_IDS.LOOM_DOWNLOAD, {
+		headers: request.headers,
+	})) {
+		return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+	}
+
 	const videoId = request.nextUrl.searchParams.get("id");
 	const videoName = request.nextUrl.searchParams.get("name");
 


### PR DESCRIPTION
## What

Wires three declared-but-never-called rate-limit ids to the unauthenticated endpoints they name, and adds a test so a new unwired id fails CI instead of being found by reading.

Closes #2039.

## Why

`RATE_LIMIT_IDS` declares 13 ids, each with a doc comment naming the abuse it guards. Counting references outside the declaration file, **7 were never called**, so those endpoints ran with no limit:

```
$ git ls-files -z '*.ts' '*.tsx' | xargs -0 grep -l RATE_LIMIT_IDS.GUEST_CHECKOUT | grep -v lib/rate-limit.ts
(no output)
```

This is quiet because there is already one silent-failure mode by design — the file's own comment notes that an id with no matching Vercel Firewall dashboard rule **fails open**. A declared-but-uncalled id is a second one, and it is invisible from the dashboard side too: someone can create `rl_guest_checkout` in the Firewall, see it configured, and reasonably assume the endpoint is protected while no code ever calls it.

## What this PR wires

Three endpoints I read end to end and confirmed are unauthenticated with no existing limit:

- **`api/settings/billing/guest-checkout`** — no auth of any kind. Reads `priceId`/`quantity` from the body and calls `stripe().checkout.sessions.create(...)`. Limited before anything is read from the body.
- **`api/analytics/track`** — anonymous by design (`provideOptionalAuth`). Each accepted call is a Tinybird ingest and can fan out into `createAnonymousViewNotification` / `sendFirstViewEmail`. Exactly the cost the comment describes.
- **`api/tools/loom-download`** — unauthenticated, downloads a remote video and can run it through ffmpeg. Limited before any fetching starts.

All three follow the existing `api/docs/ask` pattern: `isRateLimited(id, { headers: request.headers })`, return 429. They inherit the helper's existing best-effort semantics, so a firewall outage or a self-hosted deploy without the Firewall behaves exactly as it does today.

## What this PR deliberately does NOT wire

`AUTH_OTP_VERIFY`, `AUTH_OTP_SEND`, `MESSENGER_MESSAGE` and `DESKTOP_LOGS`. I could not confidently locate the single right call site for each, and guessing at an auth or messaging path is not something I want to do blind in a security change. They are listed in a `KNOWN_UNWIRED` map in the test with a reason each, so:

- the suite passes today,
- a **new** unwired id fails immediately rather than joining an already-failing count,
- and removing an entry is the explicit act of wiring one.

Tell me which of the four you want next and I will follow up with the call sites.

## Testing

New `__tests__/unit/rate-limit-ids.test.ts`, 4 tests:

- every declared id is referenced somewhere outside `lib/rate-limit.ts`, except the documented `KNOWN_UNWIRED` entries
- **no stale allowance**: an id in `KNOWN_UNWIRED` that *is* now referenced fails, so the list cannot linger and mask a future regression
- **no phantom allowance**: an entry naming an id that no longer exists fails
- rule ids are unique

The scan uses `git ls-files` for its file list, so it sees exactly the tracked sources and never walks `node_modules` or `.next`.

**Verification.** I ran the test's logic against the real repo rather than a copy, since the result depends on the actual file set:

```text
files scanned: 960
unused (should be []): []
stale allowances (should be []): []
unknown allowances (should be []): []
```

**Revert check.** Reverting just the `analytics/track` wiring and re-running:

```text
after reverting ANALYTICS_TRACK wiring, unused = ["ANALYTICS_TRACK"]
```

so the test genuinely detects an unwired id rather than passing by construction.

**What I did not do.** I have not exercised these three routes against a live deploy with the Firewall rules present — `isRateLimited` returns `false` outside production, so the added branch is inert in a local run. The three ids still need matching Rate Limit rules in the Vercel Firewall dashboard for the protection to take effect, per the helper's own documentation; this PR only makes the code path exist.
