### PR TITLE
fix(web): always render DNS records in custom domain setup

### DIFF
--- a/apps/web/actions/organization/domain-utils.ts
+++ b/apps/web/actions/organization/domain-utils.ts
@@ -1,3 +1,20 @@
+import { parse } from "tldts";
+
+const VERCEL_CNAME_TARGET = "cname.vercel-dns.com";
+const VERCEL_A_RECORD = "76.76.21.21";
+
+export const isSubdomain = (raw: string): boolean => {
+	const input =
+		raw
+			.trim()
+			.replace(/^https?:\/\//i, "")
+			.split("/")[0] ?? "";
+	if (!input) return false;
+	const host = (input.replace(/\.$/, "").split(":")[0] || "").toLowerCase();
+	const { subdomain } = parse(host);
+	return Boolean(subdomain);
+};
+
 export const getConfigResponse = async (domain: string) => {
 	const response = await fetch(
 		`https://api.vercel.com/v6/domains/${domain.toLowerCase()}/config?teamId=${
@@ -61,6 +78,22 @@ export const addDomain = async (domain: string) => {
 			},
 			body: JSON.stringify({ name: domain }),
 			cache: "no-store",
+		},
+	).then((res) => res.json());
+
+	return response;
+};
+
+export const removeDomain = async (domain: string) => {
+	const response = await fetch(
+		`https://api.vercel.com/v9/projects/${
+			process.env.VERCEL_PROJECT_ID
+		}/domains/${domain.toLowerCase()}?teamId=${process.env.VERCEL_TEAM_ID}`,
+		{
+			method: "DELETE",
+			headers: {
+				Authorization: `Bearer ${process.env.VERCEL_AUTH_TOKEN}`,
+			},
 		},
 	).then((res) => res.json());
 
@@ -162,9 +195,28 @@ export const checkDomainStatus = async (domain: string) => {
 			verified = verificationJson?.verified;
 		}
 
-		// Get the current and required A records
 		const currentAValues = configJson.aValues || [];
-		const requiredAValue = requiredConfigJson.aValues?.[0];
+		const subdomain = isSubdomain(domain);
+
+		// Vercel's recommendations are the source of truth, but the config
+		// endpoint can omit them (e.g. for domains not using Vercel DNS). Fall
+		// back to the well-known Vercel targets so the setup UI always has a
+		// record to display instead of rendering empty.
+		let recommendedCNAME: Array<{ rank: number; value: string }> =
+			configJson.recommendedCNAME || [];
+		let recommendedIPv4: Array<{ rank: number; value: string[] | string }> =
+			configJson.recommendedIPv4 || [];
+
+		if (subdomain && recommendedCNAME.length === 0) {
+			recommendedCNAME = [{ rank: 0, value: VERCEL_CNAME_TARGET }];
+		}
+		if (!subdomain && recommendedIPv4.length === 0) {
+			recommendedIPv4 = [{ rank: 0, value: [VERCEL_A_RECORD] }];
+		}
+
+		const requiredAValue =
+			requiredConfigJson.aValues?.[0] ??
+			(!subdomain ? VERCEL_A_RECORD : undefined);
 
 		return {
 			verified,
@@ -173,10 +225,13 @@ export const checkDomainStatus = async (domain: string) => {
 				verification: domainJson?.verification || [],
 				currentAValues,
 				requiredAValue,
+				recommendedCNAME,
+				recommendedIPv4,
 			},
 			status: domainJson,
 		};
-	} catch (_error) {
+	} catch (error) {
+		console.error("checkDomainStatus failed", { domain, error });
 		return {
 			verified: false,
 			error: "Failed to check domain status",

--- a/apps/web/actions/organization/remove-domain.ts
+++ b/apps/web/actions/organization/remove-domain.ts
@@ -7,6 +7,7 @@ import type { Organisation } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { requireOrganizationSettingsManager } from "./authorization";
+import { removeDomain } from "./domain-utils";
 
 export async function removeOrganizationDomain(
 	organizationId: Organisation.OrganisationId,
@@ -28,19 +29,7 @@ export async function removeOrganizationDomain(
 
 	try {
 		if (organization.customDomain) {
-			await fetch(
-				`https://api.vercel.com/v9/projects/${
-					process.env.VERCEL_PROJECT_ID
-				}/domains/${organization.customDomain.toLowerCase()}?teamId=${
-					process.env.VERCEL_TEAM_ID
-				}`,
-				{
-					method: "DELETE",
-					headers: {
-						Authorization: `Bearer ${process.env.VERCEL_AUTH_TOKEN}`,
-					},
-				},
-			);
+			await removeDomain(organization.customDomain);
 		}
 
 		await db()

--- a/apps/web/actions/organization/update-domain.ts
+++ b/apps/web/actions/organization/update-domain.ts
@@ -24,6 +24,8 @@ export async function updateDomain(
 		throw new Error("User is not subscribed");
 	}
 
+	const normalizedDomain = domain.trim().toLowerCase();
+
 	const [organization] = await db()
 		.select()
 		.from(organizations)
@@ -37,7 +39,7 @@ export async function updateDomain(
 	const existingDomain = await db()
 		.select()
 		.from(organizations)
-		.where(eq(organizations.customDomain, domain))
+		.where(eq(organizations.customDomain, normalizedDomain))
 		.limit(1);
 
 	if (existingDomain.length > 0 && existingDomain[0]?.id !== organizationId) {
@@ -45,7 +47,7 @@ export async function updateDomain(
 	}
 
 	try {
-		const addDomainResponse = await addDomain(domain);
+		const addDomainResponse = await addDomain(normalizedDomain);
 
 		if (addDomainResponse.error) {
 			throw new Error(addDomainResponse.error.message);
@@ -54,12 +56,12 @@ export async function updateDomain(
 		await db()
 			.update(organizations)
 			.set({
-				customDomain: domain,
+				customDomain: normalizedDomain,
 				domainVerified: null,
 			})
 			.where(eq(organizations.id, organizationId));
 
-		const status = await checkDomainStatus(domain);
+		const status = await checkDomainStatus(normalizedDomain);
 
 		if (status.verified) {
 			await db()

--- a/apps/web/app/(org)/dashboard/settings/organization/components/CustomDomainDialog/VerifyStep.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/CustomDomainDialog/VerifyStep.tsx
@@ -99,6 +99,14 @@ const VerifyStep = ({
 		hasRecommendedCNAME && !cnameConfigured && isSubdomain(domain);
 	const showTXTRecord = hasTXTVerification && !isVerified;
 
+	const showFallbackRecords =
+		!showTXTRecord &&
+		!showARecord &&
+		!showCNAMERecord &&
+		!aRecordConfigured &&
+		!cnameConfigured;
+	const fallbackIsSubdomain = isSubdomain(domain);
+
 	const handleCopy = async (text: string, fieldId: string) => {
 		try {
 			await navigator.clipboard.writeText(text);
@@ -145,6 +153,13 @@ const VerifyStep = ({
 			{initialConfigLoading && !domainConfig ? (
 				<div className="flex justify-center items-center w-full h-20">
 					<LoadingSpinner size={36} />
+				</div>
+			) : !isVerified && !domainConfig ? (
+				<div className="px-4 py-3 text-center rounded-lg border border-gray-4 bg-gray-2">
+					<p className="text-sm text-gray-11">
+						We couldn't load the DNS configuration for this domain. Use Check
+						Status to try again.
+					</p>
 				</div>
 			) : (
 				!isVerified &&
@@ -428,6 +443,73 @@ const VerifyStep = ({
 													</div>
 												);
 											})}
+									</dl>
+								</div>
+							</div>
+						)}
+
+						{/* Fallback when Vercel returned no recommendations */}
+						{showFallbackRecords && (
+							<div className="overflow-hidden rounded-lg border border-gray-4">
+								<div className="px-4 py-3 border-b bg-gray-2 border-gray-4">
+									<p className="font-medium text-md text-gray-12">
+										{fallbackIsSubdomain
+											? "CNAME Record Configuration"
+											: "A Record Configuration"}
+									</p>
+									<p className="mt-1 text-sm text-gray-10">
+										Add this record to your domain:
+									</p>
+								</div>
+								<div className="px-4 py-3">
+									<dl className="grid gap-4">
+										<div className="grid grid-cols-[100px,1fr] items-center">
+											<dt className="text-sm font-medium text-gray-12">Type</dt>
+											<dd className="text-sm text-gray-10">
+												{fallbackIsSubdomain ? "CNAME" : "A"}
+											</dd>
+										</div>
+										<div className="grid grid-cols-[100px,1fr] items-center">
+											<dt className="text-sm font-medium text-gray-12">Name</dt>
+											<dd className="text-sm text-gray-10">
+												<code className="px-2 py-1 text-xs rounded bg-gray-4">
+													{fallbackIsSubdomain ? domain.split(".")[0] : "@"}
+												</code>
+											</dd>
+										</div>
+										<div className="grid grid-cols-[100px,1fr] items-center">
+											<dt className="text-sm font-medium text-gray-12">
+												Value
+											</dt>
+											<dd className="text-sm text-gray-10">
+												<div className="flex items-center justify-between gap-1.5 bg-gray-3 px-2 py-1 rounded-lg flex-1 min-w-0 border border-gray-4">
+													<code className="text-xs text-gray-10">
+														{fallbackIsSubdomain
+															? "cname.vercel-dns.com"
+															: "76.76.21.21"}
+													</code>
+													<button
+														type="button"
+														onClick={() =>
+															handleCopy(
+																fallbackIsSubdomain
+																	? "cname.vercel-dns.com"
+																	: "76.76.21.21",
+																"fallback-record",
+															)
+														}
+														className="p-1 rounded-md transition-colors hover:bg-gray-1 shrink-0"
+														title="Copy to clipboard"
+													>
+														{copiedField === "fallback-record" ? (
+															<Check className="size-3.5 text-green-500" />
+														) : (
+															<Copy className="size-3.5 text-gray-10" />
+														)}
+													</button>
+												</div>
+											</dd>
+										</div>
 									</dl>
 								</div>
 							</div>


### PR DESCRIPTION
## Problem
The custom domain verify step could render with no DNS records and the Check Status button spun indefinitely. Repro path: set up a subdomain whose Vercel config response omits recommended records, or any transient failure in the status check (errors are swallowed and polling suppresses toasts).

## Fix
- `checkDomainStatus` falls back to Vercel's well-known targets (`cname.vercel-dns.com` for subdomains, `76.76.21.21` for apex domains) when the config response has no recommendations, and logs failures server-side instead of silently returning an empty result.
- `VerifyStep` renders a fallback record card when no recommended records come back, and shows an explicit retry message when the config fails to load entirely.
- `updateDomain` normalizes the stored domain (trim + lowercase).
- `remove-domain` uses a shared `removeDomain` helper for the Vercel API call.

## Testing
- Biome + tsc pass on touched files.
- Manual: enter a subdomain on the custom domain step → the CNAME record (`cname.vercel-dns.com`) is displayed even if Vercel omits recommendations.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes custom-domain verification display well-known Vercel DNS targets when recommendations are missing, adds an explicit configuration-load error state, normalizes newly stored domains, and extracts Vercel domain deletion into a shared helper.
- Adds PSL-backed apex/subdomain classification and fallback CNAME/A recommendations.
- Adds fallback DNS guidance and retry messaging to the verification UI.
- Normalizes domains before uniqueness checks, Vercel registration, persistence, and status checks.
- Reuses a shared helper when removing domains from Vercel.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking response-handling issue in the extracted Vercel deletion helper.

The DNS fallback and normalization paths are internally consistent, but parsing every DELETE response as JSON can prevent local cleanup when Vercel returns a successful response without a JSON body.

**Files Needing Attention:** apps/web/actions/organization/domain-utils.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/actions/organization/domain-utils.ts | Adds domain classification, fallback DNS recommendations, logging, and a DELETE helper whose unconditional JSON parsing should be hardened. |
| apps/web/actions/organization/remove-domain.ts | Replaces the inline Vercel request with the shared helper while preserving authorization and local cleanup ordering. |
| apps/web/actions/organization/update-domain.ts | Consistently applies trimmed, lowercase domain normalization to lookup, registration, persistence, and verification. |
| apps/web/app/(org)/dashboard/settings/organization/components/CustomDomainDialog/VerifyStep.tsx | Adds explicit load-failure messaging and fallback DNS record rendering without an identified current behavioral defect. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/actions/organization/domain-utils.ts:98
**DELETE response requires JSON body**

If Vercel returns an empty or non-JSON body for this DELETE request, `res.json()` rejects before `removeOrganizationDomain` clears the local domain fields, leaving the organization with stale custom-domain state even when the HTTP request completed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): always render DNS records in c..."](https://github.com/capsoftware/cap/commit/ee18edb97dae762d6dabf4a77a23decb592c418a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50471528)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/capsoftware/cap/blob/main/CLAUDE.md))
- Context used - AGENTS.md ([source](https://github.com/capsoftware/cap/blob/main/AGENTS.md))
- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-app.md)
</details>

<!-- /greptile_comment -->