### PR TITLE
fix(desktop): honor tauri relaunch() on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "cap-desktop"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/apps/desktop/src-tauri/src/exit_shutdown.rs
+++ b/apps/desktop/src-tauri/src/exit_shutdown.rs
@@ -1,5 +1,17 @@
 use tokio::task::JoinHandle;
 
+// The .app bundle for a relaunch via LaunchServices, derived from the running
+// executable (…/Cap.app/Contents/MacOS/<binary>). None outside a bundle (dev
+// runs) — callers must NOT hand a bare Mach-O to open(1), which would route it
+// to Terminal and re-attribute TCC to Terminal.
+pub(crate) fn relaunch_target(current_exe: &std::path::Path) -> Option<std::path::PathBuf> {
+    current_exe
+        .ancestors()
+        .nth(3)
+        .filter(|p| p.extension().is_some_and(|e| e == "app"))
+        .map(std::path::Path::to_path_buf)
+}
+
 pub(crate) fn run_while_active<T, FExit, F>(is_exiting: FExit, operation: F) -> Option<T>
 where
     FExit: Fn() -> bool,
@@ -149,5 +161,47 @@ pub(crate) fn abort_join_handles<T>(
 
     if let Some(task) = task {
         task.abort();
+    }
+}
+
+#[cfg(test)]
+mod relaunch_target_tests {
+    use super::relaunch_target;
+    use std::path::Path;
+
+    #[test]
+    fn bundle_layouts_resolve_to_the_app() {
+        for (exe, want) in [
+            (
+                "/Applications/Cap.app/Contents/MacOS/Cap",
+                "/Applications/Cap.app",
+            ),
+            (
+                "/Applications/Cap.app/Contents/MacOS/Cap - Development",
+                "/Applications/Cap.app",
+            ),
+            (
+                "/Volumes/Cap 0.5.7/Cap.app/Contents/MacOS/Cap",
+                "/Volumes/Cap 0.5.7/Cap.app",
+            ),
+        ] {
+            assert_eq!(
+                relaunch_target(Path::new(exe)).as_deref(),
+                Some(Path::new(want)),
+                "exe: {exe}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_bundle_layouts_are_refused() {
+        for exe in [
+            "/repo/src-tauri/target/debug/cap-desktop",
+            "/usr/local/bin/cap",
+            "/a/b",
+            "/",
+        ] {
+            assert_eq!(relaunch_target(Path::new(exe)), None, "exe: {exe}");
+        }
     }
 }

--- a/apps/desktop/src-tauri/src/exit_shutdown.rs
+++ b/apps/desktop/src-tauri/src/exit_shutdown.rs
@@ -12,6 +12,24 @@ pub(crate) fn relaunch_target(current_exe: &std::path::Path) -> Option<std::path
         .map(std::path::Path::to_path_buf)
 }
 
+// The relaunch command reaches this script as positional arguments ("$@"),
+// never interpolated into it, so spaces/quotes/non-UTF8 in paths pass
+// verbatim; the delay lets the old instance die before the new one starts.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) const RELAUNCH_SH: &str = r#"/bin/sleep 0.7; exec "$@""#;
+
+// The command that respawns Cap, as discrete argv elements for RELAUNCH_SH.
+// Bundles go through `open` (LaunchServices keeps the new instance's own TCC
+// identity); a bare Mach-O is exec'd directly, since open(1) would route it
+// to Terminal and re-attribute TCC there.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) fn relaunch_argv(current_exe: &std::path::Path) -> Vec<std::ffi::OsString> {
+    match relaunch_target(current_exe) {
+        Some(bundle) => vec!["/usr/bin/open".into(), bundle.into_os_string()],
+        None => vec![current_exe.as_os_str().to_os_string()],
+    }
+}
+
 pub(crate) fn run_while_active<T, FExit, F>(is_exiting: FExit, operation: F) -> Option<T>
 where
     FExit: Fn() -> bool,
@@ -184,6 +202,10 @@ mod relaunch_target_tests {
                 "/Volumes/Cap 0.5.7/Cap.app/Contents/MacOS/Cap",
                 "/Volumes/Cap 0.5.7/Cap.app",
             ),
+            (
+                "/Users/alice/Alice's Apps/Cap.app/Contents/MacOS/Cap",
+                "/Users/alice/Alice's Apps/Cap.app",
+            ),
         ] {
             assert_eq!(
                 relaunch_target(Path::new(exe)).as_deref(),
@@ -191,6 +213,53 @@ mod relaunch_target_tests {
                 "exe: {exe}"
             );
         }
+    }
+
+    #[test]
+    fn bundle_argv_is_open_plus_bundle_as_discrete_elements() {
+        use std::ffi::OsString;
+
+        assert_eq!(
+            super::relaunch_argv(Path::new(
+                "/Users/alice/Alice's Apps/Cap.app/Contents/MacOS/Cap"
+            )),
+            vec![
+                OsString::from("/usr/bin/open"),
+                OsString::from("/Users/alice/Alice's Apps/Cap.app"),
+            ],
+            "apostrophes and spaces must survive as a single argv element"
+        );
+    }
+
+    #[test]
+    fn non_bundle_argv_is_the_executable_itself() {
+        use std::ffi::OsString;
+
+        assert_eq!(
+            super::relaunch_argv(Path::new("/repo/src-tauri/target/debug/cap-desktop")),
+            vec![OsString::from("/repo/src-tauri/target/debug/cap-desktop")],
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn relaunch_sh_delivers_hostile_paths_as_one_argument() {
+        // The doubled space is load-bearing: an unquoted $@ would field-split
+        // and /bin/echo would rejoin with single spaces, changing the output.
+        let hostile = "/tmp/Alice's  \"quoted\" $HOME `Apps`/Cap.app";
+        let out = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg(super::RELAUNCH_SH)
+            .arg("cap-relaunch")
+            .args(["/bin/echo", hostile])
+            .output()
+            .expect("spawn /bin/sh");
+        assert!(out.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout),
+            format!("{hostile}\n"),
+            "the script must pass \"$@\" through unsplit and uninterpolated"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -450,10 +450,12 @@ pub(crate) fn note_exit_requested_code(code: Option<i32>) {
         // Logged here, not in force_exit: the non-blocking appender drops
         // records emitted microseconds before _exit().
         info!("Relaunch requested; will respawn after exit");
-        // A deliberate relaunch is a clean shutdown. tauri exempts restart
-        // requests from prevent_exit, so the runtime exits before the async
-        // cleanup (which normally disarms the crash sentinel) can finish —
-        // without this, every relaunch reports a phantom crash on next boot.
+        // A deliberate relaunch is a clean shutdown. In tauri 2.8.5,
+        // prevent_exit() is a no-op when code == RESTART_EXIT_CODE (app.rs),
+        // so this exit can no longer be prevented and the state armed here is
+        // always consumed by the force_exit it precedes — and the runtime
+        // exits before the async cleanup that normally disarms the crash
+        // sentinel, so without this every relaunch reports a phantom crash.
         crash_sentinel::mark_clean_exit();
         RESTART_REQUESTED_ON_EXIT.store(true, std::sync::atomic::Ordering::Release);
     }
@@ -473,29 +475,17 @@ fn spawn_relauncher_if_requested() {
             eprintln!("cap relaunch: current_exe() failed; not respawning");
             return;
         };
-        match exit_shutdown::relaunch_target(&exe) {
-            Some(bundle) => {
-                let path = bundle.display().to_string();
-                if path.contains('\'') {
-                    eprintln!("cap relaunch: bundle path contains a quote; not respawning: {path}");
-                    return;
-                }
-                // A detached shell survives this process (reparented to
-                // launchd). The delay lets the old instance die completely
-                // first, so the single-instance plugin in the fresh one never
-                // meets a live listener; `open` goes through LaunchServices so
-                // the new instance keeps normal app context (TCC, dock).
-                let _ = std::process::Command::new("/bin/sh")
-                    .arg("-c")
-                    .arg(format!("sleep 0.7; /usr/bin/open '{path}'"))
-                    .spawn();
-            }
-            None => {
-                // Dev / non-bundle run: open(1) would route a bare Mach-O to
-                // Terminal and re-attribute TCC to it — spawn the executable
-                // directly instead, like tauri's own process::restart does.
-                let _ = std::process::Command::new(&exe).spawn();
-            }
+        // A detached shell survives this process (reparented to launchd); the
+        // delay lets the old instance die first so the fresh single-instance
+        // plugin never meets a live listener.
+        if let Err(err) = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg(exit_shutdown::RELAUNCH_SH)
+            .arg("cap-relaunch")
+            .args(exit_shutdown::relaunch_argv(&exe))
+            .spawn()
+        {
+            eprintln!("cap relaunch: failed to spawn relauncher: {err}");
         }
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -435,7 +435,73 @@ fn spawn_process_memory_sampler(app: AppHandle) {
     });
 }
 
+static RESTART_REQUESTED_ON_EXIT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+// tauri's relaunch() contract is "exit with RESTART_EXIT_CODE, respawn after
+// the event loop unwinds" — but every macOS exit here funnels into
+// force_exit's hard _exit(), so the loop never unwinds and tauri's respawn
+// never runs: the onboarding "Restart Required" prompt quit without
+// restarting (observed on the official 0.5.7 build, exit code 2147483647 with
+// no relaunch). The intent is recorded at ExitRequested and honored at the
+// force_exit choke point, which also covers the exit watchdog's hard exit.
+pub(crate) fn note_exit_requested_code(code: Option<i32>) {
+    if code == Some(tauri::RESTART_EXIT_CODE) {
+        // Logged here, not in force_exit: the non-blocking appender drops
+        // records emitted microseconds before _exit().
+        info!("Relaunch requested; will respawn after exit");
+        // A deliberate relaunch is a clean shutdown. tauri exempts restart
+        // requests from prevent_exit, so the runtime exits before the async
+        // cleanup (which normally disarms the crash sentinel) can finish —
+        // without this, every relaunch reports a phantom crash on next boot.
+        crash_sentinel::mark_clean_exit();
+        RESTART_REQUESTED_ON_EXIT.store(true, std::sync::atomic::Ordering::Release);
+    }
+}
+
+fn spawn_relauncher_if_requested() {
+    #[cfg(target_os = "macos")]
+    {
+        // swap: exactly one relauncher even if the exit watchdog and the main
+        // exit path race into force_exit together.
+        if !RESTART_REQUESTED_ON_EXIT.swap(false, std::sync::atomic::Ordering::AcqRel) {
+            return;
+        }
+        // eprintln below, not tracing: the non-blocking appender drops records
+        // this close to _exit(), stderr writes are synchronous.
+        let Ok(exe) = std::env::current_exe() else {
+            eprintln!("cap relaunch: current_exe() failed; not respawning");
+            return;
+        };
+        match exit_shutdown::relaunch_target(&exe) {
+            Some(bundle) => {
+                let path = bundle.display().to_string();
+                if path.contains('\'') {
+                    eprintln!("cap relaunch: bundle path contains a quote; not respawning: {path}");
+                    return;
+                }
+                // A detached shell survives this process (reparented to
+                // launchd). The delay lets the old instance die completely
+                // first, so the single-instance plugin in the fresh one never
+                // meets a live listener; `open` goes through LaunchServices so
+                // the new instance keeps normal app context (TCC, dock).
+                let _ = std::process::Command::new("/bin/sh")
+                    .arg("-c")
+                    .arg(format!("sleep 0.7; /usr/bin/open '{path}'"))
+                    .spawn();
+            }
+            None => {
+                // Dev / non-bundle run: open(1) would route a bare Mach-O to
+                // Terminal and re-attribute TCC to it — spawn the executable
+                // directly instead, like tauri's own process::restart does.
+                let _ = std::process::Command::new(&exe).spawn();
+            }
+        }
+    }
+}
+
 fn force_exit(code: i32) -> ! {
+    spawn_relauncher_if_requested();
     unsafe extern "C" {
         fn _exit(code: i32) -> !;
     }
@@ -6039,6 +6105,7 @@ fn handle_run_event(_handle: &AppHandle, event: tauri::RunEvent) {
         }
         tauri::RunEvent::ExitRequested { code, api, .. } => {
             info!(?code, "App exit requested");
+            note_exit_requested_code(code);
 
             match handle_exit_requested(
                 _handle
@@ -6828,5 +6895,28 @@ mod screenshot_share_cache_tests {
         let link = screenshot_share_link_for_hash(Some(&sharing(None)), "hash-a");
 
         assert!(link.is_none());
+    }
+}
+
+#[cfg(test)]
+mod relaunch_intent_tests {
+    use super::*;
+
+    #[test]
+    fn restart_exit_code_sets_relaunch_intent() {
+        RESTART_REQUESTED_ON_EXIT.store(false, std::sync::atomic::Ordering::Release);
+        note_exit_requested_code(None);
+        note_exit_requested_code(Some(0));
+        note_exit_requested_code(Some(1));
+        assert!(
+            !RESTART_REQUESTED_ON_EXIT.load(std::sync::atomic::Ordering::Acquire),
+            "ordinary exits must not schedule a relaunch"
+        );
+        note_exit_requested_code(Some(tauri::RESTART_EXIT_CODE));
+        assert!(
+            RESTART_REQUESTED_ON_EXIT.load(std::sync::atomic::Ordering::Acquire),
+            "tauri relaunch() exits with RESTART_EXIT_CODE and must respawn"
+        );
+        RESTART_REQUESTED_ON_EXIT.store(false, std::sync::atomic::Ordering::Release);
     }
 }


### PR DESCRIPTION
### Summary

On macOS, `relaunch()` quits the app without restarting it. The onboarding "Restart Required" prompt ("Restart, I've granted permission") and any other caller of the process plugin's restart therefore terminate Cap and never bring it back — on the onboarding path the user is left with a closed app and the permission they just granted never re-evaluated.

Reproduced on 0.5.7 (macOS 26.4.1, M1 Max) including the official signed build; the code path is unchanged on `main`.

### Cause

tauri restarts by exiting with `RESTART_EXIT_CODE` and respawning **after the event loop unwinds** (`tauri-2.8.5/src/app.rs` — the run-event callback fires first, then `cleanup_before_exit()`, then the `restart_on_exit` → `process::restart()` check).

Every macOS exit path in `cap-desktop` funnels into `force_exit()`'s `_exit()`:

- `RunEvent::Exit` → `force_exit(0)`
- `finalize_app_exit()` → `AppExitAction::Process(code)` → `force_exit(code)`
- `spawn_exit_watchdog()` → `force_exit(0)`

`_exit()` never returns, so the loop never unwinds and the respawn is unreachable. Log signature is an exit with code `2147483647` (`i32::MAX`) and no subsequent launch.

The hard exit is deliberate — it is what bounds shutdown — so this honors the restart intent at that choke point instead of removing it.

### Changes

- `note_exit_requested_code()` records intent when `ExitRequested` carries `RESTART_EXIT_CODE`; `force_exit()` acts on it. One choke point covers `RunEvent::Exit`, `finalize_app_exit`, the SIGTERM handler, `applicationShouldTerminate`, and the watchdog. `swap()` keeps it exactly-once if the watchdog races the main path.
- Respawn uses a detached `sleep 0.7; open <bundle>`. `open` goes through LaunchServices so the new instance gets its own TCC identity by code signature — which matters here, because the onboarding restart exists precisely to re-evaluate screen-recording permission. The delay lets the old process die first so `tauri-plugin-single-instance` never meets a live listener (its macOS impl unlinks the socket on `RunEvent::Exit`, and a stale socket yields `ECONNREFUSED` → the new instance claims singleton, so this is fail-open either way).
- Outside a `.app` bundle (dev runs) the executable is spawned directly: `open(1)` hands a bare Mach-O to Terminal, which would both fail to relaunch properly and re-attribute TCC to Terminal. `relaunch_target()` is extracted into `exit_shutdown.rs` so that derivation is unit-testable.
- Marks the crash sentinel clean on the restart path. tauri exempts `RESTART_EXIT_CODE` from `prevent_exit`, so the runtime exits before the async cleanup that normally disarms the sentinel completes — without this, **every** relaunch is reported as an unexpected termination on the next launch.

### Tests

- `relaunch_target_tests` — bundle-path derivation across `/Applications`, paths containing spaces, `/Volumes`, and non-bundle/dev layouts (table-driven).
- `relaunch_intent_tests::restart_exit_code_sets_relaunch_intent` — only `RESTART_EXIT_CODE` arms the respawn; `None`, `Some(0)` and `Some(1)` do not.

`cargo fmt --check`, `cargo check -p cap-desktop`, and the tests all pass against `main`.

### Notes / open questions

- macOS-only by `#[cfg]`; other platforms keep tauri's own respawn, which works there because `finalize_app_exit` uses `app.exit()`. One pre-existing gap I did **not** touch: on all platforms `spawn_exit_watchdog` hard-exits, so a restart lost to the watchdog timeout stays lost. Happy to address that here if you'd prefer.
- Verified against vendored `tauri-2.8.5` and `tauri-plugin-single-instance-2.3.4` rather than assumed, including the `prevent_exit` carve-out for restart codes and the plugin's socket-cleanup ordering.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes macOS restart requests survive Cap’s hard-exit shutdown path while preserving clean-shutdown crash tracking.
- Records Tauri restart intent and consumes it exactly once at `force_exit`.
- Relaunches bundles through LaunchServices and development executables directly after a short delay.
- Passes relaunch paths as discrete arguments and adds coverage for bundle layouts, hostile path characters, and restart intent.
- Updates the desktop package lockfile version to 0.5.8.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains in the previously reported restart-intent, quoted-path, or development singleton-race paths.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/lib.rs | Integrates restart-intent tracking, clean-exit sentinel handling, and exactly-once relaunch spawning into the macOS shutdown flow; the previously reported stale-intent concern is contradicted by the restart-code exit contract. |
| apps/desktop/src-tauri/src/exit_shutdown.rs | Adds bundle-target and argv derivation with tests showing quoted and spaced paths remain discrete arguments and development relaunches use the delayed path. |
| Cargo.lock | Updates only the cap-desktop package version from 0.5.7 to 0.5.8. |

<sub>Reviews (2): Last reviewed commit: ["fix(desktop): harden the macOS relaunche..."](https://github.com/capsoftware/cap/commit/6ee0bec45d8cd9fee5a4496866e68ed7ef6d23f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50531561)</sub>

**Context used:**

- Knowledge Base — [Desktop Tauri App (Rust Backend)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-tauri-app.md)

<!-- /greptile_comment -->