### PR TITLE
fix(desktop): don't close picker webview before window screenshot

### DIFF
--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -694,8 +694,12 @@ function Inner() {
 												onRecordingStart={() => {
 													setOriginalCameraBounds(null);
 													if (options.mode === "screenshot") {
-														// The window variant has always dismissed the picker
-														// for screenshots too; keep that, tagged as such.
+														// Only mark the dismissal here. takeScreenshot is
+														// invoked from THIS webview right after, and closing
+														// destroys the webview before the invoke is dispatched,
+														// so the screenshot silently never happens. The start
+														// handler hides these windows and closes them once the
+														// capture is done.
 														if (options.targetModeSource === "editor") {
 															setOptions({
 																targetMode: null,
@@ -708,7 +712,6 @@ function Inner() {
 																targetModeDismissal: "screenshot",
 															});
 														}
-														commands.closeTargetSelectOverlays();
 													} else {
 														dismissPickerForRecordingStart();
 													}
@@ -2005,11 +2008,16 @@ function RecordingControls(props: {
 				if (shouldOpenEditor) {
 					await commands.showWindow({ ScreenshotEditor: { path } });
 				}
-				await commands.closeTargetSelectOverlays();
 			} catch (e) {
 				const message = e instanceof Error ? e.message : String(e);
 				toast.error(`Failed to take screenshot: ${message}`);
 				console.error("Failed to take screenshot", e);
+			} finally {
+				await commands
+					.closeTargetSelectOverlays()
+					.catch((e) =>
+						console.error("Failed to close target select overlays", e),
+					);
 			}
 			return;
 		}


### PR DESCRIPTION
Addresses #2046.

## Problem

On Windows, selecting a window for a screenshot closed the target-picker webview before its `takeScreenshot` IPC call could be dispatched, so no screenshot was captured.

## Fix

- Keep the picker alive until the screenshot request is dispatched.
- Close target-selection overlays after both successful and failed captures.
- Keep overlay-cleanup failures from masking the original screenshot error.

## Verification

- Reproduced the failure on Windows 11 before the fix.
- Confirmed a selected-window screenshot is written at the correct bounds and opens in the screenshot editor after the fix.
- Scoped Biome check passes on the changed file.