### PR TITLE
fix(web): require an explicit share for org video downloads

### DIFF
--- a/apps/web/__tests__/unit/video-download-permissions.test.ts
+++ b/apps/web/__tests__/unit/video-download-permissions.test.ts
@@ -1,0 +1,114 @@
+import type { Organisation, User, Video } from "@cap/web-domain";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const schema = {
+	organizationMembers: { table: "organizationMembers" },
+	sharedVideos: { table: "sharedVideos" },
+	spaceMembers: { table: "spaceMembers" },
+	spaceVideos: { table: "spaceVideos" },
+};
+
+vi.mock("@cap/database/schema", () => schema);
+
+// Each select() call resolves against the next queued result, and the table it
+// read is recorded so a test can assert which lookups actually happened.
+let queued: unknown[][] = [];
+const tablesRead: string[] = [];
+
+const mockDb = {
+	select: () => mockDb,
+	from: (table: { table: string }) => {
+		tablesRead.push(table.table);
+		return mockDb;
+	},
+	where: () => {
+		const rows = queued.shift() ?? [];
+		const result = Promise.resolve(rows) as Promise<unknown[]> & {
+			limit: () => Promise<unknown[]>;
+		};
+		result.limit = () => Promise.resolve(rows);
+		return result;
+	},
+};
+
+vi.mock("@cap/database", () => ({ db: () => mockDb }));
+
+const { canUserDownloadVideo } = await import(
+	"../../lib/video-download-permissions"
+);
+
+const OWNER = "user-owner" as User.UserId;
+const OTHER = "user-other" as User.UserId;
+const VIDEO = "video-1" as Video.VideoId;
+const VIDEO_ORG = "org-owning-the-video" as Organisation.OrganisationId;
+
+function call(userId: User.UserId) {
+	return canUserDownloadVideo({ userId, ownerId: OWNER, videoId: VIDEO });
+}
+
+describe("canUserDownloadVideo", () => {
+	beforeEach(() => {
+		queued = [];
+		tablesRead.length = 0;
+	});
+
+	it("allows the owner without querying shares", async () => {
+		expect(await call(OWNER)).toBe(true);
+		expect(tablesRead).toEqual([]);
+	});
+
+	// The video's own orgId must not grant download access: VideosPolicy.canView
+	// requires an explicit sharedVideos row, and no creation path writes one, so
+	// trusting orgId let org colleagues download videos they cannot open.
+	it("denies an org colleague when the video was never explicitly shared", async () => {
+		queued = [
+			[], // sharedVideos: no explicit org share
+			[], // spaceVideos: no space share
+		];
+
+		expect(await call(OTHER)).toBe(false);
+		expect(tablesRead).toContain("sharedVideos");
+		expect(tablesRead).not.toContain("organizationMembers");
+	});
+
+	it("allows a member of an org the video was explicitly shared with", async () => {
+		queued = [
+			[{ organizationId: VIDEO_ORG }], // sharedVideos
+			[{ id: "membership-1" }], // organizationMembers
+		];
+
+		expect(await call(OTHER)).toBe(true);
+		expect(tablesRead).toEqual(["sharedVideos", "organizationMembers"]);
+	});
+
+	it("denies a non-member even when the video is shared with some org", async () => {
+		queued = [
+			[{ organizationId: VIDEO_ORG }], // sharedVideos
+			[], // organizationMembers: not a member
+			[], // spaceVideos
+		];
+
+		expect(await call(OTHER)).toBe(false);
+	});
+
+	it("allows a member of a space the video was shared into", async () => {
+		queued = [
+			[], // sharedVideos
+			[{ spaceId: "space-1" }], // spaceVideos
+			[{ id: "space-membership-1" }], // spaceMembers
+		];
+
+		expect(await call(OTHER)).toBe(true);
+		expect(tablesRead).toContain("spaceMembers");
+	});
+
+	it("denies a non-member of the space the video was shared into", async () => {
+		queued = [
+			[], // sharedVideos
+			[{ spaceId: "space-1" }], // spaceVideos
+			[], // spaceMembers
+		];
+
+		expect(await call(OTHER)).toBe(false);
+	});
+});

--- a/apps/web/actions/videos/download.ts
+++ b/apps/web/actions/videos/download.ts
@@ -90,7 +90,6 @@ export async function getVideoDownloadInfo(
 		userId: user.id,
 		ownerId: video.ownerId,
 		videoId,
-		orgId: video.orgId,
 	});
 
 	if (!allowed) {

--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -801,7 +801,6 @@ async function AuthorizedContent({
 					userId,
 					ownerId: video.owner.id,
 					videoId,
-					orgId: video.orgId,
 				})
 			: false;
 

--- a/apps/web/lib/video-download-permissions.ts
+++ b/apps/web/lib/video-download-permissions.ts
@@ -5,19 +5,22 @@ import {
 	spaceMembers,
 	spaceVideos,
 } from "@cap/database/schema";
-import type { Organisation, User, Video } from "@cap/web-domain";
+import type { User, Video } from "@cap/web-domain";
 import { and, eq, inArray } from "drizzle-orm";
 
+// Download access must not be broader than view access. VideosPolicy.canView
+// grants org members access only through an explicit sharedVideos row (see
+// OrganisationsRepo.membershipForVideo), and no video-creation path writes one,
+// so trusting the video's own orgId here let colleagues download recordings
+// they cannot open.
 export async function canUserDownloadVideo({
 	userId,
 	ownerId,
 	videoId,
-	orgId,
 }: {
 	userId: User.UserId;
 	ownerId: User.UserId;
 	videoId: Video.VideoId;
-	orgId: Organisation.OrganisationId;
 }): Promise<boolean> {
 	if (userId === ownerId) return true;
 
@@ -26,20 +29,23 @@ export async function canUserDownloadVideo({
 		.from(sharedVideos)
 		.where(eq(sharedVideos.videoId, videoId));
 
-	const orgIds = [orgId, ...sharedOrgs.map((org) => org.organizationId)];
+	if (sharedOrgs.length > 0) {
+		const [orgMembership] = await db()
+			.select({ id: organizationMembers.id })
+			.from(organizationMembers)
+			.where(
+				and(
+					eq(organizationMembers.userId, userId),
+					inArray(
+						organizationMembers.organizationId,
+						sharedOrgs.map((org) => org.organizationId),
+					),
+				),
+			)
+			.limit(1);
 
-	const [orgMembership] = await db()
-		.select({ id: organizationMembers.id })
-		.from(organizationMembers)
-		.where(
-			and(
-				eq(organizationMembers.userId, userId),
-				inArray(organizationMembers.organizationId, orgIds),
-			),
-		)
-		.limit(1);
-
-	if (orgMembership) return true;
+		if (orgMembership) return true;
+	}
 
 	const sharedSpaces = await db()
 		.select({ spaceId: spaceVideos.spaceId })


### PR DESCRIPTION
Download access was broader than view access.

`VideosPolicy.canView` grants an org member access only through an explicit `sharedVideos` row (via `OrganisationsRepo.membershipForVideo`), and no video-creation path writes one, so a private recording is invisible to colleagues. `canUserDownloadVideo` additionally trusted the video's own `orgId`, which meant any member of the owner's organization could download any video created in that org, including ones they get a 404 on. `getVideoDownloadInfo` is a directly invocable server action with no second guard: it authenticates, calls this helper, and returns a signed S3 URL.

This drops `orgId` from the lookup so download requires an explicit org or space share. Owners keep access, explicit shares are unchanged, and no listing surface is affected (dashboard, folders and share page all join through `sharedVideos`).

### One deliberate behaviour change worth a decision

For **private** videos this is pure over-grant removal: the people who lose download already could not open the video.

For a **public** video owned by an org member that was never explicitly shared, org colleagues can view it (anyone can) and today can also download it; after this change they cannot. Note that anonymous viewers of that same public video already could not download it, since the share page only offers download to signed-in users who pass this check, so the result is consistent rather than novel. If we would rather public videos stay downloadable by anyone signed in, that should be an explicit `video.public` branch here rather than an implicit consequence of org membership.

Credit to @wasim-builds, who reported and fixed this in #2052. This version takes the permission change on its own, without the unrelated sdk-recorder edit, and replaces the test (the original had a broken import path and asserted by stringifying Drizzle internals).

Validated: the new test fails 3 of 6 cases against the old logic, including the exploit case, and passes here; full web unit suite 1256/1257, the one failure a pre-existing unrelated Slack manifest test; typecheck and Biome clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR narrows video-download authorization so organization membership grants access only when the video has an explicit organization share, matching existing view authorization.
- Removes the video's owning organization from download permission checks.
- Updates the server action and share page to use the narrowed helper signature.
- Adds unit coverage for owner, organization-share, and space-share permission states.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with download authorization now consistently requiring ownership or an explicit organization or space share.

The changed helper matches the repository's view-policy semantics, all current callers use its new signature, and no concrete regression remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/lib/video-download-permissions.ts | Removes implicit access through the video's owning organization while preserving owner and explicit organization or space-share access. |
| apps/web/actions/videos/download.ts | Updates the signed-download server action to call the narrowed permission helper without the video's organization ID. |
| apps/web/app/s/[videoId]/page.tsx | Updates share-page download availability to use the same explicit-share-only permission check. |
| apps/web/__tests__/unit/video-download-permissions.test.ts | Adds focused coverage for owner access, unshared organization colleagues, explicit organization shares, and space shares. |

<sub>Reviews (1): Last reviewed commit: ["fix(web): require an explicit share for ..."](https://github.com/capsoftware/cap/commit/2f0b713a21329dc434d2b5866ee43a94fab713c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49543176)</sub>

**Context used:**

- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-app.md)

<!-- /greptile_comment -->