### PR TITLE
fix(web): auto-provision personal org when video create finds none

### DIFF
--- a/apps/web/__tests__/unit/desktop-video-create.test.ts
+++ b/apps/web/__tests__/unit/desktop-video-create.test.ts
@@ -1,0 +1,250 @@
+import { getCurrentUser } from "@cap/database/auth/session";
+import { Option } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const schema = {
+	organizations: { table: "organizations" },
+	organizationMembers: { table: "organizationMembers" },
+	users: { table: "users" },
+	videos: { table: "videos" },
+	videoUploads: { table: "videoUploads" },
+	importedVideos: { table: "importedVideos" },
+};
+
+const mockDb = {
+	select: vi.fn(),
+	from: vi.fn(),
+	innerJoin: vi.fn(),
+	insert: vi.fn(),
+	values: vi.fn(),
+	update: vi.fn(),
+	set: vi.fn(),
+	where: vi.fn(),
+	delete: vi.fn(),
+	for: vi.fn(),
+	limit: vi.fn(),
+	transaction: vi.fn(),
+};
+
+vi.mock("@cap/database", () => ({
+	db: () => mockDb,
+}));
+
+vi.mock("@cap/database/auth/session", () => ({
+	getCurrentUser: vi.fn(),
+}));
+
+vi.mock("@cap/database/schema", () => schema);
+
+vi.mock("@cap/database/emails/config", () => ({
+	sendEmail: vi.fn(),
+}));
+
+vi.mock("@cap/database/emails/first-shareable-link", () => ({
+	FirstShareableLink: () => null,
+}));
+
+vi.mock("@cap/env", () => ({
+	serverEnv: () => ({
+		CAP_VIDEOS_DEFAULT_PUBLIC: true,
+		WEB_URL: "https://cap.test",
+	}),
+	buildEnv: {
+		NEXT_PUBLIC_IS_CAP: true,
+		NEXT_PUBLIC_WEB_URL: "https://cap.test",
+	},
+}));
+
+vi.mock("@cap/utils", () => ({
+	userIsPro: vi.fn(() => true),
+}));
+
+vi.mock("@cap/web-backend", () => ({
+	Storage: {
+		getOrganizationWritableAccess: vi.fn(),
+		getS3WritableAccessForUser: vi.fn(),
+	},
+}));
+
+vi.mock("@/lib/server", () => ({
+	runPromise: vi.fn(async (value: unknown) => value),
+}));
+
+vi.mock("@/lib/video-storage", () => ({
+	decodeStorageVideo: vi.fn(() => null),
+}));
+
+vi.mock("@/lib/google-drive-storage-quota", () => ({
+	invalidateGoogleDriveStorageQuotaCache: vi.fn(),
+}));
+
+vi.mock("drizzle-orm", () => ({
+	and: vi.fn((...args: unknown[]) => args),
+	eq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
+	count: vi.fn(() => "count()"),
+	lte: vi.fn(() => "lte()"),
+}));
+
+const mockGetCurrentUser = getCurrentUser as ReturnType<typeof vi.fn>;
+const { Storage } = await import("@cap/web-backend");
+
+const effectLike = <T>(value: T) => ({
+	pipe: (fn: (value: T) => unknown) => fn(value),
+});
+
+function resetMockDb() {
+	for (const key of Object.keys(mockDb)) {
+		const fn = mockDb[key as keyof typeof mockDb];
+		if (typeof fn?.mockClear === "function") {
+			fn.mockClear();
+		}
+	}
+	mockDb.select.mockReturnValue(mockDb);
+	mockDb.from.mockReturnValue(mockDb);
+	mockDb.innerJoin.mockReturnValue(mockDb);
+	mockDb.insert.mockReturnValue(mockDb);
+	mockDb.values.mockResolvedValue([]);
+	mockDb.update.mockReturnValue(mockDb);
+	mockDb.set.mockReturnValue(mockDb);
+	mockDb.where.mockResolvedValue([]);
+	mockDb.for.mockResolvedValue([]);
+	mockDb.limit.mockResolvedValue([]);
+	mockDb.transaction.mockImplementation(
+		async (fn: (tx: typeof mockDb) => unknown) => fn(mockDb),
+	);
+}
+
+function insertedValues(table: unknown) {
+	const index = mockDb.insert.mock.calls.findIndex(([t]) => t === table);
+	if (index === -1) return undefined;
+	return mockDb.values.mock.calls[index]?.[0] as
+		| Record<string, unknown>
+		| undefined;
+}
+
+function stubStorage() {
+	const getOrganizationWritableAccess =
+		Storage.getOrganizationWritableAccess as ReturnType<typeof vi.fn>;
+	const getS3WritableAccessForUser =
+		Storage.getS3WritableAccessForUser as ReturnType<typeof vi.fn>;
+	getOrganizationWritableAccess.mockReturnValue(effectLike(Option.none()));
+	getS3WritableAccessForUser.mockReturnValue(
+		effectLike({
+			bucketId: Option.some("bucket-1"),
+			storageIntegrationId: Option.none(),
+		}),
+	);
+}
+
+describe("GET /create", () => {
+	let app: typeof import("@/app/api/desktop/[...route]/video")["app"];
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		resetMockDb();
+		stubStorage();
+		const mod = await import("@/app/api/desktop/[...route]/video");
+		app = mod.app;
+	});
+
+	it("provisions a personal org and creates the video there when the user has none", async () => {
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			email: "grant@cap.test",
+			defaultOrgId: null,
+			activeOrganizationId: "",
+		});
+		mockDb.where
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([{ count: 5 }]);
+
+		const response = await app.request("https://cap.test/create");
+
+		expect(response.status).toBe(200);
+		expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+
+		const orgValues = insertedValues(schema.organizations) as
+			| { id: string; ownerId: string; name: string }
+			| undefined;
+		expect(orgValues).toMatchObject({
+			ownerId: "user-1",
+			name: "My Organization",
+		});
+
+		expect(insertedValues(schema.organizationMembers)).toMatchObject({
+			userId: "user-1",
+			role: "owner",
+			organizationId: orgValues?.id,
+		});
+
+		expect(mockDb.set).toHaveBeenCalledWith(
+			expect.objectContaining({
+				activeOrganizationId: orgValues?.id,
+				defaultOrgId: orgValues?.id,
+			}),
+		);
+
+		expect(insertedValues(schema.videos)).toMatchObject({
+			orgId: orgValues?.id,
+			ownerId: "user-1",
+		});
+
+		const body = await response.json();
+		expect(body.id).toBeTruthy();
+	});
+
+	it("does not provision when the user already belongs to an org", async () => {
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			email: "someone@cap.test",
+			defaultOrgId: "org-1",
+			activeOrganizationId: "org-1",
+		});
+		mockDb.where
+			.mockResolvedValueOnce([
+				{ id: "org-1", name: "Acme", createdAt: new Date() },
+			])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([{ count: 5 }]);
+
+		const response = await app.request("https://cap.test/create");
+
+		expect(response.status).toBe(200);
+		expect(mockDb.transaction).not.toHaveBeenCalled();
+
+		expect(insertedValues(schema.videos)).toMatchObject({
+			orgId: "org-1",
+			ownerId: "user-1",
+		});
+	});
+
+	it("heals a dangling defaultOrgId when the user has no remaining orgs", async () => {
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			email: "grant@cap.test",
+			defaultOrgId: "org-stale",
+			activeOrganizationId: "",
+		});
+		mockDb.where
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([{ count: 5 }]);
+
+		const response = await app.request("https://cap.test/create");
+
+		expect(response.status).toBe(200);
+		expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+
+		const orgValues = insertedValues(schema.organizations) as
+			| { id: string }
+			| undefined;
+
+		expect(insertedValues(schema.videos)).toMatchObject({
+			orgId: orgValues?.id,
+		});
+	});
+});

--- a/apps/web/__tests__/unit/desktop-video-create.test.ts
+++ b/apps/web/__tests__/unit/desktop-video-create.test.ts
@@ -247,4 +247,92 @@ describe("GET /create", () => {
 			orgId: orgValues?.id,
 		});
 	});
+
+	it("routes a stale explicit orgId to the provisioned org when the user has none", async () => {
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			email: "grant@cap.test",
+			defaultOrgId: "org-stale",
+			activeOrganizationId: "",
+		});
+		mockDb.where
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([{ count: 5 }]);
+
+		const response = await app.request(
+			"https://cap.test/create?orgId=org-stale",
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+
+		const orgValues = insertedValues(schema.organizations) as
+			| { id: string }
+			| undefined;
+
+		expect(insertedValues(schema.videos)).toMatchObject({
+			orgId: orgValues?.id,
+		});
+
+		expect(mockDb.set).toHaveBeenCalledWith(
+			expect.objectContaining({ defaultOrgId: orgValues?.id }),
+		);
+	});
+
+	it("falls back to the default org when a stale explicit orgId is sent and the user still has orgs", async () => {
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			email: "someone@cap.test",
+			defaultOrgId: "org-1",
+			activeOrganizationId: "org-1",
+		});
+		mockDb.where
+			.mockResolvedValueOnce([
+				{ id: "org-1", name: "Acme", createdAt: new Date() },
+			])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([{ count: 5 }]);
+
+		const response = await app.request(
+			"https://cap.test/create?orgId=org-stale",
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockDb.transaction).not.toHaveBeenCalled();
+
+		expect(insertedValues(schema.videos)).toMatchObject({
+			orgId: "org-1",
+			ownerId: "user-1",
+		});
+	});
+
+	it("honours an explicit orgId the user belongs to", async () => {
+		mockGetCurrentUser.mockResolvedValue({
+			id: "user-1",
+			email: "someone@cap.test",
+			defaultOrgId: "org-1",
+			activeOrganizationId: "org-1",
+		});
+		mockDb.where
+			.mockResolvedValueOnce([
+				{ id: "org-1", name: "Acme", createdAt: new Date() },
+			])
+			.mockResolvedValueOnce([
+				{ id: "org-2", name: "Team", createdAt: new Date() },
+			])
+			.mockResolvedValueOnce([{ count: 5 }]);
+
+		const response = await app.request("https://cap.test/create?orgId=org-2");
+
+		expect(response.status).toBe(200);
+		expect(mockDb.transaction).not.toHaveBeenCalled();
+
+		expect(insertedValues(schema.videos)).toMatchObject({
+			orgId: "org-2",
+			ownerId: "user-1",
+		});
+	});
 });

--- a/apps/web/app/api/desktop/[...route]/video.ts
+++ b/apps/web/app/api/desktop/[...route]/video.ts
@@ -183,6 +183,35 @@ app.get(
 				ownedOrganizations,
 				memberOrganizations,
 			);
+
+			// Accounts can end up org-less (e.g. after declining a team invite or
+			// being removed from their last org); provision a personal org like
+			// signup does instead of failing every upload.
+			if (userOrganizations.length === 0) {
+				const organizationId = Organisation.OrganisationId.make(nanoId());
+				await db().transaction(async (tx) => {
+					await tx.insert(organizations).values({
+						id: organizationId,
+						ownerId: user.id,
+						name: "My Organization",
+					});
+					await tx.insert(organizationMembers).values({
+						id: nanoId(),
+						organizationId,
+						userId: user.id,
+						role: "owner",
+					});
+					await tx
+						.update(users)
+						.set({
+							activeOrganizationId: organizationId,
+							defaultOrgId: organizationId,
+						})
+						.where(eq(users.id, user.id));
+				});
+				userOrganizations.push({ id: organizationId, name: "My Organization" });
+			}
+
 			const userOrgIds = userOrganizations.map((org) => org.id);
 
 			let videoOrgId: Organisation.OrganisationId;

--- a/apps/web/app/api/desktop/[...route]/video.ts
+++ b/apps/web/app/api/desktop/[...route]/video.ts
@@ -215,10 +215,10 @@ app.get(
 			const userOrgIds = userOrganizations.map((org) => org.id);
 
 			let videoOrgId: Organisation.OrganisationId;
-			if (orgId) {
-				// Hard error if the user requested org is non-existent or they don't have access.
-				if (!userOrgIds.includes(orgId))
-					return c.json({ error: "forbidden_org" }, { status: 403 });
+			// Desktop persists orgId in settings and keeps sending it after the
+			// user leaves the org, so an unknown orgId falls back to the
+			// default/first org below instead of hard-failing every upload.
+			if (orgId && userOrgIds.includes(orgId)) {
 				videoOrgId = orgId;
 			} else if (user.defaultOrgId) {
 				// User's defaultOrgId is no longer valid, switch to first available org


### PR DESCRIPTION
User report: Instant Mode recordings on desktop fail with `Could not create the shareable link: AuthedApiError/Other: create_or_get_video/error/403 Forbidden` with body `{"error": "no_valid_org"}`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR repairs desktop video creation for users whose persisted organization is no longer accessible.
- Provisions a personal organization when the authenticated user has no organizations.
- Resolves stale desktop organization IDs to a currently accessible organization.
- Adds unit coverage for provisioning, stale IDs, defaults, and valid explicit selections.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; current organization selection no longer reuses the stale ID after provisioning or fallback.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/api/desktop/[...route]/video.ts | Provisions an organization before resolving the video target, so stale explicit and default IDs now resolve to a valid organization. |
| apps/web/__tests__/unit/desktop-video-create.test.ts | Covers org-less provisioning and the stale-ID recovery paths relevant to the previously reported failure. |

<sub>Reviews (2): Last reviewed commit: ["fix(web): fall back to default org when ..."](https://github.com/capsoftware/cap/commit/258cf36b214297f8e23cb1c87e1c3f5f7b8620e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49539915)</sub>

<!-- /greptile_comment -->