### PR TITLE
Add opt-in reverse-proxy header auth (e.g. OpenHost SSO)

### DIFF
--- a/packages/database/auth/auth-options.ts
+++ b/packages/database/auth/auth-options.ts
@@ -7,6 +7,7 @@ import { getServerSession as _getServerSession } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
 import { decode, type JWT, type JWTDecodeParams } from "next-auth/jwt";
 import AppleProvider from "next-auth/providers/apple";
+import CredentialsProvider from "next-auth/providers/credentials";
 import EmailProvider from "next-auth/providers/email";
 import GoogleProvider from "next-auth/providers/google";
 import type { Provider } from "next-auth/providers/index";
@@ -71,6 +72,14 @@ export const authOptions = (): NextAuthOptions => {
 			if (_providers) return _providers;
 			const appleClientId = serverEnv().APPLE_CLIENT_ID;
 			const appleClientSecret = serverEnv().APPLE_CLIENT_SECRET;
+			if (
+				serverEnv().TRUSTED_PROXY_AUTH_HEADER &&
+				serverEnv().TRUSTED_PROXY_AUTH_EMAIL
+			) {
+				console.warn(
+					"[auth] trusted-proxy sign-in is ENABLED. Only run this behind a reverse proxy that strips client-sent copies of the trust header, or a login bypass is possible.",
+				);
+			}
 			_providers = [
 				...(appleClientId && appleClientSecret
 					? [
@@ -107,6 +116,62 @@ export const authOptions = (): NextAuthOptions => {
 						};
 					},
 				}),
+				...(serverEnv().TRUSTED_PROXY_AUTH_HEADER &&
+				serverEnv().TRUSTED_PROXY_AUTH_EMAIL
+					? [
+							CredentialsProvider({
+								id: "trusted-proxy",
+								name: "Reverse Proxy",
+								credentials: {},
+								// SECURITY: this header is trusted ONLY because the operator
+								// opted in via env, asserting Cap runs behind a reverse proxy
+								// that strips any client-sent copy of the header and sets it
+								// only on authenticated requests. Never enable without such a
+								// proxy — it would be a login bypass. Fails closed below.
+								async authorize(_credentials, req) {
+									const env = serverEnv();
+									const header = env.TRUSTED_PROXY_AUTH_HEADER!.toLowerCase();
+									// The router is the sole authority for this header (it strips
+									// any client-sent copy), so its presence means the request was
+									// owner-authenticated. Fail closed on anything else.
+									if (req?.headers?.[header] !== "true") return null;
+
+									// Defense-in-depth: when a shared secret is configured, the proxy
+									// must also send it, so a request that reaches Cap outside the
+									// proxy can't spoof the header. Constant-time and length-blind.
+									const secret = env.TRUSTED_PROXY_AUTH_SECRET;
+									if (secret) {
+										const provided =
+											req?.headers?.["x-trusted-proxy-secret"] ?? "";
+										const digest = (s: string) =>
+											crypto.createHash("sha256").update(s).digest();
+										if (!crypto.timingSafeEqual(digest(provided), digest(secret)))
+											return null;
+									}
+
+									const email = env.TRUSTED_PROXY_AUTH_EMAIL!.toLowerCase();
+									const [user] = await db()
+										.select({
+											id: users.id,
+											email: users.email,
+											name: users.name,
+											image: users.image,
+										})
+										.from(users)
+										.where(eq(users.email, email))
+										.limit(1);
+									if (!user) return null;
+
+									return {
+										id: user.id,
+										email: user.email,
+										name: user.name,
+										image: user.image,
+									};
+								},
+							}),
+						]
+					: []),
 				EmailProvider({
 					async generateVerificationToken() {
 						return crypto.randomInt(100000, 1000000).toString();

--- a/packages/env/server.ts
+++ b/packages/env/server.ts
@@ -87,6 +87,7 @@ function createServerEnv() {
 				),
 			TRUSTED_PROXY_AUTH_EMAIL: z
 				.string()
+				.email()
 				.optional()
 				.describe(
 					"Email of the Cap account to sign in when the trusted header is present.",

--- a/packages/env/server.ts
+++ b/packages/env/server.ts
@@ -75,6 +75,29 @@ function createServerEnv() {
 			WORKOS_CLIENT_ID: z.string().optional(),
 			WORKOS_API_KEY: z.string().optional(),
 
+			/// Reverse-proxy (trusted header) auth
+			// Sign in via an authenticating reverse proxy (e.g. OpenHost). Set BOTH
+			// to enable. SECURITY: only use behind a proxy that strips any client-sent
+			// copy of the header — otherwise it is a login bypass.
+			TRUSTED_PROXY_AUTH_HEADER: z
+				.string()
+				.optional()
+				.describe(
+					"Header an authenticating reverse proxy sets to 'true' on owner-authenticated requests (e.g. 'x-openhost-is-owner'). Unset disables the provider.",
+				),
+			TRUSTED_PROXY_AUTH_EMAIL: z
+				.string()
+				.optional()
+				.describe(
+					"Email of the Cap account to sign in when the trusted header is present.",
+				),
+			TRUSTED_PROXY_AUTH_SECRET: z
+				.string()
+				.optional()
+				.describe(
+					"Optional defense-in-depth: if set, the proxy must also send this value as the 'x-trusted-proxy-secret' header, so a request that reaches Cap outside the proxy can't spoof the trust header.",
+				),
+
 			/// Settings
 			CAP_VIDEOS_DEFAULT_PUBLIC: boolString(true).describe(
 				"Should videos be public or private by default",


### PR DESCRIPTION
Lets self-hosters who front Cap with an authenticating reverse proxy sign in via that proxy instead of Cap's email code. A CredentialsProvider is added to the providers array only when TRUSTED_PROXY_AUTH_HEADER and TRUSTED_PROXY_AUTH_EMAIL are both set; it signs in the one configured account when the trusted header equals "true", and fails closed otherwise. Same opt-in pattern as Grafana auth.proxy / Gitea reverse-proxy auth.

Hardening:
- Optional TRUSTED_PROXY_AUTH_SECRET, compared in constant time and length-blind (sha256 both sides, then timingSafeEqual), so a request reaching Cap outside the proxy can't spoof the header.
- A boot-time console.warn whenever the provider is enabled.

Works with Cap's existing jwt/session callbacks unchanged — the jwt callback already re-fetches by token.email and stamps id + sessionVersion. Typechecked against next-auth 4.24.5 under --strict.

Trigger via signIn("trusted-proxy"); a login-page button is a small follow-up.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds opt-in reverse-proxy authentication for a configured existing account.
- Registers a NextAuth credentials provider when the trusted-header and account-email settings are present.
- Validates the proxy assertion and optional shared secret before loading the configured user.
- Adds the corresponding server environment schema and an enablement warning.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the authentication provider failing closed unless its explicitly configured proxy assertion succeeds.

The new path is opt-in, rejects absent or mismatched assertions and secrets, requires an existing normalized user, and integrates with the existing session callbacks without changing their contracts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/database/auth/auth-options.ts | Adds the conditional trusted-proxy credentials provider; its returned user remains compatible with the existing JWT, session-version, and session callbacks. |
| packages/env/server.ts | Adds optional server-side configuration for the trusted assertion header, account email, and defense-in-depth shared secret. |

<sub>Reviews (1): Last reviewed commit: ["Add opt-in reverse-proxy header auth (e...."](https://github.com/capsoftware/cap/commit/b4c5aff1c4a92d60af614b0d5adb03bbc5759156) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49238714)</sub>

**Context used:**

- Knowledge Base — [Database (`packages/database`)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/database.md)
- Knowledge Base — [Infra, Storage and Config](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/infra-storage-config.md)

<!-- /greptile_comment -->