### PR TITLE
feat: confirm recordings without a microphone

### DIFF
--- a/apps/desktop/src-tauri/src/hotkeys.rs
+++ b/apps/desktop/src-tauri/src/hotkeys.rs
@@ -1,9 +1,10 @@
 use crate::{
-    RequestOpenRecordingPicker, RequestStartRecording, recording,
+    App, ArcLock, RequestOpenRecordingPicker, RequestStartRecording, recording,
     recording_settings::{RecordingSettingsStore, RecordingTargetMode},
     tray,
     windows::ShowCapWindow,
 };
+use cap_recording::feeds::microphone::MicrophoneFeed;
 use cap_recording::screen_capture::ScreenCaptureTarget;
 use global_hotkey::HotKeyState;
 use serde::{Deserialize, Serialize};
@@ -11,6 +12,7 @@ use specta::Type;
 use std::collections::HashMap;
 use std::sync::Mutex;
 use tauri::{AppHandle, Manager};
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut};
 use tauri_plugin_store::StoreExt;
 use tauri_specta::Event;
@@ -87,6 +89,93 @@ impl HotkeysStore {
 pub struct OnEscapePress;
 
 pub type HotkeysState = Mutex<HotkeysStore>;
+
+const RECORDING_START_SAFETY_STORE_KEY: &str = "recording_start_safety";
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct RecordingStartSafetySettings {
+    confirm_before_recording_without_microphone: bool,
+}
+
+impl Default for RecordingStartSafetySettings {
+    fn default() -> Self {
+        Self {
+            confirm_before_recording_without_microphone: true,
+        }
+    }
+}
+
+fn should_confirm_without_microphone(enabled: bool, microphone_available: bool) -> bool {
+    enabled && !microphone_available
+}
+
+fn should_confirm_direct_recording(app: &AppHandle) -> bool {
+    let enabled = app
+        .store("store")
+        .ok()
+        .and_then(|store| store.get(RECORDING_START_SAFETY_STORE_KEY))
+        .and_then(|value| serde_json::from_value::<RecordingStartSafetySettings>(value).ok())
+        .unwrap_or_default()
+        .confirm_before_recording_without_microphone;
+
+    if !enabled {
+        return false;
+    }
+
+    let microphone_name = RecordingSettingsStore::get(app)
+        .ok()
+        .flatten()
+        .and_then(|settings| settings.mic_name);
+    let microphone_available = microphone_name
+        .as_deref()
+        .is_some_and(|name| MicrophoneFeed::list().contains_key(name));
+
+    should_confirm_without_microphone(enabled, microphone_available)
+}
+
+async fn confirm_direct_recording_without_microphone(app: &AppHandle) -> bool {
+    if !should_confirm_direct_recording(app) {
+        return true;
+    }
+
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    app.dialog()
+        .message("This recording will not include your voice.")
+        .title("No microphone detected")
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Record without microphone".to_string(),
+            "Cancel".to_string(),
+        ))
+        .show(move |confirmed| {
+            let _ = sender.send(confirmed);
+        });
+
+    receiver.await.unwrap_or(false)
+}
+
+async fn start_recording_from_hotkey(
+    app: AppHandle,
+    mode: cap_recording::RecordingMode,
+) -> Result<(), String> {
+    if app
+        .state::<ArcLock<App>>()
+        .read()
+        .await
+        .is_recording_active_or_pending()
+    {
+        let _ = RequestStartRecording { mode }.emit(&app);
+        return Ok(());
+    }
+
+    if confirm_direct_recording_without_microphone(&app).await {
+        let _ = RequestStartRecording { mode }.emit(&app);
+    }
+
+    Ok(())
+}
+
 pub fn init(app: &AppHandle) {
     app.plugin(
         tauri_plugin_global_shortcut::Builder::new()
@@ -139,18 +228,10 @@ pub fn init(app: &AppHandle) {
 async fn handle_hotkey(app: AppHandle, action: HotkeyAction) -> Result<(), String> {
     match action {
         HotkeyAction::StartStudioRecording => {
-            let _ = RequestStartRecording {
-                mode: cap_recording::RecordingMode::Studio,
-            }
-            .emit(&app);
-            Ok(())
+            start_recording_from_hotkey(app, cap_recording::RecordingMode::Studio).await
         }
         HotkeyAction::StartInstantRecording => {
-            let _ = RequestStartRecording {
-                mode: cap_recording::RecordingMode::Instant,
-            }
-            .emit(&app);
-            Ok(())
+            start_recording_from_hotkey(app, cap_recording::RecordingMode::Instant).await
         }
         HotkeyAction::StopRecording => recording::stop_recording(app.clone(), app.state()).await,
         HotkeyAction::RestartRecording => recording::restart_recording(app.clone(), app.state())
@@ -282,4 +363,24 @@ pub fn set_hotkey(app: AppHandle, action: HotkeyAction, hotkey: Option<Hotkey>) 
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_confirm_without_microphone;
+
+    #[test]
+    fn confirms_when_enabled_without_microphone() {
+        assert!(should_confirm_without_microphone(true, false));
+    }
+
+    #[test]
+    fn skips_confirmation_with_selected_microphone() {
+        assert!(!should_confirm_without_microphone(true, true));
+    }
+
+    #[test]
+    fn skips_confirmation_when_disabled() {
+        assert!(!should_confirm_without_microphone(false, false));
+    }
 }

--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -26,11 +26,17 @@ import themePreviewAuto from "~/assets/theme-previews/auto.jpg";
 import themePreviewDark from "~/assets/theme-previews/dark.jpg";
 import themePreviewLight from "~/assets/theme-previews/light.jpg";
 import { Input } from "~/routes/editor/ui";
-import { authStore, generalSettingsStore } from "~/store";
+import {
+	authStore,
+	generalSettingsStore,
+	recordingStartSafetyStore,
+} from "~/store";
 import { clientEnv } from "~/utils/env";
 import {
 	deriveGeneralSettings,
 	type GeneralSettingsStore,
+	RECORDING_START_SAFETY_DEFAULTS,
+	type RecordingStartSafetySettings,
 } from "~/utils/general-settings";
 import {
 	type AppTheme,
@@ -126,11 +132,20 @@ const FREE_INSTANT_MODE_MAX_RESOLUTION = 1280;
 const PRO_INSTANT_MODE_MAX_RESOLUTION = 1920;
 
 export default function GeneralSettings() {
-	const [store] = createResource(() => generalSettingsStore.get());
+	const [stores] = createResource(() =>
+		Promise.all([generalSettingsStore.get(), recordingStartSafetyStore.get()]),
+	);
 
 	return (
-		<Show when={store.state === "ready" && ([store()] as const)}>
-			{(store) => <Inner initialStore={store()[0] ?? null} />}
+		<Show when={stores()} keyed>
+			{(stores) => (
+				<Inner
+					initialStore={stores[0] ?? null}
+					initialRecordingStartSafety={
+						stores[1] ?? RECORDING_START_SAFETY_DEFAULTS
+					}
+				/>
+			)}
 		</Show>
 	);
 }
@@ -209,9 +224,18 @@ function AppearanceSection(props: {
 	);
 }
 
-function Inner(props: { initialStore: GeneralSettingsStore | null }) {
+function Inner(props: {
+	initialStore: GeneralSettingsStore | null;
+	initialRecordingStartSafety: RecordingStartSafetySettings;
+}) {
 	const [settings, setSettings] = createStore<ExtendedGeneralSettingsStore>(
 		deriveGeneralSettings(props.initialStore),
+	);
+	const [
+		confirmBeforeRecordingWithoutMicrophone,
+		setConfirmBeforeRecordingWithoutMicrophone,
+	] = createSignal(
+		props.initialRecordingStartSafety.confirmBeforeRecordingWithoutMicrophone,
 	);
 	const auth = authStore.createQuery();
 	const hasCapPro = createMemo(() => {
@@ -309,6 +333,19 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 		} catch (error) {
 			setSettings(key as keyof GeneralSettingsStore, previousValue);
 			console.error(`Failed to update ${key}`, error);
+		}
+	};
+
+	const handleRecordingStartSafetyChange = async (value: boolean) => {
+		const previousValue = confirmBeforeRecordingWithoutMicrophone();
+		setConfirmBeforeRecordingWithoutMicrophone(value);
+		try {
+			await recordingStartSafetyStore.set({
+				confirmBeforeRecordingWithoutMicrophone: value,
+			});
+		} catch (error) {
+			setConfirmBeforeRecordingWithoutMicrophone(previousValue);
+			console.error("Failed to update recording start safety", error);
 		}
 	};
 
@@ -551,6 +588,12 @@ function Inner(props: { initialStore: GeneralSettingsStore | null }) {
 								{ text: "5 seconds", value: 5 },
 								{ text: "10 seconds", value: 10 },
 							]}
+						/>
+						<ToggleSettingItem
+							label="Confirm before recording without a microphone"
+							description="Require confirmation when no microphone is selected or the selected microphone is unavailable."
+							value={confirmBeforeRecordingWithoutMicrophone()}
+							onChange={handleRecordingStartSafetyChange}
 						/>
 						<SelectSettingItem
 							label="Main window when recording starts"

--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@cap/ui-solid";
+import { Popover } from "@kobalte/core/popover";
 import { createEventListener } from "@solid-primitives/event-listener";
 import { createElementSize } from "@solid-primitives/resize-observer";
 import { makePersisted } from "@solid-primitives/storage";
@@ -57,7 +58,11 @@ import {
 } from "~/components/Cropper";
 import ModeSelect from "~/components/ModeSelect";
 import SelectionHint from "~/components/selection-hint";
-import { authStore, generalSettingsStore } from "~/store";
+import {
+	authStore,
+	generalSettingsStore,
+	recordingStartSafetyStore,
+} from "~/store";
 import {
 	AREA_SELECTION_STORAGE_KEY,
 	AREA_SELECTION_STORAGE_SYNC,
@@ -70,6 +75,7 @@ import {
 } from "~/utils/area-selection";
 import { getCameraWindow } from "~/utils/camera-window";
 import { createDevicesQuery } from "~/utils/devices";
+import { shouldConfirmRecordingWithoutMicrophone } from "~/utils/general-settings";
 import {
 	createCameraMutation,
 	createOptionsQuery,
@@ -1859,7 +1865,10 @@ function RecordingControls(props: {
 	const { setOptions, rawOptions } = useRecordingOptions();
 
 	const generalSetings = generalSettingsStore.createQuery();
+	const recordingStartSafety = recordingStartSafetyStore.createQuery();
 	const devices = createDevicesQuery();
+	const [noMicrophoneWarningOpen, setNoMicrophoneWarningOpen] =
+		createSignal(false);
 	const cameras = createMemo(() => devices.data?.cameras ?? []);
 	const mics = createMemo(() => devices.data?.microphones ?? []);
 	const permissions = createMemo(() => devices.data?.permissions);
@@ -1911,6 +1920,137 @@ function RecordingControls(props: {
 		if (!rawOptions.micName) return null;
 		return mics().find((name) => name === rawOptions.micName) ?? null;
 	});
+
+	createEffect(() => {
+		if (
+			!shouldConfirmRecordingWithoutMicrophone(
+				rawOptions.mode,
+				recordingStartSafety.data?.confirmBeforeRecordingWithoutMicrophone ??
+					true,
+				selectedMicName(),
+			)
+		) {
+			setNoMicrophoneWarningOpen(false);
+		}
+	});
+
+	const startDisabled = () =>
+		!!props.disabled || devices.isPending || recordingStartSafety.isPending;
+
+	const startRecording = async (confirmedWithoutMicrophone = false) => {
+		if (rawOptions.mode === "instant" && !auth.data) {
+			emit("start-sign-in");
+			return;
+		}
+		if (startDisabled()) return;
+
+		if (
+			!confirmedWithoutMicrophone &&
+			shouldConfirmRecordingWithoutMicrophone(
+				rawOptions.mode,
+				recordingStartSafety.data?.confirmBeforeRecordingWithoutMicrophone ??
+					true,
+				selectedMicName(),
+			)
+		) {
+			setNoMicrophoneWarningOpen(true);
+			return;
+		}
+
+		setNoMicrophoneWarningOpen(false);
+
+		// Snapshot before onRecordingStart: dismissing the picker
+		// (targetMode: null) disposes the <Match> branch that owns
+		// this component, and the display/area target props call its
+		// narrowed accessor — reading props.target afterwards throws
+		// "Stale read from <Match>." and the recording never starts.
+		const target = props.target;
+
+		if (target.variant === "area") {
+			setOptions(
+				"captureTarget",
+				reconcile({
+					variant: "area",
+					screen: target.screen,
+					bounds: {
+						position: {
+							x: target.bounds.position.x,
+							y: target.bounds.position.y,
+						},
+						size: {
+							width: target.bounds.size.width,
+							height: target.bounds.size.height,
+						},
+					},
+				}),
+			);
+		}
+
+		props.onRecordingStart?.();
+
+		if (rawOptions.mode === "screenshot") {
+			try {
+				const allWindows = await WebviewWindow.getAll();
+				for (const win of allWindows) {
+					if (win.label.startsWith("target-select-overlay-")) {
+						await win.setIgnoreCursorEvents(true);
+						await win.hide();
+					}
+				}
+
+				const path = await commands.takeScreenshot(target);
+				const shouldOpenEditor =
+					await commands.automationShouldOpenScreenshotEditor(target);
+				if (shouldOpenEditor) {
+					await commands.showWindow({ ScreenshotEditor: { path } });
+				}
+				await commands.closeTargetSelectOverlays();
+			} catch (e) {
+				const message = e instanceof Error ? e.message : String(e);
+				toast.error(`Failed to take screenshot: ${message}`);
+				console.error("Failed to take screenshot", e);
+			}
+			return;
+		}
+
+		commands
+			.startRecording({
+				capture_target: target,
+				mode: rawOptions.mode,
+				capture_system_audio: rawOptions.captureSystemAudio,
+			})
+			.then((action) => {
+				// On success the backend closes the overlay windows; the
+				// non-Started actions leave our hidden windows behind.
+				// User-facing feedback for them arrives via the backend's
+				// StartFailed event in the main window.
+				if (action !== "Started") void commands.closeTargetSelectOverlays();
+			})
+			.catch((e: unknown) => {
+				const msg = e instanceof Error ? e.message : String(e);
+				// This webview is hidden by now, so the toast is a
+				// best-effort extra — the visible feedback comes from the
+				// backend's StartFailed event toasted in the main window.
+				if (
+					msg.includes("no longer available") ||
+					msg.includes("DeviceNotFound")
+				) {
+					toast.error(
+						"Selected microphone is not available. Please select a different microphone in settings.",
+					);
+				} else {
+					toast.error(`Failed to start recording: ${msg}`);
+				}
+				// An IPC-level rejection never reaches the backend, so no
+				// StartFailed event fires; the picker flow hid the main
+				// window and dismissal closed the overlays — without this,
+				// the whole app visually vanishes with no recording.
+				void commands.showWindow({
+					Main: { init_target_mode: null },
+				});
+				void commands.closeTargetSelectOverlays();
+			});
+	};
 
 	const menuModes = async () =>
 		await Menu.new({
@@ -1985,8 +2125,6 @@ function RecordingControls(props: {
 		menu.then((menu) => menu.popup(new LogicalPosition(rect.x, rect.y + 40)));
 	}
 
-	const startDisabled = () => !!props.disabled;
-
 	return (
 		<>
 			<div class="flex flex-col gap-2.5 items-stretch my-2.5 w-104 max-w-[90vw]">
@@ -2009,154 +2147,88 @@ function RecordingControls(props: {
 						>
 							<IconCapX class="invert will-change-transform size-3 dark:invert-0" />
 						</div>
-						<div
-							data-inactive={rawOptions.mode === "instant" && !auth.data}
-							data-disabled={startDisabled()}
-							class="flex flex-1 min-w-0 max-w-[18rem] overflow-hidden flex-row h-11 rounded-full text-white bg-linear-to-r from-blue-10 via-blue-10 to-blue-11 dark:from-blue-9 dark:via-blue-9 dark:to-blue-10 group"
-							onClick={async () => {
-								if (rawOptions.mode === "instant" && !auth.data) {
-									emit("start-sign-in");
-									return;
-								}
-								if (startDisabled()) return;
-
-								// Snapshot before onRecordingStart: dismissing the picker
-								// (targetMode: null) disposes the <Match> branch that owns
-								// this component, and the display/area target props call its
-								// narrowed accessor — reading props.target afterwards throws
-								// "Stale read from <Match>." and the recording never starts.
-								const target = props.target;
-
-								if (target.variant === "area") {
-									setOptions(
-										"captureTarget",
-										reconcile({
-											variant: "area",
-											screen: target.screen,
-											bounds: {
-												position: {
-													x: target.bounds.position.x,
-													y: target.bounds.position.y,
-												},
-												size: {
-													width: target.bounds.size.width,
-													height: target.bounds.size.height,
-												},
-											},
-										}),
-									);
-								}
-
-								props.onRecordingStart?.();
-
-								if (rawOptions.mode === "screenshot") {
-									try {
-										const allWindows = await WebviewWindow.getAll();
-										for (const win of allWindows) {
-											if (win.label.startsWith("target-select-overlay-")) {
-												await win.setIgnoreCursorEvents(true);
-												await win.hide();
-											}
-										}
-
-										const path = await commands.takeScreenshot(target);
-										const shouldOpenEditor =
-											await commands.automationShouldOpenScreenshotEditor(
-												target,
-											);
-										if (shouldOpenEditor) {
-											await commands.showWindow({ ScreenshotEditor: { path } });
-										}
-										await commands.closeTargetSelectOverlays();
-									} catch (e) {
-										const message = e instanceof Error ? e.message : String(e);
-										toast.error(`Failed to take screenshot: ${message}`);
-										console.error("Failed to take screenshot", e);
-									}
-									return;
-								}
-
-								commands
-									.startRecording({
-										capture_target: target,
-										mode: rawOptions.mode,
-										capture_system_audio: rawOptions.captureSystemAudio,
-									})
-									.then((action) => {
-										// On success the backend closes the overlay windows; the
-										// non-Started actions leave our hidden windows behind.
-										// User-facing feedback for them arrives via the backend's
-										// StartFailed event in the main window.
-										if (action !== "Started")
-											void commands.closeTargetSelectOverlays();
-									})
-									.catch((e: unknown) => {
-										const msg = e instanceof Error ? e.message : String(e);
-										// This webview is hidden by now, so the toast is a
-										// best-effort extra — the visible feedback comes from the
-										// backend's StartFailed event toasted in the main window.
-										if (
-											msg.includes("no longer available") ||
-											msg.includes("DeviceNotFound")
-										) {
-											toast.error(
-												"Selected microphone is not available. Please select a different microphone in settings.",
-											);
-										} else {
-											toast.error(`Failed to start recording: ${msg}`);
-										}
-										// An IPC-level rejection never reaches the backend, so no
-										// StartFailed event fires; the picker flow hid the main
-										// window and dismissal closed the overlays — without this,
-										// the whole app visually vanishes with no recording.
-										void commands.showWindow({
-											Main: { init_target_mode: null },
-										});
-										void commands.closeTargetSelectOverlays();
-									});
-							}}
+						<Popover
+							open={noMicrophoneWarningOpen()}
+							onOpenChange={setNoMicrophoneWarningOpen}
+							placement="bottom"
+							gutter={8}
 						>
-							<div
-								class="flex flex-1 items-center py-1 pl-4 transition-colors hover:bg-white/10 min-w-0"
-								classList={{
-									"opacity-60 cursor-not-allowed hover:bg-transparent":
-										startDisabled(),
-								}}
+							<Popover.Anchor
+								data-inactive={rawOptions.mode === "instant" && !auth.data}
+								data-disabled={startDisabled()}
+								class="flex flex-1 min-w-0 max-w-[18rem] overflow-hidden flex-row h-11 rounded-full text-white bg-linear-to-r from-blue-10 via-blue-10 to-blue-11 dark:from-blue-9 dark:via-blue-9 dark:to-blue-10 group"
+								onClick={() => void startRecording()}
 							>
-								<Switch>
-									<Match when={rawOptions.mode === "studio"}>
-										<IconCapFilmCut class="size-4 shrink-0" />
-									</Match>
-									<Match when={rawOptions.mode === "instant"}>
-										<IconCapInstant class="size-4 shrink-0" />
-									</Match>
-									<Match when={(rawOptions.mode as string) === "screenshot"}>
-										<IconCapCamera class="size-4 shrink-0" />
-									</Match>
-								</Switch>
-								<div class="flex flex-col mr-2 ml-3 min-w-0">
-									<span class="text-[0.95rem] font-medium text-white text-nowrap">
-										{(() => {
-											if (rawOptions.mode === "instant" && !auth.data)
-												return "Sign In To Use";
-											if (rawOptions.mode === "screenshot")
-												return "Take Screenshot";
-											return "Start Recording";
-										})()}
-									</span>
-									<span class="text-[11px] flex items-center text-nowrap gap-1 transition-opacity duration-200 text-white/90 font-light -mt-0.5">
-										{`${capitalize(rawOptions.mode)} Mode`}
-									</span>
+								<div
+									class="flex flex-1 items-center py-1 pl-4 transition-colors hover:bg-white/10 min-w-0"
+									classList={{
+										"opacity-60 cursor-not-allowed hover:bg-transparent":
+											startDisabled(),
+									}}
+								>
+									<Switch>
+										<Match when={rawOptions.mode === "studio"}>
+											<IconCapFilmCut class="size-4 shrink-0" />
+										</Match>
+										<Match when={rawOptions.mode === "instant"}>
+											<IconCapInstant class="size-4 shrink-0" />
+										</Match>
+										<Match when={(rawOptions.mode as string) === "screenshot"}>
+											<IconCapCamera class="size-4 shrink-0" />
+										</Match>
+									</Switch>
+									<div class="flex flex-col mr-2 ml-3 min-w-0">
+										<span class="text-[0.95rem] font-medium text-white text-nowrap">
+											{(() => {
+												if (rawOptions.mode === "instant" && !auth.data)
+													return "Sign In To Use";
+												if (rawOptions.mode === "screenshot")
+													return "Take Screenshot";
+												return "Start Recording";
+											})()}
+										</span>
+										<span class="text-[11px] flex items-center text-nowrap gap-1 transition-opacity duration-200 text-white/90 font-light -mt-0.5">
+											{`${capitalize(rawOptions.mode)} Mode`}
+										</span>
+									</div>
 								</div>
-							</div>
-							<div
-								class="pl-2.5 pr-3 py-1.5 flex items-center border-l border-white/20 bg-white/5 transition-colors group-hover:bg-white/10"
-								onMouseDown={(e) => showMenu(menuModes(), e)}
-								onClick={(e) => showMenu(menuModes(), e)}
-							>
-								<IconCapCaretDown class="pointer-events-none" />
-							</div>
-						</div>
+								<div
+									class="pl-2.5 pr-3 py-1.5 flex items-center border-l border-white/20 bg-white/5 transition-colors group-hover:bg-white/10"
+									onMouseDown={(e) => showMenu(menuModes(), e)}
+									onClick={(e) => showMenu(menuModes(), e)}
+								>
+									<IconCapCaretDown class="pointer-events-none" />
+								</div>
+							</Popover.Anchor>
+							<Popover.Portal>
+								<Popover.Content class="z-200 w-[min(21rem,calc(100vw-1.5rem))] rounded-xl border border-amber-6 bg-gray-1 p-3.5 text-gray-12 shadow-xl outline-hidden data-expanded:animate-in data-expanded:fade-in data-expanded:zoom-in-95">
+									<div class="flex gap-2.5 items-start">
+										<IconLucideAlertTriangle class="mt-0.5 size-4 shrink-0 text-amber-10" />
+										<div class="flex flex-col gap-1">
+											<p class="text-sm font-semibold">
+												No microphone detected
+											</p>
+											<p class="text-xs leading-relaxed text-gray-10">
+												This recording will not include your voice. Select a
+												microphone, or continue without one.
+											</p>
+										</div>
+									</div>
+									<div class="flex gap-2 justify-end mt-3">
+										<Popover.CloseButton class="px-3 h-8 text-xs font-medium rounded-lg border border-gray-4 bg-gray-2 text-gray-12 hover:bg-gray-3">
+											Go back
+										</Popover.CloseButton>
+										<button
+											type="button"
+											class="px-3 h-8 text-xs font-medium text-white rounded-lg bg-blue-9 hover:bg-blue-10"
+											onClick={() => void startRecording(true)}
+										>
+											Record without microphone
+										</button>
+									</div>
+								</Popover.Content>
+							</Popover.Portal>
+						</Popover>
 						<div
 							class="flex justify-center items-center rounded-full border transition-opacity bg-gray-6 text-gray-12 size-9 hover:opacity-80"
 							onMouseDown={(e) => showMenu(preRecordingMenu(), e)}

--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -1934,8 +1934,9 @@ function RecordingControls(props: {
 		}
 	});
 
-	const startDisabled = () =>
-		!!props.disabled || devices.isPending || recordingStartSafety.isPending;
+	const startLoading = () =>
+		devices.isPending || recordingStartSafety.isPending;
+	const startDisabled = () => !!props.disabled || startLoading();
 
 	const startRecording = async (confirmedWithoutMicrophone = false) => {
 		if (rawOptions.mode === "instant" && !auth.data) {
@@ -2182,6 +2183,7 @@ function RecordingControls(props: {
 											{(() => {
 												if (rawOptions.mode === "instant" && !auth.data)
 													return "Sign In To Use";
+												if (startLoading()) return "Preparing...";
 												if (rawOptions.mode === "screenshot")
 													return "Take Screenshot";
 												return "Start Recording";

--- a/apps/desktop/src/store.ts
+++ b/apps/desktop/src/store.ts
@@ -2,7 +2,11 @@ import { createQuery } from "@tanstack/solid-query";
 import { Store } from "@tauri-apps/plugin-store";
 import { onCleanup } from "solid-js";
 import type { AutomationsStore } from "~/utils/automations";
-import type { GeneralSettingsStore } from "~/utils/general-settings";
+import {
+	type GeneralSettingsStore,
+	RECORDING_START_SAFETY_DEFAULTS,
+	type RecordingStartSafetySettings,
+} from "~/utils/general-settings";
 import type {
 	AuthStore,
 	HotkeysStore,
@@ -107,6 +111,11 @@ export const mainWindowUIStore = declareStore<MainWindowUIStore>(
 export const hotkeysStore = declareStore<HotkeysStore>("hotkeys");
 export const generalSettingsStore =
 	declareStore<GeneralSettingsStore>("general_settings");
+export const recordingStartSafetyStore =
+	declareStore<RecordingStartSafetySettings>(
+		"recording_start_safety",
+		RECORDING_START_SAFETY_DEFAULTS,
+	);
 export const recordingSettingsStore = declareStore<RecordingSettingsStore>(
 	"recording_settings",
 	{

--- a/apps/desktop/src/utils/general-settings.test.ts
+++ b/apps/desktop/src/utils/general-settings.test.ts
@@ -6,6 +6,8 @@ import {
 	formatTranscriptionHints,
 	normalizeTranscriptionHints,
 	parseTranscriptionHints,
+	RECORDING_START_SAFETY_DEFAULTS,
+	shouldConfirmRecordingWithoutMicrophone,
 } from "~/utils/general-settings";
 
 describe("general-settings", () => {
@@ -59,4 +61,50 @@ describe("general-settings", () => {
 			custom_cursor_capture2: false,
 		});
 	});
+
+	it("enables microphone confirmation by default", () => {
+		expect(
+			RECORDING_START_SAFETY_DEFAULTS.confirmBeforeRecordingWithoutMicrophone,
+		).toBe(true);
+	});
+
+	it.each([
+		{
+			mode: "studio" as const,
+			enabled: true,
+			microphone: null,
+			expected: true,
+		},
+		{
+			mode: "instant" as const,
+			enabled: true,
+			microphone: null,
+			expected: true,
+		},
+		{
+			mode: "studio" as const,
+			enabled: true,
+			microphone: "MacBook Microphone",
+			expected: false,
+		},
+		{
+			mode: "instant" as const,
+			enabled: false,
+			microphone: null,
+			expected: false,
+		},
+		{
+			mode: "screenshot" as const,
+			enabled: true,
+			microphone: null,
+			expected: false,
+		},
+	])(
+		"returns $expected for $mode with enabled=$enabled and microphone=$microphone",
+		({ mode, enabled, microphone, expected }) => {
+			expect(
+				shouldConfirmRecordingWithoutMicrophone(mode, enabled, microphone),
+			).toBe(expected);
+		},
+	);
 });

--- a/apps/desktop/src/utils/general-settings.ts
+++ b/apps/desktop/src/utils/general-settings.ts
@@ -1,4 +1,7 @@
-import type { GeneralSettingsStore as TauriGeneralSettingsStore } from "~/utils/tauri";
+import type {
+	RecordingMode,
+	GeneralSettingsStore as TauriGeneralSettingsStore,
+} from "~/utils/tauri";
 
 export type GeneralSettingsStore = TauriGeneralSettingsStore & {
 	captureKeyboardEvents?: boolean;
@@ -13,6 +16,26 @@ export const DEFAULT_TRANSCRIPTION_HINTS = [
 	"My Brand Name",
 	"mywebsite.com",
 ];
+
+export type RecordingStartSafetySettings = {
+	confirmBeforeRecordingWithoutMicrophone: boolean;
+};
+
+export const RECORDING_START_SAFETY_DEFAULTS: RecordingStartSafetySettings = {
+	confirmBeforeRecordingWithoutMicrophone: true,
+};
+
+export function shouldConfirmRecordingWithoutMicrophone(
+	mode: RecordingMode,
+	confirmBeforeRecordingWithoutMicrophone: boolean,
+	selectedMicrophone: string | null,
+): boolean {
+	return (
+		mode !== "screenshot" &&
+		confirmBeforeRecordingWithoutMicrophone &&
+		selectedMicrophone === null
+	);
+}
 
 export function createDefaultGeneralSettings(): GeneralSettingsStore {
 	return {


### PR DESCRIPTION
## Summary
- add an enabled-by-default General Settings preference requiring confirmation before recording without an available selected microphone
- show an anchored picker warning and a native confirmation for direct Studio/Instant shortcuts
- preserve existing behavior for screenshots, automation/deep links, valid microphones, and users who disable the preference

## Validation
- `pnpm exec biome check` on the five touched TypeScript files
- desktop TypeScript type check
- 12 focused Vitest tests
- `cargo fmt --all -- --check`
- `cargo check -p cap-desktop`
- 3 focused hotkey unit tests
- isolated diff integrity checks

Runtime UI smoke testing was not performed because the shared desktop runtime was owned by another active session.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an enabled-by-default recording safety preference for missing microphones.
- Adds persisted settings and shared decision logic for microphone confirmation.
- Shows a picker warning before Studio or Instant recording without an available selected microphone.
- Adds native confirmation for direct recording hotkeys while preserving active-recording and screenshot behavior.
- Adds focused TypeScript and Rust tests for the new decision logic.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/hotkeys.rs | Adds microphone availability checks and native confirmation before direct Studio or Instant hotkey starts. |
| apps/desktop/src/routes/(window-chrome)/settings/general.tsx | Adds the persisted General Settings toggle and optimistic update rollback. |
| apps/desktop/src/routes/target-select-overlay.tsx | Adds the anchored no-microphone warning and explicitly displays “Preparing...” while required queries initially load. |
| apps/desktop/src/store.ts | Defines the defaulted persisted recording-start safety store and query integration. |
| apps/desktop/src/utils/general-settings.ts | Defines the safety preference shape, defaults, and recording-mode confirmation predicate. |
| apps/desktop/src/utils/general-settings.test.ts | Covers enabled, disabled, microphone-available, and screenshot decision cases. |

<sub>Reviews (2): Last reviewed commit: ["fix: show recording start loading state"](https://github.com/capsoftware/cap/commit/5428196bc9f6c4814c2af417403734257334bbdc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48128080)</sub>

<!-- /greptile_comment -->