### PR TITLE
fix(desktop): main-thread deadlock in macOS screen-recording permission check

### DIFF
--- a/apps/desktop/src-tauri/src/permissions.rs
+++ b/apps/desktop/src-tauri/src/permissions.rs
@@ -10,7 +10,7 @@ use objc2_app_kit::{NSApplicationActivationOptions, NSRunningApplication};
 use std::{
     future::Future,
     str::FromStr,
-    sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
+    sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering},
     time::Duration,
 };
 #[cfg(target_os = "macos")]
@@ -26,10 +26,25 @@ static MACOS_SCK_PERMISSION_MISMATCH_LOGGED: AtomicBool = AtomicBool::new(false)
 #[cfg(target_os = "macos")]
 static MACOS_SCK_DISPLAYS_VALIDATED: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
+static MACOS_SCK_DISPLAYS_VALIDATION_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "macos")]
+static MACOS_SCK_LAST_STRICT_OUTCOME: AtomicU8 = AtomicU8::new(MACOS_SCK_OUTCOME_UNKNOWN);
+#[cfg(target_os = "macos")]
 static MACOS_SCK_LAST_VALIDATION_ATTEMPT: std::sync::Mutex<Option<std::time::Instant>> =
     std::sync::Mutex::new(None);
 #[cfg(target_os = "macos")]
 const MACOS_SCK_VALIDATION_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+// Strictly less than the retry interval: the backoff stamp is refreshed when
+// an attempt completes, and a timeout that consumed the whole interval would
+// otherwise leave zero backoff between attempts against a wedged replayd.
+#[cfg(target_os = "macos")]
+const MACOS_SCK_VALIDATION_TIMEOUT: Duration = Duration::from_secs(4);
+#[cfg(target_os = "macos")]
+const MACOS_SCK_OUTCOME_UNKNOWN: u8 = 0;
+#[cfg(target_os = "macos")]
+const MACOS_SCK_OUTCOME_OK: u8 = 1;
+#[cfg(target_os = "macos")]
+const MACOS_SCK_OUTCOME_FAILED: u8 = 2;
 
 #[cfg(target_os = "macos")]
 pub(crate) struct MacosPanelWindowActivationGuard {
@@ -301,22 +316,88 @@ fn macos_permission_status(permission: &OSPermission, initial_check: bool) -> OS
 // Failed validations retry at most once per MACOS_SCK_VALIDATION_RETRY_INTERVAL.
 #[cfg(target_os = "macos")]
 fn macos_screen_recording_available() -> bool {
-    if !scap_screencapturekit::has_permission() {
+    macos_screen_recording_available_with(
+        scap_screencapturekit::has_permission(),
+        MACOS_SCK_DISPLAYS_VALIDATED.load(Ordering::Acquire),
+        MACOS_SCK_LAST_STRICT_OUTCOME.load(Ordering::Acquire),
+        objc2::MainThreadMarker::new().is_some(),
+        macos_spawn_sck_displays_validation,
+        || {
+            // block_in_place covers the mutex acquisition too: waiters serialised
+            // behind an in-flight validation would otherwise park a tokio worker
+            // without telling the runtime.
+            if tokio::runtime::Handle::try_current().is_ok() {
+                tokio::task::block_in_place(macos_validate_sck_displays)
+            } else {
+                macos_validate_sck_displays()
+            }
+        },
+    )
+}
+
+// SCShareableContent's completion needs the main run loop, so blocking the
+// main thread on the strict validation deadlocks the whole app. Both
+// 2026-08-03 macOS hang reports show it: onboarding tray rebuilds
+// (run_on_main_thread → build_tray_menu → do_permissions_check) parked the
+// main thread in block_on for 76+s until force-quit. Main-thread callers are
+// the tray menu builds (tray.rs), create_tray, the setup-time log line
+// (lib.rs), and RunEvent::Reopen → should_show_onboarding (lib.rs); they get
+// the last strictly-observed answer without blocking — optimistic until the
+// first strict validation completes, since CGPreflight already passed. Reopen
+// consuming an optimistic answer is self-correcting: ShowCapWindow::Main
+// re-checks off-main (windows.rs) and redirects back to Onboarding. The
+// onboarding/permission UIs poll via async commands and keep the strict path.
+#[cfg(target_os = "macos")]
+fn macos_screen_recording_available_with(
+    preflight_granted: bool,
+    displays_validated: bool,
+    last_strict_outcome: u8,
+    on_main_thread: bool,
+    spawn_background_validation: impl FnOnce(),
+    validate: impl FnOnce() -> bool,
+) -> bool {
+    if !preflight_granted {
         return false;
     }
 
-    if MACOS_SCK_DISPLAYS_VALIDATED.load(Ordering::Acquire) {
+    if displays_validated {
         return true;
     }
 
-    // block_in_place covers the mutex acquisition too: waiters serialised
-    // behind an in-flight validation would otherwise park a tokio worker
-    // without telling the runtime.
-    if tokio::runtime::Handle::try_current().is_ok() {
-        tokio::task::block_in_place(macos_validate_sck_displays)
-    } else {
-        macos_validate_sck_displays()
+    if on_main_thread {
+        spawn_background_validation();
+        return last_strict_outcome != MACOS_SCK_OUTCOME_FAILED;
     }
+
+    validate()
+}
+
+#[cfg(target_os = "macos")]
+struct MacosSckValidationInFlightReset;
+
+#[cfg(target_os = "macos")]
+impl Drop for MacosSckValidationInFlightReset {
+    fn drop(&mut self) {
+        MACOS_SCK_DISPLAYS_VALIDATION_IN_FLIGHT.store(false, Ordering::Release);
+    }
+}
+
+// Blocking pool rather than a raw std::thread: pool threads carry the runtime
+// handle without tokio's "entered" flag, so the validator's nested
+// Handle::block_on is legal there (it panics on entered threads, which rules
+// out tokio::spawn), they inherit the 16MiB stack configured in main.rs
+// (SCK graph walks are why it was raised), and an idle pool thread is reused
+// instead of spawning one per check. The Drop guard clears the in-flight
+// latch even if the validation panics.
+#[cfg(target_os = "macos")]
+fn macos_spawn_sck_displays_validation() {
+    if MACOS_SCK_DISPLAYS_VALIDATION_IN_FLIGHT.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    tauri::async_runtime::spawn_blocking(|| {
+        let _reset = MacosSckValidationInFlightReset;
+        macos_validate_sck_displays();
+    });
 }
 
 #[cfg(target_os = "macos")]
@@ -339,7 +420,25 @@ fn macos_validate_sck_displays() -> bool {
 
     let validated = objc2::rc::autoreleasepool(|_| {
         tauri::async_runtime::block_on(async {
-            match sc::ShareableContent::current().await {
+            // Bounded: a wedged replayd (post-sleep, or right after a TCC
+            // grant before relaunch) can leave this future unresolved forever,
+            // which would park whichever thread is validating.
+            let content = match tokio::time::timeout(
+                MACOS_SCK_VALIDATION_TIMEOUT,
+                sc::ShareableContent::current(),
+            )
+            .await
+            {
+                Ok(result) => result,
+                Err(_) => {
+                    tracing::warn!(
+                        timeout_ms = MACOS_SCK_VALIDATION_TIMEOUT.as_millis() as u64,
+                        "ScreenCaptureKit shareable content query timed out during permission check"
+                    );
+                    return false;
+                }
+            };
+            match content {
                 Ok(content) => {
                     let display_count = content.displays().len();
                     if display_count == 0
@@ -367,6 +466,20 @@ fn macos_validate_sck_displays() -> bool {
     if validated {
         MACOS_SCK_DISPLAYS_VALIDATED.store(true, Ordering::Release);
     }
+    MACOS_SCK_LAST_STRICT_OUTCOME.store(
+        if validated {
+            MACOS_SCK_OUTCOME_OK
+        } else {
+            MACOS_SCK_OUTCOME_FAILED
+        },
+        Ordering::Release,
+    );
+    // Re-stamp on completion: an attempt can consume up to the SCK timeout,
+    // so a start-only stamp would leave a timed-out attempt with an already
+    // expired backoff window (back-to-back attempts against a wedged
+    // replayd). The start stamp above stays as insurance in case this thread
+    // dies mid-attempt.
+    *last_attempt = Some(std::time::Instant::now());
     validated
 }
 
@@ -425,11 +538,16 @@ where
 async fn macos_wait_for_permission_update(permission: &OSPermission) -> bool {
     // The user just interacted with the permission prompt; drop the SCK
     // validation backoff so this poll loop sees fresh answers instead of a
-    // stale negative from up to 5s ago.
+    // stale negative from up to 5s ago. block_in_place because an in-flight
+    // validation holds this mutex for up to the SCK timeout, and waiting it
+    // out is deliberate — its result predates the grant, so the reset must
+    // land after it finishes.
     if matches!(permission, OSPermission::ScreenRecording) {
-        *MACOS_SCK_LAST_VALIDATION_ATTEMPT
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+        tokio::task::block_in_place(|| {
+            *MACOS_SCK_LAST_VALIDATION_ATTEMPT
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+        });
     }
 
     macos_wait_for_permission_update_with(
@@ -637,6 +755,123 @@ mod tests {
                 .await;
 
         assert!(!granted);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn main_thread_never_validates_inline() {
+        use std::cell::Cell;
+
+        let spawned = Cell::new(false);
+        let validated_inline = Cell::new(false);
+
+        let result = macos_screen_recording_available_with(
+            true,
+            false,
+            MACOS_SCK_OUTCOME_UNKNOWN,
+            true,
+            || spawned.set(true),
+            || {
+                validated_inline.set(true);
+                true
+            },
+        );
+
+        assert!(result, "optimistic before the first strict validation");
+        assert!(spawned.get(), "must kick a background validation");
+        assert!(
+            !validated_inline.get(),
+            "the main thread must never run the blocking SCK validation"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn main_thread_reports_last_failed_strict_outcome() {
+        use std::cell::Cell;
+
+        let spawned = Cell::new(false);
+
+        let result = macos_screen_recording_available_with(
+            true,
+            false,
+            MACOS_SCK_OUTCOME_FAILED,
+            true,
+            || spawned.set(true),
+            || unreachable!("main thread must not validate inline"),
+        );
+
+        assert!(!result, "a strictly-observed failure must not be masked");
+        assert!(spawned.get(), "still revalidates in the background");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn off_main_thread_keeps_the_strict_path() {
+        use std::cell::Cell;
+
+        let spawned = Cell::new(false);
+        let validated_inline = Cell::new(false);
+
+        let result = macos_screen_recording_available_with(
+            true,
+            false,
+            MACOS_SCK_OUTCOME_UNKNOWN,
+            false,
+            || spawned.set(true),
+            || {
+                validated_inline.set(true);
+                false
+            },
+        );
+
+        assert!(!result);
+        assert!(validated_inline.get(), "off-main callers validate inline");
+        assert!(!spawned.get());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn preflight_denial_and_cached_validation_short_circuit() {
+        let denied = macos_screen_recording_available_with(
+            false,
+            false,
+            MACOS_SCK_OUTCOME_UNKNOWN,
+            true,
+            || unreachable!("no work when preflight is denied"),
+            || unreachable!("no work when preflight is denied"),
+        );
+        assert!(!denied);
+
+        let cached = macos_screen_recording_available_with(
+            true,
+            true,
+            MACOS_SCK_OUTCOME_UNKNOWN,
+            true,
+            || unreachable!("no work once displays are validated"),
+            || unreachable!("no work once displays are validated"),
+        );
+        assert!(cached);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn sck_timeout_fits_inside_the_retry_backoff() {
+        assert!(MACOS_SCK_VALIDATION_TIMEOUT < MACOS_SCK_VALIDATION_RETRY_INTERVAL);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn in_flight_latch_clears_even_when_validation_panics() {
+        MACOS_SCK_DISPLAYS_VALIDATION_IN_FLIGHT.store(true, Ordering::Release);
+
+        let panicked = std::panic::catch_unwind(|| {
+            let _reset = MacosSckValidationInFlightReset;
+            panic!("validation blew up");
+        });
+
+        assert!(panicked.is_err());
+        assert!(!MACOS_SCK_DISPLAYS_VALIDATION_IN_FLIGHT.load(Ordering::Acquire));
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Summary

Cap can deadlock its own main thread during first-boot onboarding. The app becomes permanently unresponsive — no recovery, force quit required — while the user is clicking through the permission steps.

Reproduced on 0.5.7 (macOS 26.4.1, M1 Max) including the official signed build; the code path is unchanged on main. Two macOS .hang reports capture it.

Cause

macos_validate_sck_displays() blocks on sc::ShareableContent::current(). ScreenCaptureKit delivers that completion via the main run loop — so when the caller is the main thread, the run loop needed to deliver the answer is the one blocked awaiting it. Circular wait, never resolves.

The main thread reaches it through the tray:

tao event loop
  tauri_runtime_wry::handle_user_message
    cap_desktop_lib::tray::build_tray_menu
      cap_desktop_lib::permissions::do_permissions_check
        cap_desktop_lib::permissions::macos_permission_status
          tauri::async_runtime::block_on
            tokio ... park            <- 76+ seconds, ~0% CPU

It surfaces during onboarding specifically because should_use_minimal_onboarding_tray_menu() only consults permissions while the onboarding window exists, and the tray rebuilds on every permission grant (request_permission → refresh_tray_menu_for_app). So the freeze lands exactly when the user is granting permissions.

Worth noting for review: main() runs the tokio runtime via block_on on the main thread, so Handle::try_current() is Ok there and the existing block_in_place branch was reachable from main — it parked rather than panicking, which matches the hang reports.

Changes

- Main-thread callers no longer run the blocking validation. They answer from the last strictly-observed result and spawn a background revalidation. scap_screencapturekit::has_permission() (CGPreflight) has already gated the answer, so the optimistic reply cannot claim a permission the OS denied, and once a strict check observes a failure it is recorded and never masked.
- The SCK query is bounded at 4s, strictly inside MACOS_SCK_VALIDATION_RETRY_INTERVAL (5s) so a timed-out attempt does not consume its own backoff window. This also means a wedged replayd degrades to "validation failed" instead of parking a thread forever — possibly relevant to #1994, where the reporter's workaround is killall replayd.
- The background validation runs on the blocking pool with a Drop-guarded in-flight latch, so a panic cannot wedge future checks, and it inherits the 16 MiB stack configured in main.rs rather than a raw thread's 2 MiB.
- The availability logic is extracted into a pure, parameter-injected function so the invariants are testable without ObjC.

The display-validation caching from a9a6b9d29 (#2023) is preserved — the expensive SCShareableContent snapshot is still taken at most once per process on success, and the background path reuses the same in-flight guard, so this does not reintroduce the leak.

Tests

Six new unit tests in permissions.rs, notably:

- main_thread_never_validates_inline — the load-bearing one; fails if the guard is ever reordered below the strict path.
- main_thread_reports_last_failed_strict_outcome — an observed failure is not masked by the optimistic path.
- off_main_thread_keeps_the_strict_path — off-main behaviour is unchanged.
- sck_timeout_fits_inside_the_retry_backoff — pins timeout < retry interval.
- plus short-circuit and panic-safety coverage.

cargo fmt --check, cargo check -p cap-desktop, and cargo test -p cap-desktop --lib permissions (11 passing) all clean against main.

Notes / open questions

- I kept the optimistic main-thread answer rather than making the tray async, because the tray build is synchronous by nature and the strict answer is only needed by the permission UIs, which poll off-main. If you'd rather the tray not consult permissions at all, that would be a smaller change and I'm happy to redo it that way.
- The .hang reports are available if useful — they contain full process state, so I have not attached them to a public thread.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents macOS permission checks from blocking the application’s main thread while waiting for ScreenCaptureKit.
- Main-thread checks now return the latest strictly observed outcome and trigger background revalidation.
- ScreenCaptureKit validation is bounded by a four-second timeout and guarded against overlapping background work.
- Retry timestamps and strict outcomes are updated after validation, with tests covering main-thread behavior, timeout/backoff ordering, and panic-safe latch cleanup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The main-thread deadlock path is removed while strict off-main validation remains available, background work is bounded and panic-safe, and the intentionally optimistic UI paths are subsequently corrected where strict permission status is required.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/permissions.rs | Refactors macOS screen-recording availability checks to avoid main-thread validation, adds bounded background revalidation and strict-outcome caching, and extends focused unit coverage. |

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): main-thread deadlock in ma..."](https://github.com/capsoftware/cap/commit/3524384147535daea8f0c6e8bfcf960ebea15979) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50581407)</sub>

**Context used:**

- Knowledge Base — [Desktop Tauri App (Rust Backend)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-tauri-app.md)

<!-- /greptile_comment -->