### PR TITLE
fix(integrations): surface why the S3 config request failed

### DIFF
--- a/apps/desktop/src/routes/(window-chrome)/settings/integrations/google-drive-config.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/integrations/google-drive-config.tsx
@@ -6,6 +6,7 @@ import { commands } from "~/utils/tauri";
 import { apiClient, protectedHeaders } from "~/utils/web-api";
 import { Section, SectionCard, SettingsPageContent } from "../Setting";
 import { IntegrationConfigHeader } from "./config-header";
+import { describeS3ConfigError } from "./s3-config-error";
 
 const byteUnits = ["B", "KB", "MB", "GB", "TB", "PB"] as const;
 const googleDriveConnectionPollIntervalMs = 1500;
@@ -71,7 +72,9 @@ const fetchS3Config = async (orgId: string | null) => {
 		headers: await protectedHeaders(),
 	});
 
-	if (response.status !== 200) throw new Error("Failed to fetch S3 config");
+	if (response.status !== 200) {
+		throw new Error(describeS3ConfigError(response));
+	}
 
 	return response.body;
 };

--- a/apps/desktop/src/routes/(window-chrome)/settings/integrations/s3-config-error.ts
+++ b/apps/desktop/src/routes/(window-chrome)/settings/integrations/s3-config-error.ts
@@ -1,0 +1,29 @@
+/**
+ * Turn a non-200 `getS3Config` response into something a user can act on or
+ * paste into an issue.
+ *
+ * The route already returns `{ error, details }` (see
+ * `apps/web/app/api/desktop/[...route]/s3Config.ts`), but both callers threw a
+ * fixed "Failed to fetch S3 config" and dropped it. Since there is no local
+ * ErrorBoundary on these pages, that string reached `CapErrorBoundary` and was
+ * all the user could see or copy — which is exactly what was reported in #1840.
+ */
+export function describeS3ConfigError(response: {
+	status: number;
+	body: unknown;
+}): string {
+	const body = response.body as
+		| { error?: unknown; details?: unknown }
+		| undefined;
+	const error = typeof body?.error === "string" ? body.error : undefined;
+	const details = typeof body?.details === "string" ? body.details : undefined;
+
+	if (response.status === 403 || error === "forbidden_org") {
+		return "You don't have access to this organization's storage settings.";
+	}
+
+	if (error && details) return `${error}: ${details}`;
+	if (error) return error;
+
+	return `Failed to fetch S3 config (HTTP ${response.status})`;
+}

--- a/apps/desktop/src/routes/(window-chrome)/settings/integrations/s3-config.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/integrations/s3-config.tsx
@@ -8,6 +8,7 @@ import { commands } from "~/utils/tauri";
 import { apiClient, protectedHeaders } from "~/utils/web-api";
 import { Section, SectionCard, SettingsPageContent } from "../Setting";
 import { IntegrationConfigHeader } from "./config-header";
+import { describeS3ConfigError } from "./s3-config-error";
 
 interface S3Config {
 	provider: string;
@@ -37,7 +38,13 @@ export default function S3ConfigPage() {
 				headers: await protectedHeaders(),
 			});
 
-			if (response.status !== 200) throw new Error("Failed to fetch S3 config");
+			if (response.status !== 200) {
+				// The server already explains what went wrong (a stored bucket row
+				// that fails to decrypt, an org the user is no longer in, ...).
+				// Throwing a fixed string discarded that and left "Failed to fetch
+				// S3 config" as the only thing the user could see or report.
+				throw new Error(describeS3ConfigError(response));
+			}
 
 			return response.body;
 		},

--- a/packages/web-api-contract/src/desktop.ts
+++ b/packages/web-api-contract/src/desktop.ts
@@ -175,6 +175,8 @@ const protectedContract = c.router(
 					source: z.enum(["default", "user", "organization"]),
 					managedByOrganization: ManagedOrganizationStorage,
 				}),
+				403: z.object({ error: z.string() }),
+				500: z.object({ error: z.string(), details: z.string().optional() }),
 			},
 		},
 		setS3Config: {


### PR DESCRIPTION
Closes #1840.

### What @pulgueta saw

A full-page "An Error Occured" when opening Integrations → S3 Config, and the only copyable text was:

```
Error: Failed to fetch S3 config
@tauri://localhost/_build/assets/s3-config-RlCqiTlF.js:1:3123
```

That string is the whole diagnosis available to them — and to anyone triaging it.

### Why it says nothing

Both integration pages collapse every failure into one fixed message:

```ts
if (response.status !== 200) throw new Error("Failed to fetch S3 config");
```

The route is more informative than that. It already distinguishes **403 `forbidden_org`** from **500** and returns `{ error, details }`, where `details` is the caught error's message — a decrypt failure on a stored bucket row, a DB error, and so on. All of it was thrown away at the call site.

Neither page has a local `ErrorBoundary`, so the thrown string propagates to `CapErrorBoundary`, which renders the generic page and offers "Copy Error to Clipboard" — that's why the report contains a bundled JS stack frame instead of a cause. **The reporter did everything right; the app had nothing to tell them.**

### Fix

- **Contract:** `getS3Config` declared only a `200`, so the error body was untyped at the call site. Added `403` and `500` shapes, matching the existing style of `createGoogleDriveAuthUrl` (`403: z.object({ error: ... })`).
- **`describeS3ConfigError`**, shared by both pages: 403 → a plain sentence about organization access; otherwise `error: details` from the server; falling back to `Failed to fetch S3 config (HTTP <status>)` when the body isn't shaped as expected.
- **`google-drive-config.tsx` made the identical call with the identical fixed string** — it would have produced the same opaque page. Both now go through the helper, which is why this touches two pages rather than one.

### On showing server messages to users

I checked before piping `details` through: it is `error instanceof Error ? error.message : String(error)` from the route's catch, and the handler doesn't put bucket credentials into it. So this surfaces failure causes, not secrets.

### Verification

- `npx tsc --noEmit -p apps/desktop/tsconfig.json` → **0 errors**.
- `biome check` clean on all four files.
- `packages/web-api-contract` reports **1 error, `TS4023` in `util.ts`** — I stashed and re-ran on unmodified `main` to confirm it is **pre-existing and unrelated** (a `@ts-rest/core` name-visibility issue in a file this PR doesn't touch).

**What I have not done:** reproduce the original 500 on a live instance. I don't have R2 credentials or a Cap server to point at, so I traced the path statically — route → contract → call site → `CapErrorBoundary` — rather than observing it. The change is presentational and the failing path is unchanged, but the exact wording is worth a glance from someone who can trigger it.

I'd also gently suggest #1840 stays open until someone confirms *why* @pulgueta's request 500'd; this makes the cause visible, it doesn't fix whatever the underlying cause was.
