### PR TITLE
fix(desktop): don't close picker webview before window screenshot

### DIFF
--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -694,8 +694,12 @@ function Inner() {
 												onRecordingStart={() => {
 													setOriginalCameraBounds(null);
 													if (options.mode === "screenshot") {
-														// The window variant has always dismissed the picker
-														// for screenshots too; keep that, tagged as such.
+														// Only mark the dismissal here. takeScreenshot is
+														// invoked from THIS webview right after, and closing
+														// destroys the webview before the invoke is dispatched,
+														// so the screenshot silently never happens. The start
+														// handler hides these windows and closes them once the
+														// capture is done.
 														if (options.targetModeSource === "editor") {
 															setOptions({
 																targetMode: null,
@@ -708,7 +712,6 @@ function Inner() {
 																targetModeDismissal: "screenshot",
 															});
 														}
-														commands.closeTargetSelectOverlays();
 													} else {
 														dismissPickerForRecordingStart();
 													}
@@ -2005,11 +2008,16 @@ function RecordingControls(props: {
 				if (shouldOpenEditor) {
 					await commands.showWindow({ ScreenshotEditor: { path } });
 				}
-				await commands.closeTargetSelectOverlays();
 			} catch (e) {
 				const message = e instanceof Error ? e.message : String(e);
 				toast.error(`Failed to take screenshot: ${message}`);
 				console.error("Failed to take screenshot", e);
+			} finally {
+				await commands
+					.closeTargetSelectOverlays()
+					.catch((e) =>
+						console.error("Failed to close target select overlays", e),
+					);
 			}
 			return;
 		}


### PR DESCRIPTION
Closes #2046.

## Problem
On Windows, taking a screenshot of a specific window silently never happened: no file written, no error, no log. The window variant's `onRecordingStart` called `closeTargetSelectOverlays()` while `options.mode === "screenshot"`. On Windows that command closes the overlay webviews (to release the DirectComposition surface) rather than hiding them, and `takeScreenshot` is invoked from that same webview immediately afterwards, so the webview was destroyed before the IPC call was dispatched.

## Fix
- Keep the picker webview alive until the screenshot request is dispatched (remove the premature close from the window-variant screenshot branch), matching the display-target flow that already works.
- Close the overlays after both successful and failed captures (move the post-capture close into a `finally`).
- Keep overlay-cleanup failures from masking the original screenshot error (`.catch(console.error)`).

## Verification
- The window variant already hides overlays via the frontend `win.hide()` plus the backend `hide_overlay()` + 150 ms settle inside `take_screenshot`, identical to the display flow, so this change does not extend the time a hidden overlay could be captured.
- All `closeTargetSelectOverlays` / `takeScreenshot` call sites audited: recording modes and the area-screenshot path are untouched.
- Scoped `biome check` passes.

Known pre-existing gaps, out of scope: on failure the toast renders in an already-hidden webview, and the area-screenshot path only closes overlays on success. Worth a follow-up issue.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the desktop window-screenshot lifecycle by keeping the picker webview alive until screenshot IPC is dispatched.
- Removes premature overlay closure from the window-target screenshot callback.
- Moves overlay cleanup into `finally` so it runs after successful and failed captures.
- Prevents cleanup errors from replacing the original screenshot failure.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because screenshot dispatch now completes before overlay destruction while cleanup still runs on both success and failure.

The selected target is preserved before dismissal, overlays are hidden before capture by both frontend and backend paths, and post-capture cleanup errors are contained without masking screenshot failures.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/target-select-overlay.tsx | Defers picker-overlay closure until after screenshot capture and makes cleanup failure-safe; no actionable changed-code defect was identified. |

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): don&#39;t close picker webview..."](https://github.com/capsoftware/cap/commit/144018b4fae12ace39ab268a83f1eec331f16225) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49801401)</sub>

**Context used:**

- Knowledge Base — [Desktop Frontend (apps/desktop/src)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-frontend.md)

<!-- /greptile_comment -->