### PR TITLE
fix(auth): expire login OTP codes after the advertised 10 minutes

### DIFF
--- a/apps/web/__tests__/unit/auth-options.test.ts
+++ b/apps/web/__tests__/unit/auth-options.test.ts
@@ -39,4 +39,17 @@ describe("authOptions", () => {
 
 		expect(providers).not.toContain("apple");
 	});
+
+	// Without an explicit maxAge next-auth falls back to 24 hours, which is far
+	// too long for a 6-digit code and contradicts what the OTP email tells users.
+	it("expires email verification codes after the advertised 10 minutes", () => {
+		const email = authOptions().providers.find(
+			(provider) => provider.id === "email",
+		);
+
+		expect(email).toBeDefined();
+		expect((email as { options?: { maxAge?: number } }).options?.maxAge).toBe(
+			10 * 60,
+		);
+	});
 });

--- a/packages/database/auth/auth-options.ts
+++ b/packages/database/auth/auth-options.ts
@@ -19,6 +19,8 @@ import { DrizzleAdapter } from "./drizzle-adapter.ts";
 
 export const maxDuration = 120;
 
+const OTP_CODE_MAX_AGE_SECONDS = 10 * 60;
+
 export async function decodeSessionToken(
 	params: JWTDecodeParams,
 ): Promise<JWT | null> {
@@ -108,6 +110,11 @@ export const authOptions = (): NextAuthOptions => {
 					},
 				}),
 				EmailProvider({
+					// next-auth defaults to 24h, but the code is 6 digits and the
+					// verify path has no attempt limiting, so a day-long window is a
+					// practical brute-force target. The OTP email and the dev console
+					// have always told users 10 minutes; this makes that true.
+					maxAge: OTP_CODE_MAX_AGE_SECONDS,
 					async generateVerificationToken() {
 						return crypto.randomInt(100000, 1000000).toString();
 					},
@@ -123,7 +130,9 @@ export const authOptions = (): NextAuthOptions => {
 							);
 							console.log(`📧 Email: ${identifier}`);
 							console.log(`🔢 Code: ${token}`);
-							console.log(`⏱  Expires in: 10 minutes`);
+							console.log(
+								`⏱  Expires in: ${OTP_CODE_MAX_AGE_SECONDS / 60} minutes`,
+							);
 							console.log(
 								"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
 							);


### PR DESCRIPTION
The email provider had no `maxAge`, so next-auth applied its 24 hour default to login codes. The code is 6 digits (900k values), the verify path has no attempt limiting, `proxy.ts` excludes `/api/auth/*` from middleware, and the only throttle is a 30 second client-side cooldown that is bypassed by calling the callback URL directly. A day-long window against that keyspace is a practical brute-force target.

The OTP email already tells users "This code will expire in 10 minutes" and the dev console prints the same, so this makes the implementation match the contract users are already given. No user-visible change, 144x smaller window.

Also derives the dev console message from the constant so the two cannot drift again, and adds a test pinning `maxAge`, since the failure mode here is silent: remove the line and next-auth quietly returns to 24 hours.

Validated: the new test fails when the `maxAge` line is removed and passes with it, auth-options suite 3/3, typecheck and Biome clean.

Follow-up worth tracking separately: shortening the window reduces exposure but does not close brute force. The durable fix is an attempt counter in `useVerificationToken` (works for self-hosted too) or Vercel Firewall rules for the `AUTH_OTP_VERIFY` and `AUTH_OTP_SEND` ids that already exist unused in `lib/rate-limit.ts`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns login OTP expiration with the advertised ten-minute lifetime.
- Adds an explicit ten-minute `maxAge` to the NextAuth email provider.
- Derives the development-console expiration message from the shared constant.
- Adds a unit test preventing regression to NextAuth’s longer default.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the implementation and regression test consistently enforcing the advertised ten-minute OTP lifetime.

The email provider now receives an explicit 600-second maximum age, the development message derives from the same constant, and the focused test pins the provider configuration without introducing a blocking failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/database/auth/auth-options.ts | Configures email verification tokens to expire after ten minutes and reuses that duration in development logging; no actionable issue found. |
| apps/web/__tests__/unit/auth-options.test.ts | Adds a focused regression test asserting the email provider’s explicit ten-minute maximum age; no actionable issue found. |

<sub>Reviews (1): Last reviewed commit: ["fix(auth): expire login OTP codes after ..."](https://github.com/capsoftware/cap/commit/36f8c4920a1dd33ed11b4c3da4053a2decf16341) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49543628)</sub>

<!-- /greptile_comment -->