### PR TITLE
fix(hotkeys): report shortcuts the OS refuses instead of silently dropping them

### DIFF
--- a/apps/desktop/src-tauri/src/hotkeys.rs
+++ b/apps/desktop/src-tauri/src/hotkeys.rs
@@ -129,8 +129,13 @@ pub fn init(app: &AppHandle) {
     };
 
     let global_shortcut = app.global_shortcut();
-    for hotkey in store.hotkeys.values() {
-        global_shortcut.register(Shortcut::from(*hotkey)).ok();
+    for (action, hotkey) in store.hotkeys.iter() {
+        // A shortcut stored on a previous run can stop being registrable, e.g.
+        // another application claimed it since. Surface it in the log rather
+        // than starting up with a binding the user believes is active.
+        if let Err(e) = global_shortcut.register(Shortcut::from(*hotkey)) {
+            tracing::warn!(?action, ?hotkey, "failed to register stored hotkey: {e}");
+        }
     }
 
     app.manage(Mutex::new(store));
@@ -258,27 +263,63 @@ async fn handle_hotkey(app: AppHandle, action: HotkeyAction) -> Result<(), Strin
 #[tauri::command(async)]
 #[specta::specta]
 #[instrument(skip(app))]
-pub fn set_hotkey(app: AppHandle, action: HotkeyAction, hotkey: Option<Hotkey>) -> Result<(), ()> {
+pub fn set_hotkey(
+    app: AppHandle,
+    action: HotkeyAction,
+    hotkey: Option<Hotkey>,
+) -> Result<(), String> {
     let global_shortcut = app.global_shortcut();
     let state = app.state::<HotkeysState>();
     let mut store = state.lock().unwrap();
 
     let prev = store.hotkeys.get(&action).cloned();
 
+    // Apply to the store first so the "is this combination still used by
+    // another action?" check below sees the post-change state, then reconcile
+    // the OS registrations.
     if let Some(hotkey) = hotkey {
         store.hotkeys.insert(action, hotkey);
     } else {
         store.hotkeys.remove(&action);
     }
 
+    // Release the previous combination before registering the new one: the
+    // underlying global-hotkey layer rejects a shortcut that is already
+    // registered, so re-binding an action to a combination another action just
+    // gave up would otherwise fail.
     if let Some(prev) = prev
         && !store.hotkeys.values().any(|h| h == &prev)
     {
-        global_shortcut.unregister(Shortcut::from(prev)).ok();
+        if let Err(e) = global_shortcut.unregister(Shortcut::from(prev)) {
+            // Not fatal on its own; log it so a stale registration that keeps
+            // firing the old combination is diagnosable.
+            tracing::warn!(?action, prev = ?prev, "failed to unregister previous hotkey: {e}");
+        }
     }
 
     if let Some(hotkey) = hotkey {
-        global_shortcut.register(Shortcut::from(hotkey)).ok();
+        // The OS can refuse a shortcut: reserved by the system (PrintScreen on
+        // Windows) or already claimed by another application. Previously this
+        // was `.ok()`, so the binding was stored and shown in Settings while
+        // pressing it did nothing.
+        if let Err(e) = global_shortcut.register(Shortcut::from(hotkey)) {
+            tracing::warn!(?action, ?hotkey, "failed to register hotkey: {e}");
+
+            // Roll the store back so it matches what is actually registered.
+            match prev {
+                Some(prev) => {
+                    store.hotkeys.insert(action, prev);
+                    global_shortcut.register(Shortcut::from(prev)).ok();
+                }
+                None => {
+                    store.hotkeys.remove(&action);
+                }
+            }
+
+            return Err(format!(
+                "Could not register this shortcut. It may already be in use by another application, or reserved by the system. ({e})"
+            ));
+        }
     }
 
     Ok(())

--- a/apps/desktop/src/routes/(window-chrome)/settings/hotkeys.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/hotkeys.tsx
@@ -12,6 +12,7 @@ import {
 	Switch,
 } from "solid-js";
 import { createStore } from "solid-js/store";
+import toast from "solid-toast";
 import { hotkeysStore } from "~/store";
 
 import {
@@ -141,14 +142,29 @@ function Inner(props: { initialStore: HotkeysStore | null }) {
 																	class="w-fit"
 																	type="button"
 																	onBlur={(e) => console.log(e)}
-																	onClick={(e) => {
+																	onClick={async (e) => {
 																		e.stopPropagation();
 
+																		const action = item();
+																		const binding = hotkeys[action] ?? null;
+																		const previous = listening()?.prev;
+
 																		setListening();
-																		commands.setHotkey(
-																			item(),
-																			hotkeys[item()] ?? null,
-																		);
+
+																		try {
+																			await commands.setHotkey(action, binding);
+																		} catch (error) {
+																			// The OS can refuse a shortcut (reserved, or
+																			// already taken by another app). Roll the row
+																			// back so it doesn't display as bound when
+																			// pressing it will do nothing.
+																			setHotkeys(action, previous);
+																			toast.error(
+																				typeof error === "string"
+																					? error
+																					: "Could not register this shortcut.",
+																			);
+																		}
 																	}}
 																>
 																	<IconCapCircleCheck class="transition-colors text-gray-12 hover:text-gray-10 size-5" />


### PR DESCRIPTION
Closes #1883.

### What @rlnt hit

Two complaints in that issue, and they turn out to be one bug plus one misreading:

1. *"I can't bind the print key"* — PrintScreen is reserved by Windows, so `register()` fails. But the binding was **still stored and still shown in Settings as bound.** Nothing surfaced the failure, so the only observable behaviour was "I set it and it does nothing".
2. *"key combinations are not possible"* — they are; modifiers are captured (`ctrl/shift/alt/meta`) and rendered by `HotkeyText`. What almost certainly happened is that the combination they tried was already owned by another application, which fails the **same silent way** and is indistinguishable from "combinations aren't supported".

### Root cause

Every registration threw its result away:

```rust
global_shortcut.register(Shortcut::from(hotkey)).ok();   // set_hotkey
global_shortcut.register(Shortcut::from(*hotkey)).ok();  // init, on startup
global_shortcut.unregister(Shortcut::from(prev)).ok();
```

`set_hotkey` was `-> Result<(), ()>` and unconditionally returned `Ok(())`, so the frontend had nothing to react to either.

### Fix

- `set_hotkey` returns `Result<(), String>` and reports the failure. **On error the store is rolled back** to the previous binding (and that binding re-registered), so what Settings shows matches what the OS actually has.
- **Ordering change worth flagging:** the previous combination is now unregistered *before* the new one is registered. `global-hotkey` rejects an already-registered shortcut, so registering-then-unregistering would have broken re-binding an action to a combination another action had just released. I caught this by reading `tauri-plugin-global-shortcut`'s `register_internal` after writing the first version the other way round.
- Startup registration logs failures instead of dropping them — a shortcut claimed by another app since last launch is now diagnosable from the log rather than being a mystery.
- Settings shows a toast and reverts the row.

### On the generated bindings

`tauri.ts` is unchanged and that is expected, not an oversight: specta maps `Result<(), String>` to the same `Promise<null>` it already produced for `Result<(), ()>` — same shape as `set_mic_input`, which is also `Result<(), String>`. The difference is that the promise now **rejects** instead of resolving, which is what the new `try/catch` handles.

### Verification

- `npx tsc --noEmit -p apps/desktop/tsconfig.json` → **0 errors**.
- `biome check` clean; `cargo fmt` applied.
- Confirmed `solid-toast` is a real dependency of `apps/desktop` and `<Toaster>` is mounted in `app.tsx`, so the error actually renders in the settings window rather than going nowhere.

**What I could not do:** I don't have a Windows machine, so I have not pressed PrintScreen against a running build — the OS-refusal path is reasoned from the `global-hotkey` API contract, not observed. `cargo check` doesn't complete in my environment either, for a reason unrelated to this change: the build script needs `binaries/cap-muxer-aarch64-apple-darwin` and `target/native-deps/Spacedrive.framework`, and **it fails identically on unmodified `main`** — I verified that by stashing. So the Rust side is compile-checked by review only, and worth a real build before merge.
