### PR TITLE
fix(web): correct seat usage copy to say the owner uses a seat

### DIFF
--- a/apps/web/app/(org)/dashboard/settings/organization/components/SeatManagementCard.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/SeatManagementCard.tsx
@@ -118,12 +118,12 @@ export function SeatManagementCard() {
 					<span>
 						<span className="font-medium text-gray-12">{proSeatsUsed}</span> of{" "}
 						<span className="font-medium text-gray-12">{proSeatsTotal}</span>{" "}
-						Pro seats assigned to members
+						Pro seats in use
 					</span>
 					{activeOrganization?.ownerIsPro && (
 						<span className="text-xs text-gray-10">
-							The organization owner is always on Cap Pro and doesn't use a
-							seat.
+							The organization owner is always on Cap Pro and uses one of your
+							seats.
 						</span>
 					)}
 				</div>


### PR DESCRIPTION
The seat management card said the organization owner "doesn't use a seat", but the seat math has always counted the owner against the purchased quantity (`calculateProSeats` counts the owner whenever `ownerIsPro`, and `inviteQuota` mirrors the Stripe subscription quantity). A user reasonably read the two together as a billing bug: their dashboard showed "2 of 12 assigned" with only one member toggled on.

The counting is intentional (the subscription quantity is the total number of Pro users including the owner), so this fixes the copy to match:

- "Pro seats assigned to members" -> "Pro seats in use" (the count includes the owner, who is not an assignable member)
- "The organization owner is always on Cap Pro and doesn't use a seat." -> "...and uses one of your seats."

No logic changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the organization seat-management copy to clarify that Pro-seat usage includes the owner.
- Renames the utilization label from “Pro seats assigned to members” to “Pro seats in use.”
- States that a Pro organization owner uses one of the purchased seats.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the revised copy matches the existing seat-counting behavior.

The owner is added to the organization membership used by the seat calculation, and the explanatory sentence is shown only when the owner is on Pro, so the copy consistently describes the displayed utilization.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/(org)/dashboard/settings/organization/components/SeatManagementCard.tsx | Updates two user-facing labels so the displayed explanation matches the existing owner-inclusive seat calculation; no actionable issue found. |

<sub>Reviews (1): Last reviewed commit: ["fix(web): correct seat usage copy to say..."](https://github.com/capsoftware/cap/commit/78e8ae54baae1a525f3f1e0eccbb2fe5f180c87a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50456245)</sub>

<!-- /greptile_comment -->