### PR TITLE
Decode QR codes and barcodes in text capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,6 +1508,7 @@ dependencies = [
  "relative-path",
  "reqwest",
  "rodio",
+ "rxing",
  "sanitize-filename",
  "scap-direct3d",
  "scap-screencapturekit",
@@ -2186,6 +2196,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "cidre"
 version = "0.11.0"
 source = "git+https://github.com/CapSoftware/cidre?rev=bf84b67079a8#bf84b67079a89d6eaf01c1dab073baaba1ea8f77"
@@ -2337,6 +2357,15 @@ dependencies = [
  "core-foundation 0.10.1",
  "core-graphics-types 0.2.0",
  "objc",
+]
+
+[[package]]
+name = "codepage-437"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40c1169585d8d08e5675a39f2fc056cd19a258fc4cba5e3bbf4a9c1026de535"
+dependencies = [
+ "csv",
 ]
 
 [[package]]
@@ -2850,6 +2879,27 @@ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3566,6 +3616,17 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4954,6 +5015,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "imageproc"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602b4e8a4cc3e98372b766cd184ab532999bc0e839b7469e759511ccabc65d77"
+dependencies = [
+ "ab_glyph",
+ "approx",
+ "getrandom 0.2.16",
+ "image 0.25.8",
+ "itertools 0.12.1",
+ "nalgebra",
+ "num",
+ "rand 0.8.5",
+ "rand_distr",
+ "rayon",
+]
+
+[[package]]
 name = "imagequant"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6147,6 +6226,21 @@ dependencies = [
  "strum 0.26.3",
  "thiserror 2.0.16",
  "unicode-ident",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
 ]
 
 [[package]]
@@ -7506,6 +7600,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7605,6 +7708,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.1",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher 1.0.1",
 ]
@@ -8175,6 +8287,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8418,9 +8540,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8430,9 +8552,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8447,9 +8569,9 @@ checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -8856,10 +8978,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rxing"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6609a7ccb6435312dd3a2bff9924cdbb1c96050510fff30676c3d7b8b0045739"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "codepage-437",
+ "encoding_rs",
+ "fancy-regex",
+ "image 0.25.8",
+ "imageproc",
+ "num",
+ "once_cell",
+ "regex",
+ "rxing-one-d-proc-derive",
+ "serde",
+ "thiserror 2.0.16",
+ "unicode-segmentation",
+ "uriparse",
+ "urlencoding",
+]
+
+[[package]]
+name = "rxing-one-d-proc-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee3a551320da932c705835119f5f9a69a144966d18780d35e3b394585c22ce3"
+dependencies = [
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -9605,6 +9770,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10136,6 +10314,17 @@ name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11828,9 +12017,9 @@ checksum = "9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-vo"
@@ -11906,6 +12095,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uriparse"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
+dependencies = [
+ "fnv",
+ "lazy_static",
+]
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11916,6 +12115,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"
@@ -12610,6 +12815,16 @@ dependencies = [
  "cfg-if",
  "cmake",
  "fs_extra",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -51,6 +51,7 @@ specta-typescript = "0.0.7"
 tokio = { workspace = true, features = ["signal"] }
 uuid = { version = "1.10.0", features = ["v4"] }
 image = "0.25.2"
+rxing = "0.9.2"
 futures-intrusive = "0.5.0"
 anyhow.workspace = true
 futures = { workspace = true }

--- a/apps/desktop/src-tauri/src/barcode.rs
+++ b/apps/desktop/src-tauri/src/barcode.rs
@@ -1,6 +1,5 @@
 use rxing::{DecodeHintValue, DecodeHints};
 
-/// Decodes a QR code or barcode from an image, returning its text payload.
 pub fn decode_barcode(image: &image::DynamicImage) -> Option<String> {
     let luma = image.to_luma8();
     let width = luma.width();

--- a/apps/desktop/src-tauri/src/barcode.rs
+++ b/apps/desktop/src-tauri/src/barcode.rs
@@ -1,0 +1,15 @@
+use rxing::{DecodeHintValue, DecodeHints};
+
+/// Decodes a QR code or barcode from an image, returning its text payload.
+pub fn decode_barcode(image: &image::DynamicImage) -> Option<String> {
+    let luma = image.to_luma8();
+    let width = luma.width();
+    let height = luma.height();
+
+    let mut hints = DecodeHints::default().with(DecodeHintValue::TryHarder(true));
+
+    rxing::helpers::detect_in_luma_with_hints(luma.into_raw(), width, height, None, &mut hints)
+        .ok()
+        .map(|result| result.getText().to_string())
+        .filter(|text| !text.is_empty())
+}

--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -247,6 +247,10 @@ pub struct GeneralSettingsStore {
     pub camera_blur_disabled_by_crash: Option<String>,
     #[serde(default)]
     pub update_channel: UpdateChannel,
+    #[serde(default)]
+    pub ocr_keep_screenshot: bool,
+    #[serde(default)]
+    pub ocr_show_notification: bool,
 }
 
 fn default_enable_native_camera_preview() -> bool {
@@ -350,6 +354,8 @@ impl Default for GeneralSettingsStore {
             previous_recordings_paths: Vec::new(),
             camera_blur_disabled_by_crash: None,
             update_channel: UpdateChannel::Stable,
+            ocr_keep_screenshot: false,
+            ocr_show_notification: false,
         }
     }
 }

--- a/apps/desktop/src-tauri/src/hotkeys.rs
+++ b/apps/desktop/src-tauri/src/hotkeys.rs
@@ -212,15 +212,19 @@ pub fn init(app: &AppHandle) {
     .unwrap();
 
     let mut store = match HotkeysStore::get(app) {
-        Ok(Some(s)) => s,
-        Ok(None) => HotkeysStore::default(),
+        Ok(Some(s)) => Some(s),
+        Ok(None) => Some(HotkeysStore::default()),
         Err(e) => {
             eprintln!("Failed to load hotkeys store: {e}");
-            HotkeysStore::default()
+            None
         }
     };
 
-    seed_default_hotkeys(app, &mut store);
+    if let Some(store) = &mut store {
+        seed_default_hotkeys(app, store);
+    }
+
+    let store = store.unwrap_or_default();
 
     let global_shortcut = app.global_shortcut();
     for hotkey in store.hotkeys.values() {

--- a/apps/desktop/src-tauri/src/hotkeys.rs
+++ b/apps/desktop/src-tauri/src/hotkeys.rs
@@ -66,6 +66,7 @@ pub enum HotkeyAction {
     ScreenshotDisplay,
     ScreenshotWindow,
     ScreenshotArea,
+    OcrArea,
     #[serde(other)]
     Other,
 }
@@ -73,6 +74,8 @@ pub enum HotkeyAction {
 #[derive(Serialize, Deserialize, Type, Default)]
 pub struct HotkeysStore {
     hotkeys: HashMap<HotkeyAction, Hotkey>,
+    #[serde(default)]
+    seeded: Vec<HotkeyAction>,
 }
 
 impl HotkeysStore {
@@ -208,7 +211,7 @@ pub fn init(app: &AppHandle) {
     )
     .unwrap();
 
-    let store = match HotkeysStore::get(app) {
+    let mut store = match HotkeysStore::get(app) {
         Ok(Some(s)) => s,
         Ok(None) => HotkeysStore::default(),
         Err(e) => {
@@ -217,12 +220,54 @@ pub fn init(app: &AppHandle) {
         }
     };
 
+    seed_default_hotkeys(app, &mut store);
+
     let global_shortcut = app.global_shortcut();
     for hotkey in store.hotkeys.values() {
         global_shortcut.register(Shortcut::from(*hotkey)).ok();
     }
 
     app.manage(Mutex::new(store));
+}
+
+fn default_hotkey(action: HotkeyAction) -> Option<Hotkey> {
+    match action {
+        HotkeyAction::OcrArea => Some(Hotkey {
+            code: Code::KeyT,
+            meta: cfg!(target_os = "macos"),
+            ctrl: !cfg!(target_os = "macos"),
+            alt: false,
+            shift: true,
+        }),
+        _ => None,
+    }
+}
+
+fn seed_default_hotkeys(app: &AppHandle, store: &mut HotkeysStore) {
+    let mut changed = false;
+
+    for action in [HotkeyAction::OcrArea] {
+        if store.seeded.contains(&action) || store.hotkeys.contains_key(&action) {
+            continue;
+        }
+
+        let Some(hotkey) = default_hotkey(action) else {
+            continue;
+        };
+
+        if !store.hotkeys.values().any(|h| h == &hotkey) {
+            store.hotkeys.insert(action, hotkey);
+        }
+        store.seeded.push(action);
+        changed = true;
+    }
+
+    if changed && let Ok(s) = app.store("store") {
+        s.set("hotkeys", serde_json::json!(&*store));
+        if let Err(e) = s.save() {
+            eprintln!("Failed to save hotkeys store: {e}");
+        }
+    }
 }
 
 async fn handle_hotkey(app: AppHandle, action: HotkeyAction) -> Result<(), String> {
@@ -328,6 +373,13 @@ async fn handle_hotkey(app: AppHandle, action: HotkeyAction) -> Result<(), Strin
 
             let _ = RequestOpenRecordingPicker {
                 target_mode: Some(RecordingTargetMode::Area),
+            }
+            .emit(&app);
+            Ok(())
+        }
+        HotkeyAction::OcrArea => {
+            let _ = RequestOpenRecordingPicker {
+                target_mode: Some(RecordingTargetMode::Ocr),
             }
             .emit(&app);
             Ok(())

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod audio_library;
 mod audio_meter;
 mod auth;
 mod automation;
+mod barcode;
 mod camera;
 mod camera_legacy;
 #[cfg(target_os = "macos")]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4936,6 +4936,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             clip_thumbnails::get_clip_thumbnail,
             windows::position_traffic_lights,
             windows::set_theme,
+            windows::show_window_without_activating,
             windows::set_teleprompter_window_level,
             windows::set_teleprompter_window_opacity,
             windows::apply_macos_liquid_glass_background,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4853,6 +4853,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             recording::restart_recording,
             recording::delete_recording,
             recording::take_screenshot,
+            recording::capture_ocr_text,
             recording::import_current_desktop_background,
             recording::list_cameras,
             recording::get_camera_formats,

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2826,8 +2826,24 @@ pub async fn capture_ocr_text(
 
     let image = capture_screen_image(&app, target.clone()).await?;
 
-    let text = crate::screenshot_editor::recognize_text_from_dynamic_image(&image).await?;
-    let text = text.trim().to_string();
+    // A QR code or barcode in the selection takes priority over OCR: its
+    // decoded payload is what the user is after, and OCR would only pick up
+    // surrounding text.
+    let barcode = {
+        let image = image.clone();
+        tokio::task::spawn_blocking(move || crate::barcode::decode_barcode(&image))
+            .await
+            .ok()
+            .flatten()
+    };
+
+    let text = match barcode {
+        Some(payload) => payload,
+        None => {
+            let text = crate::screenshot_editor::recognize_text_from_dynamic_image(&image).await?;
+            text.trim().to_string()
+        }
+    };
 
     if text.is_empty() {
         return Err("No text was found in the selected area".to_string());

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2845,7 +2845,7 @@ pub async fn capture_ocr_text(
         error!("Failed to save OCR screenshot: {e}");
     }
 
-    if settings.ocr_show_notification {
+    if settings.enable_notifications && settings.ocr_show_notification {
         use tauri_plugin_notification::NotificationExt;
 
         let preview: String = text.chars().take(120).collect();

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2807,7 +2807,7 @@ pub async fn take_screenshot(
 
     AppSounds::Notification.play();
 
-    save_screenshot_project(&app, image, &target)
+    save_screenshot_project(&app, image, &target, true)
 }
 
 #[tauri::command(async)]
@@ -2840,7 +2840,7 @@ pub async fn capture_ocr_text(
     AppSounds::Notification.play();
 
     if settings.ocr_keep_screenshot
-        && let Err(e) = save_screenshot_project(&app, image, &target)
+        && let Err(e) = save_screenshot_project(&app, image, &target, false)
     {
         error!("Failed to save OCR screenshot: {e}");
     }
@@ -2914,10 +2914,15 @@ async fn capture_screen_image(
     result
 }
 
+/// `run_side_effects` controls whether screenshot automations and the
+/// "screenshot saved" notification fire once the project is written. OCR
+/// captures skip them: an automation like copy-to-clipboard would overwrite
+/// the text that was just copied.
 fn save_screenshot_project(
     app: &AppHandle,
     image: image::DynamicImage,
     target: &ScreenCaptureTarget,
+    run_side_effects: bool,
 ) -> Result<PathBuf, String> {
     use crate::NewScreenshotAdded;
     use crate::notifications;
@@ -3063,16 +3068,18 @@ fn save_screenshot_project(
                 }
                 .emit(&app_handle);
 
-                crate::automation::run_screenshot_automations(
-                    app_handle.clone(),
-                    image_path_for_emit.clone(),
-                    &automation_target,
-                );
+                if run_side_effects {
+                    crate::automation::run_screenshot_automations(
+                        app_handle.clone(),
+                        image_path_for_emit.clone(),
+                        &automation_target,
+                    );
 
-                notifications::send_notification(
-                    &app_handle,
-                    notifications::NotificationType::ScreenshotSaved,
-                );
+                    notifications::send_notification(
+                        &app_handle,
+                        notifications::NotificationType::ScreenshotSaved,
+                    );
+                }
             }
             Ok(Err(e)) => {
                 error!("Failed to encode PNG: {e}");

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2879,15 +2879,18 @@ async fn capture_screen_image(
                     | CapWindowId::ModeSelect
                     | CapWindowId::RecordingsOverlay
             )
-            && window.is_visible().unwrap_or(false)
         {
+            let was_visible = window.is_visible().unwrap_or(false);
             hide_overlay(&window);
             hid_any = true;
             // The target-select overlay's lifecycle is owned by the frontend,
             // which hides it before invoking a capture and closes or restores
-            // it afterwards; re-showing it here would fight that.
-            if !matches!(id, CapWindowId::TargetSelectOverlay { .. }) {
-                hidden_windows.push(window);
+            // it afterwards; re-showing it here would fight that. The occluder
+            // must keep ignoring cursor events, so it is re-shown without the
+            // show_overlay cursor-event reset.
+            if was_visible && !matches!(id, CapWindowId::TargetSelectOverlay { .. }) {
+                let ignores_cursor = matches!(id, CapWindowId::WindowCaptureOccluder { .. });
+                hidden_windows.push((window, ignores_cursor));
             }
         }
     }
@@ -2900,8 +2903,12 @@ async fn capture_screen_image(
         .await
         .map_err(|e| format!("Failed to capture screenshot: {e}"));
 
-    for window in hidden_windows {
-        show_overlay(&window);
+    for (window, ignores_cursor) in hidden_windows {
+        if ignores_cursor {
+            let _ = window.show();
+        } else {
+            show_overlay(&window);
+        }
     }
 
     result

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2803,25 +2803,68 @@ pub async fn take_screenshot(
     app: AppHandle,
     target: ScreenCaptureTarget,
 ) -> Result<PathBuf, String> {
-    use crate::NewScreenshotAdded;
-    use crate::notifications;
-    use crate::{PendingScreenshot, PendingScreenshots};
+    let image = capture_screen_image(&app, target.clone()).await?;
+
+    AppSounds::Notification.play();
+
+    save_screenshot_project(&app, image, &target)
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+#[tracing::instrument(name = "capture_ocr_text", skip(app))]
+pub async fn capture_ocr_text(
+    app: AppHandle,
+    target: ScreenCaptureTarget,
+) -> Result<String, String> {
+    use tauri_plugin_clipboard_manager::ClipboardExt;
+
+    let settings = GeneralSettingsStore::get(&app)
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+
+    let image = capture_screen_image(&app, target.clone()).await?;
+
+    let text = crate::screenshot_editor::recognize_text_from_dynamic_image(&image).await?;
+    let text = text.trim().to_string();
+
+    if text.is_empty() {
+        return Err("No text was found in the selected area".to_string());
+    }
+
+    app.clipboard()
+        .write_text(text.clone())
+        .map_err(|e| format!("Failed to copy text to clipboard: {e}"))?;
+
+    AppSounds::Notification.play();
+
+    if settings.ocr_keep_screenshot
+        && let Err(e) = save_screenshot_project(&app, image, &target)
+    {
+        error!("Failed to save OCR screenshot: {e}");
+    }
+
+    if settings.ocr_show_notification {
+        use tauri_plugin_notification::NotificationExt;
+
+        let preview: String = text.chars().take(120).collect();
+        app.notification()
+            .builder()
+            .title("Text copied to clipboard")
+            .body(preview)
+            .show()
+            .ok();
+    }
+
+    Ok(text)
+}
+
+async fn capture_screen_image(
+    app: &AppHandle,
+    target: ScreenCaptureTarget,
+) -> Result<image::DynamicImage, String> {
     use cap_recording::screenshot::capture_screenshot;
-    use image::ImageEncoder;
-    use std::time::Instant;
-
-    let general_settings = GeneralSettingsStore::get(&app).ok().flatten();
-    let general_settings = general_settings.as_ref();
-
-    let project_name = format_project_name(
-        general_settings
-            .and_then(|s| s.default_project_name_template.clone())
-            .as_deref(),
-        target.title().as_deref().unwrap_or("Unknown"),
-        target.kind_str(),
-        RecordingMode::Screenshot,
-        None,
-    );
 
     let mut hid_any = false;
     for (label, window) in app.webview_windows() {
@@ -2844,13 +2887,36 @@ pub async fn take_screenshot(
         tokio::time::sleep(std::time::Duration::from_millis(150)).await;
     }
 
-    let automation_target = target.clone();
-
-    let image = capture_screenshot(target)
+    capture_screenshot(target)
         .await
-        .map_err(|e| format!("Failed to capture screenshot: {e}"))?;
+        .map_err(|e| format!("Failed to capture screenshot: {e}"))
+}
 
-    AppSounds::Notification.play();
+fn save_screenshot_project(
+    app: &AppHandle,
+    image: image::DynamicImage,
+    target: &ScreenCaptureTarget,
+) -> Result<PathBuf, String> {
+    use crate::NewScreenshotAdded;
+    use crate::notifications;
+    use crate::{PendingScreenshot, PendingScreenshots};
+    use image::ImageEncoder;
+    use std::time::Instant;
+
+    let general_settings = GeneralSettingsStore::get(app).ok().flatten();
+    let general_settings = general_settings.as_ref();
+
+    let project_name = format_project_name(
+        general_settings
+            .and_then(|s| s.default_project_name_template.clone())
+            .as_deref(),
+        target.title().as_deref().unwrap_or("Unknown"),
+        target.kind_str(),
+        RecordingMode::Screenshot,
+        None,
+    );
+
+    let automation_target = target.clone();
 
     let image_width = image.width();
     let image_height = image.height();

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2864,8 +2864,10 @@ async fn capture_screen_image(
     app: &AppHandle,
     target: ScreenCaptureTarget,
 ) -> Result<image::DynamicImage, String> {
+    use crate::windows::show_overlay;
     use cap_recording::screenshot::capture_screenshot;
 
+    let mut hidden_windows = Vec::new();
     let mut hid_any = false;
     for (label, window) in app.webview_windows() {
         if let Ok(id) = CapWindowId::from_str(&label)
@@ -2877,9 +2879,16 @@ async fn capture_screen_image(
                     | CapWindowId::ModeSelect
                     | CapWindowId::RecordingsOverlay
             )
+            && window.is_visible().unwrap_or(false)
         {
             hide_overlay(&window);
             hid_any = true;
+            // The target-select overlay's lifecycle is owned by the frontend,
+            // which hides it before invoking a capture and closes or restores
+            // it afterwards; re-showing it here would fight that.
+            if !matches!(id, CapWindowId::TargetSelectOverlay { .. }) {
+                hidden_windows.push(window);
+            }
         }
     }
 
@@ -2887,9 +2896,15 @@ async fn capture_screen_image(
         tokio::time::sleep(std::time::Duration::from_millis(150)).await;
     }
 
-    capture_screenshot(target)
+    let result = capture_screenshot(target)
         .await
-        .map_err(|e| format!("Failed to capture screenshot: {e}"))
+        .map_err(|e| format!("Failed to capture screenshot: {e}"));
+
+    for window in hidden_windows {
+        show_overlay(&window);
+    }
+
+    result
 }
 
 fn save_screenshot_project(

--- a/apps/desktop/src-tauri/src/recording_settings.rs
+++ b/apps/desktop/src-tauri/src/recording_settings.rs
@@ -19,6 +19,7 @@ pub enum RecordingTargetMode {
     Window,
     Area,
     Camera,
+    Ocr,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, specta::Type, Debug, Clone, Default)]

--- a/apps/desktop/src-tauri/src/screenshot_editor.rs
+++ b/apps/desktop/src-tauri/src/screenshot_editor.rs
@@ -986,6 +986,12 @@ pub async fn recognize_screenshot_text(
 
 pub async fn recognize_text_from_image_path(path: &std::path::Path) -> Result<String, String> {
     let dynamic = image::open(path).map_err(|e| format!("Failed to open image for OCR: {e}"))?;
+    recognize_text_from_dynamic_image(&dynamic).await
+}
+
+pub async fn recognize_text_from_dynamic_image(
+    dynamic: &image::DynamicImage,
+) -> Result<String, String> {
     let rgba = dynamic.to_rgba8();
     let width = rgba.width();
     let height = rgba.height();

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -130,6 +130,27 @@ pub fn show_overlay(window: &WebviewWindow) {
     let _ = window.show();
 }
 
+/// Shows the calling window without activating it, so the foreground app
+/// keeps keyboard focus.
+#[tauri::command]
+#[specta::specta]
+pub fn show_window_without_activating(window: WebviewWindow) {
+    #[cfg(windows)]
+    if let Ok(hwnd) = window.hwnd() {
+        use ::windows::Win32::UI::WindowsAndMessaging::{SW_SHOWNOACTIVATE, ShowWindow};
+
+        unsafe {
+            let _ = ShowWindow(
+                ::windows::Win32::Foundation::HWND(hwnd.0),
+                SW_SHOWNOACTIVATE,
+            );
+        }
+        return;
+    }
+
+    let _ = window.show();
+}
+
 fn emit_app_event<E>(app: &AppHandle, event: E)
 where
     E: Event + serde::Serialize + Clone,

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -1707,6 +1707,7 @@ impl ShowCapWindow {
                     Some(RecordingTargetMode::Window) => "&targetMode=window",
                     Some(RecordingTargetMode::Area) => "&targetMode=area",
                     Some(RecordingTargetMode::Camera) => "&targetMode=camera",
+                    Some(RecordingTargetMode::Ocr) => "&targetMode=ocr",
                     None => "",
                 };
 

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -2038,11 +2038,15 @@ function Page() {
 				dismissal === "ocr" ||
 				dismissal === "recordingInstant";
 			if (shouldRevealMainWindow && dismissalReveals) {
-				const currentWindow = getCurrentWindow();
-				void currentWindow.show();
 				// An OCR capture is a background copy-to-clipboard gesture; bring
 				// the window back without stealing focus from the user's app.
-				if (dismissal !== "ocr") void currentWindow.setFocus();
+				if (dismissal === "ocr") {
+					void commands.showWindowWithoutActivating();
+				} else {
+					const currentWindow = getCurrentWindow();
+					void currentWindow.show();
+					void currentWindow.setFocus();
+				}
 			}
 		}
 	});

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -2035,11 +2035,14 @@ function Page() {
 			const dismissalReveals =
 				dismissal === "cancelled" ||
 				dismissal === "screenshot" ||
+				dismissal === "ocr" ||
 				dismissal === "recordingInstant";
 			if (shouldRevealMainWindow && dismissalReveals) {
 				const currentWindow = getCurrentWindow();
 				void currentWindow.show();
-				void currentWindow.setFocus();
+				// An OCR capture is a background copy-to-clipboard gesture; bring
+				// the window back without stealing focus from the user's app.
+				if (dismissal !== "ocr") void currentWindow.setFocus();
 			}
 		}
 	});

--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -573,6 +573,35 @@ function Inner(props: {
 				/>
 
 				<Section
+					title="Text capture (OCR)"
+					description="Copy text from anywhere on your screen with the OCR hotkey."
+				>
+					<SectionRows>
+						<ToggleSettingItem
+							label="Keep a screenshot of the captured area"
+							description="Save the selected region to your screenshots when copying text. When off, nothing is stored."
+							value={!!settings.ocrKeepScreenshot}
+							onChange={(value) => handleChange("ocrKeepScreenshot", value)}
+						/>
+						<ToggleSettingItem
+							label="Show a notification when text is copied"
+							description="Display a system notification with a preview of the copied text."
+							value={!!settings.ocrShowNotification}
+							onChange={async (value) => {
+								if (value) {
+									const permissionGranted = await isPermissionGranted();
+									if (!permissionGranted) {
+										const permission = await requestPermission();
+										if (permission !== "granted") return;
+									}
+								}
+								handleChange("ocrShowNotification", value);
+							}}
+						/>
+					</SectionRows>
+				</Section>
+
+				<Section
 					title="Recording"
 					description="Behaviour while you record and after you stop."
 				>

--- a/apps/desktop/src/routes/(window-chrome)/settings/hotkeys.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/hotkeys.tsx
@@ -36,6 +36,7 @@ const ACTION_TEXT = {
 	screenshotDisplay: "Screenshot current display",
 	screenshotWindow: "Screenshot current window",
 	screenshotArea: "Screenshot area picker",
+	ocrArea: "Copy text from area (OCR)",
 } satisfies { [K in HotkeyAction]?: string };
 
 export default function () {
@@ -87,6 +88,7 @@ function Inner(props: { initialStore: HotkeysStore | null }) {
 			"screenshotDisplay",
 			"screenshotWindow",
 			"screenshotArea",
+			"ocrArea",
 			"openRecordingPicker",
 			"stopRecording",
 			"restartRecording",

--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -194,7 +194,7 @@ function Inner() {
 	const [params] = useSearchParams<{
 		displayId: DisplayId;
 		isHoveredDisplay: string;
-		targetMode: "display" | "window" | "area" | "camera";
+		targetMode: "display" | "window" | "area" | "camera" | "ocr";
 	}>();
 	const [options, setOptions] = useOptions();
 	const [areaSelectionPreferences, setAreaSelectionPreferences] = makePersisted(
@@ -293,7 +293,16 @@ function Inner() {
 	});
 
 	createEffect(
-		(prevMode: "display" | "window" | "area" | "camera" | null | undefined) => {
+		(
+			prevMode:
+				| "display"
+				| "window"
+				| "area"
+				| "camera"
+				| "ocr"
+				| null
+				| undefined,
+		) => {
 			const mode = options.targetMode ?? null;
 			if (prevMode === "area" && mode !== "area") {
 				const target = pendingAreaTarget();
@@ -779,8 +788,16 @@ function Inner() {
 					);
 				}}
 			</Match>
-			<Match when={options.targetMode === "area" && params.displayId}>
+			<Match
+				when={
+					(options.targetMode === "area" || options.targetMode === "ocr") &&
+					params.displayId
+				}
+			>
 				{(displayId) => {
+					const isOcr = () => options.targetMode === "ocr";
+					const isImmediateCapture = () =>
+						isOcr() || options.mode === "screenshot";
 					let controlsEl: HTMLDivElement | undefined;
 					let cropperRef: CropperRef | undefined;
 
@@ -812,19 +829,19 @@ function Inner() {
 					const [screenshotSnapToRatio, setScreenshotSnapToRatio] =
 						createSignal(true);
 					const minSize = () =>
-						options.mode === "screenshot" ? MIN_SCREENSHOT_SIZE : MIN_SIZE;
+						isImmediateCapture() ? MIN_SCREENSHOT_SIZE : MIN_SIZE;
 					const currentAspect = () =>
-						options.mode === "screenshot"
+						isImmediateCapture()
 							? screenshotAspect()
 							: areaSelectionPreferences.aspectRatio;
 					const currentSnapToRatio = () =>
-						options.mode === "screenshot"
+						isImmediateCapture()
 							? screenshotSnapToRatio()
 							: areaSelectionPreferences.snapToRatio;
 					const effectiveInitialAreaBounds = createMemo(() => {
 						const explicitBounds = initialAreaBounds();
 						if (explicitBounds) return explicitBounds;
-						if (options.mode === "screenshot") return undefined;
+						if (isImmediateCapture()) return undefined;
 						return getLockedAreaBounds(
 							areaSelectionPreferences,
 							displayId(),
@@ -855,7 +872,7 @@ function Inner() {
 					});
 					const isSelectionLocked = createMemo(
 						() =>
-							options.mode !== "screenshot" &&
+							!isImmediateCapture() &&
 							getLockedAreaBounds(
 								areaSelectionPreferences,
 								displayId(),
@@ -864,7 +881,7 @@ function Inner() {
 					);
 
 					function setAspect(aspect: Ratio | null) {
-						if (options.mode === "screenshot") {
+						if (isImmediateCapture()) {
 							setScreenshotAspect(aspect);
 							return;
 						}
@@ -875,7 +892,7 @@ function Inner() {
 					}
 
 					function setSnapToRatio(enabled: boolean) {
-						if (options.mode === "screenshot") {
+						if (isImmediateCapture()) {
 							setScreenshotSnapToRatio(enabled);
 							return;
 						}
@@ -884,7 +901,7 @@ function Inner() {
 
 					function persistLockedSelection() {
 						if (
-							options.mode === "screenshot" ||
+							isImmediateCapture() ||
 							!areaSelectionPreferences.locked ||
 							areaSelectionPreferences.screenId !== displayId() ||
 							!isValid()
@@ -920,7 +937,7 @@ function Inner() {
 						}
 						if (
 							isInteracting() ||
-							options.mode === "screenshot" ||
+							isImmediateCapture() ||
 							!areaSelectionPreferences.locked ||
 							areaSelectionPreferences.screenId !== displayId() ||
 							!isValid() ||
@@ -989,7 +1006,7 @@ function Inner() {
 					});
 
 					createEffect(async () => {
-						if (options.mode === "screenshot") return;
+						if (isImmediateCapture()) return;
 						const bounds = crop();
 						const interacting = isInteracting();
 						const displayInfo = areaDisplayInfo.data;
@@ -1252,6 +1269,51 @@ function Inner() {
 
 						if (was && !interacting) {
 							persistLockedSelection();
+							if (isOcr() && isValid()) {
+								const cropBounds = crop();
+								const target: ScreenCaptureTarget = {
+									variant: "area",
+									screen: displayId(),
+									bounds: {
+										position: {
+											x: cropBounds.x,
+											y: cropBounds.y,
+										},
+										size: {
+											width: cropBounds.width,
+											height: cropBounds.height,
+										},
+									},
+								};
+
+								const overlayWindows = (await WebviewWindow.getAll()).filter(
+									(win) => win.label.startsWith("target-select-overlay-"),
+								);
+
+								try {
+									for (const win of overlayWindows) {
+										await win.setIgnoreCursorEvents(true);
+										await win.hide();
+									}
+									await new Promise((resolve) => setTimeout(resolve, 50));
+
+									await commands.captureOcrText(target);
+									setOptions({
+										targetMode: null,
+										targetModeDismissal: "screenshot",
+									});
+									await commands.closeTargetSelectOverlays();
+								} catch (e) {
+									for (const win of overlayWindows) {
+										await win.setIgnoreCursorEvents(false);
+										await win.show();
+									}
+									const message = e instanceof Error ? e.message : String(e);
+									toast.error(`Failed to copy text: ${message}`);
+									console.error("Failed to copy text", e);
+								}
+								return;
+							}
 							if (options.mode === "screenshot" && isValid()) {
 								const cropBounds = crop();
 								const displayInfo = areaDisplayInfo.data;
@@ -1330,7 +1392,9 @@ function Inner() {
 										<div class="min-w-28 px-2 text-base font-normal leading-none tracking-[-0.01em] tabular-nums">
 											{isValid()
 												? `${Math.round(crop().width)} × ${Math.round(crop().height)}`
-												: "Draw an area"}
+												: isOcr()
+													? "Draw an area to copy text"
+													: "Draw an area"}
 										</div>
 
 										<div class="h-6 w-px bg-gray-5" />
@@ -1402,7 +1466,7 @@ function Inner() {
 										>
 											<IconLucideMaximize2 class="size-4" />
 										</button>
-										<Show when={options.mode !== "screenshot"}>
+										<Show when={!isImmediateCapture()}>
 											<button
 												type="button"
 												class="flex h-9 items-center gap-1.5 rounded-xl px-2.5 text-xs font-normal transition-colors disabled:cursor-not-allowed disabled:opacity-40"
@@ -1434,7 +1498,7 @@ function Inner() {
 								style={controlsStyle()}
 							>
 								<div class="flex flex-col items-center">
-									<Show when={options.mode !== "screenshot"}>
+									<Show when={!isImmediateCapture()}>
 										<RecordingControls
 											target={{
 												variant: "area",
@@ -1479,7 +1543,7 @@ function Inner() {
 											</small>
 										</div>
 									</Show>
-									<Show when={isValid()}>
+									<Show when={isValid() && !isOcr()}>
 										<ShowCapFreeWarning
 											isInstantMode={options.mode === "instant"}
 										/>

--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -1300,7 +1300,7 @@ function Inner() {
 									await commands.captureOcrText(target);
 									setOptions({
 										targetMode: null,
-										targetModeDismissal: "screenshot",
+										targetModeDismissal: "ocr",
 									});
 									await commands.closeTargetSelectOverlays();
 								} catch (e) {

--- a/apps/desktop/src/utils/queries.ts
+++ b/apps/desktop/src/utils/queries.ts
@@ -162,6 +162,7 @@ export type TargetModeDismissal =
 	| "recordingStudio"
 	| "recordingInstant"
 	| "screenshot"
+	| "ocr"
 	| "superseded"
 	| "cancelled";
 

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -569,7 +569,6 @@ videoImportProgress: "video-import-progress"
 /** user-defined types **/
 
 export type Action = { type: "copyToClipboard"; source?: ClipboardSource } | { type: "saveToLocation"; dir: string; filenameTemplate?: string | null } | { type: "export"; profile: ExportProfile; destination?: ExportDestination } | { type: "upload"; organizationId?: string | null; copyLink?: boolean; openInBrowser?: boolean } | { type: "revealInFileManager" } | { type: "openFile" } | { type: "runCommand"; program: string; args?: string[]; cwd?: string | null; env?: { [key in string]: string }; useShell?: boolean } | { type: "webhook"; url: string; method?: string; headers?: { [key in string]: string }; bodyTemplate?: string | null } | { type: "recognizeTextToClipboard" } | { type: "notify"; titleTemplate?: string; bodyTemplate?: string } | { type: "openEditor" } | { type: "skipEditor" } | { type: "applyPreset"; name: string } | { type: "deleteLocalFiles" }
-export type AllGpusInfo = { gpus: GpuInfoDiag[]; primaryGpuIndex: number | null; isMultiGpuSystem: boolean; hasDiscreteGpu: boolean }
 export type Annotation = { id: string; type: AnnotationType; x: number; y: number; width: number; height: number; strokeColor: string; strokeWidth: number; fillColor: string; opacity: number; rotation: number; text: string | null; maskType?: MaskType | null; maskLevel?: number | null }
 export type AnnotationType = "arrow" | "circle" | "rectangle" | "text" | "mask"
 export type AppTheme = "system" | "light" | "dark"
@@ -821,7 +820,6 @@ quality: number | null;
  */
 fast: boolean | null }
 export type GlideDirection = "none" | "left" | "right" | "up" | "down"
-export type GpuInfoDiag = { vendor: string; description: string; dedicatedVideoMemoryMb: number; adapterIndex: number; isSoftwareAdapter: boolean; isBasicRenderDriver: boolean; supportsHardwareEncoding: boolean }
 export type HapticPattern = "alignment" | "levelChange" | "generic"
 export type HapticPerformanceTime = "default" | "now" | "drawCompleted"
 export type Hotkey = { code: string; meta: boolean; ctrl: boolean; alt: boolean; shift: boolean }
@@ -844,6 +842,7 @@ export type KeyboardTrackSegment = { id: string; start: number; end: number; dis
 export type LogicalBounds = { position: LogicalPosition; size: LogicalSize }
 export type LogicalPosition = { x: number; y: number }
 export type LogicalSize = { width: number; height: number }
+export type MacOSVersionInfo = { major: number; minor: number; patch: number; displayName: string; buildNumber: string; isAppleSilicon: boolean }
 export type MainWindowRecordingStartBehaviour = "close" | "minimise"
 export type MaskKeyframes = { position?: MaskVectorKeyframe[]; size?: MaskVectorKeyframe[]; intensity?: MaskScalarKeyframe[] }
 export type MaskKind = "sensitive" | "highlight"
@@ -916,7 +915,6 @@ export type RecordingsMigrationFailure = { name: string; error: string }
 export type RecordingsMigrationProgress = { total: number; done: number; current: string | null }
 export type RecordingsMigrationSummary = { moved: number; skippedInUse: number; failed: RecordingsMigrationFailure[] }
 export type RenderFrameEvent = { frame_number: number; fps: number; resolution_base: XY<number> }
-export type RenderingStatus = { isUsingSoftwareRendering: boolean; isUsingBasicRenderDriver: boolean; hardwareEncodingAvailable: boolean; warningMessage: string | null }
 export type RequestOpenRecordingPicker = { target_mode: RecordingTargetMode | null }
 export type RequestOpenSettings = { page: string }
 export type RequestScreenCapturePrewarm = { force?: boolean }
@@ -961,7 +959,7 @@ export type StereoMode = "stereo" | "monoL" | "monoR"
 export type StudioRecordingMeta = { segment: SingleSegment } | { inner: MultipleSegments }
 export type StudioRecordingQuality = "compatibility" | "balanced" | "ultra"
 export type StudioRecordingStatus = { status: "InProgress" } | { status: "NeedsRemux" } | { status: "Failed"; error: string } | { status: "Complete" }
-export type SystemDiagnostics = { windowsVersion: WindowsVersionInfo | null; gpuInfo: GpuInfoDiag | null; allGpus: AllGpusInfo | null; renderingStatus: RenderingStatus; availableEncoders: string[]; graphicsCaptureSupported: boolean; d3D11VideoProcessorAvailable: boolean }
+export type SystemDiagnostics = { macosVersion: MacOSVersionInfo | null; availableEncoders: string[]; screenCaptureSupported: boolean; metalSupported: boolean; gpuName: string | null }
 export type TargetUnderCursor = { display_id: DisplayId | null; window: WindowUnderCursor | null }
 export type TextSegment = { start: number; end: number; track?: number; enabled?: boolean; content?: string; center?: XY<number>; size?: XY<number>; fontFamily?: string; fontSize?: number; fontWeight?: number; italic?: boolean; color?: string; fadeDuration?: number }
 export type TimelineConfiguration = { segments: TimelineSegment[]; transitions: ClipTransition[]; zoomSegments: ZoomSegment[]; sceneSegments?: SceneSegment[]; maskSegments?: MaskSegment[]; textSegments?: TextSegment[]; captionSegments?: CaptionTrackSegment[]; keyboardSegments?: KeyboardTrackSegment[]; audioSegments?: AudioTrackSegment[] }
@@ -986,7 +984,6 @@ export type WindowExclusion = { bundleIdentifier?: string | null; ownerName?: st
 export type WindowId = string
 export type WindowPosition = { x: number; y: number; displayId?: DisplayId | null }
 export type WindowUnderCursor = { id: WindowId; app_name: string; bounds: LogicalBounds }
-export type WindowsVersionInfo = { major: number; minor: number; build: number; displayName: string; meetsRequirements: boolean; isWindows11: boolean }
 export type XY<T> = { x: T; y: T }
 export type ZoomMode = "auto" | { manual: { x: number; y: number } }
 export type ZoomSegment = { start: number; end: number; amount: number; mode: ZoomMode; glideDirection?: GlideDirection; glideSpeed?: number; instantAnimation?: boolean; edgeSnapRatio?: number }

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -308,6 +308,13 @@ async positionTrafficLights(controlsInset: [number, number] | null) : Promise<vo
 async setTheme(theme: AppTheme) : Promise<void> {
     await TAURI_INVOKE("set_theme", { theme });
 },
+/**
+ * Shows the calling window without activating it, so the foreground app
+ * keeps keyboard focus.
+ */
+async showWindowWithoutActivating() : Promise<void> {
+    await TAURI_INVOKE("show_window_without_activating");
+},
 async setTeleprompterWindowLevel(alwaysOnTop: boolean) : Promise<void> {
     await TAURI_INVOKE("set_teleprompter_window_level", { alwaysOnTop });
 },
@@ -569,6 +576,7 @@ videoImportProgress: "video-import-progress"
 /** user-defined types **/
 
 export type Action = { type: "copyToClipboard"; source?: ClipboardSource } | { type: "saveToLocation"; dir: string; filenameTemplate?: string | null } | { type: "export"; profile: ExportProfile; destination?: ExportDestination } | { type: "upload"; organizationId?: string | null; copyLink?: boolean; openInBrowser?: boolean } | { type: "revealInFileManager" } | { type: "openFile" } | { type: "runCommand"; program: string; args?: string[]; cwd?: string | null; env?: { [key in string]: string }; useShell?: boolean } | { type: "webhook"; url: string; method?: string; headers?: { [key in string]: string }; bodyTemplate?: string | null } | { type: "recognizeTextToClipboard" } | { type: "notify"; titleTemplate?: string; bodyTemplate?: string } | { type: "openEditor" } | { type: "skipEditor" } | { type: "applyPreset"; name: string } | { type: "deleteLocalFiles" }
+export type AllGpusInfo = { gpus: GpuInfoDiag[]; primaryGpuIndex: number | null; isMultiGpuSystem: boolean; hasDiscreteGpu: boolean }
 export type Annotation = { id: string; type: AnnotationType; x: number; y: number; width: number; height: number; strokeColor: string; strokeWidth: number; fillColor: string; opacity: number; rotation: number; text: string | null; maskType?: MaskType | null; maskLevel?: number | null }
 export type AnnotationType = "arrow" | "circle" | "rectangle" | "text" | "mask"
 export type AppTheme = "system" | "light" | "dark"
@@ -820,6 +828,7 @@ quality: number | null;
  */
 fast: boolean | null }
 export type GlideDirection = "none" | "left" | "right" | "up" | "down"
+export type GpuInfoDiag = { vendor: string; description: string; dedicatedVideoMemoryMb: number; adapterIndex: number; isSoftwareAdapter: boolean; isBasicRenderDriver: boolean; supportsHardwareEncoding: boolean }
 export type HapticPattern = "alignment" | "levelChange" | "generic"
 export type HapticPerformanceTime = "default" | "now" | "drawCompleted"
 export type Hotkey = { code: string; meta: boolean; ctrl: boolean; alt: boolean; shift: boolean }
@@ -842,7 +851,6 @@ export type KeyboardTrackSegment = { id: string; start: number; end: number; dis
 export type LogicalBounds = { position: LogicalPosition; size: LogicalSize }
 export type LogicalPosition = { x: number; y: number }
 export type LogicalSize = { width: number; height: number }
-export type MacOSVersionInfo = { major: number; minor: number; patch: number; displayName: string; buildNumber: string; isAppleSilicon: boolean }
 export type MainWindowRecordingStartBehaviour = "close" | "minimise"
 export type MaskKeyframes = { position?: MaskVectorKeyframe[]; size?: MaskVectorKeyframe[]; intensity?: MaskScalarKeyframe[] }
 export type MaskKind = "sensitive" | "highlight"
@@ -915,6 +923,7 @@ export type RecordingsMigrationFailure = { name: string; error: string }
 export type RecordingsMigrationProgress = { total: number; done: number; current: string | null }
 export type RecordingsMigrationSummary = { moved: number; skippedInUse: number; failed: RecordingsMigrationFailure[] }
 export type RenderFrameEvent = { frame_number: number; fps: number; resolution_base: XY<number> }
+export type RenderingStatus = { isUsingSoftwareRendering: boolean; isUsingBasicRenderDriver: boolean; hardwareEncodingAvailable: boolean; warningMessage: string | null }
 export type RequestOpenRecordingPicker = { target_mode: RecordingTargetMode | null }
 export type RequestOpenSettings = { page: string }
 export type RequestScreenCapturePrewarm = { force?: boolean }
@@ -959,7 +968,7 @@ export type StereoMode = "stereo" | "monoL" | "monoR"
 export type StudioRecordingMeta = { segment: SingleSegment } | { inner: MultipleSegments }
 export type StudioRecordingQuality = "compatibility" | "balanced" | "ultra"
 export type StudioRecordingStatus = { status: "InProgress" } | { status: "NeedsRemux" } | { status: "Failed"; error: string } | { status: "Complete" }
-export type SystemDiagnostics = { macosVersion: MacOSVersionInfo | null; availableEncoders: string[]; screenCaptureSupported: boolean; metalSupported: boolean; gpuName: string | null }
+export type SystemDiagnostics = { windowsVersion: WindowsVersionInfo | null; gpuInfo: GpuInfoDiag | null; allGpus: AllGpusInfo | null; renderingStatus: RenderingStatus; availableEncoders: string[]; graphicsCaptureSupported: boolean; d3D11VideoProcessorAvailable: boolean }
 export type TargetUnderCursor = { display_id: DisplayId | null; window: WindowUnderCursor | null }
 export type TextSegment = { start: number; end: number; track?: number; enabled?: boolean; content?: string; center?: XY<number>; size?: XY<number>; fontFamily?: string; fontSize?: number; fontWeight?: number; italic?: boolean; color?: string; fadeDuration?: number }
 export type TimelineConfiguration = { segments: TimelineSegment[]; transitions: ClipTransition[]; zoomSegments: ZoomSegment[]; sceneSegments?: SceneSegment[]; maskSegments?: MaskSegment[]; textSegments?: TextSegment[]; captionSegments?: CaptionTrackSegment[]; keyboardSegments?: KeyboardTrackSegment[]; audioSegments?: AudioTrackSegment[] }
@@ -984,6 +993,7 @@ export type WindowExclusion = { bundleIdentifier?: string | null; ownerName?: st
 export type WindowId = string
 export type WindowPosition = { x: number; y: number; displayId?: DisplayId | null }
 export type WindowUnderCursor = { id: WindowId; app_name: string; bounds: LogicalBounds }
+export type WindowsVersionInfo = { major: number; minor: number; build: number; displayName: string; meetsRequirements: boolean; isWindows11: boolean }
 export type XY<T> = { x: T; y: T }
 export type ZoomMode = "auto" | { manual: { x: number; y: number } }
 export type ZoomSegment = { start: number; end: number; amount: number; mode: ZoomMode; glideDirection?: GlideDirection; glideSpeed?: number; instantAnimation?: boolean; edgeSnapRatio?: number }

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -59,6 +59,9 @@ async deleteRecording() : Promise<null> {
 async takeScreenshot(target: ScreenCaptureTarget) : Promise<string> {
     return await TAURI_INVOKE("take_screenshot", { target });
 },
+async captureOcrText(target: ScreenCaptureTarget) : Promise<string> {
+    return await TAURI_INVOKE("capture_ocr_text", { target });
+},
 async importCurrentDesktopBackground(projectPath: string) : Promise<string> {
     return await TAURI_INVOKE("import_current_desktop_background", { projectPath });
 },
@@ -566,6 +569,7 @@ videoImportProgress: "video-import-progress"
 /** user-defined types **/
 
 export type Action = { type: "copyToClipboard"; source?: ClipboardSource } | { type: "saveToLocation"; dir: string; filenameTemplate?: string | null } | { type: "export"; profile: ExportProfile; destination?: ExportDestination } | { type: "upload"; organizationId?: string | null; copyLink?: boolean; openInBrowser?: boolean } | { type: "revealInFileManager" } | { type: "openFile" } | { type: "runCommand"; program: string; args?: string[]; cwd?: string | null; env?: { [key in string]: string }; useShell?: boolean } | { type: "webhook"; url: string; method?: string; headers?: { [key in string]: string }; bodyTemplate?: string | null } | { type: "recognizeTextToClipboard" } | { type: "notify"; titleTemplate?: string; bodyTemplate?: string } | { type: "openEditor" } | { type: "skipEditor" } | { type: "applyPreset"; name: string } | { type: "deleteLocalFiles" }
+export type AllGpusInfo = { gpus: GpuInfoDiag[]; primaryGpuIndex: number | null; isMultiGpuSystem: boolean; hasDiscreteGpu: boolean }
 export type Annotation = { id: string; type: AnnotationType; x: number; y: number; width: number; height: number; strokeColor: string; strokeWidth: number; fillColor: string; opacity: number; rotation: number; text: string | null; maskType?: MaskType | null; maskLevel?: number | null }
 export type AnnotationType = "arrow" | "circle" | "rectangle" | "text" | "mask"
 export type AppTheme = "system" | "light" | "dark"
@@ -805,7 +809,7 @@ previousRecordingsPaths?: string[];
  * Cleared automatically when the app version changes (one retry per
  * update, since a new ort/wgpu/driver stack may have fixed the crash).
  */
-cameraBlurDisabledByCrash?: string | null; updateChannel?: UpdateChannel }
+cameraBlurDisabledByCrash?: string | null; updateChannel?: UpdateChannel; ocrKeepScreenshot?: boolean; ocrShowNotification?: boolean }
 export type GifExportSettings = { fps: number; resolution_base: XY<number>; quality: GifQuality | null }
 export type GifQuality = { 
 /**
@@ -817,12 +821,13 @@ quality: number | null;
  */
 fast: boolean | null }
 export type GlideDirection = "none" | "left" | "right" | "up" | "down"
+export type GpuInfoDiag = { vendor: string; description: string; dedicatedVideoMemoryMb: number; adapterIndex: number; isSoftwareAdapter: boolean; isBasicRenderDriver: boolean; supportsHardwareEncoding: boolean }
 export type HapticPattern = "alignment" | "levelChange" | "generic"
 export type HapticPerformanceTime = "default" | "now" | "drawCompleted"
 export type Hotkey = { code: string; meta: boolean; ctrl: boolean; alt: boolean; shift: boolean }
-export type HotkeyAction = "startStudioRecording" | "startInstantRecording" | "stopRecording" | "restartRecording" | "togglePauseRecording" | "cycleRecordingMode" | "openRecordingPicker" | "openRecordingPickerDisplay" | "openRecordingPickerWindow" | "openRecordingPickerArea" | "screenshotDisplay" | "screenshotWindow" | "screenshotArea" | "other"
+export type HotkeyAction = "startStudioRecording" | "startInstantRecording" | "stopRecording" | "restartRecording" | "togglePauseRecording" | "cycleRecordingMode" | "openRecordingPicker" | "openRecordingPickerDisplay" | "openRecordingPickerWindow" | "openRecordingPickerArea" | "screenshotDisplay" | "screenshotWindow" | "screenshotArea" | "ocrArea" | "other"
 export type HotkeysConfiguration = { show: boolean }
-export type HotkeysStore = { hotkeys: { [key in HotkeyAction]: Hotkey } }
+export type HotkeysStore = { hotkeys: { [key in HotkeyAction]: Hotkey }; seeded?: HotkeyAction[] }
 export type ImportStage = "Probing" | "Converting" | "Finalizing" | "Complete" | "Failed"
 export type ImportedAudioTrack = { 
 /**
@@ -839,7 +844,6 @@ export type KeyboardTrackSegment = { id: string; start: number; end: number; dis
 export type LogicalBounds = { position: LogicalPosition; size: LogicalSize }
 export type LogicalPosition = { x: number; y: number }
 export type LogicalSize = { width: number; height: number }
-export type MacOSVersionInfo = { major: number; minor: number; patch: number; displayName: string; buildNumber: string; isAppleSilicon: boolean }
 export type MainWindowRecordingStartBehaviour = "close" | "minimise"
 export type MaskKeyframes = { position?: MaskVectorKeyframe[]; size?: MaskVectorKeyframe[]; intensity?: MaskScalarKeyframe[] }
 export type MaskKind = "sensitive" | "highlight"
@@ -907,11 +911,12 @@ export type RecordingSettingsStore = { target: ScreenCaptureTarget | null; micNa
 export type RecordingStarted = null
 export type RecordingStatus = "pending" | "recording"
 export type RecordingStopped = null
-export type RecordingTargetMode = "display" | "window" | "area" | "camera"
+export type RecordingTargetMode = "display" | "window" | "area" | "camera" | "ocr"
 export type RecordingsMigrationFailure = { name: string; error: string }
 export type RecordingsMigrationProgress = { total: number; done: number; current: string | null }
 export type RecordingsMigrationSummary = { moved: number; skippedInUse: number; failed: RecordingsMigrationFailure[] }
 export type RenderFrameEvent = { frame_number: number; fps: number; resolution_base: XY<number> }
+export type RenderingStatus = { isUsingSoftwareRendering: boolean; isUsingBasicRenderDriver: boolean; hardwareEncodingAvailable: boolean; warningMessage: string | null }
 export type RequestOpenRecordingPicker = { target_mode: RecordingTargetMode | null }
 export type RequestOpenSettings = { page: string }
 export type RequestScreenCapturePrewarm = { force?: boolean }
@@ -956,7 +961,7 @@ export type StereoMode = "stereo" | "monoL" | "monoR"
 export type StudioRecordingMeta = { segment: SingleSegment } | { inner: MultipleSegments }
 export type StudioRecordingQuality = "compatibility" | "balanced" | "ultra"
 export type StudioRecordingStatus = { status: "InProgress" } | { status: "NeedsRemux" } | { status: "Failed"; error: string } | { status: "Complete" }
-export type SystemDiagnostics = { macosVersion: MacOSVersionInfo | null; availableEncoders: string[]; screenCaptureSupported: boolean; metalSupported: boolean; gpuName: string | null }
+export type SystemDiagnostics = { windowsVersion: WindowsVersionInfo | null; gpuInfo: GpuInfoDiag | null; allGpus: AllGpusInfo | null; renderingStatus: RenderingStatus; availableEncoders: string[]; graphicsCaptureSupported: boolean; d3D11VideoProcessorAvailable: boolean }
 export type TargetUnderCursor = { display_id: DisplayId | null; window: WindowUnderCursor | null }
 export type TextSegment = { start: number; end: number; track?: number; enabled?: boolean; content?: string; center?: XY<number>; size?: XY<number>; fontFamily?: string; fontSize?: number; fontWeight?: number; italic?: boolean; color?: string; fadeDuration?: number }
 export type TimelineConfiguration = { segments: TimelineSegment[]; transitions: ClipTransition[]; zoomSegments: ZoomSegment[]; sceneSegments?: SceneSegment[]; maskSegments?: MaskSegment[]; textSegments?: TextSegment[]; captionSegments?: CaptionTrackSegment[]; keyboardSegments?: KeyboardTrackSegment[]; audioSegments?: AudioTrackSegment[] }
@@ -981,6 +986,7 @@ export type WindowExclusion = { bundleIdentifier?: string | null; ownerName?: st
 export type WindowId = string
 export type WindowPosition = { x: number; y: number; displayId?: DisplayId | null }
 export type WindowUnderCursor = { id: WindowId; app_name: string; bounds: LogicalBounds }
+export type WindowsVersionInfo = { major: number; minor: number; build: number; displayName: string; meetsRequirements: boolean; isWindows11: boolean }
 export type XY<T> = { x: T; y: T }
 export type ZoomMode = "auto" | { manual: { x: number; y: number } }
 export type ZoomSegment = { start: number; end: number; amount: number; mode: ZoomMode; glideDirection?: GlideDirection; glideSpeed?: number; instantAnimation?: boolean; edgeSnapRatio?: number }


### PR DESCRIPTION
## Summary

Extends the text-capture flow (Ctrl/Cmd+Shift+T) with QR code and barcode recognition: if the selected area contains a QR code or barcode, its decoded payload is copied to the clipboard instead of running OCR. No code found → falls back to OCR exactly as before.

- New `barcode` module using [`rxing`](https://crates.io/crates/rxing) (Rust port of ZXing — free, on-device, supports QR plus the common 1D/2D barcode formats), decoding with `TryHarder` on the captured region's luma data.
- `capture_ocr_text` tries the barcode decode first (on a blocking task), and only falls back to OCR when nothing is found:
  ```
  capture region in-memory → decode QR/barcode
     ├─ payload found → clipboard
     └─ none → native OCR → clipboard
  ```
- No new UI or settings: same shortcut, same selector, same default-off screenshot/notification toggles.

Builds on #2095 (OCR text capture); the barcode change itself is the top commit.

## Showcase

Select a QR code and its payload is on the clipboard, ready to paste:

![QR payload copied to clipboard](https://raw.githubusercontent.com/x1xhlol/Cap/assets/pr-media/media/02-qr-payload-pasted.png)

## Testing (Windows, end-to-end on a live dev build)

| Test | Result |
|---|---|
| QR-only selection → clipboard = exact payload | ✅ |
| QR + surrounding caption text → payload wins over OCR | ✅ |
| Text-only selection → OCR fallback (exact text match) | ✅ |
| No click-blocking overlay left after capture | ✅ |
| Regression: normal screenshot flow unaffected | ✅ |

macOS compiles the same path (the decoder is pure Rust, platform-independent); runtime-tested on Windows only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds barcode and QR decoding ahead of native OCR in the desktop text-capture flow.
- Adds an on-device `rxing` decoder and copies decoded payloads directly to the clipboard.
- Adds OCR-area target selection, a default global shortcut, persisted capture preferences, and the corresponding Rust/TypeScript IPC wiring.
- Retains native OCR as the fallback when no barcode payload is found.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking redundant comment to remove.

The barcode-first capture path retains OCR fallback behavior, keeps persisted fields backward-compatible, and coordinates overlay cleanup across success and failure paths; the only accepted concern is comment-policy compliance.

**Files Needing Attention:** apps/desktop/src-tauri/src/barcode.rs

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/barcode.rs | Adds luma-based barcode decoding through rxing; contains one redundant doc comment. |
| apps/desktop/src-tauri/src/recording.rs | Adds barcode-first text capture with blocking decode work, native OCR fallback, clipboard output, and capture-window handling. |
| apps/desktop/src-tauri/src/hotkeys.rs | Adds the OCR-area action and conflict-aware one-time default shortcut seeding. |
| apps/desktop/src/routes/target-select-overlay.tsx | Extends area selection with OCR capture and explicit overlay cleanup and error restoration. |
| apps/desktop/src/utils/tauri.ts | Updates generated bindings to match the new Rust commands, target mode, settings, and hotkey action. |
| apps/desktop/src-tauri/src/general_settings.rs | Adds backward-compatible default-off settings for retaining OCR screenshots and showing notifications. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/desktop/src-tauri/src/barcode.rs:3
**Redundant barcode helper comment**

This comment only restates that `decode_barcode` decodes a barcode and returns text, adding maintenance noise without documenting a non-obvious invariant or rationale.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Decode QR codes and barcodes in text cap..."](https://github.com/capsoftware/cap/commit/dbd271e98617d93c03b4487ae6f182f201fbc958) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50858114)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - AGENTS.md ([source](https://github.com/capsoftware/cap/blob/main/AGENTS.md))
- Knowledge Base — [Desktop Tauri App (Rust Backend)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-tauri-app.md)
- Knowledge Base — [Desktop Frontend (apps/desktop/src)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-frontend.md)
</details>

<!-- /greptile_comment -->