### PR TITLE
fix: lifetime memory growth from macOS permission-check SCShareableContent polling

### DIFF
--- a/apps/desktop/src-tauri/src/audio_meter.rs
+++ b/apps/desktop/src-tauri/src/audio_meter.rs
@@ -56,6 +56,22 @@ impl VolumeMeter {
         self.maxes.push(time, value);
         self.times.push_back(time);
 
+        // The duration-window eviction below stalls permanently when a
+        // device's capture clock is frozen or non-monotonic (duration_since
+        // yields Zero forever or None), and this meter lives for the whole
+        // process; without a hard cap it grows one entry per audio callback
+        // until quit.
+        const MAX_WINDOW_ENTRIES: usize = 512;
+        while self.times.len() > MAX_WINDOW_ENTRIES {
+            // A frozen clock produces duplicate keys that share one `maxes`
+            // entry; only drop that entry once no duplicate remains queued.
+            if let Some(front) = self.times.pop_front()
+                && !self.times.contains(&front)
+            {
+                self.maxes.remove(&front);
+            }
+        }
+
         while let Some(time) = self
             .times
             .back()

--- a/apps/desktop/src-tauri/src/permissions.rs
+++ b/apps/desktop/src-tauri/src/permissions.rs
@@ -23,6 +23,13 @@ static MACOS_DOCK_VISIBILITY_SYNC_GENERATION: AtomicU64 = AtomicU64::new(0);
 static MACOS_PENDING_PANEL_WINDOWS: AtomicU32 = AtomicU32::new(0);
 #[cfg(target_os = "macos")]
 static MACOS_SCK_PERMISSION_MISMATCH_LOGGED: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "macos")]
+static MACOS_SCK_DISPLAYS_VALIDATED: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "macos")]
+static MACOS_SCK_LAST_VALIDATION_ATTEMPT: std::sync::Mutex<Option<std::time::Instant>> =
+    std::sync::Mutex::new(None);
+#[cfg(target_os = "macos")]
+const MACOS_SCK_VALIDATION_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 
 #[cfg(target_os = "macos")]
 pub(crate) struct MacosPanelWindowActivationGuard {
@@ -283,42 +290,84 @@ fn macos_permission_status(permission: &OSPermission, initial_check: bool) -> OS
     }
 }
 
+// The SCShareableContent snapshot behind this validation materialises every
+// window/app/display on the system (~1MB+ of ObjC objects per call). Polling
+// callers (devices snapshot emitter every 5s, permission UIs down to 250ms)
+// used to re-run it for the whole process lifetime, leaking the graph on
+// pool-less tokio threads at ~15MB/min until macOS exhausted swap (issue
+// #2023, the 82GB incident). A successful validation is cached for the rest
+// of the process: runtime revocation is caught by the cheap CGPreflight gate,
+// and macOS relaunches the app on screen-recording permission changes anyway.
+// Failed validations retry at most once per MACOS_SCK_VALIDATION_RETRY_INTERVAL.
 #[cfg(target_os = "macos")]
 fn macos_screen_recording_available() -> bool {
     if !scap_screencapturekit::has_permission() {
         return false;
     }
 
-    let future = async {
-        match sc::ShareableContent::current().await {
-            Ok(content) => {
-                let display_count = content.displays().len();
-                if display_count == 0
-                    && !MACOS_SCK_PERMISSION_MISMATCH_LOGGED.swap(true, Ordering::AcqRel)
-                {
-                    tracing::debug!(
-                        window_count = content.windows().len(),
-                        application_count = content.apps().len(),
-                        "ScreenCaptureKit returned no displays despite CoreGraphics screen-recording permission"
-                    );
-                }
-                display_count > 0
-            }
-            Err(error) => {
-                tracing::debug!(
-                    error = %error,
-                    "ScreenCaptureKit shareable content unavailable during permission check"
-                );
-                false
-            }
-        }
-    };
-
-    if tokio::runtime::Handle::try_current().is_ok() {
-        tokio::task::block_in_place(|| tauri::async_runtime::block_on(future))
-    } else {
-        tauri::async_runtime::block_on(future)
+    if MACOS_SCK_DISPLAYS_VALIDATED.load(Ordering::Acquire) {
+        return true;
     }
+
+    // block_in_place covers the mutex acquisition too: waiters serialised
+    // behind an in-flight validation would otherwise park a tokio worker
+    // without telling the runtime.
+    if tokio::runtime::Handle::try_current().is_ok() {
+        tokio::task::block_in_place(macos_validate_sck_displays)
+    } else {
+        macos_validate_sck_displays()
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_validate_sck_displays() -> bool {
+    // Serialise validators: concurrent callers during the first startup check
+    // must wait for the in-flight validation rather than tripping the backoff
+    // and transiently reporting a granted permission as denied.
+    let mut last_attempt = MACOS_SCK_LAST_VALIDATION_ATTEMPT
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if MACOS_SCK_DISPLAYS_VALIDATED.load(Ordering::Acquire) {
+        return true;
+    }
+    if let Some(attempted_at) = *last_attempt
+        && attempted_at.elapsed() < MACOS_SCK_VALIDATION_RETRY_INTERVAL
+    {
+        return false;
+    }
+    *last_attempt = Some(std::time::Instant::now());
+
+    let validated = objc2::rc::autoreleasepool(|_| {
+        tauri::async_runtime::block_on(async {
+            match sc::ShareableContent::current().await {
+                Ok(content) => {
+                    let display_count = content.displays().len();
+                    if display_count == 0
+                        && !MACOS_SCK_PERMISSION_MISMATCH_LOGGED.swap(true, Ordering::AcqRel)
+                    {
+                        tracing::debug!(
+                            window_count = content.windows().len(),
+                            application_count = content.apps().len(),
+                            "ScreenCaptureKit returned no displays despite CoreGraphics screen-recording permission"
+                        );
+                    }
+                    display_count > 0
+                }
+                Err(error) => {
+                    tracing::debug!(
+                        error = %error,
+                        "ScreenCaptureKit shareable content unavailable during permission check"
+                    );
+                    false
+                }
+            }
+        })
+    });
+
+    if validated {
+        MACOS_SCK_DISPLAYS_VALIDATED.store(true, Ordering::Release);
+    }
+    validated
 }
 
 #[cfg(target_os = "macos")]
@@ -374,6 +423,15 @@ where
 
 #[cfg(target_os = "macos")]
 async fn macos_wait_for_permission_update(permission: &OSPermission) -> bool {
+    // The user just interacted with the permission prompt; drop the SCK
+    // validation backoff so this poll loop sees fresh answers instead of a
+    // stale negative from up to 5s ago.
+    if matches!(permission, OSPermission::ScreenRecording) {
+        *MACOS_SCK_LAST_VALIDATION_ATTEMPT
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+    }
+
     macos_wait_for_permission_update_with(
         || macos_permission_status(permission, false).permitted(),
         || tokio::time::sleep(Duration::from_millis(200)),
@@ -497,9 +555,12 @@ impl OSPermissionsCheck {
 #[tauri::command(async)]
 #[specta::specta]
 pub fn do_permissions_check(_initial_check: bool) -> OSPermissionsCheck {
+    // Pool-wrapped because this runs on tokio/tauri worker threads (which have
+    // no ambient NSAutoreleasePool) from polling callers; without it every
+    // autoreleased AVFoundation/AppKit temporary leaks for the process lifetime.
     #[cfg(target_os = "macos")]
     {
-        OSPermissionsCheck {
+        objc2::rc::autoreleasepool(|_| OSPermissionsCheck {
             screen_recording: macos_permission_status(
                 &OSPermission::ScreenRecording,
                 _initial_check,
@@ -507,7 +568,7 @@ pub fn do_permissions_check(_initial_check: bool) -> OSPermissionsCheck {
             microphone: macos_permission_status(&OSPermission::Microphone, _initial_check),
             camera: macos_permission_status(&OSPermission::Camera, _initial_check),
             accessibility: macos_permission_status(&OSPermission::Accessibility, _initial_check),
-        }
+        })
     }
 
     #[cfg(not(target_os = "macos"))]

--- a/crates/camera-avfoundation/src/lib.rs
+++ b/crates/camera-avfoundation/src/lib.rs
@@ -11,36 +11,41 @@ use std::{
 };
 use tracing::warn;
 
+// Pool-wrapped: device polling calls this every few seconds from tokio threads
+// that have no ambient NSAutoreleasePool, so the discovery session's
+// autoreleased temporaries would otherwise leak for the process lifetime.
 pub fn list_video_devices() -> arc::R<ns::Array<av::CaptureDevice>> {
-    let mut device_types = vec![av::CaptureDeviceType::built_in_wide_angle_camera()];
+    objc::ar_pool(|| {
+        let mut device_types = vec![av::CaptureDeviceType::built_in_wide_angle_camera()];
 
-    if api::macos_available("13.0")
-        && let Some(typ) = unsafe { av::CaptureDeviceType::desk_view_camera() }
-    {
-        device_types.push(typ);
-    }
-
-    if api::macos_available("14.0") {
-        if let Some(typ) = unsafe { av::CaptureDeviceType::external() } {
+        if api::macos_available("13.0")
+            && let Some(typ) = unsafe { av::CaptureDeviceType::desk_view_camera() }
+        {
             device_types.push(typ);
         }
-        if let Some(typ) = unsafe { av::CaptureDeviceType::continuity_camera() } {
-            device_types.push(typ);
+
+        if api::macos_available("14.0") {
+            if let Some(typ) = unsafe { av::CaptureDeviceType::external() } {
+                device_types.push(typ);
+            }
+            if let Some(typ) = unsafe { av::CaptureDeviceType::continuity_camera() } {
+                device_types.push(typ);
+            }
+        } else {
+            device_types.push(av::CaptureDeviceType::external_unknown());
         }
-    } else {
-        device_types.push(av::CaptureDeviceType::external_unknown());
-    }
 
-    let device_types = ns::Array::from_slice(&device_types);
+        let device_types = ns::Array::from_slice(&device_types);
 
-    let video_discovery_session =
-        av::CaptureDeviceDiscoverySession::with_device_types_media_and_pos(
-            &device_types,
-            Some(av::MediaType::video()),
-            av::CaptureDevicePos::Unspecified,
-        );
+        let video_discovery_session =
+            av::CaptureDeviceDiscoverySession::with_device_types_media_and_pos(
+                &device_types,
+                Some(av::MediaType::video()),
+                av::CaptureDevicePos::Unspecified,
+            );
 
-    video_discovery_session.devices()
+        video_discovery_session.devices()
+    })
 }
 
 #[derive(Clone, Copy)]

--- a/crates/camera/src/macos.rs
+++ b/crates/camera/src/macos.rs
@@ -5,16 +5,21 @@ use cidre::*;
 use objc2_av_foundation::*;
 
 pub(super) fn list_cameras_impl() -> impl Iterator<Item = CameraInfo> {
-    let devices = cap_camera_avfoundation::list_video_devices();
-    devices
-        .iter()
-        .map(|d| CameraInfo {
-            device_id: d.unique_id().to_string(),
-            model_id: ModelID::from_avfoundation(d),
-            display_name: d.localized_name().to_string(),
-        })
-        .collect::<Vec<_>>()
-        .into_iter()
+    // ar_pool: called from pool-less tokio threads on a polling cadence; the
+    // unique_id/localized_name accessors autorelease NSStrings that would
+    // otherwise accumulate for the process lifetime.
+    objc::ar_pool(|| {
+        let devices = cap_camera_avfoundation::list_video_devices();
+        devices
+            .iter()
+            .map(|d| CameraInfo {
+                device_id: d.unique_id().to_string(),
+                model_id: ModelID::from_avfoundation(d),
+                display_name: d.localized_name().to_string(),
+            })
+            .collect::<Vec<_>>()
+    })
+    .into_iter()
 }
 
 impl CameraInfo {

--- a/crates/recording/src/feeds/microphone.rs
+++ b/crates/recording/src/feeds/microphone.rs
@@ -510,7 +510,7 @@ fn list_input_device_names() -> Vec<String> {
     let default_id = macos_helpers::get_default_device_id(true);
 
     if let Some(name) = default_id
-        .and_then(|id| macos_helpers::get_device_name(id).ok())
+        .and_then(macos_device_name_released)
         .filter(|name| !name.is_empty())
     {
         names.insert(name, ());
@@ -521,7 +521,7 @@ fn list_input_device_names() -> Vec<String> {
             for device_id in device_ids {
                 if macos_helpers::get_audio_device_supports_scope(device_id, Scope::Input)
                     .unwrap_or(false)
-                    && let Ok(name) = macos_helpers::get_device_name(device_id)
+                    && let Some(name) = macos_device_name_released(device_id)
                     && !name.is_empty()
                 {
                     names.entry(name).or_insert(());
@@ -534,6 +534,44 @@ fn list_input_device_names() -> Vec<String> {
     }
 
     names.into_keys().collect()
+}
+
+// coreaudio-rs's get_device_name never releases the CFString it copies out of
+// AudioObjectGetPropertyData (twice on the CFStringGetCStringPtr fallback
+// path), leaking one or two strings per device per call; the devices snapshot
+// emitter calls this every 5s for the process lifetime. This variant hands the
+// +1 ref to core-foundation, which releases it on drop.
+#[cfg(target_os = "macos")]
+fn macos_device_name_released(device_id: coreaudio::sys::AudioDeviceID) -> Option<String> {
+    use core_foundation::{
+        base::TCFType,
+        string::{CFString, CFStringRef},
+    };
+    use coreaudio::sys;
+
+    let property_address = sys::AudioObjectPropertyAddress {
+        mSelector: sys::kAudioDevicePropertyDeviceNameCFString,
+        mScope: sys::kAudioDevicePropertyScopeOutput,
+        mElement: sys::kAudioObjectPropertyElementMaster,
+    };
+
+    let mut device_name: CFStringRef = std::ptr::null();
+    let mut data_size = std::mem::size_of::<CFStringRef>() as u32;
+    let status = unsafe {
+        sys::AudioObjectGetPropertyData(
+            device_id,
+            &property_address,
+            0,
+            std::ptr::null(),
+            &mut data_size,
+            (&mut device_name) as *mut CFStringRef as *mut _,
+        )
+    };
+    if status != sys::kAudioHardwareNoError as i32 || device_name.is_null() {
+        return None;
+    }
+
+    Some(unsafe { CFString::wrap_under_create_rule(device_name) }.to_string())
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -1333,7 +1371,19 @@ impl Message<RemoveInput> for MicrophoneFeed {
     async fn handle(&mut self, _: RemoveInput, _: &mut Context<Self, Self::Reply>) -> Self::Reply {
         trace!("MicrophoneFeed.RemoveInput");
 
-        let state = self.state.try_as_open()?;
+        // Callers routinely discard this reply; a locked feed silently keeps
+        // the cpal stream (and its per-callback allocations) alive, so make
+        // that path visible in logs. debug-level because deselecting the mic
+        // during a studio recording hits this legitimately.
+        let state = match self.state.try_as_open() {
+            Ok(state) => state,
+            Err(err) => {
+                debug!(
+                    "Microphone feed RemoveInput deferred: feed is locked by an active consumer"
+                );
+                return Err(err);
+            }
+        };
 
         state.connecting = None;
 

--- a/crates/recording/src/sources/microphone.rs
+++ b/crates/recording/src/sources/microphone.rs
@@ -46,6 +46,17 @@ pub struct Microphone {
     cancel: CancellationToken,
 }
 
+// The detached bridge tasks hold clones of the feed lock and only exit via
+// this token. If the pipeline is torn down without stop() (wedged muxer,
+// error paths), a live-but-orphaned lock would keep the feed in State::Locked
+// forever, making RemoveInput a silent no-op and pinning the cpal stream for
+// the rest of the process.
+impl Drop for Microphone {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum MicrophoneSourceError {
     #[error("microphone actor not running")]

--- a/crates/scap-targets/src/platform/macos.rs
+++ b/crates/scap-targets/src/platform/macos.rs
@@ -114,7 +114,11 @@ impl DisplayImpl {
     }
 
     pub fn scale(&self) -> Option<f64> {
-        Some(unsafe { NSScreen::backingScaleFactor(self.as_ns_screen()?) })
+        // ar pool: reached from pool-less tokio threads on a polling cadence
+        // (display lists, cursor info); drains the NSScreen temporaries.
+        objc::rc::autoreleasepool(|| {
+            Some(unsafe { NSScreen::backingScaleFactor(self.as_ns_screen()?) })
+        })
     }
 
     pub fn refresh_rate(&self) -> f64 {
@@ -136,19 +140,21 @@ impl DisplayImpl {
         use objc::{msg_send, *};
         use std::ffi::CStr;
 
-        unsafe {
-            if let Some(ns_screen) = self.as_ns_screen() {
-                let name: id = msg_send![ns_screen, localizedName];
-                if !name.is_null() {
-                    let name = CStr::from_ptr(NSString::UTF8String(name))
-                        .to_string_lossy()
-                        .to_string();
-                    return Some(name);
+        objc::rc::autoreleasepool(|| {
+            unsafe {
+                if let Some(ns_screen) = self.as_ns_screen() {
+                    let name: id = msg_send![ns_screen, localizedName];
+                    if !name.is_null() {
+                        let name = CStr::from_ptr(NSString::UTF8String(name))
+                            .to_string_lossy()
+                            .to_string();
+                        return Some(name);
+                    }
                 }
             }
-        }
 
-        None
+            None
+        })
     }
 
     fn as_ns_screen(&self) -> Option<*mut objc::runtime::Object> {
@@ -160,25 +166,28 @@ impl DisplayImpl {
         unsafe {
             let screens = NSScreen::screens(nil);
             let screen_count = NSArray::count(screens);
+            // init_str returns a +1 NSString; without the explicit release it
+            // leaked one key string per screen on every lookup.
+            let screen_number_key = NSString::alloc(nil).init_str("NSScreenNumber");
 
+            let mut found = None;
             for i in 0..screen_count {
                 let screen: *mut objc::runtime::Object = screens.objectAtIndex(i);
 
                 let device_description = NSScreen::deviceDescription(screen);
-                let num = NSDictionary::valueForKey_(
-                    device_description,
-                    NSString::alloc(nil).init_str("NSScreenNumber"),
-                ) as id;
+                let num = NSDictionary::valueForKey_(device_description, screen_number_key) as id;
 
                 let num_value: u32 = msg_send![num, unsignedIntValue];
 
                 if num_value == self.0.id {
-                    return Some(screen);
+                    found = Some(screen);
+                    break;
                 }
             }
-        }
 
-        None
+            let _: () = msg_send![screen_number_key, release];
+            found
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #2023 (CAP-761) and the swap-exhaustion incident documented in maxktz/cap-memory-leak-incident (Cap suspended by macOS at 82.29 GB).

Since ae303efae, the screen-recording permission check ran a full \`SCShareableContent\` enumeration, and polling callers (5s device-snapshot emitter, UI polls, 250ms onboarding poll) drove it on tokio threads with no autorelease pool for the entire process lifetime — measured at ~138 KB leaked per call (scales with system window count), matching the reported ~15–18 MiB/min growth.

- Cache a successful SCK display validation for the process lifetime (revocation is still caught by the cheap \`CGPreflightScreenCaptureAccess\` gate); throttle failed validations to one per 5s and serialise concurrent validators
- Wrap the permission check, camera device enumeration, and display name/scale lookups in autorelease pools
- Release the +1 \`NSScreen\` lookup key (leaked per screen per call) and the CoreAudio device-name \`CFString\` (leaked by the upstream helper, twice on its fallback path)
- Hard-cap the mic volume meter window (frozen/non-monotonic capture clocks stalled eviction forever) and cancel the mic source's bridge tasks on drop so a wedged teardown can't pin the cpal stream

Validated: \`cargo clippy -D warnings\` clean on all five touched crates; 31 microphone tests pass; a probe replicating the old call pattern shows ~138 KB/call linear growth unpooled vs flat (~1 KB/call) with the fix. Note #1589 (growth while a recording is paused) is a separate report and not addressed here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR addresses long-running macOS memory growth by reducing repeated ScreenCaptureKit enumeration, introducing autorelease pools and explicit native-object cleanup, and bounding or cancelling microphone-related resources.
- Caches successful ScreenCaptureKit display validation and throttles failed attempts.
- Adds autorelease pools around macOS permission, camera, and display metadata polling.
- Corrects CoreAudio and AppKit native-object ownership.
- Bounds audio-meter retention and cancels microphone bridge tasks during teardown.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The resource-lifetime changes preserve existing capture and permission behavior while bounding retained state, serializing expensive validation, and releasing or draining native resources at their intended ownership boundaries.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/permissions.rs | Serializes, throttles, and caches ScreenCaptureKit validation while pooling Objective-C temporaries during permission polling. |
| apps/desktop/src-tauri/src/audio_meter.rs | Adds a 512-entry fallback bound for volume-meter timestamps when capture clocks stop advancing. |
| crates/camera-avfoundation/src/lib.rs | Wraps AVFoundation device discovery in an autorelease pool without changing the returned retained device array. |
| crates/camera/src/macos.rs | Materializes camera metadata inside an autorelease pool before returning owned Rust values. |
| crates/recording/src/feeds/microphone.rs | Replaces the leaking CoreAudio device-name helper with an explicitly owned CFString lookup and adds diagnostics for deferred removal. |
| crates/recording/src/sources/microphone.rs | Cancels detached microphone bridge tasks when their owning source is dropped. |
| crates/scap-targets/src/platform/macos.rs | Pools display metadata lookups and releases the owned NSScreen dictionary key after use. |

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): cap mic volume meter windo..."](https://github.com/capsoftware/cap/commit/a2f4eadd1c6e47c2633772cc4a21f0eca581ea17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49525029)</sub>

**Context used:**

- Knowledge Base — [Desktop Tauri App (Rust Backend)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-tauri-app.md)
- Knowledge Base — [Desktop Recording Capture Pipeline](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-recording-capture.md)

<!-- /greptile_comment -->