### PR TITLE
fix: add time and size estimation below export buttons (#224)

### DIFF
--- a/apps/desktop/src/routes/editor/ExportPage.tsx
+++ b/apps/desktop/src/routes/editor/ExportPage.tsx
@@ -1414,19 +1414,23 @@ export function ExportPage() {
 								</Button>
 								<Show when={renderEstimate()}>
 									{(est) => {
-										const sec = Math.max(
-											1,
-											Math.round(
-												(est().frameRenderTimeMs * est().totalFrames) / 1000,
-											),
-										);
+										const estimate = est();
+										const rawSec =
+											(estimate.frameRenderTimeMs * estimate.totalFrames) /
+											1000;
+										const sec = Number.isFinite(rawSec)
+											? Math.max(1, Math.ceil(rawSec))
+											: 1;
 										const timeStr =
 											sec < 60
 												? `~${sec}s`
 												: `~${Math.floor(sec / 60)}m ${sec % 60}s`;
+										const sizeStr = Number.isFinite(estimate.estimatedSizeMb)
+											? estimate.estimatedSizeMb.toFixed(1)
+											: "?";
 										return (
 											<p class="text-xs text-gray-10 text-center mt-0.5">
-												Est. size: {est().estimatedSizeMb.toFixed(1)} MB • Est. time: {timeStr}
+												Est. size: {sizeStr} MB • Est. time: {timeStr}
 											</p>
 										);
 									}}

--- a/apps/desktop/src/routes/editor/ExportPage.tsx
+++ b/apps/desktop/src/routes/editor/ExportPage.tsx
@@ -1412,6 +1412,25 @@ export function ExportPage() {
 										</>
 									)}
 								</Button>
+								<Show when={renderEstimate()}>
+									{(est) => {
+										const sec = Math.max(
+											1,
+											Math.round(
+												(est().frameRenderTimeMs * est().totalFrames) / 1000,
+											),
+										);
+										const timeStr =
+											sec < 60
+												? `~${sec}s`
+												: `~${Math.floor(sec / 60)}m ${sec % 60}s`;
+										return (
+											<p class="text-xs text-gray-10 text-center mt-0.5">
+												Est. size: {est().estimatedSizeMb.toFixed(1)} MB • Est. time: {timeStr}
+											</p>
+										);
+									}}
+								</Show>
 							</div>
 						)}
 					</div>

--- a/apps/desktop/src/routes/recordings-overlay.tsx
+++ b/apps/desktop/src/routes/recordings-overlay.tsx
@@ -384,16 +384,21 @@ export default function () {
 														</Button>
 														<Show when={metadata.latest}>
 															{(metadata) => {
-																const sec = Math.ceil(
-																	metadata().estimatedExportTime,
-																);
+																const rawSec = metadata().estimatedExportTime;
+																const sec = Number.isFinite(rawSec)
+																	? Math.max(1, Math.ceil(rawSec))
+																	: 1;
 																const timeStr =
 																	sec < 60
 																		? `~${sec}s`
 																		: `~${Math.floor(sec / 60)}m ${sec % 60}s`;
+																const sizeVal = metadata().size;
+																const sizeStr = Number.isFinite(sizeVal)
+																	? sizeVal.toFixed(1)
+																	: "?";
 																return (
 																	<span class="text-[10px] text-gray-200 font-medium bg-black/50 px-2 py-0.5 rounded backdrop-blur-sm">
-																		Est. {metadata().size.toFixed(1)} MB • {timeStr}
+																		Est. {sizeStr} MB • {timeStr}
 																	</span>
 																);
 															}}

--- a/apps/desktop/src/routes/recordings-overlay.tsx
+++ b/apps/desktop/src/routes/recordings-overlay.tsx
@@ -383,11 +383,20 @@ export default function () {
 															Export
 														</Button>
 														<Show when={metadata.latest}>
-															{(metadata) => (
-																<span class="text-[10px] text-gray-200 font-medium bg-black/50 px-2 py-0.5 rounded backdrop-blur-sm">
-																	Est. {metadata().size.toFixed(1)} MB • ~{Math.ceil(metadata().estimatedExportTime)}s
-																</span>
-															)}
+															{(metadata) => {
+																const sec = Math.ceil(
+																	metadata().estimatedExportTime,
+																);
+																const timeStr =
+																	sec < 60
+																		? `~${sec}s`
+																		: `~${Math.floor(sec / 60)}m ${sec % 60}s`;
+																return (
+																	<span class="text-[10px] text-gray-200 font-medium bg-black/50 px-2 py-0.5 rounded backdrop-blur-sm">
+																		Est. {metadata().size.toFixed(1)} MB • {timeStr}
+																	</span>
+																);
+															}}
 														</Show>
 													</div>
 												</div>

--- a/apps/desktop/src/routes/recordings-overlay.tsx
+++ b/apps/desktop/src/routes/recordings-overlay.tsx
@@ -374,7 +374,7 @@ export default function () {
 													>
 														<IconCapUpload class="size-4" />
 													</TooltipIconButton>
-													<div class="flex absolute inset-0 justify-center items-center">
+													<div class="flex flex-col absolute inset-0 justify-center items-center gap-1">
 														<Button
 															variant="white"
 															size="sm"
@@ -382,6 +382,13 @@ export default function () {
 														>
 															Export
 														</Button>
+														<Show when={metadata.latest}>
+															{(metadata) => (
+																<span class="text-[10px] text-gray-200 font-medium bg-black/50 px-2 py-0.5 rounded backdrop-blur-sm">
+																	Est. {metadata().size.toFixed(1)} MB • ~{Math.ceil(metadata().estimatedExportTime)}s
+																</span>
+															)}
+														</Show>
 													</div>
 												</div>
 												<Show when={metadata.latest}>


### PR DESCRIPTION
Adds estimated export time and file size indicators directly under the export buttons to resolve #224.

### Changes
- Added size (MB) and duration (sec/min) estimation text below the main export button in `ExportPage.tsx`.
- Added estimated size and time badge to thumbnail hover cards in `recordings-overlay.tsx`.

Tested locally with short and long recording lengths.

/claim #224

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds estimated export size and duration text to the editor export action and recording-thumbnail hover cards.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking readability issue for long duration estimates in the recording overlay.

The estimate units and guarded data access are consistent with their producers, but the overlay’s seconds-only formatting becomes difficult to interpret for long recordings.

**Files Needing Attention:** apps/desktop/src/routes/recordings-overlay.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/editor/ExportPage.tsx | Adds a guarded size and duration estimate beneath the export button with appropriate seconds-to-minutes formatting. |
| apps/desktop/src/routes/recordings-overlay.tsx | Adds the estimate to thumbnail hover cards, but formats arbitrarily long durations exclusively as raw seconds. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/desktop/src/routes/recordings-overlay.tsx:388
**Format long estimates readably**

The badge renders every `estimatedExportTime` value as raw seconds, so long recordings display values such as `~10800s` instead of the more readable minutes-and-seconds format used by the main export view.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add time and size estimation below ..."](https://github.com/capsoftware/cap/commit/9e25afc8a9fb75be87996cee012b2f896c7ee34f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48288428)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->