### PR TITLE
fix(comments): require canView access before posting a comment

### DIFF
--- a/apps/web/actions/videos/new-comment.ts
+++ b/apps/web/actions/videos/new-comment.ts
@@ -55,7 +55,12 @@ export async function newComment(data: {
 		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
 	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
 
-	if (Exit.isFailure(accessExit) || accessExit.value.length === 0) {
+	if (Exit.isFailure(accessExit)) {
+		console.error("Video access check failed:", accessExit);
+		throw new Error("Video not found");
+	}
+
+	if (accessExit.value.length === 0) {
 		throw new Error("Video not found");
 	}
 

--- a/apps/web/actions/videos/new-comment.ts
+++ b/apps/web/actions/videos/new-comment.ts
@@ -51,7 +51,11 @@ export async function newComment(data: {
 	const accessExit = await Effect.gen(function* () {
 		const videosPolicy = yield* VideosPolicy;
 		return yield* Effect.promise(() =>
-			db().select({ id: videos.id }).from(videos).where(eq(videos.id, videoId)),
+			db()
+				.select({ id: videos.id })
+				.from(videos)
+				.where(eq(videos.id, videoId))
+				.limit(1),
 		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
 	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
 

--- a/apps/web/actions/videos/new-comment.ts
+++ b/apps/web/actions/videos/new-comment.ts
@@ -3,10 +3,11 @@
 import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { nanoId } from "@cap/database/helpers";
-import { comments } from "@cap/database/schema";
+import { comments, videos } from "@cap/database/schema";
 import { provideOptionalAuth, VideosPolicy } from "@cap/web-backend";
 import type { ImageUpload } from "@cap/web-domain";
 import { Comment, Policy, type Video } from "@cap/web-domain";
+import { eq } from "drizzle-orm";
 import { Effect, Exit } from "effect";
 import { revalidatePath } from "next/cache";
 import { createNotification } from "@/lib/Notification";
@@ -41,16 +42,20 @@ export async function newComment(data: {
 		throw new Error("Content and videoId are required");
 	}
 
-	// Authentication alone isn't authorization: without this, any logged-in
-	// user could comment on someone else's private video (CVE-worthy IDOR).
+	// Authentication alone isn't authorization: without this, any logged-in user could
+	// comment on someone else's private video by guessing its id.
+	//
+	// This also fetches the video row (rather than gating a no-op) because
+	// canView returns true for a nonexistent videoId by design, so a bogus id
+	// would otherwise reach the insert below.
 	const accessExit = await Effect.gen(function* () {
 		const videosPolicy = yield* VideosPolicy;
-		return yield* Effect.void.pipe(
-			Policy.withPublicPolicy(videosPolicy.canView(videoId)),
-		);
+		return yield* Effect.promise(() =>
+			db().select({ id: videos.id }).from(videos).where(eq(videos.id, videoId)),
+		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
 	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
 
-	if (Exit.isFailure(accessExit)) {
+	if (Exit.isFailure(accessExit) || accessExit.value.length === 0) {
 		throw new Error("Video not found");
 	}
 

--- a/apps/web/actions/videos/new-comment.ts
+++ b/apps/web/actions/videos/new-comment.ts
@@ -4,10 +4,13 @@ import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { nanoId } from "@cap/database/helpers";
 import { comments } from "@cap/database/schema";
+import { provideOptionalAuth, VideosPolicy } from "@cap/web-backend";
 import type { ImageUpload } from "@cap/web-domain";
-import { Comment, type Video } from "@cap/web-domain";
+import { Comment, Policy, type Video } from "@cap/web-domain";
+import { Effect, Exit } from "effect";
 import { revalidatePath } from "next/cache";
 import { createNotification } from "@/lib/Notification";
+import * as EffectRuntime from "@/lib/server";
 
 export async function newComment(data: {
 	content: string;
@@ -37,6 +40,20 @@ export async function newComment(data: {
 	if (!content || !videoId) {
 		throw new Error("Content and videoId are required");
 	}
+
+	// Authentication alone isn't authorization: without this, any logged-in
+	// user could comment on someone else's private video (CVE-worthy IDOR).
+	const accessExit = await Effect.gen(function* () {
+		const videosPolicy = yield* VideosPolicy;
+		return yield* Effect.void.pipe(
+			Policy.withPublicPolicy(videosPolicy.canView(videoId)),
+		);
+	}).pipe(provideOptionalAuth, EffectRuntime.runPromiseExit);
+
+	if (Exit.isFailure(accessExit)) {
+		throw new Error("Video not found");
+	}
+
 	const id = Comment.CommentId.make(nanoId());
 
 	const newComment = {


### PR DESCRIPTION
Closes #1982.

## Problem
The `newComment` server action inserted a comment for any authenticated user on any caller-supplied `videoId`, with no check that the caller can view the video. Any authenticated user could inject comments, replies, and reactions into other users' private videos (IDOR).

## Fix
Gate the insert on the existing view policy, following the exact pattern used in `get-transcript.ts` / `get-status.ts`: fetch the video id inside an `Effect.gen`, run it through `Policy.withPublicPolicy(videosPolicy.canView(videoId))`, and throw "Video not found" when the policy denies or the row does not exist. The id-only select doubles as an existence check, since `canView` returns true for nonexistent videos by design.

Denial is reported as "Video not found" rather than "Forbidden" so the endpoint does not become an existence oracle for private videos.

## Verification
- Every currently-working comment flow maps to a `canView` grant path: owner, org/space share, public video, password-protected (the verified `x-cap-password` cookie is attached by `CookiePasswordAttachmentLive` in the shared runtime), and email-restricted shares. Anonymous comments were never a working flow (the action already required auth).
- All other comment/reaction write paths (mobile, v1 agent API, delete routes) already enforce view access or ownership; this action was the only unguarded write.
- Scoped `biome check` passes.

Note: denied comments fail silently in the UI after an optimistic insert, which matches the pre-existing failure UX of this action. A sibling low-severity leak (per-day comment counts via dashboard analytics `capId`) was found during review and will be filed as a follow-up; it is out of scope here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR closes the comment-posting IDOR by requiring the authenticated caller to pass the existing video view policy and by verifying that the referenced video exists before insertion.
- Adds the shared `VideosPolicy.canView` authorization gate to `newComment`.
- Preserves non-disclosure behavior by reporting denied and nonexistent videos as "Video not found".
- Uses the shared Effect runtime so owner, organization, space, email-restricted, and password-authorized access contexts remain available.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and closes the unauthorized private-video comment path without breaking established access flows.

The new gate uses the repository's established optional-auth and password-aware Effect runtime pattern, denies callers who cannot view the video, and separately rejects nonexistent video IDs before insertion.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/actions/videos/new-comment.ts | Adds a policy-backed existence and view-access check before comment insertion; no actionable regression was identified. |

<sub>Reviews (1): Last reviewed commit: ["address review: cap existence check with..."](https://github.com/capsoftware/cap/commit/af6f11c2cb4b895d76b54cd47fecd59825307af0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49801262)</sub>

**Context used:**

- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-app.md)

<!-- /greptile_comment -->