### PR TITLE
fix: enforce video view policy on transcription status endpoint

### DIFF
--- a/apps/web/app/api/video/transcribe/status/route.ts
+++ b/apps/web/app/api/video/transcribe/status/route.ts
@@ -2,9 +2,9 @@ import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { videos } from "@cap/database/schema";
 import { provideOptionalAuth, VideosPolicy } from "@cap/web-backend";
-import { Policy, type Video } from "@cap/web-domain";
+import { Policy, Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
-import { Effect, Exit } from "effect";
+import { Cause, Effect, Exit, Option, Schema } from "effect";
 import type { NextRequest } from "next/server";
 import * as EffectRuntime from "@/lib/server";
 
@@ -35,9 +35,20 @@ export async function GET(request: NextRequest) {
 	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
 
 	if (Exit.isFailure(exit)) {
+		const error = Option.getOrUndefined(Cause.failureOption(exit.cause));
+		if (
+			Schema.is(Policy.PolicyDeniedError)(error) ||
+			Schema.is(Video.VerifyVideoPasswordError)(error)
+		) {
+			return Response.json(
+				{ error: true, message: "Video does not exist" },
+				{ status: 404 },
+			);
+		}
+
 		return Response.json(
-			{ error: true, message: "Video does not exist" },
-			{ status: 404 },
+			{ error: true, message: "An unexpected error occurred" },
+			{ status: 500 },
 		);
 	}
 

--- a/apps/web/app/api/video/transcribe/status/route.ts
+++ b/apps/web/app/api/video/transcribe/status/route.ts
@@ -1,9 +1,12 @@
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { videos } from "@cap/database/schema";
-import type { Video } from "@cap/web-domain";
+import { provideOptionalAuth, VideosPolicy } from "@cap/web-backend";
+import { Policy, type Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
+import { Effect, Exit } from "effect";
 import type { NextRequest } from "next/server";
+import * as EffectRuntime from "@/lib/server";
 
 export const dynamic = "force-dynamic";
 
@@ -23,7 +26,22 @@ export async function GET(request: NextRequest) {
 		);
 	}
 
-	const video = await db().select().from(videos).where(eq(videos.id, videoId));
+	const exit = await Effect.gen(function* () {
+		const videosPolicy = yield* VideosPolicy;
+
+		return yield* Effect.promise(() =>
+			db().select().from(videos).where(eq(videos.id, videoId)),
+		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
+	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+
+	if (Exit.isFailure(exit)) {
+		return Response.json(
+			{ error: true, message: "Video does not exist" },
+			{ status: 404 },
+		);
+	}
+
+	const video = exit.value;
 
 	if (video.length === 0 || !video[0]) {
 		return Response.json(

--- a/apps/web/app/api/video/transcribe/status/route.ts
+++ b/apps/web/app/api/video/transcribe/status/route.ts
@@ -11,35 +11,51 @@ import * as EffectRuntime from "@/lib/server";
 export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
-	const user = await getCurrentUser();
-	const url = new URL(request.url);
-	const videoId = url.searchParams.get("videoId") as Video.VideoId;
+	try {
+		const user = await getCurrentUser();
+		const url = new URL(request.url);
+		const videoId = url.searchParams.get("videoId") as Video.VideoId;
 
-	if (!user) {
-		return Response.json({ auth: false }, { status: 401 });
-	}
+		if (!user) {
+			return Response.json({ auth: false }, { status: 401 });
+		}
 
-	if (!videoId) {
-		return Response.json(
-			{ error: true, message: "videoId not supplied" },
-			{ status: 400 },
-		);
-	}
+		if (!videoId) {
+			return Response.json(
+				{ error: true, message: "videoId not supplied" },
+				{ status: 400 },
+			);
+		}
 
-	const exit = await Effect.gen(function* () {
-		const videosPolicy = yield* VideosPolicy;
+		const exit = await Effect.gen(function* () {
+			const videosPolicy = yield* VideosPolicy;
 
-		return yield* Effect.promise(() =>
-			db().select().from(videos).where(eq(videos.id, videoId)),
-		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
-	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+			return yield* Effect.promise(() =>
+				db().select().from(videos).where(eq(videos.id, videoId)),
+			).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
+		}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
 
-	if (Exit.isFailure(exit)) {
-		const error = Option.getOrUndefined(Cause.failureOption(exit.cause));
-		if (
-			Schema.is(Policy.PolicyDeniedError)(error) ||
-			Schema.is(Video.VerifyVideoPasswordError)(error)
-		) {
+		if (Exit.isFailure(exit)) {
+			const error = Option.getOrUndefined(Cause.failureOption(exit.cause));
+			if (
+				Schema.is(Policy.PolicyDeniedError)(error) ||
+				Schema.is(Video.VerifyVideoPasswordError)(error)
+			) {
+				return Response.json(
+					{ error: true, message: "Video does not exist" },
+					{ status: 404 },
+				);
+			}
+
+			return Response.json(
+				{ error: true, message: "An unexpected error occurred" },
+				{ status: 500 },
+			);
+		}
+
+		const video = exit.value;
+
+		if (video.length === 0 || !video[0]) {
 			return Response.json(
 				{ error: true, message: "Video does not exist" },
 				{ status: 404 },
@@ -47,22 +63,17 @@ export async function GET(request: NextRequest) {
 		}
 
 		return Response.json(
+			{ transcriptionStatus: video[0].transcriptionStatus },
+			{ status: 200 },
+		);
+	} catch (error) {
+		console.error(
+			"[transcribe status] Unexpected error checking video access:",
+			error,
+		);
+		return Response.json(
 			{ error: true, message: "An unexpected error occurred" },
 			{ status: 500 },
 		);
 	}
-
-	const video = exit.value;
-
-	if (video.length === 0 || !video[0]) {
-		return Response.json(
-			{ error: true, message: "Video does not exist" },
-			{ status: 404 },
-		);
-	}
-
-	return Response.json(
-		{ transcriptionStatus: video[0].transcriptionStatus },
-		{ status: 200 },
-	);
 }


### PR DESCRIPTION
Fixes #1623.

The AI metadata endpoint gained a VideosPolicy.canView check earlier, but /api/video/transcribe/status still looked videos up by id with no ownership or sharing check, so any signed-in user could poll any video's transcription status. This applies the same policy wrap used by the AI route: public or shared videos still work, everything else returns 404.

Validated with a scoped Biome check; the change mirrors the existing pattern in app/api/video/ai/route.ts.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The transcription-status endpoint now enforces the video-view policy before returning status.
- Preserves access for public, shared, and otherwise authorized videos.
- Returns 404 for policy or password denial and 500 for operational failures.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/api/video/transcribe/status/route.ts | Adds policy-gated video lookup and distinguishes access denial from operational failures, resolving the previously reported error-classification issue. |

<sub>Reviews (3): Last reviewed commit: ["fix(web): return clean 500 when transcri..."](https://github.com/capsoftware/cap/commit/f05789e1f336b94f92df0966945f9a49c9002cf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49534277)</sub>

**Context used:**

- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-app.md)

<!-- /greptile_comment -->