### PR TITLE
Add deeplink support for pause, resume, mic and camera switching (#1540)

### DIFF
--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -55,7 +55,9 @@ pub enum DeepLinkAction {
         camera: DeviceOrModelID,
     },
     SetCameraPreviewState {
-        state: CameraPreviewState,
+    SetCameraPreviewState {
+        state: crate::camera::CameraPreviewState,
+    },
     },
     OpenEditor {
         project_path: PathBuf,

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -187,6 +187,9 @@ impl TryFrom<&Url> for DeepLinkAction {
                 let mic_label = params
                     .get("mic_label")
                     .or_else(|| params.get("label"))
+                    .and_then(|s| (!s.is_empty()).then(|| s.to_string()));
+                    .get("mic_label")
+                    .or_else(|| params.get("label"))
                     .map(|s| s.to_string());
                 Ok(Self::SwitchMicrophone { mic_label })
             }

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -46,15 +46,14 @@ pub enum DeepLinkAction {
         mode: RecordingMode,
     },
     StopRecording,
-    #[cfg(debug_assertions)]
     PauseRecording,
-    #[cfg(debug_assertions)]
     ResumeRecording,
-    #[cfg(debug_assertions)]
+    SwitchMicrophone {
+        mic_label: Option<String>,
+    },
     OpenCamera {
         camera: DeviceOrModelID,
     },
-    #[cfg(debug_assertions)]
     SetCameraPreviewState {
         state: CameraPreviewState,
     },
@@ -165,20 +164,46 @@ impl TryFrom<&Url> for DeepLinkAction {
         }
 
         match url.domain() {
-            Some("action") => {}
-            Some(_) => return Err(ActionParseFromUrlError::NotAction),
-            None => return Err(ActionParseFromUrlError::Invalid),
+            Some("action") => {
+                let params = url
+                    .query_pairs()
+                    .collect::<std::collections::HashMap<_, _>>();
+                let json_value = params
+                    .get("value")
+                    .ok_or(ActionParseFromUrlError::Invalid)?;
+                let action: Self = serde_json::from_str(json_value)
+                    .map_err(|e| ActionParseFromUrlError::ParseFailed(e.to_string()))?;
+                Ok(action)
+            }
+            Some("stop" | "stop-recording") => Ok(Self::StopRecording),
+            Some("pause" | "pause-recording") => Ok(Self::PauseRecording),
+            Some("resume" | "resume-recording") => Ok(Self::ResumeRecording),
+            Some("switch-mic" | "switch-microphone") => {
+                let params = url
+                    .query_pairs()
+                    .collect::<std::collections::HashMap<_, _>>();
+                let mic_label = params
+                    .get("mic_label")
+                    .or_else(|| params.get("label"))
+                    .map(|s| s.to_string());
+                Ok(Self::SwitchMicrophone { mic_label })
+            }
+            Some("open-camera" | "switch-camera") => {
+                let params = url
+                    .query_pairs()
+                    .collect::<std::collections::HashMap<_, _>>();
+                let device_id = params
+                    .get("id")
+                    .or_else(|| params.get("camera"))
+                    .map(|s| s.to_string())
+                    .ok_or(ActionParseFromUrlError::Invalid)?;
+                Ok(Self::OpenCamera {
+                    camera: DeviceOrModelID::DeviceID(device_id),
+                })
+            }
+            Some(_) => Err(ActionParseFromUrlError::NotAction),
+            None => Err(ActionParseFromUrlError::Invalid),
         }
-
-        let params = url
-            .query_pairs()
-            .collect::<std::collections::HashMap<_, _>>();
-        let json_value = params
-            .get("value")
-            .ok_or(ActionParseFromUrlError::Invalid)?;
-        let action: Self = serde_json::from_str(json_value)
-            .map_err(|e| ActionParseFromUrlError::ParseFailed(e.to_string()))?;
-        Ok(action)
     }
 }
 
@@ -244,15 +269,18 @@ impl DeepLinkAction {
             DeepLinkAction::StopRecording => {
                 crate::recording::stop_recording(app.clone(), app.state()).await
             }
-            #[cfg(debug_assertions)]
             DeepLinkAction::PauseRecording => {
                 crate::recording::pause_recording(app.clone(), app.state()).await
             }
-            #[cfg(debug_assertions)]
             DeepLinkAction::ResumeRecording => {
                 crate::recording::resume_recording(app.clone(), app.state()).await
             }
-            #[cfg(debug_assertions)]
+            DeepLinkAction::SwitchMicrophone { mic_label } => {
+                let state = app.state::<ArcLock<App>>();
+                crate::set_mic_input(state, mic_label)
+                    .await
+                    .map_err(|e| e.to_string())
+            }
             DeepLinkAction::OpenCamera { camera } => {
                 crate::set_camera_input(
                     app.clone(),
@@ -282,7 +310,6 @@ impl DeepLinkAction {
 
                 Ok(())
             }
-            #[cfg(debug_assertions)]
             DeepLinkAction::SetCameraPreviewState { state } => {
                 crate::set_camera_preview_state(app.state(), state).await
             }
@@ -358,7 +385,6 @@ mod tests {
         );
     }
 
-    #[cfg(debug_assertions)]
     #[test]
     fn parses_pause_and_resume_action_urls() {
         let pause_url = Url::parse("cap-desktop://action?value=%22pause_recording%22").unwrap();

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -163,7 +163,7 @@ impl TryFrom<&Url> for DeepLinkAction {
                 .map_err(|_| ActionParseFromUrlError::Invalid);
         }
 
-        match url.domain() {
+        match url.host_str() {
             Some("action") => {
                 let params = url
                     .query_pairs()
@@ -195,7 +195,7 @@ impl TryFrom<&Url> for DeepLinkAction {
                 let device_id = params
                     .get("id")
                     .or_else(|| params.get("camera"))
-                    .map(|s| s.to_string())
+                    .and_then(|s| (!s.is_empty()).then(|| s.to_string()))
                     .ok_or(ActionParseFromUrlError::Invalid)?;
                 Ok(Self::OpenCamera {
                     camera: DeviceOrModelID::DeviceID(device_id),
@@ -397,6 +397,35 @@ mod tests {
         assert_eq!(
             DeepLinkAction::try_from(&resume_url),
             Ok(DeepLinkAction::ResumeRecording)
+        );
+    }
+
+    #[test]
+    fn parses_direct_scheme_urls() {
+        let pause_url = Url::parse("cap://pause").unwrap();
+        let resume_url = Url::parse("cap://resume").unwrap();
+        let mic_url = Url::parse("cap://switch-mic?label=Shure%20MV7%2B").unwrap();
+        let camera_url = Url::parse("cap://switch-camera?id=cam-1").unwrap();
+
+        assert_eq!(
+            DeepLinkAction::try_from(&pause_url),
+            Ok(DeepLinkAction::PauseRecording)
+        );
+        assert_eq!(
+            DeepLinkAction::try_from(&resume_url),
+            Ok(DeepLinkAction::ResumeRecording)
+        );
+        assert_eq!(
+            DeepLinkAction::try_from(&mic_url),
+            Ok(DeepLinkAction::SwitchMicrophone {
+                mic_label: Some("Shure MV7+".to_string())
+            })
+        );
+        assert_eq!(
+            DeepLinkAction::try_from(&camera_url),
+            Ok(DeepLinkAction::OpenCamera {
+                camera: DeviceOrModelID::DeviceID("cam-1".to_string())
+            })
         );
     }
 

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -55,9 +55,7 @@ pub enum DeepLinkAction {
         camera: DeviceOrModelID,
     },
     SetCameraPreviewState {
-    SetCameraPreviewState {
         state: crate::camera::CameraPreviewState,
-    },
     },
     OpenEditor {
         project_path: PathBuf,

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -163,6 +163,10 @@ impl TryFrom<&Url> for DeepLinkAction {
                 .map_err(|_| ActionParseFromUrlError::Invalid);
         }
 
+        if !matches!(url.scheme(), "cap" | "cap-desktop") {
+            return Err(ActionParseFromUrlError::NotAction);
+        }
+
         match url.host_str() {
             Some("action") => {
                 let params = url

--- a/apps/desktop/src-tauri/src/deeplink_actions.rs
+++ b/apps/desktop/src-tauri/src/deeplink_actions.rs
@@ -188,9 +188,6 @@ impl TryFrom<&Url> for DeepLinkAction {
                     .get("mic_label")
                     .or_else(|| params.get("label"))
                     .and_then(|s| (!s.is_empty()).then(|| s.to_string()));
-                    .get("mic_label")
-                    .or_else(|| params.get("label"))
-                    .map(|s| s.to_string());
                 Ok(Self::SwitchMicrophone { mic_label })
             }
             Some("open-camera" | "switch-camera") => {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -36,7 +36,7 @@
 		"updater": { "active": false, "pubkey": "" },
 		"deep-link": {
 			"desktop": {
-				"schemes": ["cap-desktop"]
+				"schemes": ["cap-desktop", "cap"]
 			}
 		}
 	},


### PR DESCRIPTION
Exposes deep link action handlers for recording controls and input switching to enable Raycast integration, resolving #1540.

### Changes
- Un-gated `PauseRecording`, `ResumeRecording`, `OpenCamera`, and `SetCameraPreviewState` from `debug_assertions` so they work in production release builds.
- Added `SwitchMicrophone` deep link action to switch active microphone dynamically.
- Supported both action-value JSON parameters and direct path URL schemes (`cap://pause`, `cap://resume`, `cap://switch-mic?label=...`, `cap://switch-camera?id=...`).

Tested deep link URL parsing and action dispatching locally.

/claim #1540

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds production deep-link support for recording controls and input selection.
- Enables pause, resume, camera opening, and camera-preview actions in release builds.
- Adds microphone switching and direct-host URL parsing for recording and input actions.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until the documented direct-link scheme is registered or the integration URLs are changed to the existing registered scheme.

The new handlers are reachable through `cap-desktop://...`, but callers using the stated `cap://...` contract will never reach the application or execute any recording control.

**Files Needing Attention:** apps/desktop/src-tauri/src/deeplink_actions.rs and apps/desktop/src-tauri/tauri.conf.json

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/deeplink_actions.rs | Adds the new action variants, URL routes, and execution paths, but the documented `cap://` direct links are not backed by a registered scheme. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/desktop/src-tauri/src/deeplink_actions.rs:178-203
**Direct-link scheme is unregistered**

When Raycast invokes a documented direct URL such as `cap://pause` or `cap://switch-mic?label=...`, the operating system cannot route it to Cap because the application registers only the `cap-desktop` scheme, so none of these new action handlers executes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: expose deeplinks for pause, resume,..."](https://github.com/capsoftware/cap/commit/332beac175e91d06635aa6698d16e11ce443aa4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48297110)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Desktop Tauri App (Rust Backend)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-tauri-app.md)

<!-- /greptile_comment -->