### PR TITLE
fix(editor): show an error instead of an endless skeleton when metadata fails

### DIFF
--- a/apps/desktop/src/routes/editor/Editor.tsx
+++ b/apps/desktop/src/routes/editor/Editor.tsx
@@ -54,6 +54,7 @@ import {
 import { EditorErrorScreen } from "./EditorErrorScreen";
 import { Header } from "./Header";
 import { ImportProgress } from "./ImportProgress";
+import { deriveImportStatus, deriveRawImportStatus } from "./import-status";
 import { PlayerContent } from "./Player";
 import { Timeline } from "./Timeline";
 import { Dialog, DialogContent, EditorButton, Input, Subfield } from "./ui";
@@ -148,20 +149,12 @@ export function Editor() {
 		refetchOnReconnect: false,
 	}));
 
-	const rawImportStatus = createMemo(() => {
-		const meta = rawMetaQuery.data;
-		if (!meta) return "loading" as const;
-		if (
-			"status" in meta &&
-			meta.status &&
-			typeof meta.status === "object" &&
-			"status" in meta.status &&
-			meta.status.status === "InProgress"
-		) {
-			return "importing" as const;
-		}
-		return "ready" as const;
-	});
+	const rawImportStatus = createMemo(() =>
+		deriveRawImportStatus({
+			data: rawMetaQuery.data,
+			isError: rawMetaQuery.isError,
+		}),
+	);
 
 	const [lockedToImporting, setLockedToImporting] = createSignal(false);
 
@@ -171,10 +164,8 @@ export function Editor() {
 		}
 	});
 
-	const importStatus = () => {
-		if (lockedToImporting()) return "importing" as const;
-		return rawImportStatus();
-	};
+	const importStatus = () =>
+		deriveImportStatus(rawImportStatus(), lockedToImporting());
 
 	const [importAborted, setImportAborted] = createSignal(false);
 
@@ -211,6 +202,12 @@ export function Editor() {
 				</div>
 			}
 		>
+			<Match when={importStatus() === "error"}>
+				<EditorErrorScreen
+					error={getEditorErrorMessage(rawMetaQuery.error)}
+					projectPath={projectPath() ?? ""}
+				/>
+			</Match>
 			<Match
 				when={importStatus() === "importing" ? (projectPath() ?? null) : null}
 			>

--- a/apps/desktop/src/routes/editor/import-status.test.ts
+++ b/apps/desktop/src/routes/editor/import-status.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveImportStatus, deriveRawImportStatus } from "./import-status";
+
+describe("editor import status", () => {
+	it("reports loading while the metadata query is still in flight", () => {
+		expect(deriveRawImportStatus({ data: undefined, isError: false })).toBe(
+			"loading",
+		);
+	});
+
+	it("reports ready once metadata arrives", () => {
+		expect(
+			deriveRawImportStatus({ data: { status: null }, isError: false }),
+		).toBe("ready");
+	});
+
+	it("reports importing while an import is in progress", () => {
+		expect(
+			deriveRawImportStatus({
+				data: { status: { status: "InProgress" } },
+				isError: false,
+			}),
+		).toBe("importing");
+	});
+
+	// #1812: a failed query also has no data. Before the fix this returned
+	// "loading", so an unreadable recording-meta.json left the editor on the
+	// skeleton with no error and no way forward.
+	it("reports error when the metadata query fails", () => {
+		expect(deriveRawImportStatus({ data: undefined, isError: true })).toBe(
+			"error",
+		);
+	});
+
+	it("still reports error when a stale success payload is present", () => {
+		expect(
+			deriveRawImportStatus({ data: { status: null }, isError: true }),
+		).toBe("error");
+	});
+
+	it("keeps showing the import screen while the lock is held", () => {
+		expect(deriveImportStatus("loading", true)).toBe("importing");
+	});
+
+	it("lets an error override the importing lock", () => {
+		expect(deriveImportStatus("error", true)).toBe("error");
+	});
+
+	it("passes through the raw status when nothing is latched", () => {
+		expect(deriveImportStatus("ready", false)).toBe("ready");
+		expect(deriveImportStatus("loading", false)).toBe("loading");
+	});
+});

--- a/apps/desktop/src/routes/editor/import-status.ts
+++ b/apps/desktop/src/routes/editor/import-status.ts
@@ -1,0 +1,48 @@
+/**
+ * Which screen the editor should show while a recording's metadata loads.
+ *
+ * Extracted from `Editor.tsx` so the state machine can be tested without a
+ * running editor. The case that matters is `error`: `getRecordingMetaByPath`
+ * returns `Result<RecordingMeta, String>` and fails whenever
+ * `recording-meta.json` is missing or unparseable. A failed query has no
+ * `data`, so treating "no data" as "still loading" leaves the editor on the
+ * loading skeleton indefinitely (#1812).
+ */
+export type EditorImportStatus = "loading" | "importing" | "ready" | "error";
+
+export function deriveRawImportStatus(query: {
+	data: unknown;
+	isError: boolean;
+}): EditorImportStatus {
+	if (query.isError) return "error";
+	if (!query.data) return "loading";
+
+	const meta = query.data as { status?: unknown };
+	if (
+		"status" in meta &&
+		meta.status &&
+		typeof meta.status === "object" &&
+		"status" in meta.status &&
+		(meta.status as { status?: unknown }).status === "InProgress"
+	) {
+		return "importing";
+	}
+
+	return "ready";
+}
+
+/**
+ * `lockedToImporting` latches once an import starts, so the UI doesn't flicker
+ * between screens as the metadata is re-read. An error has to outrank that
+ * latch: if the metadata stops being readable mid-import there is nothing left
+ * to wait for, and without this the editor would stay on the import screen for
+ * the same reason it used to stay on the skeleton.
+ */
+export function deriveImportStatus(
+	rawStatus: EditorImportStatus,
+	lockedToImporting: boolean,
+): EditorImportStatus {
+	if (rawStatus === "error") return "error";
+	if (lockedToImporting) return "importing";
+	return rawStatus;
+}


### PR DESCRIPTION
Closes #1812.

### What @shreyastaware saw

Open a previous recording → the editor shows the loading skeleton → it never leaves. Their screenshot is the skeleton, and they noted *"couldn't find logs in macOS"*, so there was nothing to report beyond "it hangs".

### Why it hangs forever

`getRecordingMetaByPath` is `Result<RecordingMeta, String>` — it fails whenever `recording-meta.json` is missing or unparseable (`RecordingMeta::load_for_project` does `read_to_string` then `serde_json::from_str`, both fallible). But the status derivation only consulted `data`:

```ts
const meta = rawMetaQuery.data;
if (!meta) return "loading" as const;
```

**A failed query has no `data` either**, so failure was indistinguishable from a query still in flight. The `<Switch>` had arms for `importing` and `ready` and nothing for failure, so it fell through to the spinner fallback — permanently. No error, no log, no way forward.

`EditorErrorScreen` already exists for exactly this, complete with a recovery path and a "reveal in folder" button. It was simply unreachable on a metadata failure. This wires it up.

### The second half

The error also has to outrank the `lockedToImporting` latch. That latch exists so the UI doesn't flicker while metadata is re-read, but if the metadata stops being readable *mid-import* there is nothing left to wait for — without this it would strand the import screen for the same reason it used to strand the skeleton.

### Verification

Both derivations are extracted into `import-status.ts` so the state machine is testable without a running editor, and covered by 8 vitest cases.

**Confirmed the tests actually catch the bug** rather than just passing: reverting only the two error branches in the extracted module gives

```
Tests  3 failed | 5 passed (8)
```

and restoring them gives `8 passed`. `npx tsc --noEmit -p apps/desktop/tsconfig.json` → **0 errors**; `biome check` clean.

**What I have not done:** reproduce the hang on a real build. I can't compile the desktop crate here — the build script needs `binaries/cap-muxer-*` and `target/native-deps/Spacedrive.framework`, and it fails identically on unmodified `main` (verified by stashing). So the diagnosis is traced statically from the Rust command through to the `<Switch>`, and the fix is covered by unit tests rather than an end-to-end run.

One thing worth a maintainer's judgement: I did not try to work out *why* @shreyastaware's `recording-meta.json` was unreadable. This makes the failure visible and offers recovery, but if there is an underlying cause producing broken recordings on macOS 26.4.1, that is a separate issue and this shouldn't be taken as closing it.
