### PR TITLE
fix(web): make bulk Loom CSV import resilient to batch failures

### DIFF
--- a/apps/web/app/(org)/dashboard/import/loom/ImportLoomPage.tsx
+++ b/apps/web/app/(org)/dashboard/import/loom/ImportLoomPage.tsx
@@ -80,6 +80,8 @@ const MAX_SPACE_NAME_LENGTH = 255;
 const MAX_LOOM_CSV_IMPORT_ROWS = 500;
 const LOOM_CSV_BATCH_SIZE = 10;
 const LOOM_CSV_BATCH_DELAY_MS = 1500;
+const LOOM_CSV_RATE_LIMIT_RETRY_DELAY_MS = 30000;
+const LOOM_CSV_NOT_ATTEMPTED_MESSAGE = "Not attempted.";
 const LOOM_CSV_LIMIT_MESSAGE =
 	"CSV imports are limited to 500 videos at a time. Contact support to raise this limit.";
 const LOOM_CSV_PERMISSION_MESSAGE =
@@ -113,6 +115,89 @@ function buildCsvImportResult(
 			error ??
 			(importedCount > 0 ? undefined : "No Loom videos were imported."),
 	};
+}
+
+function buildRowFailure(
+	row: MappedRow,
+	error: string,
+): LoomCsvImportRowResult {
+	return {
+		rowNumber: row.rowNumber,
+		userEmail: row.userEmail,
+		spaceName: row.spaceName || undefined,
+		success: false,
+		error,
+	};
+}
+
+function withNotAttemptedRows(
+	rows: MappedRow[],
+	results: LoomCsvImportRowResult[],
+): LoomCsvImportRowResult[] {
+	const attempted = new Set(results.map((row) => row.rowNumber));
+	const missing = rows.filter((row) => !attempted.has(row.rowNumber));
+	if (missing.length === 0) return results;
+
+	return [
+		...results,
+		...missing.map((row) =>
+			buildRowFailure(row, LOOM_CSV_NOT_ATTEMPTED_MESSAGE),
+		),
+	].sort((a, b) => a.rowNumber - b.rowNumber);
+}
+
+function isRateLimitError(message: string | undefined) {
+	if (!message) return false;
+	const normalized = message.toLowerCase();
+	return normalized.includes("rate limit") || normalized.includes("too many");
+}
+
+function rateLimitedBatchRows(
+	batch: MappedRow[],
+	results: LoomCsvImportRowResult[],
+) {
+	const limited = new Set(
+		results
+			.filter((row) => !row.success && isRateLimitError(row.error))
+			.map((row) => row.rowNumber),
+	);
+	return batch.filter((row) => limited.has(row.rowNumber));
+}
+
+function importErrorMessage(error: unknown) {
+	return error instanceof Error && error.message
+		? error.message
+		: "The import request failed for this batch.";
+}
+
+function escapeCsvValue(value: string) {
+	if (/[",\n\r]/.test(value)) {
+		return `"${value.replace(/"/g, '""')}"`;
+	}
+	return value;
+}
+
+function buildResultsCsv(
+	results: LoomCsvImportRowResult[],
+	sourceRows: MappedRow[],
+) {
+	const rowsByNumber = new Map(sourceRows.map((row) => [row.rowNumber, row]));
+	const lines = [
+		["row", "loom_video_url", "user_email", "space_name", "status", "error"],
+		...results.map((row) => [
+			String(row.rowNumber),
+			rowsByNumber.get(row.rowNumber)?.loomUrl ?? "",
+			row.userEmail,
+			row.spaceName ?? "",
+			row.success
+				? "started"
+				: row.error === LOOM_CSV_NOT_ATTEMPTED_MESSAGE
+					? "not_attempted"
+					: "failed",
+			row.error ?? "",
+		]),
+	];
+	return `${lines.map((line) => line.map(escapeCsvValue).join(",")).join("\n")}\n`;
 }
 
 function parseCsvRecords(text: string) {
@@ -261,6 +346,7 @@ export const ImportLoomPage = () => {
 	const [isCsvImporting, setIsCsvImporting] = useState(false);
 	const [csvImportProgress, setCsvImportProgress] = useState(0);
 	const [result, setResult] = useState<LoomCsvImportResult | null>(null);
+	const importRowsRef = useRef<MappedRow[]>([]);
 
 	const selectedColumnValues = [
 		mapping.loomUrl,
@@ -461,27 +547,71 @@ export const ImportLoomPage = () => {
 
 		if (!activeOrganization || !canImport) return;
 
+		const orgId = activeOrganization.organization.id;
+		const importRows = readyRows;
+		importRowsRef.current = importRows;
+		let combinedResults: LoomCsvImportRowResult[] = [];
+
 		setIsCsvImporting(true);
 		setResult(null);
 		setCsvImportProgress(0);
 
 		try {
-			const batches = chunkRows(readyRows, LOOM_CSV_BATCH_SIZE);
-			let combinedResults: LoomCsvImportRowResult[] = [];
+			const batches = chunkRows(importRows, LOOM_CSV_BATCH_SIZE);
 			let blockedError: string | undefined;
 
 			for (const [batchIndex, batch] of batches.entries()) {
-				const importResult = await importFromLoomCsv({
-					orgId: activeOrganization.organization.id,
-					rows: batch,
-				});
+				let batchResults: LoomCsvImportRowResult[];
+				let retryRows: MappedRow[] = [];
 
-				if (importResult.results.length === 0 && importResult.error) {
-					blockedError = importResult.error;
-					break;
+				try {
+					const importResult = await importFromLoomCsv({
+						orgId,
+						rows: batch,
+					});
+
+					if (importResult.results.length === 0 && importResult.error) {
+						blockedError = importResult.error;
+						const message = importResult.error;
+						combinedResults = [
+							...combinedResults,
+							...batch.map((row) => buildRowFailure(row, message)),
+						];
+						setCsvImportProgress(combinedResults.length);
+						break;
+					}
+
+					batchResults = importResult.results;
+					retryRows = rateLimitedBatchRows(batch, batchResults);
+				} catch (error) {
+					const message = importErrorMessage(error);
+					batchResults = batch.map((row) => buildRowFailure(row, message));
+					if (isRateLimitError(message)) retryRows = batch;
 				}
 
-				combinedResults = [...combinedResults, ...importResult.results];
+				if (retryRows.length > 0) {
+					await delay(LOOM_CSV_RATE_LIMIT_RETRY_DELAY_MS);
+
+					try {
+						const retryResult = await importFromLoomCsv({
+							orgId,
+							rows: retryRows,
+						});
+
+						if (retryResult.results.length > 0) {
+							const retriedByRowNumber = new Map(
+								retryResult.results.map((row) => [row.rowNumber, row]),
+							);
+							batchResults = batchResults.map(
+								(row) => retriedByRowNumber.get(row.rowNumber) ?? row,
+							);
+						}
+					} catch {
+						// Keep the first attempt's failures for this batch.
+					}
+				}
+
+				combinedResults = [...combinedResults, ...batchResults];
 				setCsvImportProgress(combinedResults.length);
 				setResult(buildCsvImportResult(combinedResults));
 
@@ -490,7 +620,10 @@ export const ImportLoomPage = () => {
 				}
 			}
 
-			const finalResult = buildCsvImportResult(combinedResults, blockedError);
+			const finalResult = buildCsvImportResult(
+				withNotAttemptedRows(importRows, combinedResults),
+				blockedError,
+			);
 			setResult(finalResult);
 
 			if (finalResult.importedCount > 0) {
@@ -508,10 +641,28 @@ export const ImportLoomPage = () => {
 
 			setConfirmOpen(false);
 		} catch {
+			setResult(
+				buildCsvImportResult(withNotAttemptedRows(importRows, combinedResults)),
+			);
 			toast.error("An unexpected error occurred. Please try again.");
 		} finally {
 			setIsCsvImporting(false);
 		}
+	};
+
+	const handleResultsDownload = () => {
+		if (!result) return;
+
+		const blob = new Blob(
+			[buildResultsCsv(result.results, importRowsRef.current)],
+			{ type: "text/csv;charset=utf-8" },
+		);
+		const url = URL.createObjectURL(blob);
+		const link = document.createElement("a");
+		link.href = url;
+		link.download = "cap-loom-import-results.csv";
+		link.click();
+		URL.revokeObjectURL(url);
 	};
 
 	return (
@@ -906,7 +1057,7 @@ export const ImportLoomPage = () => {
 											{pluralize(result.failedCount, "failed", "failed")}
 										</p>
 									</div>
-									<div className="flex gap-2 items-center">
+									<div className="flex flex-wrap gap-2 items-center">
 										<StatusPill
 											ready
 											label={`${result.importedCount} started`}
@@ -917,6 +1068,17 @@ export const ImportLoomPage = () => {
 												label={`${result.failedCount} failed`}
 											/>
 										)}
+										<Button
+											type="button"
+											variant="white"
+											size="sm"
+											onClick={handleResultsDownload}
+											disabled={isCsvImporting}
+											className="flex-shrink-0"
+										>
+											<FontAwesomeIcon className="size-3.5" icon={faDownload} />
+											Download Results
+										</Button>
 									</div>
 								</div>
 								<div className="overflow-hidden">


### PR DESCRIPTION
## Problem

The bulk Loom CSV importer sends rows to `importFromLoomCsv` in batches of 10, but the entire multi-batch loop ran inside a single try/catch. One failed batch call (server error, timeout, network blip, rate-limit rejection) aborted the loop: every remaining batch was never attempted and never appeared in the results table, not even as failed. On large CSVs this silently dropped most rows - the UI reported only the imports from the batches that ran, with no record of the rest anywhere.

Bulk imports also share a per-user rate limit, which large CSVs can exhaust mid-run, making this failure mode common rather than exotic.

## Fix

All changes are client-side in `ImportLoomPage.tsx`; the server action, rate-limit code, and single-video import path are untouched.

- **Per-batch error isolation.** Each batch call now has its own try/catch. A failed batch is recorded as failed rows (carrying the error message) and the loop continues with the remaining batches.
- **Every row is always accounted for.** Rows that were never attempted (blocked run, unexpected interruption) are appended to the results as "Not attempted." instead of vanishing. The final results always cover the full CSV.
- **Rate-limit backoff.** When a batch failure looks like rate limiting (per-row "Too many..." errors, or a thrown rate-limit-shaped error), the client waits 30s and retries once - only the rate-limited rows - before recording the failure and moving on. The server rejects rate-limited rows before creating anything, and dedupes already-imported Loom IDs, so the retry cannot create duplicates.
- **Downloadable results CSV.** A "Download Results" button on the results card exports the full per-row outcome (row number, Loom URL, email, space, status, error) as a client-generated blob. The headers match the import template, so failed/not-attempted rows can be filtered and re-uploaded directly to retry.

## Regression analysis

What could have regressed, and why it can't:

- **Successful runs.** The happy path is unchanged: same batch size (10), same 1.5s cadence, same server calls in the same order, same per-batch progress and results rendering, same toasts and `router.refresh()`. The not-attempted fill is a no-op when every row has a result (early return before any sort), and the retry block never executes when no row failed with a rate-limit error. The only visible addition on success is the Download Results button.
- **Duplicate imports from retries.** Retries resend only rows whose result was a rate-limit failure. Those rows are rejected server-side before any DB write, so nothing was created on the first attempt. Independently, the server's `importedVideos` dedupe rejects any Loom ID already imported for the org. Successful rows in a partially rate-limited batch are never resent.
- **Server behavior.** `actions/loom.ts` is untouched; server-action tests (`loom-import.test.ts`, 12 tests) pass unchanged.
- **Other consumers.** Every new helper is module-private to `ImportLoomPage.tsx`, and the component's only consumer is its route page. The single-video import handler, CSV parsing/mapping/preview, and shared `@cap/ui` components are behaviorally untouched (one layout class, `flex-wrap`, added to the results-card header so the new button wraps on narrow screens).
- **Blocked runs (permission/plan/limit errors).** Previously the loop broke and only a toast showed; the toast logic is unchanged, but the blocked batch's rows now appear as failed and the rest as not attempted - strictly more information, no removed behavior.
- **Worst-case duration.** The backoff adds at most one 30s wait + one retry call per batch, only while failures look like rate limiting; the run still terminates and the results table updates live throughout.

## Verification

- `pnpm typecheck` (next typegen + `tsc -b`): pass
- `pnpm exec biome check` on the changed file: clean
- `vitest run __tests__/unit/loom-import.test.ts`: 12/12 pass (server action unchanged)
- No existing tests cover the client page component itself

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes bulk Loom CSV imports continue after individual batch failures, retries rate-limited rows once, accounts for unattempted rows, and adds a downloadable result report.
- Isolates failures and maintains progress per batch.
- Retries only rows identified as rate-limited after a fixed backoff.
- Produces complete result accounting and a client-generated CSV download.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking CSV-formula hardening issue in the new results download.

Batch and retry result accounting preserves submitted row numbers and failed outcomes, while the remaining concern is that imported email and space-name values can be emitted as active spreadsheet formulas.

**Files Needing Attention:** apps/web/app/(org)/dashboard/import/loom/ImportLoomPage.tsx

<details open><summary><h3>Security Review</h3></summary>

The downloadable results CSV does not neutralize formula-prefixed email or space-name values before spreadsheet consumption.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/(org)/dashboard/import/loom/ImportLoomPage.tsx | The batch-failure and retry accounting is consistent with the server action contract, but the new results exporter should neutralize spreadsheet formulas in imported fields. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/app/(org)/dashboard/import/loom/ImportLoomPage.tsx:173-178
**Neutralize formulas in CSV cells**

Formula-prefixed email and space-name values pass the current validation and are written directly to the downloadable CSV. Opening that file in formula-evaluating spreadsheet software interprets those values as formulas rather than literal data, so the exporter should neutralize spreadsheet control prefixes while preserving the intended retry workflow.

**How this was verified:** The imported fields flow through `buildResultsCsv` to `escapeCsvValue`, which escapes CSV delimiters but does not neutralize leading formula characters.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): make bulk Loom CSV import resi..."](https://github.com/capsoftware/cap/commit/4d32a83f720d2de76379de8d4c59b03adc7b695f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50185308)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->