### PR TITLE
Add global OCR text capture (Ctrl/Cmd+Shift+T)

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -247,6 +247,10 @@ pub struct GeneralSettingsStore {
     pub camera_blur_disabled_by_crash: Option<String>,
     #[serde(default)]
     pub update_channel: UpdateChannel,
+    #[serde(default)]
+    pub ocr_keep_screenshot: bool,
+    #[serde(default)]
+    pub ocr_show_notification: bool,
 }
 
 fn default_enable_native_camera_preview() -> bool {
@@ -350,6 +354,8 @@ impl Default for GeneralSettingsStore {
             previous_recordings_paths: Vec::new(),
             camera_blur_disabled_by_crash: None,
             update_channel: UpdateChannel::Stable,
+            ocr_keep_screenshot: false,
+            ocr_show_notification: false,
         }
     }
 }

--- a/apps/desktop/src-tauri/src/hotkeys.rs
+++ b/apps/desktop/src-tauri/src/hotkeys.rs
@@ -212,15 +212,19 @@ pub fn init(app: &AppHandle) {
     .unwrap();
 
     let mut store = match HotkeysStore::get(app) {
-        Ok(Some(s)) => s,
-        Ok(None) => HotkeysStore::default(),
+        Ok(Some(s)) => Some(s),
+        Ok(None) => Some(HotkeysStore::default()),
         Err(e) => {
             eprintln!("Failed to load hotkeys store: {e}");
-            HotkeysStore::default()
+            None
         }
     };
 
-    seed_default_hotkeys(app, &mut store);
+    if let Some(store) = &mut store {
+        seed_default_hotkeys(app, store);
+    }
+
+    let store = store.unwrap_or_default();
 
     let global_shortcut = app.global_shortcut();
     for hotkey in store.hotkeys.values() {

--- a/apps/desktop/src-tauri/src/hotkeys.rs
+++ b/apps/desktop/src-tauri/src/hotkeys.rs
@@ -66,6 +66,7 @@ pub enum HotkeyAction {
     ScreenshotDisplay,
     ScreenshotWindow,
     ScreenshotArea,
+    OcrArea,
     #[serde(other)]
     Other,
 }
@@ -73,6 +74,8 @@ pub enum HotkeyAction {
 #[derive(Serialize, Deserialize, Type, Default)]
 pub struct HotkeysStore {
     hotkeys: HashMap<HotkeyAction, Hotkey>,
+    #[serde(default)]
+    seeded: Vec<HotkeyAction>,
 }
 
 impl HotkeysStore {
@@ -208,7 +211,7 @@ pub fn init(app: &AppHandle) {
     )
     .unwrap();
 
-    let store = match HotkeysStore::get(app) {
+    let mut store = match HotkeysStore::get(app) {
         Ok(Some(s)) => s,
         Ok(None) => HotkeysStore::default(),
         Err(e) => {
@@ -217,12 +220,54 @@ pub fn init(app: &AppHandle) {
         }
     };
 
+    seed_default_hotkeys(app, &mut store);
+
     let global_shortcut = app.global_shortcut();
     for hotkey in store.hotkeys.values() {
         global_shortcut.register(Shortcut::from(*hotkey)).ok();
     }
 
     app.manage(Mutex::new(store));
+}
+
+fn default_hotkey(action: HotkeyAction) -> Option<Hotkey> {
+    match action {
+        HotkeyAction::OcrArea => Some(Hotkey {
+            code: Code::KeyT,
+            meta: cfg!(target_os = "macos"),
+            ctrl: !cfg!(target_os = "macos"),
+            alt: false,
+            shift: true,
+        }),
+        _ => None,
+    }
+}
+
+fn seed_default_hotkeys(app: &AppHandle, store: &mut HotkeysStore) {
+    let mut changed = false;
+
+    for action in [HotkeyAction::OcrArea] {
+        if store.seeded.contains(&action) || store.hotkeys.contains_key(&action) {
+            continue;
+        }
+
+        let Some(hotkey) = default_hotkey(action) else {
+            continue;
+        };
+
+        if !store.hotkeys.values().any(|h| h == &hotkey) {
+            store.hotkeys.insert(action, hotkey);
+        }
+        store.seeded.push(action);
+        changed = true;
+    }
+
+    if changed && let Ok(s) = app.store("store") {
+        s.set("hotkeys", serde_json::json!(&*store));
+        if let Err(e) = s.save() {
+            eprintln!("Failed to save hotkeys store: {e}");
+        }
+    }
 }
 
 async fn handle_hotkey(app: AppHandle, action: HotkeyAction) -> Result<(), String> {
@@ -328,6 +373,13 @@ async fn handle_hotkey(app: AppHandle, action: HotkeyAction) -> Result<(), Strin
 
             let _ = RequestOpenRecordingPicker {
                 target_mode: Some(RecordingTargetMode::Area),
+            }
+            .emit(&app);
+            Ok(())
+        }
+        HotkeyAction::OcrArea => {
+            let _ = RequestOpenRecordingPicker {
+                target_mode: Some(RecordingTargetMode::Ocr),
             }
             .emit(&app);
             Ok(())

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4936,6 +4936,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             clip_thumbnails::get_clip_thumbnail,
             windows::position_traffic_lights,
             windows::set_theme,
+            windows::show_window_without_activating,
             windows::set_teleprompter_window_level,
             windows::set_teleprompter_window_opacity,
             windows::apply_macos_liquid_glass_background,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4853,6 +4853,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             recording::restart_recording,
             recording::delete_recording,
             recording::take_screenshot,
+            recording::capture_ocr_text,
             recording::import_current_desktop_background,
             recording::list_cameras,
             recording::get_camera_formats,

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2845,7 +2845,7 @@ pub async fn capture_ocr_text(
         error!("Failed to save OCR screenshot: {e}");
     }
 
-    if settings.ocr_show_notification {
+    if settings.enable_notifications && settings.ocr_show_notification {
         use tauri_plugin_notification::NotificationExt;
 
         let preview: String = text.chars().take(120).collect();

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2807,7 +2807,7 @@ pub async fn take_screenshot(
 
     AppSounds::Notification.play();
 
-    save_screenshot_project(&app, image, &target)
+    save_screenshot_project(&app, image, &target, true)
 }
 
 #[tauri::command(async)]
@@ -2840,7 +2840,7 @@ pub async fn capture_ocr_text(
     AppSounds::Notification.play();
 
     if settings.ocr_keep_screenshot
-        && let Err(e) = save_screenshot_project(&app, image, &target)
+        && let Err(e) = save_screenshot_project(&app, image, &target, false)
     {
         error!("Failed to save OCR screenshot: {e}");
     }
@@ -2914,10 +2914,15 @@ async fn capture_screen_image(
     result
 }
 
+/// `run_side_effects` controls whether screenshot automations and the
+/// "screenshot saved" notification fire once the project is written. OCR
+/// captures skip them: an automation like copy-to-clipboard would overwrite
+/// the text that was just copied.
 fn save_screenshot_project(
     app: &AppHandle,
     image: image::DynamicImage,
     target: &ScreenCaptureTarget,
+    run_side_effects: bool,
 ) -> Result<PathBuf, String> {
     use crate::NewScreenshotAdded;
     use crate::notifications;
@@ -3063,16 +3068,18 @@ fn save_screenshot_project(
                 }
                 .emit(&app_handle);
 
-                crate::automation::run_screenshot_automations(
-                    app_handle.clone(),
-                    image_path_for_emit.clone(),
-                    &automation_target,
-                );
+                if run_side_effects {
+                    crate::automation::run_screenshot_automations(
+                        app_handle.clone(),
+                        image_path_for_emit.clone(),
+                        &automation_target,
+                    );
 
-                notifications::send_notification(
-                    &app_handle,
-                    notifications::NotificationType::ScreenshotSaved,
-                );
+                    notifications::send_notification(
+                        &app_handle,
+                        notifications::NotificationType::ScreenshotSaved,
+                    );
+                }
             }
             Ok(Err(e)) => {
                 error!("Failed to encode PNG: {e}");

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2879,15 +2879,18 @@ async fn capture_screen_image(
                     | CapWindowId::ModeSelect
                     | CapWindowId::RecordingsOverlay
             )
-            && window.is_visible().unwrap_or(false)
         {
+            let was_visible = window.is_visible().unwrap_or(false);
             hide_overlay(&window);
             hid_any = true;
             // The target-select overlay's lifecycle is owned by the frontend,
             // which hides it before invoking a capture and closes or restores
-            // it afterwards; re-showing it here would fight that.
-            if !matches!(id, CapWindowId::TargetSelectOverlay { .. }) {
-                hidden_windows.push(window);
+            // it afterwards; re-showing it here would fight that. The occluder
+            // must keep ignoring cursor events, so it is re-shown without the
+            // show_overlay cursor-event reset.
+            if was_visible && !matches!(id, CapWindowId::TargetSelectOverlay { .. }) {
+                let ignores_cursor = matches!(id, CapWindowId::WindowCaptureOccluder { .. });
+                hidden_windows.push((window, ignores_cursor));
             }
         }
     }
@@ -2900,8 +2903,12 @@ async fn capture_screen_image(
         .await
         .map_err(|e| format!("Failed to capture screenshot: {e}"));
 
-    for window in hidden_windows {
-        show_overlay(&window);
+    for (window, ignores_cursor) in hidden_windows {
+        if ignores_cursor {
+            let _ = window.show();
+        } else {
+            show_overlay(&window);
+        }
     }
 
     result

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2803,25 +2803,68 @@ pub async fn take_screenshot(
     app: AppHandle,
     target: ScreenCaptureTarget,
 ) -> Result<PathBuf, String> {
-    use crate::NewScreenshotAdded;
-    use crate::notifications;
-    use crate::{PendingScreenshot, PendingScreenshots};
+    let image = capture_screen_image(&app, target.clone()).await?;
+
+    AppSounds::Notification.play();
+
+    save_screenshot_project(&app, image, &target)
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+#[tracing::instrument(name = "capture_ocr_text", skip(app))]
+pub async fn capture_ocr_text(
+    app: AppHandle,
+    target: ScreenCaptureTarget,
+) -> Result<String, String> {
+    use tauri_plugin_clipboard_manager::ClipboardExt;
+
+    let settings = GeneralSettingsStore::get(&app)
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+
+    let image = capture_screen_image(&app, target.clone()).await?;
+
+    let text = crate::screenshot_editor::recognize_text_from_dynamic_image(&image).await?;
+    let text = text.trim().to_string();
+
+    if text.is_empty() {
+        return Err("No text was found in the selected area".to_string());
+    }
+
+    app.clipboard()
+        .write_text(text.clone())
+        .map_err(|e| format!("Failed to copy text to clipboard: {e}"))?;
+
+    AppSounds::Notification.play();
+
+    if settings.ocr_keep_screenshot
+        && let Err(e) = save_screenshot_project(&app, image, &target)
+    {
+        error!("Failed to save OCR screenshot: {e}");
+    }
+
+    if settings.ocr_show_notification {
+        use tauri_plugin_notification::NotificationExt;
+
+        let preview: String = text.chars().take(120).collect();
+        app.notification()
+            .builder()
+            .title("Text copied to clipboard")
+            .body(preview)
+            .show()
+            .ok();
+    }
+
+    Ok(text)
+}
+
+async fn capture_screen_image(
+    app: &AppHandle,
+    target: ScreenCaptureTarget,
+) -> Result<image::DynamicImage, String> {
     use cap_recording::screenshot::capture_screenshot;
-    use image::ImageEncoder;
-    use std::time::Instant;
-
-    let general_settings = GeneralSettingsStore::get(&app).ok().flatten();
-    let general_settings = general_settings.as_ref();
-
-    let project_name = format_project_name(
-        general_settings
-            .and_then(|s| s.default_project_name_template.clone())
-            .as_deref(),
-        target.title().as_deref().unwrap_or("Unknown"),
-        target.kind_str(),
-        RecordingMode::Screenshot,
-        None,
-    );
 
     let mut hid_any = false;
     for (label, window) in app.webview_windows() {
@@ -2844,13 +2887,36 @@ pub async fn take_screenshot(
         tokio::time::sleep(std::time::Duration::from_millis(150)).await;
     }
 
-    let automation_target = target.clone();
-
-    let image = capture_screenshot(target)
+    capture_screenshot(target)
         .await
-        .map_err(|e| format!("Failed to capture screenshot: {e}"))?;
+        .map_err(|e| format!("Failed to capture screenshot: {e}"))
+}
 
-    AppSounds::Notification.play();
+fn save_screenshot_project(
+    app: &AppHandle,
+    image: image::DynamicImage,
+    target: &ScreenCaptureTarget,
+) -> Result<PathBuf, String> {
+    use crate::NewScreenshotAdded;
+    use crate::notifications;
+    use crate::{PendingScreenshot, PendingScreenshots};
+    use image::ImageEncoder;
+    use std::time::Instant;
+
+    let general_settings = GeneralSettingsStore::get(app).ok().flatten();
+    let general_settings = general_settings.as_ref();
+
+    let project_name = format_project_name(
+        general_settings
+            .and_then(|s| s.default_project_name_template.clone())
+            .as_deref(),
+        target.title().as_deref().unwrap_or("Unknown"),
+        target.kind_str(),
+        RecordingMode::Screenshot,
+        None,
+    );
+
+    let automation_target = target.clone();
 
     let image_width = image.width();
     let image_height = image.height();

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2864,8 +2864,10 @@ async fn capture_screen_image(
     app: &AppHandle,
     target: ScreenCaptureTarget,
 ) -> Result<image::DynamicImage, String> {
+    use crate::windows::show_overlay;
     use cap_recording::screenshot::capture_screenshot;
 
+    let mut hidden_windows = Vec::new();
     let mut hid_any = false;
     for (label, window) in app.webview_windows() {
         if let Ok(id) = CapWindowId::from_str(&label)
@@ -2877,9 +2879,16 @@ async fn capture_screen_image(
                     | CapWindowId::ModeSelect
                     | CapWindowId::RecordingsOverlay
             )
+            && window.is_visible().unwrap_or(false)
         {
             hide_overlay(&window);
             hid_any = true;
+            // The target-select overlay's lifecycle is owned by the frontend,
+            // which hides it before invoking a capture and closes or restores
+            // it afterwards; re-showing it here would fight that.
+            if !matches!(id, CapWindowId::TargetSelectOverlay { .. }) {
+                hidden_windows.push(window);
+            }
         }
     }
 
@@ -2887,9 +2896,15 @@ async fn capture_screen_image(
         tokio::time::sleep(std::time::Duration::from_millis(150)).await;
     }
 
-    capture_screenshot(target)
+    let result = capture_screenshot(target)
         .await
-        .map_err(|e| format!("Failed to capture screenshot: {e}"))
+        .map_err(|e| format!("Failed to capture screenshot: {e}"));
+
+    for window in hidden_windows {
+        show_overlay(&window);
+    }
+
+    result
 }
 
 fn save_screenshot_project(

--- a/apps/desktop/src-tauri/src/recording_settings.rs
+++ b/apps/desktop/src-tauri/src/recording_settings.rs
@@ -19,6 +19,7 @@ pub enum RecordingTargetMode {
     Window,
     Area,
     Camera,
+    Ocr,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, specta::Type, Debug, Clone, Default)]

--- a/apps/desktop/src-tauri/src/screenshot_editor.rs
+++ b/apps/desktop/src-tauri/src/screenshot_editor.rs
@@ -986,6 +986,12 @@ pub async fn recognize_screenshot_text(
 
 pub async fn recognize_text_from_image_path(path: &std::path::Path) -> Result<String, String> {
     let dynamic = image::open(path).map_err(|e| format!("Failed to open image for OCR: {e}"))?;
+    recognize_text_from_dynamic_image(&dynamic).await
+}
+
+pub async fn recognize_text_from_dynamic_image(
+    dynamic: &image::DynamicImage,
+) -> Result<String, String> {
     let rgba = dynamic.to_rgba8();
     let width = rgba.width();
     let height = rgba.height();

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -130,6 +130,27 @@ pub fn show_overlay(window: &WebviewWindow) {
     let _ = window.show();
 }
 
+/// Shows the calling window without activating it, so the foreground app
+/// keeps keyboard focus.
+#[tauri::command]
+#[specta::specta]
+pub fn show_window_without_activating(window: WebviewWindow) {
+    #[cfg(windows)]
+    if let Ok(hwnd) = window.hwnd() {
+        use ::windows::Win32::UI::WindowsAndMessaging::{SW_SHOWNOACTIVATE, ShowWindow};
+
+        unsafe {
+            let _ = ShowWindow(
+                ::windows::Win32::Foundation::HWND(hwnd.0),
+                SW_SHOWNOACTIVATE,
+            );
+        }
+        return;
+    }
+
+    let _ = window.show();
+}
+
 fn emit_app_event<E>(app: &AppHandle, event: E)
 where
     E: Event + serde::Serialize + Clone,

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -1707,6 +1707,7 @@ impl ShowCapWindow {
                     Some(RecordingTargetMode::Window) => "&targetMode=window",
                     Some(RecordingTargetMode::Area) => "&targetMode=area",
                     Some(RecordingTargetMode::Camera) => "&targetMode=camera",
+                    Some(RecordingTargetMode::Ocr) => "&targetMode=ocr",
                     None => "",
                 };
 

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -2038,11 +2038,15 @@ function Page() {
 				dismissal === "ocr" ||
 				dismissal === "recordingInstant";
 			if (shouldRevealMainWindow && dismissalReveals) {
-				const currentWindow = getCurrentWindow();
-				void currentWindow.show();
 				// An OCR capture is a background copy-to-clipboard gesture; bring
 				// the window back without stealing focus from the user's app.
-				if (dismissal !== "ocr") void currentWindow.setFocus();
+				if (dismissal === "ocr") {
+					void commands.showWindowWithoutActivating();
+				} else {
+					const currentWindow = getCurrentWindow();
+					void currentWindow.show();
+					void currentWindow.setFocus();
+				}
 			}
 		}
 	});

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -2035,11 +2035,14 @@ function Page() {
 			const dismissalReveals =
 				dismissal === "cancelled" ||
 				dismissal === "screenshot" ||
+				dismissal === "ocr" ||
 				dismissal === "recordingInstant";
 			if (shouldRevealMainWindow && dismissalReveals) {
 				const currentWindow = getCurrentWindow();
 				void currentWindow.show();
-				void currentWindow.setFocus();
+				// An OCR capture is a background copy-to-clipboard gesture; bring
+				// the window back without stealing focus from the user's app.
+				if (dismissal !== "ocr") void currentWindow.setFocus();
 			}
 		}
 	});

--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -573,6 +573,35 @@ function Inner(props: {
 				/>
 
 				<Section
+					title="Text capture (OCR)"
+					description="Copy text from anywhere on your screen with the OCR hotkey."
+				>
+					<SectionRows>
+						<ToggleSettingItem
+							label="Keep a screenshot of the captured area"
+							description="Save the selected region to your screenshots when copying text. When off, nothing is stored."
+							value={!!settings.ocrKeepScreenshot}
+							onChange={(value) => handleChange("ocrKeepScreenshot", value)}
+						/>
+						<ToggleSettingItem
+							label="Show a notification when text is copied"
+							description="Display a system notification with a preview of the copied text."
+							value={!!settings.ocrShowNotification}
+							onChange={async (value) => {
+								if (value) {
+									const permissionGranted = await isPermissionGranted();
+									if (!permissionGranted) {
+										const permission = await requestPermission();
+										if (permission !== "granted") return;
+									}
+								}
+								handleChange("ocrShowNotification", value);
+							}}
+						/>
+					</SectionRows>
+				</Section>
+
+				<Section
 					title="Recording"
 					description="Behaviour while you record and after you stop."
 				>

--- a/apps/desktop/src/routes/(window-chrome)/settings/hotkeys.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/hotkeys.tsx
@@ -36,6 +36,7 @@ const ACTION_TEXT = {
 	screenshotDisplay: "Screenshot current display",
 	screenshotWindow: "Screenshot current window",
 	screenshotArea: "Screenshot area picker",
+	ocrArea: "Copy text from area (OCR)",
 } satisfies { [K in HotkeyAction]?: string };
 
 export default function () {
@@ -87,6 +88,7 @@ function Inner(props: { initialStore: HotkeysStore | null }) {
 			"screenshotDisplay",
 			"screenshotWindow",
 			"screenshotArea",
+			"ocrArea",
 			"openRecordingPicker",
 			"stopRecording",
 			"restartRecording",

--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -194,7 +194,7 @@ function Inner() {
 	const [params] = useSearchParams<{
 		displayId: DisplayId;
 		isHoveredDisplay: string;
-		targetMode: "display" | "window" | "area" | "camera";
+		targetMode: "display" | "window" | "area" | "camera" | "ocr";
 	}>();
 	const [options, setOptions] = useOptions();
 	const [areaSelectionPreferences, setAreaSelectionPreferences] = makePersisted(
@@ -293,7 +293,16 @@ function Inner() {
 	});
 
 	createEffect(
-		(prevMode: "display" | "window" | "area" | "camera" | null | undefined) => {
+		(
+			prevMode:
+				| "display"
+				| "window"
+				| "area"
+				| "camera"
+				| "ocr"
+				| null
+				| undefined,
+		) => {
 			const mode = options.targetMode ?? null;
 			if (prevMode === "area" && mode !== "area") {
 				const target = pendingAreaTarget();
@@ -779,8 +788,16 @@ function Inner() {
 					);
 				}}
 			</Match>
-			<Match when={options.targetMode === "area" && params.displayId}>
+			<Match
+				when={
+					(options.targetMode === "area" || options.targetMode === "ocr") &&
+					params.displayId
+				}
+			>
 				{(displayId) => {
+					const isOcr = () => options.targetMode === "ocr";
+					const isImmediateCapture = () =>
+						isOcr() || options.mode === "screenshot";
 					let controlsEl: HTMLDivElement | undefined;
 					let cropperRef: CropperRef | undefined;
 
@@ -812,19 +829,19 @@ function Inner() {
 					const [screenshotSnapToRatio, setScreenshotSnapToRatio] =
 						createSignal(true);
 					const minSize = () =>
-						options.mode === "screenshot" ? MIN_SCREENSHOT_SIZE : MIN_SIZE;
+						isImmediateCapture() ? MIN_SCREENSHOT_SIZE : MIN_SIZE;
 					const currentAspect = () =>
-						options.mode === "screenshot"
+						isImmediateCapture()
 							? screenshotAspect()
 							: areaSelectionPreferences.aspectRatio;
 					const currentSnapToRatio = () =>
-						options.mode === "screenshot"
+						isImmediateCapture()
 							? screenshotSnapToRatio()
 							: areaSelectionPreferences.snapToRatio;
 					const effectiveInitialAreaBounds = createMemo(() => {
 						const explicitBounds = initialAreaBounds();
 						if (explicitBounds) return explicitBounds;
-						if (options.mode === "screenshot") return undefined;
+						if (isImmediateCapture()) return undefined;
 						return getLockedAreaBounds(
 							areaSelectionPreferences,
 							displayId(),
@@ -855,7 +872,7 @@ function Inner() {
 					});
 					const isSelectionLocked = createMemo(
 						() =>
-							options.mode !== "screenshot" &&
+							!isImmediateCapture() &&
 							getLockedAreaBounds(
 								areaSelectionPreferences,
 								displayId(),
@@ -864,7 +881,7 @@ function Inner() {
 					);
 
 					function setAspect(aspect: Ratio | null) {
-						if (options.mode === "screenshot") {
+						if (isImmediateCapture()) {
 							setScreenshotAspect(aspect);
 							return;
 						}
@@ -875,7 +892,7 @@ function Inner() {
 					}
 
 					function setSnapToRatio(enabled: boolean) {
-						if (options.mode === "screenshot") {
+						if (isImmediateCapture()) {
 							setScreenshotSnapToRatio(enabled);
 							return;
 						}
@@ -884,7 +901,7 @@ function Inner() {
 
 					function persistLockedSelection() {
 						if (
-							options.mode === "screenshot" ||
+							isImmediateCapture() ||
 							!areaSelectionPreferences.locked ||
 							areaSelectionPreferences.screenId !== displayId() ||
 							!isValid()
@@ -920,7 +937,7 @@ function Inner() {
 						}
 						if (
 							isInteracting() ||
-							options.mode === "screenshot" ||
+							isImmediateCapture() ||
 							!areaSelectionPreferences.locked ||
 							areaSelectionPreferences.screenId !== displayId() ||
 							!isValid() ||
@@ -989,7 +1006,7 @@ function Inner() {
 					});
 
 					createEffect(async () => {
-						if (options.mode === "screenshot") return;
+						if (isImmediateCapture()) return;
 						const bounds = crop();
 						const interacting = isInteracting();
 						const displayInfo = areaDisplayInfo.data;
@@ -1252,6 +1269,51 @@ function Inner() {
 
 						if (was && !interacting) {
 							persistLockedSelection();
+							if (isOcr() && isValid()) {
+								const cropBounds = crop();
+								const target: ScreenCaptureTarget = {
+									variant: "area",
+									screen: displayId(),
+									bounds: {
+										position: {
+											x: cropBounds.x,
+											y: cropBounds.y,
+										},
+										size: {
+											width: cropBounds.width,
+											height: cropBounds.height,
+										},
+									},
+								};
+
+								const overlayWindows = (await WebviewWindow.getAll()).filter(
+									(win) => win.label.startsWith("target-select-overlay-"),
+								);
+
+								try {
+									for (const win of overlayWindows) {
+										await win.setIgnoreCursorEvents(true);
+										await win.hide();
+									}
+									await new Promise((resolve) => setTimeout(resolve, 50));
+
+									await commands.captureOcrText(target);
+									setOptions({
+										targetMode: null,
+										targetModeDismissal: "screenshot",
+									});
+									await commands.closeTargetSelectOverlays();
+								} catch (e) {
+									for (const win of overlayWindows) {
+										await win.setIgnoreCursorEvents(false);
+										await win.show();
+									}
+									const message = e instanceof Error ? e.message : String(e);
+									toast.error(`Failed to copy text: ${message}`);
+									console.error("Failed to copy text", e);
+								}
+								return;
+							}
 							if (options.mode === "screenshot" && isValid()) {
 								const cropBounds = crop();
 								const displayInfo = areaDisplayInfo.data;
@@ -1330,7 +1392,9 @@ function Inner() {
 										<div class="min-w-28 px-2 text-base font-normal leading-none tracking-[-0.01em] tabular-nums">
 											{isValid()
 												? `${Math.round(crop().width)} × ${Math.round(crop().height)}`
-												: "Draw an area"}
+												: isOcr()
+													? "Draw an area to copy text"
+													: "Draw an area"}
 										</div>
 
 										<div class="h-6 w-px bg-gray-5" />
@@ -1402,7 +1466,7 @@ function Inner() {
 										>
 											<IconLucideMaximize2 class="size-4" />
 										</button>
-										<Show when={options.mode !== "screenshot"}>
+										<Show when={!isImmediateCapture()}>
 											<button
 												type="button"
 												class="flex h-9 items-center gap-1.5 rounded-xl px-2.5 text-xs font-normal transition-colors disabled:cursor-not-allowed disabled:opacity-40"
@@ -1434,7 +1498,7 @@ function Inner() {
 								style={controlsStyle()}
 							>
 								<div class="flex flex-col items-center">
-									<Show when={options.mode !== "screenshot"}>
+									<Show when={!isImmediateCapture()}>
 										<RecordingControls
 											target={{
 												variant: "area",
@@ -1479,7 +1543,7 @@ function Inner() {
 											</small>
 										</div>
 									</Show>
-									<Show when={isValid()}>
+									<Show when={isValid() && !isOcr()}>
 										<ShowCapFreeWarning
 											isInstantMode={options.mode === "instant"}
 										/>

--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -1300,7 +1300,7 @@ function Inner() {
 									await commands.captureOcrText(target);
 									setOptions({
 										targetMode: null,
-										targetModeDismissal: "screenshot",
+										targetModeDismissal: "ocr",
 									});
 									await commands.closeTargetSelectOverlays();
 								} catch (e) {

--- a/apps/desktop/src/utils/queries.ts
+++ b/apps/desktop/src/utils/queries.ts
@@ -162,6 +162,7 @@ export type TargetModeDismissal =
 	| "recordingStudio"
 	| "recordingInstant"
 	| "screenshot"
+	| "ocr"
 	| "superseded"
 	| "cancelled";
 

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -569,7 +569,6 @@ videoImportProgress: "video-import-progress"
 /** user-defined types **/
 
 export type Action = { type: "copyToClipboard"; source?: ClipboardSource } | { type: "saveToLocation"; dir: string; filenameTemplate?: string | null } | { type: "export"; profile: ExportProfile; destination?: ExportDestination } | { type: "upload"; organizationId?: string | null; copyLink?: boolean; openInBrowser?: boolean } | { type: "revealInFileManager" } | { type: "openFile" } | { type: "runCommand"; program: string; args?: string[]; cwd?: string | null; env?: { [key in string]: string }; useShell?: boolean } | { type: "webhook"; url: string; method?: string; headers?: { [key in string]: string }; bodyTemplate?: string | null } | { type: "recognizeTextToClipboard" } | { type: "notify"; titleTemplate?: string; bodyTemplate?: string } | { type: "openEditor" } | { type: "skipEditor" } | { type: "applyPreset"; name: string } | { type: "deleteLocalFiles" }
-export type AllGpusInfo = { gpus: GpuInfoDiag[]; primaryGpuIndex: number | null; isMultiGpuSystem: boolean; hasDiscreteGpu: boolean }
 export type Annotation = { id: string; type: AnnotationType; x: number; y: number; width: number; height: number; strokeColor: string; strokeWidth: number; fillColor: string; opacity: number; rotation: number; text: string | null; maskType?: MaskType | null; maskLevel?: number | null }
 export type AnnotationType = "arrow" | "circle" | "rectangle" | "text" | "mask"
 export type AppTheme = "system" | "light" | "dark"
@@ -821,7 +820,6 @@ quality: number | null;
  */
 fast: boolean | null }
 export type GlideDirection = "none" | "left" | "right" | "up" | "down"
-export type GpuInfoDiag = { vendor: string; description: string; dedicatedVideoMemoryMb: number; adapterIndex: number; isSoftwareAdapter: boolean; isBasicRenderDriver: boolean; supportsHardwareEncoding: boolean }
 export type HapticPattern = "alignment" | "levelChange" | "generic"
 export type HapticPerformanceTime = "default" | "now" | "drawCompleted"
 export type Hotkey = { code: string; meta: boolean; ctrl: boolean; alt: boolean; shift: boolean }
@@ -844,6 +842,7 @@ export type KeyboardTrackSegment = { id: string; start: number; end: number; dis
 export type LogicalBounds = { position: LogicalPosition; size: LogicalSize }
 export type LogicalPosition = { x: number; y: number }
 export type LogicalSize = { width: number; height: number }
+export type MacOSVersionInfo = { major: number; minor: number; patch: number; displayName: string; buildNumber: string; isAppleSilicon: boolean }
 export type MainWindowRecordingStartBehaviour = "close" | "minimise"
 export type MaskKeyframes = { position?: MaskVectorKeyframe[]; size?: MaskVectorKeyframe[]; intensity?: MaskScalarKeyframe[] }
 export type MaskKind = "sensitive" | "highlight"
@@ -916,7 +915,6 @@ export type RecordingsMigrationFailure = { name: string; error: string }
 export type RecordingsMigrationProgress = { total: number; done: number; current: string | null }
 export type RecordingsMigrationSummary = { moved: number; skippedInUse: number; failed: RecordingsMigrationFailure[] }
 export type RenderFrameEvent = { frame_number: number; fps: number; resolution_base: XY<number> }
-export type RenderingStatus = { isUsingSoftwareRendering: boolean; isUsingBasicRenderDriver: boolean; hardwareEncodingAvailable: boolean; warningMessage: string | null }
 export type RequestOpenRecordingPicker = { target_mode: RecordingTargetMode | null }
 export type RequestOpenSettings = { page: string }
 export type RequestScreenCapturePrewarm = { force?: boolean }
@@ -961,7 +959,7 @@ export type StereoMode = "stereo" | "monoL" | "monoR"
 export type StudioRecordingMeta = { segment: SingleSegment } | { inner: MultipleSegments }
 export type StudioRecordingQuality = "compatibility" | "balanced" | "ultra"
 export type StudioRecordingStatus = { status: "InProgress" } | { status: "NeedsRemux" } | { status: "Failed"; error: string } | { status: "Complete" }
-export type SystemDiagnostics = { windowsVersion: WindowsVersionInfo | null; gpuInfo: GpuInfoDiag | null; allGpus: AllGpusInfo | null; renderingStatus: RenderingStatus; availableEncoders: string[]; graphicsCaptureSupported: boolean; d3D11VideoProcessorAvailable: boolean }
+export type SystemDiagnostics = { macosVersion: MacOSVersionInfo | null; availableEncoders: string[]; screenCaptureSupported: boolean; metalSupported: boolean; gpuName: string | null }
 export type TargetUnderCursor = { display_id: DisplayId | null; window: WindowUnderCursor | null }
 export type TextSegment = { start: number; end: number; track?: number; enabled?: boolean; content?: string; center?: XY<number>; size?: XY<number>; fontFamily?: string; fontSize?: number; fontWeight?: number; italic?: boolean; color?: string; fadeDuration?: number }
 export type TimelineConfiguration = { segments: TimelineSegment[]; transitions: ClipTransition[]; zoomSegments: ZoomSegment[]; sceneSegments?: SceneSegment[]; maskSegments?: MaskSegment[]; textSegments?: TextSegment[]; captionSegments?: CaptionTrackSegment[]; keyboardSegments?: KeyboardTrackSegment[]; audioSegments?: AudioTrackSegment[] }
@@ -986,7 +984,6 @@ export type WindowExclusion = { bundleIdentifier?: string | null; ownerName?: st
 export type WindowId = string
 export type WindowPosition = { x: number; y: number; displayId?: DisplayId | null }
 export type WindowUnderCursor = { id: WindowId; app_name: string; bounds: LogicalBounds }
-export type WindowsVersionInfo = { major: number; minor: number; build: number; displayName: string; meetsRequirements: boolean; isWindows11: boolean }
 export type XY<T> = { x: T; y: T }
 export type ZoomMode = "auto" | { manual: { x: number; y: number } }
 export type ZoomSegment = { start: number; end: number; amount: number; mode: ZoomMode; glideDirection?: GlideDirection; glideSpeed?: number; instantAnimation?: boolean; edgeSnapRatio?: number }

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -308,6 +308,13 @@ async positionTrafficLights(controlsInset: [number, number] | null) : Promise<vo
 async setTheme(theme: AppTheme) : Promise<void> {
     await TAURI_INVOKE("set_theme", { theme });
 },
+/**
+ * Shows the calling window without activating it, so the foreground app
+ * keeps keyboard focus.
+ */
+async showWindowWithoutActivating() : Promise<void> {
+    await TAURI_INVOKE("show_window_without_activating");
+},
 async setTeleprompterWindowLevel(alwaysOnTop: boolean) : Promise<void> {
     await TAURI_INVOKE("set_teleprompter_window_level", { alwaysOnTop });
 },
@@ -569,6 +576,7 @@ videoImportProgress: "video-import-progress"
 /** user-defined types **/
 
 export type Action = { type: "copyToClipboard"; source?: ClipboardSource } | { type: "saveToLocation"; dir: string; filenameTemplate?: string | null } | { type: "export"; profile: ExportProfile; destination?: ExportDestination } | { type: "upload"; organizationId?: string | null; copyLink?: boolean; openInBrowser?: boolean } | { type: "revealInFileManager" } | { type: "openFile" } | { type: "runCommand"; program: string; args?: string[]; cwd?: string | null; env?: { [key in string]: string }; useShell?: boolean } | { type: "webhook"; url: string; method?: string; headers?: { [key in string]: string }; bodyTemplate?: string | null } | { type: "recognizeTextToClipboard" } | { type: "notify"; titleTemplate?: string; bodyTemplate?: string } | { type: "openEditor" } | { type: "skipEditor" } | { type: "applyPreset"; name: string } | { type: "deleteLocalFiles" }
+export type AllGpusInfo = { gpus: GpuInfoDiag[]; primaryGpuIndex: number | null; isMultiGpuSystem: boolean; hasDiscreteGpu: boolean }
 export type Annotation = { id: string; type: AnnotationType; x: number; y: number; width: number; height: number; strokeColor: string; strokeWidth: number; fillColor: string; opacity: number; rotation: number; text: string | null; maskType?: MaskType | null; maskLevel?: number | null }
 export type AnnotationType = "arrow" | "circle" | "rectangle" | "text" | "mask"
 export type AppTheme = "system" | "light" | "dark"
@@ -820,6 +828,7 @@ quality: number | null;
  */
 fast: boolean | null }
 export type GlideDirection = "none" | "left" | "right" | "up" | "down"
+export type GpuInfoDiag = { vendor: string; description: string; dedicatedVideoMemoryMb: number; adapterIndex: number; isSoftwareAdapter: boolean; isBasicRenderDriver: boolean; supportsHardwareEncoding: boolean }
 export type HapticPattern = "alignment" | "levelChange" | "generic"
 export type HapticPerformanceTime = "default" | "now" | "drawCompleted"
 export type Hotkey = { code: string; meta: boolean; ctrl: boolean; alt: boolean; shift: boolean }
@@ -842,7 +851,6 @@ export type KeyboardTrackSegment = { id: string; start: number; end: number; dis
 export type LogicalBounds = { position: LogicalPosition; size: LogicalSize }
 export type LogicalPosition = { x: number; y: number }
 export type LogicalSize = { width: number; height: number }
-export type MacOSVersionInfo = { major: number; minor: number; patch: number; displayName: string; buildNumber: string; isAppleSilicon: boolean }
 export type MainWindowRecordingStartBehaviour = "close" | "minimise"
 export type MaskKeyframes = { position?: MaskVectorKeyframe[]; size?: MaskVectorKeyframe[]; intensity?: MaskScalarKeyframe[] }
 export type MaskKind = "sensitive" | "highlight"
@@ -915,6 +923,7 @@ export type RecordingsMigrationFailure = { name: string; error: string }
 export type RecordingsMigrationProgress = { total: number; done: number; current: string | null }
 export type RecordingsMigrationSummary = { moved: number; skippedInUse: number; failed: RecordingsMigrationFailure[] }
 export type RenderFrameEvent = { frame_number: number; fps: number; resolution_base: XY<number> }
+export type RenderingStatus = { isUsingSoftwareRendering: boolean; isUsingBasicRenderDriver: boolean; hardwareEncodingAvailable: boolean; warningMessage: string | null }
 export type RequestOpenRecordingPicker = { target_mode: RecordingTargetMode | null }
 export type RequestOpenSettings = { page: string }
 export type RequestScreenCapturePrewarm = { force?: boolean }
@@ -959,7 +968,7 @@ export type StereoMode = "stereo" | "monoL" | "monoR"
 export type StudioRecordingMeta = { segment: SingleSegment } | { inner: MultipleSegments }
 export type StudioRecordingQuality = "compatibility" | "balanced" | "ultra"
 export type StudioRecordingStatus = { status: "InProgress" } | { status: "NeedsRemux" } | { status: "Failed"; error: string } | { status: "Complete" }
-export type SystemDiagnostics = { macosVersion: MacOSVersionInfo | null; availableEncoders: string[]; screenCaptureSupported: boolean; metalSupported: boolean; gpuName: string | null }
+export type SystemDiagnostics = { windowsVersion: WindowsVersionInfo | null; gpuInfo: GpuInfoDiag | null; allGpus: AllGpusInfo | null; renderingStatus: RenderingStatus; availableEncoders: string[]; graphicsCaptureSupported: boolean; d3D11VideoProcessorAvailable: boolean }
 export type TargetUnderCursor = { display_id: DisplayId | null; window: WindowUnderCursor | null }
 export type TextSegment = { start: number; end: number; track?: number; enabled?: boolean; content?: string; center?: XY<number>; size?: XY<number>; fontFamily?: string; fontSize?: number; fontWeight?: number; italic?: boolean; color?: string; fadeDuration?: number }
 export type TimelineConfiguration = { segments: TimelineSegment[]; transitions: ClipTransition[]; zoomSegments: ZoomSegment[]; sceneSegments?: SceneSegment[]; maskSegments?: MaskSegment[]; textSegments?: TextSegment[]; captionSegments?: CaptionTrackSegment[]; keyboardSegments?: KeyboardTrackSegment[]; audioSegments?: AudioTrackSegment[] }
@@ -984,6 +993,7 @@ export type WindowExclusion = { bundleIdentifier?: string | null; ownerName?: st
 export type WindowId = string
 export type WindowPosition = { x: number; y: number; displayId?: DisplayId | null }
 export type WindowUnderCursor = { id: WindowId; app_name: string; bounds: LogicalBounds }
+export type WindowsVersionInfo = { major: number; minor: number; build: number; displayName: string; meetsRequirements: boolean; isWindows11: boolean }
 export type XY<T> = { x: T; y: T }
 export type ZoomMode = "auto" | { manual: { x: number; y: number } }
 export type ZoomSegment = { start: number; end: number; amount: number; mode: ZoomMode; glideDirection?: GlideDirection; glideSpeed?: number; instantAnimation?: boolean; edgeSnapRatio?: number }

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -59,6 +59,9 @@ async deleteRecording() : Promise<null> {
 async takeScreenshot(target: ScreenCaptureTarget) : Promise<string> {
     return await TAURI_INVOKE("take_screenshot", { target });
 },
+async captureOcrText(target: ScreenCaptureTarget) : Promise<string> {
+    return await TAURI_INVOKE("capture_ocr_text", { target });
+},
 async importCurrentDesktopBackground(projectPath: string) : Promise<string> {
     return await TAURI_INVOKE("import_current_desktop_background", { projectPath });
 },
@@ -566,6 +569,7 @@ videoImportProgress: "video-import-progress"
 /** user-defined types **/
 
 export type Action = { type: "copyToClipboard"; source?: ClipboardSource } | { type: "saveToLocation"; dir: string; filenameTemplate?: string | null } | { type: "export"; profile: ExportProfile; destination?: ExportDestination } | { type: "upload"; organizationId?: string | null; copyLink?: boolean; openInBrowser?: boolean } | { type: "revealInFileManager" } | { type: "openFile" } | { type: "runCommand"; program: string; args?: string[]; cwd?: string | null; env?: { [key in string]: string }; useShell?: boolean } | { type: "webhook"; url: string; method?: string; headers?: { [key in string]: string }; bodyTemplate?: string | null } | { type: "recognizeTextToClipboard" } | { type: "notify"; titleTemplate?: string; bodyTemplate?: string } | { type: "openEditor" } | { type: "skipEditor" } | { type: "applyPreset"; name: string } | { type: "deleteLocalFiles" }
+export type AllGpusInfo = { gpus: GpuInfoDiag[]; primaryGpuIndex: number | null; isMultiGpuSystem: boolean; hasDiscreteGpu: boolean }
 export type Annotation = { id: string; type: AnnotationType; x: number; y: number; width: number; height: number; strokeColor: string; strokeWidth: number; fillColor: string; opacity: number; rotation: number; text: string | null; maskType?: MaskType | null; maskLevel?: number | null }
 export type AnnotationType = "arrow" | "circle" | "rectangle" | "text" | "mask"
 export type AppTheme = "system" | "light" | "dark"
@@ -805,7 +809,7 @@ previousRecordingsPaths?: string[];
  * Cleared automatically when the app version changes (one retry per
  * update, since a new ort/wgpu/driver stack may have fixed the crash).
  */
-cameraBlurDisabledByCrash?: string | null; updateChannel?: UpdateChannel }
+cameraBlurDisabledByCrash?: string | null; updateChannel?: UpdateChannel; ocrKeepScreenshot?: boolean; ocrShowNotification?: boolean }
 export type GifExportSettings = { fps: number; resolution_base: XY<number>; quality: GifQuality | null }
 export type GifQuality = { 
 /**
@@ -817,12 +821,13 @@ quality: number | null;
  */
 fast: boolean | null }
 export type GlideDirection = "none" | "left" | "right" | "up" | "down"
+export type GpuInfoDiag = { vendor: string; description: string; dedicatedVideoMemoryMb: number; adapterIndex: number; isSoftwareAdapter: boolean; isBasicRenderDriver: boolean; supportsHardwareEncoding: boolean }
 export type HapticPattern = "alignment" | "levelChange" | "generic"
 export type HapticPerformanceTime = "default" | "now" | "drawCompleted"
 export type Hotkey = { code: string; meta: boolean; ctrl: boolean; alt: boolean; shift: boolean }
-export type HotkeyAction = "startStudioRecording" | "startInstantRecording" | "stopRecording" | "restartRecording" | "togglePauseRecording" | "cycleRecordingMode" | "openRecordingPicker" | "openRecordingPickerDisplay" | "openRecordingPickerWindow" | "openRecordingPickerArea" | "screenshotDisplay" | "screenshotWindow" | "screenshotArea" | "other"
+export type HotkeyAction = "startStudioRecording" | "startInstantRecording" | "stopRecording" | "restartRecording" | "togglePauseRecording" | "cycleRecordingMode" | "openRecordingPicker" | "openRecordingPickerDisplay" | "openRecordingPickerWindow" | "openRecordingPickerArea" | "screenshotDisplay" | "screenshotWindow" | "screenshotArea" | "ocrArea" | "other"
 export type HotkeysConfiguration = { show: boolean }
-export type HotkeysStore = { hotkeys: { [key in HotkeyAction]: Hotkey } }
+export type HotkeysStore = { hotkeys: { [key in HotkeyAction]: Hotkey }; seeded?: HotkeyAction[] }
 export type ImportStage = "Probing" | "Converting" | "Finalizing" | "Complete" | "Failed"
 export type ImportedAudioTrack = { 
 /**
@@ -839,7 +844,6 @@ export type KeyboardTrackSegment = { id: string; start: number; end: number; dis
 export type LogicalBounds = { position: LogicalPosition; size: LogicalSize }
 export type LogicalPosition = { x: number; y: number }
 export type LogicalSize = { width: number; height: number }
-export type MacOSVersionInfo = { major: number; minor: number; patch: number; displayName: string; buildNumber: string; isAppleSilicon: boolean }
 export type MainWindowRecordingStartBehaviour = "close" | "minimise"
 export type MaskKeyframes = { position?: MaskVectorKeyframe[]; size?: MaskVectorKeyframe[]; intensity?: MaskScalarKeyframe[] }
 export type MaskKind = "sensitive" | "highlight"
@@ -907,11 +911,12 @@ export type RecordingSettingsStore = { target: ScreenCaptureTarget | null; micNa
 export type RecordingStarted = null
 export type RecordingStatus = "pending" | "recording"
 export type RecordingStopped = null
-export type RecordingTargetMode = "display" | "window" | "area" | "camera"
+export type RecordingTargetMode = "display" | "window" | "area" | "camera" | "ocr"
 export type RecordingsMigrationFailure = { name: string; error: string }
 export type RecordingsMigrationProgress = { total: number; done: number; current: string | null }
 export type RecordingsMigrationSummary = { moved: number; skippedInUse: number; failed: RecordingsMigrationFailure[] }
 export type RenderFrameEvent = { frame_number: number; fps: number; resolution_base: XY<number> }
+export type RenderingStatus = { isUsingSoftwareRendering: boolean; isUsingBasicRenderDriver: boolean; hardwareEncodingAvailable: boolean; warningMessage: string | null }
 export type RequestOpenRecordingPicker = { target_mode: RecordingTargetMode | null }
 export type RequestOpenSettings = { page: string }
 export type RequestScreenCapturePrewarm = { force?: boolean }
@@ -956,7 +961,7 @@ export type StereoMode = "stereo" | "monoL" | "monoR"
 export type StudioRecordingMeta = { segment: SingleSegment } | { inner: MultipleSegments }
 export type StudioRecordingQuality = "compatibility" | "balanced" | "ultra"
 export type StudioRecordingStatus = { status: "InProgress" } | { status: "NeedsRemux" } | { status: "Failed"; error: string } | { status: "Complete" }
-export type SystemDiagnostics = { macosVersion: MacOSVersionInfo | null; availableEncoders: string[]; screenCaptureSupported: boolean; metalSupported: boolean; gpuName: string | null }
+export type SystemDiagnostics = { windowsVersion: WindowsVersionInfo | null; gpuInfo: GpuInfoDiag | null; allGpus: AllGpusInfo | null; renderingStatus: RenderingStatus; availableEncoders: string[]; graphicsCaptureSupported: boolean; d3D11VideoProcessorAvailable: boolean }
 export type TargetUnderCursor = { display_id: DisplayId | null; window: WindowUnderCursor | null }
 export type TextSegment = { start: number; end: number; track?: number; enabled?: boolean; content?: string; center?: XY<number>; size?: XY<number>; fontFamily?: string; fontSize?: number; fontWeight?: number; italic?: boolean; color?: string; fadeDuration?: number }
 export type TimelineConfiguration = { segments: TimelineSegment[]; transitions: ClipTransition[]; zoomSegments: ZoomSegment[]; sceneSegments?: SceneSegment[]; maskSegments?: MaskSegment[]; textSegments?: TextSegment[]; captionSegments?: CaptionTrackSegment[]; keyboardSegments?: KeyboardTrackSegment[]; audioSegments?: AudioTrackSegment[] }
@@ -981,6 +986,7 @@ export type WindowExclusion = { bundleIdentifier?: string | null; ownerName?: st
 export type WindowId = string
 export type WindowPosition = { x: number; y: number; displayId?: DisplayId | null }
 export type WindowUnderCursor = { id: WindowId; app_name: string; bounds: LogicalBounds }
+export type WindowsVersionInfo = { major: number; minor: number; build: number; displayName: string; meetsRequirements: boolean; isWindows11: boolean }
 export type XY<T> = { x: T; y: T }
 export type ZoomMode = "auto" | { manual: { x: number; y: number } }
 export type ZoomSegment = { start: number; end: number; amount: number; mode: ZoomMode; glideDirection?: GlideDirection; glideSpeed?: number; instantAnimation?: boolean; edgeSnapRatio?: number }


### PR DESCRIPTION
## Summary

Adds a privacy-first "copy text from screen" feature: press **Ctrl+Shift+T** (Windows) / **Cmd+Shift+T** (macOS), drag over any screen region with the existing area selector, and the recognized text is copied straight to the clipboard. Nothing is written to disk by default.

Reuses Cap's existing native OCR engines (Apple Vision on macOS, Windows.Media.Ocr on Windows) — no new dependency, free, fast, on-device.

How it fits together:

- `HotkeyAction::OcrArea` — new hotkey action, seeded with a default binding on startup via `seed_default_hotkeys` (a `seeded` list in `HotkeysStore` ensures it's only auto-added once and never overrides a user's existing binding). Pressing it opens the target-select overlay in a new `RecordingTargetMode::Ocr`.
- `target-select-overlay.tsx` — `"ocr"` target mode reuses the area-selector UI (screenshot-style: 1×1 min size, no recording controls, toolbar hint "Draw an area to copy text"). On mouse-up it invokes the new command instead of `takeScreenshot`; on error the overlay is restored with a toast.
- `capture_ocr_text` (recording.rs) — new Tauri command:
  ```
  capture region in-memory → recognize_text_from_dynamic_image (native OCR)
    → clipboard.write_text → optional save_screenshot_project → optional notification
  ```
- `take_screenshot` was split into `capture_screen_image` + `save_screenshot_project` so OCR shares the capture/persistence code without duplicating it.
- Settings:
  - General → new "Text capture (OCR)" section with two default-off toggles: `ocr_keep_screenshot` (save the region as a normal screenshot project) and `ocr_show_notification` (system notification with a preview of the copied text).
  - Shortcuts → "Copy text from area (OCR)" entry, rebindable like any other hotkey.

## Showcase

Pressing the shortcut opens the familiar area selector, in text-capture mode:

![OCR capture overlay](https://raw.githubusercontent.com/x1xhlol/Cap/assets/pr-media/media/01-ocr-overlay-hint.png)

Drag over any text and it lands on the clipboard (nothing written to disk):

![OCR text copied to clipboard](https://raw.githubusercontent.com/x1xhlol/Cap/assets/pr-media/media/03-ocr-fallback-text.png)

The capture is a background gesture — the app you were in keeps keyboard focus afterwards:

![Focus stays on the previous app](https://raw.githubusercontent.com/x1xhlol/Cap/assets/pr-media/media/10-focusfix-after-capture.png)

Settings — rebindable shortcut and the two default-off toggles:

![Shortcut entry](https://raw.githubusercontent.com/x1xhlol/Cap/assets/pr-media/media/05-settings-shortcut.png)

![Text capture settings](https://raw.githubusercontent.com/x1xhlol/Cap/assets/pr-media/media/04-settings-ocr-toggles.png)

## Testing (Windows, end-to-end on a live dev build)

| Test | Result |
|---|---|
| Ctrl+Shift+T opens OCR overlay ("Draw an area to copy text") | ✅ |
| Drag region → OCR text copied to clipboard (exact match) | ✅ |
| No screenshot persisted by default | ✅ |
| Shortcuts: "Copy text from area (OCR)" = Ctrl Shift T | ✅ |
| General: "Text capture (OCR)" toggles present, default OFF | ✅ |
| "Keep a screenshot" ON → `.cap` screenshot project created | ✅ |

Known minor limitation: a very thin selection (~30 px tall) can return "No text was found in the selected area" (Windows.Media.Ocr small-region behavior); handled gracefully with a toast, slightly larger selections work.

macOS path uses the same Vision-based OCR code Cap already ships for the screenshot editor; it compiles for both platforms but was runtime-tested on Windows only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a global area-selection OCR workflow that captures screen pixels in memory, copies recognized text to the clipboard, and optionally saves the capture or displays a notification.

- Adds and seeds a configurable OCR global hotkey.
- Extends the target-selection overlay with an OCR-specific immediate-capture mode.
- Refactors screenshot capture so OCR can reuse capture and project-persistence logic.
- Adds persisted OCR settings and generated frontend IPC bindings.

<h3>Confidence Score: 4/5</h3>

The unrelated-overlay restoration defect should be fixed before merging because invoking OCR can leave existing Cap UI windows hidden.

The new global OCR path reuses a capture helper that hides several classes of Cap windows, while its completion and recovery logic restores only target-selector overlays.

**Files Needing Attention:** apps/desktop/src-tauri/src/recording.rs, apps/desktop/src/routes/target-select-overlay.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/recording.rs | Adds the OCR command and shared capture helper, but the helper leaves unrelated Cap overlay windows hidden after capture. |
| apps/desktop/src/routes/target-select-overlay.tsx | Adds OCR selection and IPC sequencing; its cleanup only restores target-selector overlays and therefore does not compensate for the backend window-state issue. |
| apps/desktop/src-tauri/src/hotkeys.rs | Adds the OCR hotkey action and one-time conflict-aware default seeding without overriding existing bindings. |
| apps/desktop/src-tauri/src/general_settings.rs | Adds backward-compatible, default-off OCR persistence and notification settings. |
| apps/desktop/src-tauri/src/screenshot_editor.rs | Extracts the existing native OCR implementation to accept an in-memory DynamicImage. |
| apps/desktop/src-tauri/src/lib.rs | Registers the new OCR command in the Tauri command bridge. |
| apps/desktop/src/routes/(window-chrome)/settings/general.tsx | Adds controls for retaining OCR screenshots and showing notification previews. |
| apps/desktop/src/utils/tauri.ts | Updates generated IPC bindings and shared types for the new command, settings, hotkey action, and target mode. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src-tauri/src/recording.rs`, line 2878-2881 ([link](https://github.com/capsoftware/cap/blob/8a6644c5743bb7cd532f540e788894de8400bc90/apps/desktop/src-tauri/src/recording.rs#L2878-L2881)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Capture leaves overlays hidden**

   When OCR runs while another Cap overlay is visible, `capture_screen_image` hides that window without restoring its visibility or cursor-event state, causing recordings, mode-selection, capture-area, or occluder overlays to remain inaccessible after the capture succeeds or fails.

   **Knowledge Base Used:**
   - [Desktop Tauri App (Rust Backend)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-tauri-app.md)
   - [Desktop Frontend (apps/desktop/src)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-frontend.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src-tauri/src/recording.rs
   Line: 2878-2881
   
   Comment:
   **Capture leaves overlays hidden**
   
   When OCR runs while another Cap overlay is visible, `capture_screen_image` hides that window without restoring its visibility or cursor-event state, causing recordings, mode-selection, capture-area, or occluder overlays to remain inaccessible after the capture succeeds or fails.
   
   **Knowledge Base Used:**
   - [Desktop Tauri App (Rust Backend)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-tauri-app.md)
   - [Desktop Frontend (apps/desktop/src)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-frontend.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/desktop/src-tauri/src/recording.rs:2878-2881
**Capture leaves overlays hidden**

When OCR runs while another Cap overlay is visible, `capture_screen_image` hides that window without restoring its visibility or cursor-event state, causing recordings, mode-selection, capture-area, or occluder overlays to remain inaccessible after the capture succeeds or fails.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Restore macOS diagnostics types in gener..."](https://github.com/capsoftware/cap/commit/8a6644c5743bb7cd532f540e788894de8400bc90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50815837)</sub>

**Context used:**

- Knowledge Base — [Desktop Tauri App (Rust Backend)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-tauri-app.md)
- Knowledge Base — [Desktop Frontend (apps/desktop/src)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-frontend.md)

<!-- /greptile_comment -->