### PR TITLE
feat: extend deeplinks with pause/resume/toggle/restart/mic/camera/screenshot

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -272,14 +272,7 @@ impl DeepLinkAction {
                 Ok(())
             }
             DeepLinkAction::TakeScreenshot => {
-                let primary_id = scap_targets::Display::primary().id();
-                let displays = cap_recording::screen_capture::list_displays();
-                let id = displays
-                    .iter()
-                    .find(|(s, _)| s.id == primary_id)
-                    .or_else(|| displays.first())
-                    .map(|(s, _)| s.id)
-                    .ok_or_else(|| "No display available".to_string())?;
+                let id = scap_targets::Display::primary().id();
                 let capture_target = ScreenCaptureTarget::Display { id };
                 crate::recording::take_screenshot(app.clone(), capture_target).await
             }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -267,21 +267,17 @@ impl DeepLinkAction {
                 crate::set_mic_input(app.state(), mic_label).await
             }
             DeepLinkAction::SwitchCamera { camera } => {
-                crate::set_camera_input(
-                    app.clone(),
-                    app.state::<ArcLock<App>>(),
-                    camera,
-                    None,
-                )
-                .await?;
+                crate::set_camera_input(app.clone(), app.state::<ArcLock<App>>(), camera, None)
+                    .await?;
                 Ok(())
             }
             DeepLinkAction::TakeScreenshot => {
                 let primary_id = scap_targets::Display::primary().id();
-                let mut displays = cap_recording::screen_capture::list_displays().into_iter();
+                let displays = cap_recording::screen_capture::list_displays();
                 let id = displays
+                    .iter()
                     .find(|(s, _)| s.id == primary_id)
-                    .or_else(|| displays.next())
+                    .or_else(|| displays.first())
                     .map(|(s, _)| s.id)
                     .ok_or_else(|| "No display available".to_string())?;
                 let capture_target = ScreenCaptureTarget::Display { id };

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -46,10 +46,17 @@ pub enum DeepLinkAction {
         mode: RecordingMode,
     },
     StopRecording,
-    #[cfg(debug_assertions)]
     PauseRecording,
-    #[cfg(debug_assertions)]
     ResumeRecording,
+    TogglePauseRecording,
+    RestartRecording,
+    SwitchMicrophone {
+        mic_label: Option<String>,
+    },
+    SwitchCamera {
+        camera: Option<DeviceOrModelID>,
+    },
+    TakeScreenshot,
     #[cfg(debug_assertions)]
     OpenCamera {
         camera: DeviceOrModelID,
@@ -244,13 +251,41 @@ impl DeepLinkAction {
             DeepLinkAction::StopRecording => {
                 crate::recording::stop_recording(app.clone(), app.state()).await
             }
-            #[cfg(debug_assertions)]
             DeepLinkAction::PauseRecording => {
                 crate::recording::pause_recording(app.clone(), app.state()).await
             }
-            #[cfg(debug_assertions)]
             DeepLinkAction::ResumeRecording => {
                 crate::recording::resume_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::TogglePauseRecording => {
+                crate::recording::toggle_pause_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::RestartRecording => {
+                crate::recording::restart_recording(app.clone(), app.state()).await
+            }
+            DeepLinkAction::SwitchMicrophone { mic_label } => {
+                crate::set_mic_input(app.state(), mic_label).await
+            }
+            DeepLinkAction::SwitchCamera { camera } => {
+                crate::set_camera_input(
+                    app.clone(),
+                    app.state::<ArcLock<App>>(),
+                    camera,
+                    None,
+                )
+                .await?;
+                Ok(())
+            }
+            DeepLinkAction::TakeScreenshot => {
+                let state = app.state::<ArcLock<App>>();
+                let capture_target = ScreenCaptureTarget::Display {
+                    id: cap_recording::screen_capture::list_displays()
+                        .into_iter()
+                        .next()
+                        .map(|(s, _)| s.id)
+                        .ok_or("No display available".to_string())?,
+                };
+                crate::recording::take_screenshot(app.clone(), capture_target).await
             }
             #[cfg(debug_assertions)]
             DeepLinkAction::OpenCamera { camera } => {
@@ -358,7 +393,6 @@ mod tests {
         );
     }
 
-    #[cfg(debug_assertions)]
     #[test]
     fn parses_pause_and_resume_action_urls() {
         let pause_url = Url::parse("cap-desktop://action?value=%22pause_recording%22").unwrap();
@@ -371,6 +405,72 @@ mod tests {
         assert_eq!(
             DeepLinkAction::try_from(&resume_url),
             Ok(DeepLinkAction::ResumeRecording)
+        );
+    }
+
+    #[test]
+    fn parses_toggle_pause_action_url() {
+        let url = Url::parse("cap-desktop://action?value=%22toggle_pause_recording%22").unwrap();
+
+        assert_eq!(
+            DeepLinkAction::try_from(&url),
+            Ok(DeepLinkAction::TogglePauseRecording)
+        );
+    }
+
+    #[test]
+    fn parses_restart_action_url() {
+        let url = Url::parse("cap-desktop://action?value=%22restart_recording%22").unwrap();
+
+        assert_eq!(
+            DeepLinkAction::try_from(&url),
+            Ok(DeepLinkAction::RestartRecording)
+        );
+    }
+
+    #[test]
+    fn parses_switch_microphone_action_url() {
+        let value = serde_json::json!({
+            "switch_microphone": {
+                "mic_label": "Built-in Microphone"
+            }
+        })
+        .to_string();
+        let url = Url::parse_with_params("cap-desktop://action", &[("value", value)]).unwrap();
+
+        assert_eq!(
+            DeepLinkAction::try_from(&url),
+            Ok(DeepLinkAction::SwitchMicrophone {
+                mic_label: Some("Built-in Microphone".to_string())
+            })
+        );
+    }
+
+    #[test]
+    fn parses_switch_camera_action_url() {
+        let value = serde_json::json!({
+            "switch_camera": {
+                "camera": { "DeviceID": "camera-1" }
+            }
+        })
+        .to_string();
+        let url = Url::parse_with_params("cap-desktop://action", &[("value", value)]).unwrap();
+
+        assert_eq!(
+            DeepLinkAction::try_from(&url),
+            Ok(DeepLinkAction::SwitchCamera {
+                camera: Some(DeviceOrModelID::DeviceID("camera-1".to_string()))
+            })
+        );
+    }
+
+    #[test]
+    fn parses_take_screenshot_action_url() {
+        let url = Url::parse("cap-desktop://action?value=%22take_screenshot%22").unwrap();
+
+        assert_eq!(
+            DeepLinkAction::try_from(&url),
+            Ok(DeepLinkAction::TakeScreenshot)
         );
     }
 

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -261,7 +261,9 @@ impl DeepLinkAction {
                 crate::recording::toggle_pause_recording(app.clone(), app.state()).await
             }
             DeepLinkAction::RestartRecording => {
-                crate::recording::restart_recording(app.clone(), app.state()).await
+                crate::recording::restart_recording(app.clone(), app.state())
+                    .await
+                    .map(|_| ())
             }
             DeepLinkAction::SwitchMicrophone { mic_label } => {
                 crate::set_mic_input(app.state(), mic_label).await
@@ -274,7 +276,9 @@ impl DeepLinkAction {
             DeepLinkAction::TakeScreenshot => {
                 let id = scap_targets::Display::primary().id();
                 let capture_target = ScreenCaptureTarget::Display { id };
-                crate::recording::take_screenshot(app.clone(), capture_target).await
+                crate::recording::take_screenshot(app.clone(), capture_target)
+                    .await
+                    .map(|_| ())
             }
             #[cfg(debug_assertions)]
             DeepLinkAction::OpenCamera { camera } => {

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -277,14 +277,14 @@ impl DeepLinkAction {
                 Ok(())
             }
             DeepLinkAction::TakeScreenshot => {
-                let state = app.state::<ArcLock<App>>();
-                let capture_target = ScreenCaptureTarget::Display {
-                    id: cap_recording::screen_capture::list_displays()
-                        .into_iter()
-                        .next()
-                        .map(|(s, _)| s.id)
-                        .ok_or("No display available".to_string())?,
-                };
+                let primary_id = scap_targets::Display::primary().id();
+                let mut displays = cap_recording::screen_capture::list_displays().into_iter();
+                let id = displays
+                    .find(|(s, _)| s.id == primary_id)
+                    .or_else(|| displays.next())
+                    .map(|(s, _)| s.id)
+                    .ok_or_else(|| "No display available".to_string())?;
+                let capture_target = ScreenCaptureTarget::Display { id };
                 crate::recording::take_screenshot(app.clone(), capture_target).await
             }
             #[cfg(debug_assertions)]

--- a/packages/sdk-recorder/src/index.ts
+++ b/packages/sdk-recorder/src/index.ts
@@ -82,9 +82,9 @@ export class CapRecorder {
 			this.listeners.set(event, new Set());
 		}
 		const set = this.listeners.get(event);
-		if (set) set.add(handler as EventHandler<keyof RecorderEventMap>);
+		if (set) set.add(handler as unknown as EventHandler<keyof RecorderEventMap>);
 		return () => {
-			this.listeners.get(event)?.delete(handler);
+			this.listeners.get(event)?.delete(handler as unknown as EventHandler<keyof RecorderEventMap>);
 		};
 	}
 

--- a/packages/sdk-recorder/src/index.ts
+++ b/packages/sdk-recorder/src/index.ts
@@ -82,9 +82,10 @@ export class CapRecorder {
 			this.listeners.set(event, new Set());
 		}
 		const set = this.listeners.get(event);
-		if (set) set.add(handler as unknown as EventHandler<keyof RecorderEventMap>);
+		const castHandler = handler as unknown as EventHandler<keyof RecorderEventMap>;
+		if (set) set.add(castHandler);
 		return () => {
-			this.listeners.get(event)?.delete(handler as unknown as EventHandler<keyof RecorderEventMap>);
+			this.listeners.get(event)?.delete(castHandler);
 		};
 	}
 


### PR DESCRIPTION
Extends Cap desktop app deeplinks to support recording controls and device switching for Raycast extension integration.

## Changes

### deeplink_actions.rs
- Removed `#[cfg(debug_assertions)]` from `PauseRecording` and `ResumeRecording` — now available in production builds
- Added new `DeepLinkAction` variants:
  - `TogglePauseRecording` — toggles pause/resume state
  - `RestartRecording` — stops and restarts the current recording
  - `SwitchMicrophone { mic_label }` — switches active microphone
  - `SwitchCamera { camera }` — switches active camera
  - `TakeScreenshot` — captures a screenshot of the primary display
- Implemented `execute()` match arms for all new actions
- Added unit tests for URL parsing of all new actions

## Acceptance Criteria
- [x] PauseRecording, ResumeRecording available in production builds
- [x] TogglePauseRecording, RestartRecording, SwitchMicrophone, SwitchCamera, TakeScreenshot added
- [x] All new actions have URL parsing tests
- [x] Follows existing code patterns and conventions

Closes #1540

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends desktop deep-link actions with recording lifecycle controls, microphone and camera switching, and screenshot capture.
- Makes pause and resume actions available in production builds.
- Adds toggle-pause and restart recording actions.
- Adds optional microphone and camera selection actions.
- Adds screenshot capture and URL parsing tests for each new action.

<h3>Confidence Score: 4/5</h3>

The screenshot target-selection defect should be fixed before merging because the new deep link can capture the wrong monitor.

The new screenshot action assumes the first enumerated display is primary, while platform display APIs and existing screenshot paths use explicit primary or cursor-containing display resolution.

**Files Needing Attention:** apps/desktop/src-tauri/src/deeplink_actions.rs

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/deeplink_actions.rs | Adds and tests the requested deep-link actions, but screenshot target selection can capture the wrong monitor on multi-display systems. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/desktop/src-tauri/src/deeplink_actions.rs:287-289
**Arbitrary display selected for screenshot**

When this deep link runs on a multi-display system, `list_displays().next()` selects according to platform enumeration order rather than the primary or cursor-containing display, causing the screenshot to capture the wrong monitor.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: extend deeplinks with pause/resume..."](https://github.com/capsoftware/cap/commit/3bd73e648520ecf424af277356e46c442a182209) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48241651)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Desktop Tauri App (Rust Backend)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-tauri-app.md)

<!-- /greptile_comment -->