### PR TITLE
fix(web): point support page email at hello@cap.so

### DIFF
--- a/apps/web/app/(site)/support/page.tsx
+++ b/apps/web/app/(site)/support/page.tsx
@@ -5,7 +5,7 @@ import { buildMarketingMetadata } from "@/lib/og/url";
 export const metadata: Metadata = buildMarketingMetadata({
 	title: "Support — Cap",
 	description:
-		"Get help with Cap. Join our Discord community, email support@cap.so, read the docs, or report an issue on GitHub.",
+		"Get help with Cap. Join our Discord community, email hello@cap.so, read the docs, or report an issue on GitHub.",
 	path: "/support",
 	ogTitle: "Get help with Cap",
 	ogTag: "Support",

--- a/apps/web/components/pages/SupportPage.tsx
+++ b/apps/web/components/pages/SupportPage.tsx
@@ -34,8 +34,8 @@ const supportChannels: SupportChannel[] = [
 		description:
 			"Have a question, billing issue, or something you'd rather keep private? Send us an email and we'll get back to you.",
 		icon: Mail,
-		href: "mailto:support@cap.so",
-		cta: "support@cap.so",
+		href: "mailto:hello@cap.so",
+		cta: "hello@cap.so",
 	},
 	{
 		title: "Read the docs",


### PR DESCRIPTION
support@cap.so bounces (not a provisioned mailbox), and the support page was the only surface still linking it - both the mailto card in `SupportPage.tsx` and the page metadata description. Every other reference (footer, privacy, DPA, 404 page) already uses hello@cap.so.

Reported by a customer who emailed support@cap.so from the help page and got a bounce-back.

Copy-only change, no logic touched.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the public support page to use the provisioned hello@cap.so mailbox instead of the bouncing support@cap.so address.
- Updates the support-page metadata description.
- Updates both the visible email CTA and its mailto target.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The copy-only replacements consistently use the repository’s established hello@cap.so contact address in metadata, visible text, and the mailto destination, with no functional regression identified.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/(site)/support/page.tsx | Correctly updates the support metadata description to the canonical hello@cap.so address. |
| apps/web/components/pages/SupportPage.tsx | Correctly keeps the displayed support address and mailto destination aligned on hello@cap.so. |

<sub>Reviews (1): Last reviewed commit: ["fix(web): point support page email at he..."](https://github.com/capsoftware/cap/commit/c3efe722793aee5899320712a4b8d49dcc2f8f0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50174474)</sub>

<!-- /greptile_comment -->