### PR TITLE
Add scrolling capture of the window under the cursor

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -167,6 +167,7 @@ windows = { workspace = true, features = [
     "Win32_System_Power",
     "Win32_System_Threading",
     "Win32_System_WinRT",
+    "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_WindowsAndMessaging",
     "Win32_Graphics_Gdi",
 ] }

--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -247,6 +247,10 @@ pub struct GeneralSettingsStore {
     pub camera_blur_disabled_by_crash: Option<String>,
     #[serde(default)]
     pub update_channel: UpdateChannel,
+    #[serde(default)]
+    pub ocr_keep_screenshot: bool,
+    #[serde(default)]
+    pub ocr_show_notification: bool,
 }
 
 fn default_enable_native_camera_preview() -> bool {
@@ -350,6 +354,8 @@ impl Default for GeneralSettingsStore {
             previous_recordings_paths: Vec::new(),
             camera_blur_disabled_by_crash: None,
             update_channel: UpdateChannel::Stable,
+            ocr_keep_screenshot: false,
+            ocr_show_notification: false,
         }
     }
 }

--- a/apps/desktop/src-tauri/src/hotkeys.rs
+++ b/apps/desktop/src-tauri/src/hotkeys.rs
@@ -212,15 +212,19 @@ pub fn init(app: &AppHandle) {
     .unwrap();
 
     let mut store = match HotkeysStore::get(app) {
-        Ok(Some(s)) => s,
-        Ok(None) => HotkeysStore::default(),
+        Ok(Some(s)) => Some(s),
+        Ok(None) => Some(HotkeysStore::default()),
         Err(e) => {
             eprintln!("Failed to load hotkeys store: {e}");
-            HotkeysStore::default()
+            None
         }
     };
 
-    seed_default_hotkeys(app, &mut store);
+    if let Some(store) = &mut store {
+        seed_default_hotkeys(app, store);
+    }
+
+    let store = store.unwrap_or_default();
 
     let global_shortcut = app.global_shortcut();
     for hotkey in store.hotkeys.values() {

--- a/apps/desktop/src-tauri/src/hotkeys.rs
+++ b/apps/desktop/src-tauri/src/hotkeys.rs
@@ -67,6 +67,7 @@ pub enum HotkeyAction {
     ScreenshotWindow,
     ScreenshotArea,
     OcrArea,
+    ScrollingCaptureWindow,
     #[serde(other)]
     Other,
 }
@@ -387,6 +388,26 @@ async fn handle_hotkey(app: AppHandle, action: HotkeyAction) -> Result<(), Strin
             }
             .emit(&app);
             Ok(())
+        }
+        HotkeyAction::ScrollingCaptureWindow => {
+            use scap_targets::Window;
+
+            let window_id = Window::get_topmost_at_cursor()
+                .ok_or_else(|| "No window found under cursor".to_string())?
+                .id();
+            let target = ScreenCaptureTarget::Window {
+                id: window_id.clone(),
+            };
+
+            match crate::scrolling_capture::capture_scrolling_window(app.clone(), window_id).await {
+                Ok(path) => {
+                    if crate::automation::should_open_screenshot_editor(&app, &target) {
+                        let _ = ShowCapWindow::ScreenshotEditor { path }.show(&app).await;
+                    }
+                    Ok(())
+                }
+                Err(e) => Err(format!("Failed to capture scrolling window: {e}")),
+            }
         }
         HotkeyAction::Other => Ok(()),
     }

--- a/apps/desktop/src-tauri/src/hotkeys.rs
+++ b/apps/desktop/src-tauri/src/hotkeys.rs
@@ -66,6 +66,7 @@ pub enum HotkeyAction {
     ScreenshotDisplay,
     ScreenshotWindow,
     ScreenshotArea,
+    OcrArea,
     #[serde(other)]
     Other,
 }
@@ -73,6 +74,8 @@ pub enum HotkeyAction {
 #[derive(Serialize, Deserialize, Type, Default)]
 pub struct HotkeysStore {
     hotkeys: HashMap<HotkeyAction, Hotkey>,
+    #[serde(default)]
+    seeded: Vec<HotkeyAction>,
 }
 
 impl HotkeysStore {
@@ -208,7 +211,7 @@ pub fn init(app: &AppHandle) {
     )
     .unwrap();
 
-    let store = match HotkeysStore::get(app) {
+    let mut store = match HotkeysStore::get(app) {
         Ok(Some(s)) => s,
         Ok(None) => HotkeysStore::default(),
         Err(e) => {
@@ -217,12 +220,54 @@ pub fn init(app: &AppHandle) {
         }
     };
 
+    seed_default_hotkeys(app, &mut store);
+
     let global_shortcut = app.global_shortcut();
     for hotkey in store.hotkeys.values() {
         global_shortcut.register(Shortcut::from(*hotkey)).ok();
     }
 
     app.manage(Mutex::new(store));
+}
+
+fn default_hotkey(action: HotkeyAction) -> Option<Hotkey> {
+    match action {
+        HotkeyAction::OcrArea => Some(Hotkey {
+            code: Code::KeyT,
+            meta: cfg!(target_os = "macos"),
+            ctrl: !cfg!(target_os = "macos"),
+            alt: false,
+            shift: true,
+        }),
+        _ => None,
+    }
+}
+
+fn seed_default_hotkeys(app: &AppHandle, store: &mut HotkeysStore) {
+    let mut changed = false;
+
+    for action in [HotkeyAction::OcrArea] {
+        if store.seeded.contains(&action) || store.hotkeys.contains_key(&action) {
+            continue;
+        }
+
+        let Some(hotkey) = default_hotkey(action) else {
+            continue;
+        };
+
+        if !store.hotkeys.values().any(|h| h == &hotkey) {
+            store.hotkeys.insert(action, hotkey);
+        }
+        store.seeded.push(action);
+        changed = true;
+    }
+
+    if changed && let Ok(s) = app.store("store") {
+        s.set("hotkeys", serde_json::json!(&*store));
+        if let Err(e) = s.save() {
+            eprintln!("Failed to save hotkeys store: {e}");
+        }
+    }
 }
 
 async fn handle_hotkey(app: AppHandle, action: HotkeyAction) -> Result<(), String> {
@@ -328,6 +373,13 @@ async fn handle_hotkey(app: AppHandle, action: HotkeyAction) -> Result<(), Strin
 
             let _ = RequestOpenRecordingPicker {
                 target_mode: Some(RecordingTargetMode::Area),
+            }
+            .emit(&app);
+            Ok(())
+        }
+        HotkeyAction::OcrArea => {
+            let _ = RequestOpenRecordingPicker {
+                target_mode: Some(RecordingTargetMode::Ocr),
             }
             .emit(&app);
             Ok(())

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -38,6 +38,7 @@ mod recording_telemetry;
 mod recordings_locations;
 mod recovery;
 mod screenshot_editor;
+mod scrolling_capture;
 mod target_select_overlay;
 mod telemetry;
 mod thumbnails;
@@ -4854,6 +4855,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             recording::delete_recording,
             recording::take_screenshot,
             recording::capture_ocr_text,
+            scrolling_capture::capture_scrolling_window,
             recording::import_current_desktop_background,
             recording::list_cameras,
             recording::get_camera_formats,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4936,6 +4936,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             clip_thumbnails::get_clip_thumbnail,
             windows::position_traffic_lights,
             windows::set_theme,
+            windows::show_window_without_activating,
             windows::set_teleprompter_window_level,
             windows::set_teleprompter_window_opacity,
             windows::apply_macos_liquid_glass_background,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4853,6 +4853,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             recording::restart_recording,
             recording::delete_recording,
             recording::take_screenshot,
+            recording::capture_ocr_text,
             recording::import_current_desktop_background,
             recording::list_cameras,
             recording::get_camera_formats,

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2845,7 +2845,7 @@ pub async fn capture_ocr_text(
         error!("Failed to save OCR screenshot: {e}");
     }
 
-    if settings.ocr_show_notification {
+    if settings.enable_notifications && settings.ocr_show_notification {
         use tauri_plugin_notification::NotificationExt;
 
         let preview: String = text.chars().take(120).collect();

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2860,7 +2860,7 @@ pub async fn capture_ocr_text(
     Ok(text)
 }
 
-async fn capture_screen_image(
+pub async fn capture_screen_image(
     app: &AppHandle,
     target: ScreenCaptureTarget,
 ) -> Result<image::DynamicImage, String> {
@@ -2918,7 +2918,7 @@ async fn capture_screen_image(
 /// "screenshot saved" notification fire once the project is written. OCR
 /// captures skip them: an automation like copy-to-clipboard would overwrite
 /// the text that was just copied.
-fn save_screenshot_project(
+pub fn save_screenshot_project(
     app: &AppHandle,
     image: image::DynamicImage,
     target: &ScreenCaptureTarget,

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2807,7 +2807,7 @@ pub async fn take_screenshot(
 
     AppSounds::Notification.play();
 
-    save_screenshot_project(&app, image, &target)
+    save_screenshot_project(&app, image, &target, true)
 }
 
 #[tauri::command(async)]
@@ -2840,7 +2840,7 @@ pub async fn capture_ocr_text(
     AppSounds::Notification.play();
 
     if settings.ocr_keep_screenshot
-        && let Err(e) = save_screenshot_project(&app, image, &target)
+        && let Err(e) = save_screenshot_project(&app, image, &target, false)
     {
         error!("Failed to save OCR screenshot: {e}");
     }
@@ -2914,10 +2914,15 @@ async fn capture_screen_image(
     result
 }
 
+/// `run_side_effects` controls whether screenshot automations and the
+/// "screenshot saved" notification fire once the project is written. OCR
+/// captures skip them: an automation like copy-to-clipboard would overwrite
+/// the text that was just copied.
 fn save_screenshot_project(
     app: &AppHandle,
     image: image::DynamicImage,
     target: &ScreenCaptureTarget,
+    run_side_effects: bool,
 ) -> Result<PathBuf, String> {
     use crate::NewScreenshotAdded;
     use crate::notifications;
@@ -3063,16 +3068,18 @@ fn save_screenshot_project(
                 }
                 .emit(&app_handle);
 
-                crate::automation::run_screenshot_automations(
-                    app_handle.clone(),
-                    image_path_for_emit.clone(),
-                    &automation_target,
-                );
+                if run_side_effects {
+                    crate::automation::run_screenshot_automations(
+                        app_handle.clone(),
+                        image_path_for_emit.clone(),
+                        &automation_target,
+                    );
 
-                notifications::send_notification(
-                    &app_handle,
-                    notifications::NotificationType::ScreenshotSaved,
-                );
+                    notifications::send_notification(
+                        &app_handle,
+                        notifications::NotificationType::ScreenshotSaved,
+                    );
+                }
             }
             Ok(Err(e)) => {
                 error!("Failed to encode PNG: {e}");

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2879,15 +2879,18 @@ async fn capture_screen_image(
                     | CapWindowId::ModeSelect
                     | CapWindowId::RecordingsOverlay
             )
-            && window.is_visible().unwrap_or(false)
         {
+            let was_visible = window.is_visible().unwrap_or(false);
             hide_overlay(&window);
             hid_any = true;
             // The target-select overlay's lifecycle is owned by the frontend,
             // which hides it before invoking a capture and closes or restores
-            // it afterwards; re-showing it here would fight that.
-            if !matches!(id, CapWindowId::TargetSelectOverlay { .. }) {
-                hidden_windows.push(window);
+            // it afterwards; re-showing it here would fight that. The occluder
+            // must keep ignoring cursor events, so it is re-shown without the
+            // show_overlay cursor-event reset.
+            if was_visible && !matches!(id, CapWindowId::TargetSelectOverlay { .. }) {
+                let ignores_cursor = matches!(id, CapWindowId::WindowCaptureOccluder { .. });
+                hidden_windows.push((window, ignores_cursor));
             }
         }
     }
@@ -2900,8 +2903,12 @@ async fn capture_screen_image(
         .await
         .map_err(|e| format!("Failed to capture screenshot: {e}"));
 
-    for window in hidden_windows {
-        show_overlay(&window);
+    for (window, ignores_cursor) in hidden_windows {
+        if ignores_cursor {
+            let _ = window.show();
+        } else {
+            show_overlay(&window);
+        }
     }
 
     result

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2803,25 +2803,68 @@ pub async fn take_screenshot(
     app: AppHandle,
     target: ScreenCaptureTarget,
 ) -> Result<PathBuf, String> {
-    use crate::NewScreenshotAdded;
-    use crate::notifications;
-    use crate::{PendingScreenshot, PendingScreenshots};
+    let image = capture_screen_image(&app, target.clone()).await?;
+
+    AppSounds::Notification.play();
+
+    save_screenshot_project(&app, image, &target)
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+#[tracing::instrument(name = "capture_ocr_text", skip(app))]
+pub async fn capture_ocr_text(
+    app: AppHandle,
+    target: ScreenCaptureTarget,
+) -> Result<String, String> {
+    use tauri_plugin_clipboard_manager::ClipboardExt;
+
+    let settings = GeneralSettingsStore::get(&app)
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+
+    let image = capture_screen_image(&app, target.clone()).await?;
+
+    let text = crate::screenshot_editor::recognize_text_from_dynamic_image(&image).await?;
+    let text = text.trim().to_string();
+
+    if text.is_empty() {
+        return Err("No text was found in the selected area".to_string());
+    }
+
+    app.clipboard()
+        .write_text(text.clone())
+        .map_err(|e| format!("Failed to copy text to clipboard: {e}"))?;
+
+    AppSounds::Notification.play();
+
+    if settings.ocr_keep_screenshot
+        && let Err(e) = save_screenshot_project(&app, image, &target)
+    {
+        error!("Failed to save OCR screenshot: {e}");
+    }
+
+    if settings.ocr_show_notification {
+        use tauri_plugin_notification::NotificationExt;
+
+        let preview: String = text.chars().take(120).collect();
+        app.notification()
+            .builder()
+            .title("Text copied to clipboard")
+            .body(preview)
+            .show()
+            .ok();
+    }
+
+    Ok(text)
+}
+
+async fn capture_screen_image(
+    app: &AppHandle,
+    target: ScreenCaptureTarget,
+) -> Result<image::DynamicImage, String> {
     use cap_recording::screenshot::capture_screenshot;
-    use image::ImageEncoder;
-    use std::time::Instant;
-
-    let general_settings = GeneralSettingsStore::get(&app).ok().flatten();
-    let general_settings = general_settings.as_ref();
-
-    let project_name = format_project_name(
-        general_settings
-            .and_then(|s| s.default_project_name_template.clone())
-            .as_deref(),
-        target.title().as_deref().unwrap_or("Unknown"),
-        target.kind_str(),
-        RecordingMode::Screenshot,
-        None,
-    );
 
     let mut hid_any = false;
     for (label, window) in app.webview_windows() {
@@ -2844,13 +2887,36 @@ pub async fn take_screenshot(
         tokio::time::sleep(std::time::Duration::from_millis(150)).await;
     }
 
-    let automation_target = target.clone();
-
-    let image = capture_screenshot(target)
+    capture_screenshot(target)
         .await
-        .map_err(|e| format!("Failed to capture screenshot: {e}"))?;
+        .map_err(|e| format!("Failed to capture screenshot: {e}"))
+}
 
-    AppSounds::Notification.play();
+fn save_screenshot_project(
+    app: &AppHandle,
+    image: image::DynamicImage,
+    target: &ScreenCaptureTarget,
+) -> Result<PathBuf, String> {
+    use crate::NewScreenshotAdded;
+    use crate::notifications;
+    use crate::{PendingScreenshot, PendingScreenshots};
+    use image::ImageEncoder;
+    use std::time::Instant;
+
+    let general_settings = GeneralSettingsStore::get(app).ok().flatten();
+    let general_settings = general_settings.as_ref();
+
+    let project_name = format_project_name(
+        general_settings
+            .and_then(|s| s.default_project_name_template.clone())
+            .as_deref(),
+        target.title().as_deref().unwrap_or("Unknown"),
+        target.kind_str(),
+        RecordingMode::Screenshot,
+        None,
+    );
+
+    let automation_target = target.clone();
 
     let image_width = image.width();
     let image_height = image.height();

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -2864,8 +2864,10 @@ async fn capture_screen_image(
     app: &AppHandle,
     target: ScreenCaptureTarget,
 ) -> Result<image::DynamicImage, String> {
+    use crate::windows::show_overlay;
     use cap_recording::screenshot::capture_screenshot;
 
+    let mut hidden_windows = Vec::new();
     let mut hid_any = false;
     for (label, window) in app.webview_windows() {
         if let Ok(id) = CapWindowId::from_str(&label)
@@ -2877,9 +2879,16 @@ async fn capture_screen_image(
                     | CapWindowId::ModeSelect
                     | CapWindowId::RecordingsOverlay
             )
+            && window.is_visible().unwrap_or(false)
         {
             hide_overlay(&window);
             hid_any = true;
+            // The target-select overlay's lifecycle is owned by the frontend,
+            // which hides it before invoking a capture and closes or restores
+            // it afterwards; re-showing it here would fight that.
+            if !matches!(id, CapWindowId::TargetSelectOverlay { .. }) {
+                hidden_windows.push(window);
+            }
         }
     }
 
@@ -2887,9 +2896,15 @@ async fn capture_screen_image(
         tokio::time::sleep(std::time::Duration::from_millis(150)).await;
     }
 
-    capture_screenshot(target)
+    let result = capture_screenshot(target)
         .await
-        .map_err(|e| format!("Failed to capture screenshot: {e}"))
+        .map_err(|e| format!("Failed to capture screenshot: {e}"));
+
+    for window in hidden_windows {
+        show_overlay(&window);
+    }
+
+    result
 }
 
 fn save_screenshot_project(

--- a/apps/desktop/src-tauri/src/recording_settings.rs
+++ b/apps/desktop/src-tauri/src/recording_settings.rs
@@ -19,6 +19,7 @@ pub enum RecordingTargetMode {
     Window,
     Area,
     Camera,
+    Ocr,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, specta::Type, Debug, Clone, Default)]

--- a/apps/desktop/src-tauri/src/screenshot_editor.rs
+++ b/apps/desktop/src-tauri/src/screenshot_editor.rs
@@ -986,6 +986,12 @@ pub async fn recognize_screenshot_text(
 
 pub async fn recognize_text_from_image_path(path: &std::path::Path) -> Result<String, String> {
     let dynamic = image::open(path).map_err(|e| format!("Failed to open image for OCR: {e}"))?;
+    recognize_text_from_dynamic_image(&dynamic).await
+}
+
+pub async fn recognize_text_from_dynamic_image(
+    dynamic: &image::DynamicImage,
+) -> Result<String, String> {
     let rgba = dynamic.to_rgba8();
     let width = rgba.width();
     let height = rgba.height();

--- a/apps/desktop/src-tauri/src/scrolling_capture.rs
+++ b/apps/desktop/src-tauri/src/scrolling_capture.rs
@@ -34,6 +34,10 @@ pub async fn capture_scrolling_window(
     app: AppHandle,
     window_id: WindowId,
 ) -> Result<std::path::PathBuf, String> {
+    if !cfg!(any(windows, target_os = "macos")) {
+        return Err("Scrolling capture is not supported on this platform yet".to_string());
+    }
+
     let target = ScreenCaptureTarget::Window {
         id: window_id.clone(),
     };
@@ -71,7 +75,13 @@ pub async fn capture_scrolling_window(
             break;
         }
 
-        let new_rows = offset.min(frame_height);
+        let remaining_rows = MAX_STITCHED_HEIGHT.saturating_sub(stitched_height);
+        let new_rows = offset.min(frame_height).min(remaining_rows);
+        if new_rows == 0 {
+            debug!("Stitched image reached the height cap; stopping");
+            break;
+        }
+
         let strip = frame.crop_imm(0, frame_height - new_rows, frame_width, new_rows);
         stitched.push(strip);
         stitched_height += new_rows;

--- a/apps/desktop/src-tauri/src/scrolling_capture.rs
+++ b/apps/desktop/src-tauri/src/scrolling_capture.rs
@@ -1,0 +1,211 @@
+use cap_recording::screen_capture::ScreenCaptureTarget;
+use image::DynamicImage;
+use scap_targets::WindowId;
+use tauri::AppHandle;
+use tracing::debug;
+
+/// Maximum number of scroll-and-capture iterations.
+const MAX_FRAMES: usize = 60;
+/// Maximum height of the stitched image, in pixels.
+const MAX_STITCHED_HEIGHT: u32 = 16_000;
+/// Wheel lines injected per scroll step.
+const SCROLL_LINES: i32 = 5;
+/// Delay after injecting a scroll before capturing the next frame.
+const SETTLE_MS: u64 = 350;
+/// Fraction of the frame height ignored at the top when matching frames, so
+/// sticky headers and toolbars don't pin the detected offset to zero.
+const HEADER_SKIP_FRACTION: f32 = 0.2;
+/// Maximum mean absolute pixel difference for an overlap to count as a match.
+const MATCH_THRESHOLD: f64 = 8.0;
+
+/// Captures a window while scrolling it, stitching the frames into one tall
+/// image. The window must be under the cursor so the injected wheel events
+/// reach it.
+#[tauri::command(async)]
+#[specta::specta]
+#[tracing::instrument(name = "capture_scrolling_window", skip(app))]
+pub async fn capture_scrolling_window(
+    app: AppHandle,
+    window_id: WindowId,
+) -> Result<std::path::PathBuf, String> {
+    let target = ScreenCaptureTarget::Window {
+        id: window_id.clone(),
+    };
+
+    let first = crate::recording::capture_screen_image(&app, target.clone()).await?;
+    let frame_width = first.width();
+    let frame_height = first.height();
+
+    if frame_width == 0 || frame_height == 0 {
+        return Err("Captured window is empty".to_string());
+    }
+
+    let mut stitched: Vec<DynamicImage> = vec![first.clone()];
+    let mut stitched_height = frame_height;
+    let mut prev = first.to_luma8();
+
+    for frame_index in 0..MAX_FRAMES {
+        inject_scroll(-SCROLL_LINES);
+        tokio::time::sleep(std::time::Duration::from_millis(SETTLE_MS)).await;
+
+        let frame = crate::recording::capture_screen_image(&app, target.clone()).await?;
+        if frame.width() != frame_width || frame.height() != frame_height {
+            debug!("Window resized during scrolling capture; stopping");
+            break;
+        }
+
+        let cur = frame.to_luma8();
+        let Some(offset) = find_scroll_offset(&prev, &cur) else {
+            debug!("No overlap match on frame {frame_index}; stopping");
+            break;
+        };
+
+        if offset == 0 {
+            debug!("Content stopped scrolling on frame {frame_index}; done");
+            break;
+        }
+
+        let new_rows = offset.min(frame_height);
+        let strip = frame.crop_imm(0, frame_height - new_rows, frame_width, new_rows);
+        stitched.push(strip);
+        stitched_height += new_rows;
+        prev = cur;
+
+        if stitched_height >= MAX_STITCHED_HEIGHT {
+            debug!("Stitched image reached the height cap; stopping");
+            break;
+        }
+    }
+
+    let mut canvas = image::RgbaImage::new(frame_width, stitched_height);
+    let mut y = 0u32;
+    for part in &stitched {
+        image::imageops::replace(&mut canvas, &part.to_rgba8(), 0, i64::from(y));
+        y += part.height();
+    }
+
+    crate::audio::AppSounds::Notification.play();
+
+    crate::recording::save_screenshot_project(&app, DynamicImage::ImageRgba8(canvas), &target, true)
+}
+
+/// Finds how many pixels the content moved up between `prev` and `cur` by
+/// locating the vertical shift with the smallest mean absolute difference
+/// over the overlapping rows. Returns `None` when even the best candidate is
+/// a poor match (e.g. the window repainted entirely).
+fn find_scroll_offset(prev: &image::GrayImage, cur: &image::GrayImage) -> Option<u32> {
+    let width = prev.width() as usize;
+    let height = prev.height() as usize;
+    let skip_top = (height as f32 * HEADER_SKIP_FRACTION) as usize;
+
+    let prev_raw = prev.as_raw();
+    let cur_raw = cur.as_raw();
+
+    let col_step = (width / 64).max(1);
+    let row_step = 4usize;
+
+    let mut best_offset = 0usize;
+    let mut best_score = f64::MAX;
+
+    let max_offset = height - skip_top - row_step;
+    for offset in (0..max_offset).step_by(2) {
+        let overlap_rows = height - skip_top - offset;
+        let mut sum = 0u64;
+        let mut count = 0u64;
+
+        for row in (0..overlap_rows).step_by(row_step) {
+            let prev_row = skip_top + offset + row;
+            let cur_row = skip_top + row;
+            let prev_base = prev_row * width;
+            let cur_base = cur_row * width;
+
+            for col in (0..width).step_by(col_step) {
+                let a = prev_raw[prev_base + col] as i32;
+                let b = cur_raw[cur_base + col] as i32;
+                sum += a.abs_diff(b) as u64;
+                count += 1;
+            }
+        }
+
+        if count == 0 {
+            continue;
+        }
+
+        let score = sum as f64 / count as f64;
+        if score < best_score {
+            best_score = score;
+            best_offset = offset;
+        }
+
+        if score < 0.5 && offset > 0 {
+            break;
+        }
+    }
+
+    (best_score <= MATCH_THRESHOLD).then_some(best_offset as u32)
+}
+
+/// Injects vertical mouse-wheel scrolling at the current cursor position.
+/// Negative `lines` scrolls the content up (revealing content below).
+#[allow(unused_variables)]
+fn inject_scroll(lines: i32) {
+    #[cfg(windows)]
+    {
+        use ::windows::Win32::UI::Input::KeyboardAndMouse::{
+            INPUT, INPUT_0, INPUT_MOUSE, MOUSEEVENTF_WHEEL, MOUSEINPUT, SendInput,
+        };
+
+        const WHEEL_DELTA: i32 = 120;
+
+        let input = INPUT {
+            r#type: INPUT_MOUSE,
+            Anonymous: INPUT_0 {
+                mi: MOUSEINPUT {
+                    dx: 0,
+                    dy: 0,
+                    mouseData: (lines * WHEEL_DELTA) as u32,
+                    dwFlags: MOUSEEVENTF_WHEEL,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        };
+
+        unsafe {
+            SendInput(&[input], std::mem::size_of::<INPUT>() as i32);
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        use std::ffi::c_void;
+
+        // kCGScrollEventUnitLine
+        const UNITS_LINE: u32 = 1;
+        // kCGHIDEventTap
+        const HID_EVENT_TAP: u32 = 0;
+
+        #[link(name = "CoreGraphics", kind = "framework")]
+        unsafe extern "C" {
+            fn CGEventCreateScrollWheelEvent2(
+                source: *const c_void,
+                units: u32,
+                wheel_count: u32,
+                wheel1: i32,
+                wheel2: i32,
+                wheel3: i32,
+            ) -> *mut c_void;
+            fn CGEventPost(tap: u32, event: *mut c_void);
+            fn CFRelease(cf: *const c_void);
+        }
+
+        unsafe {
+            let event =
+                CGEventCreateScrollWheelEvent2(std::ptr::null(), UNITS_LINE, 1, lines, 0, 0);
+            if !event.is_null() {
+                CGEventPost(HID_EVENT_TAP, event);
+                CFRelease(event);
+            }
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/scrolling_capture.rs
+++ b/apps/desktop/src-tauri/src/scrolling_capture.rs
@@ -8,15 +8,21 @@ use tracing::debug;
 const MAX_FRAMES: usize = 60;
 /// Maximum height of the stitched image, in pixels.
 const MAX_STITCHED_HEIGHT: u32 = 16_000;
-/// Wheel lines injected per scroll step.
-const SCROLL_LINES: i32 = 5;
-/// Delay after injecting a scroll before capturing the next frame.
-const SETTLE_MS: u64 = 350;
+/// Wheel notches injected per scroll step. Kept small so consecutive frames
+/// overlap enough for reliable offset matching (one notch scrolls ~3 lines,
+/// roughly 100px in most applications).
+const SCROLL_NOTCHES: i32 = 2;
+/// Delay after injecting a scroll before capturing the next frame, long
+/// enough for smooth-scrolling animations to finish.
+const SETTLE_MS: u64 = 600;
 /// Fraction of the frame height ignored at the top when matching frames, so
 /// sticky headers and toolbars don't pin the detected offset to zero.
 const HEADER_SKIP_FRACTION: f32 = 0.2;
 /// Maximum mean absolute pixel difference for an overlap to count as a match.
-const MATCH_THRESHOLD: f64 = 8.0;
+const MATCH_THRESHOLD: f64 = 12.0;
+/// Minimum fraction of the matchable rows that must overlap for a candidate
+/// offset to be considered; small overlaps produce noisy scores.
+const MIN_OVERLAP_FRACTION: f32 = 0.25;
 
 /// Captures a window while scrolling it, stitching the frames into one tall
 /// image. The window must be under the cursor so the injected wheel events
@@ -45,7 +51,7 @@ pub async fn capture_scrolling_window(
     let mut prev = first.to_luma8();
 
     for frame_index in 0..MAX_FRAMES {
-        inject_scroll(-SCROLL_LINES);
+        inject_scroll(-SCROLL_NOTCHES);
         tokio::time::sleep(std::time::Duration::from_millis(SETTLE_MS)).await;
 
         let frame = crate::recording::capture_screen_image(&app, target.clone()).await?;
@@ -107,8 +113,10 @@ fn find_scroll_offset(prev: &image::GrayImage, cur: &image::GrayImage) -> Option
     let mut best_offset = 0usize;
     let mut best_score = f64::MAX;
 
-    let max_offset = height - skip_top - row_step;
-    for offset in (0..max_offset).step_by(2) {
+    let matchable_rows = height - skip_top;
+    let min_overlap = ((matchable_rows as f32 * MIN_OVERLAP_FRACTION) as usize).max(row_step);
+    let max_offset = matchable_rows - min_overlap;
+    for offset in 0..=max_offset {
         let overlap_rows = height - skip_top - offset;
         let mut sum = 0u64;
         let mut count = 0u64;
@@ -146,9 +154,9 @@ fn find_scroll_offset(prev: &image::GrayImage, cur: &image::GrayImage) -> Option
 }
 
 /// Injects vertical mouse-wheel scrolling at the current cursor position.
-/// Negative `lines` scrolls the content up (revealing content below).
+/// Negative `notches` scrolls the content up (revealing content below).
 #[allow(unused_variables)]
-fn inject_scroll(lines: i32) {
+fn inject_scroll(notches: i32) {
     #[cfg(windows)]
     {
         use ::windows::Win32::UI::Input::KeyboardAndMouse::{
@@ -163,7 +171,7 @@ fn inject_scroll(lines: i32) {
                 mi: MOUSEINPUT {
                     dx: 0,
                     dy: 0,
-                    mouseData: (lines * WHEEL_DELTA) as u32,
+                    mouseData: (notches * WHEEL_DELTA) as u32,
                     dwFlags: MOUSEEVENTF_WHEEL,
                     time: 0,
                     dwExtraInfo: 0,
@@ -184,6 +192,8 @@ fn inject_scroll(lines: i32) {
         const UNITS_LINE: u32 = 1;
         // kCGHIDEventTap
         const HID_EVENT_TAP: u32 = 0;
+        // Lines scrolled per wheel notch.
+        const LINES_PER_NOTCH: i32 = 3;
 
         #[link(name = "CoreGraphics", kind = "framework")]
         unsafe extern "C" {
@@ -200,8 +210,14 @@ fn inject_scroll(lines: i32) {
         }
 
         unsafe {
-            let event =
-                CGEventCreateScrollWheelEvent2(std::ptr::null(), UNITS_LINE, 1, lines, 0, 0);
+            let event = CGEventCreateScrollWheelEvent2(
+                std::ptr::null(),
+                UNITS_LINE,
+                1,
+                notches * LINES_PER_NOTCH,
+                0,
+                0,
+            );
             if !event.is_null() {
                 CGEventPost(HID_EVENT_TAP, event);
                 CFRelease(event);

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -130,6 +130,27 @@ pub fn show_overlay(window: &WebviewWindow) {
     let _ = window.show();
 }
 
+/// Shows the calling window without activating it, so the foreground app
+/// keeps keyboard focus.
+#[tauri::command]
+#[specta::specta]
+pub fn show_window_without_activating(window: WebviewWindow) {
+    #[cfg(windows)]
+    if let Ok(hwnd) = window.hwnd() {
+        use ::windows::Win32::UI::WindowsAndMessaging::{SW_SHOWNOACTIVATE, ShowWindow};
+
+        unsafe {
+            let _ = ShowWindow(
+                ::windows::Win32::Foundation::HWND(hwnd.0),
+                SW_SHOWNOACTIVATE,
+            );
+        }
+        return;
+    }
+
+    let _ = window.show();
+}
+
 fn emit_app_event<E>(app: &AppHandle, event: E)
 where
     E: Event + serde::Serialize + Clone,

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -1707,6 +1707,7 @@ impl ShowCapWindow {
                     Some(RecordingTargetMode::Window) => "&targetMode=window",
                     Some(RecordingTargetMode::Area) => "&targetMode=area",
                     Some(RecordingTargetMode::Camera) => "&targetMode=camera",
+                    Some(RecordingTargetMode::Ocr) => "&targetMode=ocr",
                     None => "",
                 };
 

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -2038,11 +2038,15 @@ function Page() {
 				dismissal === "ocr" ||
 				dismissal === "recordingInstant";
 			if (shouldRevealMainWindow && dismissalReveals) {
-				const currentWindow = getCurrentWindow();
-				void currentWindow.show();
 				// An OCR capture is a background copy-to-clipboard gesture; bring
 				// the window back without stealing focus from the user's app.
-				if (dismissal !== "ocr") void currentWindow.setFocus();
+				if (dismissal === "ocr") {
+					void commands.showWindowWithoutActivating();
+				} else {
+					const currentWindow = getCurrentWindow();
+					void currentWindow.show();
+					void currentWindow.setFocus();
+				}
 			}
 		}
 	});

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -2035,11 +2035,14 @@ function Page() {
 			const dismissalReveals =
 				dismissal === "cancelled" ||
 				dismissal === "screenshot" ||
+				dismissal === "ocr" ||
 				dismissal === "recordingInstant";
 			if (shouldRevealMainWindow && dismissalReveals) {
 				const currentWindow = getCurrentWindow();
 				void currentWindow.show();
-				void currentWindow.setFocus();
+				// An OCR capture is a background copy-to-clipboard gesture; bring
+				// the window back without stealing focus from the user's app.
+				if (dismissal !== "ocr") void currentWindow.setFocus();
 			}
 		}
 	});

--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -573,6 +573,35 @@ function Inner(props: {
 				/>
 
 				<Section
+					title="Text capture (OCR)"
+					description="Copy text from anywhere on your screen with the OCR hotkey."
+				>
+					<SectionRows>
+						<ToggleSettingItem
+							label="Keep a screenshot of the captured area"
+							description="Save the selected region to your screenshots when copying text. When off, nothing is stored."
+							value={!!settings.ocrKeepScreenshot}
+							onChange={(value) => handleChange("ocrKeepScreenshot", value)}
+						/>
+						<ToggleSettingItem
+							label="Show a notification when text is copied"
+							description="Display a system notification with a preview of the copied text."
+							value={!!settings.ocrShowNotification}
+							onChange={async (value) => {
+								if (value) {
+									const permissionGranted = await isPermissionGranted();
+									if (!permissionGranted) {
+										const permission = await requestPermission();
+										if (permission !== "granted") return;
+									}
+								}
+								handleChange("ocrShowNotification", value);
+							}}
+						/>
+					</SectionRows>
+				</Section>
+
+				<Section
 					title="Recording"
 					description="Behaviour while you record and after you stop."
 				>

--- a/apps/desktop/src/routes/(window-chrome)/settings/hotkeys.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/hotkeys.tsx
@@ -36,6 +36,7 @@ const ACTION_TEXT = {
 	screenshotDisplay: "Screenshot current display",
 	screenshotWindow: "Screenshot current window",
 	screenshotArea: "Screenshot area picker",
+	ocrArea: "Copy text from area (OCR)",
 } satisfies { [K in HotkeyAction]?: string };
 
 export default function () {
@@ -87,6 +88,7 @@ function Inner(props: { initialStore: HotkeysStore | null }) {
 			"screenshotDisplay",
 			"screenshotWindow",
 			"screenshotArea",
+			"ocrArea",
 			"openRecordingPicker",
 			"stopRecording",
 			"restartRecording",

--- a/apps/desktop/src/routes/(window-chrome)/settings/hotkeys.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/hotkeys.tsx
@@ -37,6 +37,7 @@ const ACTION_TEXT = {
 	screenshotWindow: "Screenshot current window",
 	screenshotArea: "Screenshot area picker",
 	ocrArea: "Copy text from area (OCR)",
+	scrollingCaptureWindow: "Scrolling capture of window under cursor",
 } satisfies { [K in HotkeyAction]?: string };
 
 export default function () {
@@ -89,6 +90,7 @@ function Inner(props: { initialStore: HotkeysStore | null }) {
 			"screenshotWindow",
 			"screenshotArea",
 			"ocrArea",
+			"scrollingCaptureWindow",
 			"openRecordingPicker",
 			"stopRecording",
 			"restartRecording",

--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -194,7 +194,7 @@ function Inner() {
 	const [params] = useSearchParams<{
 		displayId: DisplayId;
 		isHoveredDisplay: string;
-		targetMode: "display" | "window" | "area" | "camera";
+		targetMode: "display" | "window" | "area" | "camera" | "ocr";
 	}>();
 	const [options, setOptions] = useOptions();
 	const [areaSelectionPreferences, setAreaSelectionPreferences] = makePersisted(
@@ -293,7 +293,16 @@ function Inner() {
 	});
 
 	createEffect(
-		(prevMode: "display" | "window" | "area" | "camera" | null | undefined) => {
+		(
+			prevMode:
+				| "display"
+				| "window"
+				| "area"
+				| "camera"
+				| "ocr"
+				| null
+				| undefined,
+		) => {
 			const mode = options.targetMode ?? null;
 			if (prevMode === "area" && mode !== "area") {
 				const target = pendingAreaTarget();
@@ -779,8 +788,16 @@ function Inner() {
 					);
 				}}
 			</Match>
-			<Match when={options.targetMode === "area" && params.displayId}>
+			<Match
+				when={
+					(options.targetMode === "area" || options.targetMode === "ocr") &&
+					params.displayId
+				}
+			>
 				{(displayId) => {
+					const isOcr = () => options.targetMode === "ocr";
+					const isImmediateCapture = () =>
+						isOcr() || options.mode === "screenshot";
 					let controlsEl: HTMLDivElement | undefined;
 					let cropperRef: CropperRef | undefined;
 
@@ -812,19 +829,19 @@ function Inner() {
 					const [screenshotSnapToRatio, setScreenshotSnapToRatio] =
 						createSignal(true);
 					const minSize = () =>
-						options.mode === "screenshot" ? MIN_SCREENSHOT_SIZE : MIN_SIZE;
+						isImmediateCapture() ? MIN_SCREENSHOT_SIZE : MIN_SIZE;
 					const currentAspect = () =>
-						options.mode === "screenshot"
+						isImmediateCapture()
 							? screenshotAspect()
 							: areaSelectionPreferences.aspectRatio;
 					const currentSnapToRatio = () =>
-						options.mode === "screenshot"
+						isImmediateCapture()
 							? screenshotSnapToRatio()
 							: areaSelectionPreferences.snapToRatio;
 					const effectiveInitialAreaBounds = createMemo(() => {
 						const explicitBounds = initialAreaBounds();
 						if (explicitBounds) return explicitBounds;
-						if (options.mode === "screenshot") return undefined;
+						if (isImmediateCapture()) return undefined;
 						return getLockedAreaBounds(
 							areaSelectionPreferences,
 							displayId(),
@@ -855,7 +872,7 @@ function Inner() {
 					});
 					const isSelectionLocked = createMemo(
 						() =>
-							options.mode !== "screenshot" &&
+							!isImmediateCapture() &&
 							getLockedAreaBounds(
 								areaSelectionPreferences,
 								displayId(),
@@ -864,7 +881,7 @@ function Inner() {
 					);
 
 					function setAspect(aspect: Ratio | null) {
-						if (options.mode === "screenshot") {
+						if (isImmediateCapture()) {
 							setScreenshotAspect(aspect);
 							return;
 						}
@@ -875,7 +892,7 @@ function Inner() {
 					}
 
 					function setSnapToRatio(enabled: boolean) {
-						if (options.mode === "screenshot") {
+						if (isImmediateCapture()) {
 							setScreenshotSnapToRatio(enabled);
 							return;
 						}
@@ -884,7 +901,7 @@ function Inner() {
 
 					function persistLockedSelection() {
 						if (
-							options.mode === "screenshot" ||
+							isImmediateCapture() ||
 							!areaSelectionPreferences.locked ||
 							areaSelectionPreferences.screenId !== displayId() ||
 							!isValid()
@@ -920,7 +937,7 @@ function Inner() {
 						}
 						if (
 							isInteracting() ||
-							options.mode === "screenshot" ||
+							isImmediateCapture() ||
 							!areaSelectionPreferences.locked ||
 							areaSelectionPreferences.screenId !== displayId() ||
 							!isValid() ||
@@ -989,7 +1006,7 @@ function Inner() {
 					});
 
 					createEffect(async () => {
-						if (options.mode === "screenshot") return;
+						if (isImmediateCapture()) return;
 						const bounds = crop();
 						const interacting = isInteracting();
 						const displayInfo = areaDisplayInfo.data;
@@ -1252,6 +1269,51 @@ function Inner() {
 
 						if (was && !interacting) {
 							persistLockedSelection();
+							if (isOcr() && isValid()) {
+								const cropBounds = crop();
+								const target: ScreenCaptureTarget = {
+									variant: "area",
+									screen: displayId(),
+									bounds: {
+										position: {
+											x: cropBounds.x,
+											y: cropBounds.y,
+										},
+										size: {
+											width: cropBounds.width,
+											height: cropBounds.height,
+										},
+									},
+								};
+
+								const overlayWindows = (await WebviewWindow.getAll()).filter(
+									(win) => win.label.startsWith("target-select-overlay-"),
+								);
+
+								try {
+									for (const win of overlayWindows) {
+										await win.setIgnoreCursorEvents(true);
+										await win.hide();
+									}
+									await new Promise((resolve) => setTimeout(resolve, 50));
+
+									await commands.captureOcrText(target);
+									setOptions({
+										targetMode: null,
+										targetModeDismissal: "screenshot",
+									});
+									await commands.closeTargetSelectOverlays();
+								} catch (e) {
+									for (const win of overlayWindows) {
+										await win.setIgnoreCursorEvents(false);
+										await win.show();
+									}
+									const message = e instanceof Error ? e.message : String(e);
+									toast.error(`Failed to copy text: ${message}`);
+									console.error("Failed to copy text", e);
+								}
+								return;
+							}
 							if (options.mode === "screenshot" && isValid()) {
 								const cropBounds = crop();
 								const displayInfo = areaDisplayInfo.data;
@@ -1330,7 +1392,9 @@ function Inner() {
 										<div class="min-w-28 px-2 text-base font-normal leading-none tracking-[-0.01em] tabular-nums">
 											{isValid()
 												? `${Math.round(crop().width)} × ${Math.round(crop().height)}`
-												: "Draw an area"}
+												: isOcr()
+													? "Draw an area to copy text"
+													: "Draw an area"}
 										</div>
 
 										<div class="h-6 w-px bg-gray-5" />
@@ -1402,7 +1466,7 @@ function Inner() {
 										>
 											<IconLucideMaximize2 class="size-4" />
 										</button>
-										<Show when={options.mode !== "screenshot"}>
+										<Show when={!isImmediateCapture()}>
 											<button
 												type="button"
 												class="flex h-9 items-center gap-1.5 rounded-xl px-2.5 text-xs font-normal transition-colors disabled:cursor-not-allowed disabled:opacity-40"
@@ -1434,7 +1498,7 @@ function Inner() {
 								style={controlsStyle()}
 							>
 								<div class="flex flex-col items-center">
-									<Show when={options.mode !== "screenshot"}>
+									<Show when={!isImmediateCapture()}>
 										<RecordingControls
 											target={{
 												variant: "area",
@@ -1479,7 +1543,7 @@ function Inner() {
 											</small>
 										</div>
 									</Show>
-									<Show when={isValid()}>
+									<Show when={isValid() && !isOcr()}>
 										<ShowCapFreeWarning
 											isInstantMode={options.mode === "instant"}
 										/>

--- a/apps/desktop/src/routes/target-select-overlay.tsx
+++ b/apps/desktop/src/routes/target-select-overlay.tsx
@@ -1300,7 +1300,7 @@ function Inner() {
 									await commands.captureOcrText(target);
 									setOptions({
 										targetMode: null,
-										targetModeDismissal: "screenshot",
+										targetModeDismissal: "ocr",
 									});
 									await commands.closeTargetSelectOverlays();
 								} catch (e) {

--- a/apps/desktop/src/utils/queries.ts
+++ b/apps/desktop/src/utils/queries.ts
@@ -162,6 +162,7 @@ export type TargetModeDismissal =
 	| "recordingStudio"
 	| "recordingInstant"
 	| "screenshot"
+	| "ocr"
 	| "superseded"
 	| "cancelled";
 

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -569,7 +569,6 @@ videoImportProgress: "video-import-progress"
 /** user-defined types **/
 
 export type Action = { type: "copyToClipboard"; source?: ClipboardSource } | { type: "saveToLocation"; dir: string; filenameTemplate?: string | null } | { type: "export"; profile: ExportProfile; destination?: ExportDestination } | { type: "upload"; organizationId?: string | null; copyLink?: boolean; openInBrowser?: boolean } | { type: "revealInFileManager" } | { type: "openFile" } | { type: "runCommand"; program: string; args?: string[]; cwd?: string | null; env?: { [key in string]: string }; useShell?: boolean } | { type: "webhook"; url: string; method?: string; headers?: { [key in string]: string }; bodyTemplate?: string | null } | { type: "recognizeTextToClipboard" } | { type: "notify"; titleTemplate?: string; bodyTemplate?: string } | { type: "openEditor" } | { type: "skipEditor" } | { type: "applyPreset"; name: string } | { type: "deleteLocalFiles" }
-export type AllGpusInfo = { gpus: GpuInfoDiag[]; primaryGpuIndex: number | null; isMultiGpuSystem: boolean; hasDiscreteGpu: boolean }
 export type Annotation = { id: string; type: AnnotationType; x: number; y: number; width: number; height: number; strokeColor: string; strokeWidth: number; fillColor: string; opacity: number; rotation: number; text: string | null; maskType?: MaskType | null; maskLevel?: number | null }
 export type AnnotationType = "arrow" | "circle" | "rectangle" | "text" | "mask"
 export type AppTheme = "system" | "light" | "dark"
@@ -821,7 +820,6 @@ quality: number | null;
  */
 fast: boolean | null }
 export type GlideDirection = "none" | "left" | "right" | "up" | "down"
-export type GpuInfoDiag = { vendor: string; description: string; dedicatedVideoMemoryMb: number; adapterIndex: number; isSoftwareAdapter: boolean; isBasicRenderDriver: boolean; supportsHardwareEncoding: boolean }
 export type HapticPattern = "alignment" | "levelChange" | "generic"
 export type HapticPerformanceTime = "default" | "now" | "drawCompleted"
 export type Hotkey = { code: string; meta: boolean; ctrl: boolean; alt: boolean; shift: boolean }
@@ -844,6 +842,7 @@ export type KeyboardTrackSegment = { id: string; start: number; end: number; dis
 export type LogicalBounds = { position: LogicalPosition; size: LogicalSize }
 export type LogicalPosition = { x: number; y: number }
 export type LogicalSize = { width: number; height: number }
+export type MacOSVersionInfo = { major: number; minor: number; patch: number; displayName: string; buildNumber: string; isAppleSilicon: boolean }
 export type MainWindowRecordingStartBehaviour = "close" | "minimise"
 export type MaskKeyframes = { position?: MaskVectorKeyframe[]; size?: MaskVectorKeyframe[]; intensity?: MaskScalarKeyframe[] }
 export type MaskKind = "sensitive" | "highlight"
@@ -916,7 +915,6 @@ export type RecordingsMigrationFailure = { name: string; error: string }
 export type RecordingsMigrationProgress = { total: number; done: number; current: string | null }
 export type RecordingsMigrationSummary = { moved: number; skippedInUse: number; failed: RecordingsMigrationFailure[] }
 export type RenderFrameEvent = { frame_number: number; fps: number; resolution_base: XY<number> }
-export type RenderingStatus = { isUsingSoftwareRendering: boolean; isUsingBasicRenderDriver: boolean; hardwareEncodingAvailable: boolean; warningMessage: string | null }
 export type RequestOpenRecordingPicker = { target_mode: RecordingTargetMode | null }
 export type RequestOpenSettings = { page: string }
 export type RequestScreenCapturePrewarm = { force?: boolean }
@@ -961,7 +959,7 @@ export type StereoMode = "stereo" | "monoL" | "monoR"
 export type StudioRecordingMeta = { segment: SingleSegment } | { inner: MultipleSegments }
 export type StudioRecordingQuality = "compatibility" | "balanced" | "ultra"
 export type StudioRecordingStatus = { status: "InProgress" } | { status: "NeedsRemux" } | { status: "Failed"; error: string } | { status: "Complete" }
-export type SystemDiagnostics = { windowsVersion: WindowsVersionInfo | null; gpuInfo: GpuInfoDiag | null; allGpus: AllGpusInfo | null; renderingStatus: RenderingStatus; availableEncoders: string[]; graphicsCaptureSupported: boolean; d3D11VideoProcessorAvailable: boolean }
+export type SystemDiagnostics = { macosVersion: MacOSVersionInfo | null; availableEncoders: string[]; screenCaptureSupported: boolean; metalSupported: boolean; gpuName: string | null }
 export type TargetUnderCursor = { display_id: DisplayId | null; window: WindowUnderCursor | null }
 export type TextSegment = { start: number; end: number; track?: number; enabled?: boolean; content?: string; center?: XY<number>; size?: XY<number>; fontFamily?: string; fontSize?: number; fontWeight?: number; italic?: boolean; color?: string; fadeDuration?: number }
 export type TimelineConfiguration = { segments: TimelineSegment[]; transitions: ClipTransition[]; zoomSegments: ZoomSegment[]; sceneSegments?: SceneSegment[]; maskSegments?: MaskSegment[]; textSegments?: TextSegment[]; captionSegments?: CaptionTrackSegment[]; keyboardSegments?: KeyboardTrackSegment[]; audioSegments?: AudioTrackSegment[] }
@@ -986,7 +984,6 @@ export type WindowExclusion = { bundleIdentifier?: string | null; ownerName?: st
 export type WindowId = string
 export type WindowPosition = { x: number; y: number; displayId?: DisplayId | null }
 export type WindowUnderCursor = { id: WindowId; app_name: string; bounds: LogicalBounds }
-export type WindowsVersionInfo = { major: number; minor: number; build: number; displayName: string; meetsRequirements: boolean; isWindows11: boolean }
 export type XY<T> = { x: T; y: T }
 export type ZoomMode = "auto" | { manual: { x: number; y: number } }
 export type ZoomSegment = { start: number; end: number; amount: number; mode: ZoomMode; glideDirection?: GlideDirection; glideSpeed?: number; instantAnimation?: boolean; edgeSnapRatio?: number }

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -62,6 +62,9 @@ async takeScreenshot(target: ScreenCaptureTarget) : Promise<string> {
 async captureOcrText(target: ScreenCaptureTarget) : Promise<string> {
     return await TAURI_INVOKE("capture_ocr_text", { target });
 },
+async captureScrollingWindow(windowId: WindowId) : Promise<string> {
+    return await TAURI_INVOKE("capture_scrolling_window", { windowId });
+},
 async importCurrentDesktopBackground(projectPath: string) : Promise<string> {
     return await TAURI_INVOKE("import_current_desktop_background", { projectPath });
 },
@@ -832,7 +835,7 @@ export type GpuInfoDiag = { vendor: string; description: string; dedicatedVideoM
 export type HapticPattern = "alignment" | "levelChange" | "generic"
 export type HapticPerformanceTime = "default" | "now" | "drawCompleted"
 export type Hotkey = { code: string; meta: boolean; ctrl: boolean; alt: boolean; shift: boolean }
-export type HotkeyAction = "startStudioRecording" | "startInstantRecording" | "stopRecording" | "restartRecording" | "togglePauseRecording" | "cycleRecordingMode" | "openRecordingPicker" | "openRecordingPickerDisplay" | "openRecordingPickerWindow" | "openRecordingPickerArea" | "screenshotDisplay" | "screenshotWindow" | "screenshotArea" | "ocrArea" | "other"
+export type HotkeyAction = "startStudioRecording" | "startInstantRecording" | "stopRecording" | "restartRecording" | "togglePauseRecording" | "cycleRecordingMode" | "openRecordingPicker" | "openRecordingPickerDisplay" | "openRecordingPickerWindow" | "openRecordingPickerArea" | "screenshotDisplay" | "screenshotWindow" | "screenshotArea" | "ocrArea" | "scrollingCaptureWindow" | "other"
 export type HotkeysConfiguration = { show: boolean }
 export type HotkeysStore = { hotkeys: { [key in HotkeyAction]: Hotkey }; seeded?: HotkeyAction[] }
 export type ImportStage = "Probing" | "Converting" | "Finalizing" | "Complete" | "Failed"

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -308,6 +308,13 @@ async positionTrafficLights(controlsInset: [number, number] | null) : Promise<vo
 async setTheme(theme: AppTheme) : Promise<void> {
     await TAURI_INVOKE("set_theme", { theme });
 },
+/**
+ * Shows the calling window without activating it, so the foreground app
+ * keeps keyboard focus.
+ */
+async showWindowWithoutActivating() : Promise<void> {
+    await TAURI_INVOKE("show_window_without_activating");
+},
 async setTeleprompterWindowLevel(alwaysOnTop: boolean) : Promise<void> {
     await TAURI_INVOKE("set_teleprompter_window_level", { alwaysOnTop });
 },
@@ -569,6 +576,7 @@ videoImportProgress: "video-import-progress"
 /** user-defined types **/
 
 export type Action = { type: "copyToClipboard"; source?: ClipboardSource } | { type: "saveToLocation"; dir: string; filenameTemplate?: string | null } | { type: "export"; profile: ExportProfile; destination?: ExportDestination } | { type: "upload"; organizationId?: string | null; copyLink?: boolean; openInBrowser?: boolean } | { type: "revealInFileManager" } | { type: "openFile" } | { type: "runCommand"; program: string; args?: string[]; cwd?: string | null; env?: { [key in string]: string }; useShell?: boolean } | { type: "webhook"; url: string; method?: string; headers?: { [key in string]: string }; bodyTemplate?: string | null } | { type: "recognizeTextToClipboard" } | { type: "notify"; titleTemplate?: string; bodyTemplate?: string } | { type: "openEditor" } | { type: "skipEditor" } | { type: "applyPreset"; name: string } | { type: "deleteLocalFiles" }
+export type AllGpusInfo = { gpus: GpuInfoDiag[]; primaryGpuIndex: number | null; isMultiGpuSystem: boolean; hasDiscreteGpu: boolean }
 export type Annotation = { id: string; type: AnnotationType; x: number; y: number; width: number; height: number; strokeColor: string; strokeWidth: number; fillColor: string; opacity: number; rotation: number; text: string | null; maskType?: MaskType | null; maskLevel?: number | null }
 export type AnnotationType = "arrow" | "circle" | "rectangle" | "text" | "mask"
 export type AppTheme = "system" | "light" | "dark"
@@ -820,6 +828,7 @@ quality: number | null;
  */
 fast: boolean | null }
 export type GlideDirection = "none" | "left" | "right" | "up" | "down"
+export type GpuInfoDiag = { vendor: string; description: string; dedicatedVideoMemoryMb: number; adapterIndex: number; isSoftwareAdapter: boolean; isBasicRenderDriver: boolean; supportsHardwareEncoding: boolean }
 export type HapticPattern = "alignment" | "levelChange" | "generic"
 export type HapticPerformanceTime = "default" | "now" | "drawCompleted"
 export type Hotkey = { code: string; meta: boolean; ctrl: boolean; alt: boolean; shift: boolean }
@@ -842,7 +851,6 @@ export type KeyboardTrackSegment = { id: string; start: number; end: number; dis
 export type LogicalBounds = { position: LogicalPosition; size: LogicalSize }
 export type LogicalPosition = { x: number; y: number }
 export type LogicalSize = { width: number; height: number }
-export type MacOSVersionInfo = { major: number; minor: number; patch: number; displayName: string; buildNumber: string; isAppleSilicon: boolean }
 export type MainWindowRecordingStartBehaviour = "close" | "minimise"
 export type MaskKeyframes = { position?: MaskVectorKeyframe[]; size?: MaskVectorKeyframe[]; intensity?: MaskScalarKeyframe[] }
 export type MaskKind = "sensitive" | "highlight"
@@ -915,6 +923,7 @@ export type RecordingsMigrationFailure = { name: string; error: string }
 export type RecordingsMigrationProgress = { total: number; done: number; current: string | null }
 export type RecordingsMigrationSummary = { moved: number; skippedInUse: number; failed: RecordingsMigrationFailure[] }
 export type RenderFrameEvent = { frame_number: number; fps: number; resolution_base: XY<number> }
+export type RenderingStatus = { isUsingSoftwareRendering: boolean; isUsingBasicRenderDriver: boolean; hardwareEncodingAvailable: boolean; warningMessage: string | null }
 export type RequestOpenRecordingPicker = { target_mode: RecordingTargetMode | null }
 export type RequestOpenSettings = { page: string }
 export type RequestScreenCapturePrewarm = { force?: boolean }
@@ -959,7 +968,7 @@ export type StereoMode = "stereo" | "monoL" | "monoR"
 export type StudioRecordingMeta = { segment: SingleSegment } | { inner: MultipleSegments }
 export type StudioRecordingQuality = "compatibility" | "balanced" | "ultra"
 export type StudioRecordingStatus = { status: "InProgress" } | { status: "NeedsRemux" } | { status: "Failed"; error: string } | { status: "Complete" }
-export type SystemDiagnostics = { macosVersion: MacOSVersionInfo | null; availableEncoders: string[]; screenCaptureSupported: boolean; metalSupported: boolean; gpuName: string | null }
+export type SystemDiagnostics = { windowsVersion: WindowsVersionInfo | null; gpuInfo: GpuInfoDiag | null; allGpus: AllGpusInfo | null; renderingStatus: RenderingStatus; availableEncoders: string[]; graphicsCaptureSupported: boolean; d3D11VideoProcessorAvailable: boolean }
 export type TargetUnderCursor = { display_id: DisplayId | null; window: WindowUnderCursor | null }
 export type TextSegment = { start: number; end: number; track?: number; enabled?: boolean; content?: string; center?: XY<number>; size?: XY<number>; fontFamily?: string; fontSize?: number; fontWeight?: number; italic?: boolean; color?: string; fadeDuration?: number }
 export type TimelineConfiguration = { segments: TimelineSegment[]; transitions: ClipTransition[]; zoomSegments: ZoomSegment[]; sceneSegments?: SceneSegment[]; maskSegments?: MaskSegment[]; textSegments?: TextSegment[]; captionSegments?: CaptionTrackSegment[]; keyboardSegments?: KeyboardTrackSegment[]; audioSegments?: AudioTrackSegment[] }
@@ -984,6 +993,7 @@ export type WindowExclusion = { bundleIdentifier?: string | null; ownerName?: st
 export type WindowId = string
 export type WindowPosition = { x: number; y: number; displayId?: DisplayId | null }
 export type WindowUnderCursor = { id: WindowId; app_name: string; bounds: LogicalBounds }
+export type WindowsVersionInfo = { major: number; minor: number; build: number; displayName: string; meetsRequirements: boolean; isWindows11: boolean }
 export type XY<T> = { x: T; y: T }
 export type ZoomMode = "auto" | { manual: { x: number; y: number } }
 export type ZoomSegment = { start: number; end: number; amount: number; mode: ZoomMode; glideDirection?: GlideDirection; glideSpeed?: number; instantAnimation?: boolean; edgeSnapRatio?: number }

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -59,6 +59,9 @@ async deleteRecording() : Promise<null> {
 async takeScreenshot(target: ScreenCaptureTarget) : Promise<string> {
     return await TAURI_INVOKE("take_screenshot", { target });
 },
+async captureOcrText(target: ScreenCaptureTarget) : Promise<string> {
+    return await TAURI_INVOKE("capture_ocr_text", { target });
+},
 async importCurrentDesktopBackground(projectPath: string) : Promise<string> {
     return await TAURI_INVOKE("import_current_desktop_background", { projectPath });
 },
@@ -566,6 +569,7 @@ videoImportProgress: "video-import-progress"
 /** user-defined types **/
 
 export type Action = { type: "copyToClipboard"; source?: ClipboardSource } | { type: "saveToLocation"; dir: string; filenameTemplate?: string | null } | { type: "export"; profile: ExportProfile; destination?: ExportDestination } | { type: "upload"; organizationId?: string | null; copyLink?: boolean; openInBrowser?: boolean } | { type: "revealInFileManager" } | { type: "openFile" } | { type: "runCommand"; program: string; args?: string[]; cwd?: string | null; env?: { [key in string]: string }; useShell?: boolean } | { type: "webhook"; url: string; method?: string; headers?: { [key in string]: string }; bodyTemplate?: string | null } | { type: "recognizeTextToClipboard" } | { type: "notify"; titleTemplate?: string; bodyTemplate?: string } | { type: "openEditor" } | { type: "skipEditor" } | { type: "applyPreset"; name: string } | { type: "deleteLocalFiles" }
+export type AllGpusInfo = { gpus: GpuInfoDiag[]; primaryGpuIndex: number | null; isMultiGpuSystem: boolean; hasDiscreteGpu: boolean }
 export type Annotation = { id: string; type: AnnotationType; x: number; y: number; width: number; height: number; strokeColor: string; strokeWidth: number; fillColor: string; opacity: number; rotation: number; text: string | null; maskType?: MaskType | null; maskLevel?: number | null }
 export type AnnotationType = "arrow" | "circle" | "rectangle" | "text" | "mask"
 export type AppTheme = "system" | "light" | "dark"
@@ -805,7 +809,7 @@ previousRecordingsPaths?: string[];
  * Cleared automatically when the app version changes (one retry per
  * update, since a new ort/wgpu/driver stack may have fixed the crash).
  */
-cameraBlurDisabledByCrash?: string | null; updateChannel?: UpdateChannel }
+cameraBlurDisabledByCrash?: string | null; updateChannel?: UpdateChannel; ocrKeepScreenshot?: boolean; ocrShowNotification?: boolean }
 export type GifExportSettings = { fps: number; resolution_base: XY<number>; quality: GifQuality | null }
 export type GifQuality = { 
 /**
@@ -817,12 +821,13 @@ quality: number | null;
  */
 fast: boolean | null }
 export type GlideDirection = "none" | "left" | "right" | "up" | "down"
+export type GpuInfoDiag = { vendor: string; description: string; dedicatedVideoMemoryMb: number; adapterIndex: number; isSoftwareAdapter: boolean; isBasicRenderDriver: boolean; supportsHardwareEncoding: boolean }
 export type HapticPattern = "alignment" | "levelChange" | "generic"
 export type HapticPerformanceTime = "default" | "now" | "drawCompleted"
 export type Hotkey = { code: string; meta: boolean; ctrl: boolean; alt: boolean; shift: boolean }
-export type HotkeyAction = "startStudioRecording" | "startInstantRecording" | "stopRecording" | "restartRecording" | "togglePauseRecording" | "cycleRecordingMode" | "openRecordingPicker" | "openRecordingPickerDisplay" | "openRecordingPickerWindow" | "openRecordingPickerArea" | "screenshotDisplay" | "screenshotWindow" | "screenshotArea" | "other"
+export type HotkeyAction = "startStudioRecording" | "startInstantRecording" | "stopRecording" | "restartRecording" | "togglePauseRecording" | "cycleRecordingMode" | "openRecordingPicker" | "openRecordingPickerDisplay" | "openRecordingPickerWindow" | "openRecordingPickerArea" | "screenshotDisplay" | "screenshotWindow" | "screenshotArea" | "ocrArea" | "other"
 export type HotkeysConfiguration = { show: boolean }
-export type HotkeysStore = { hotkeys: { [key in HotkeyAction]: Hotkey } }
+export type HotkeysStore = { hotkeys: { [key in HotkeyAction]: Hotkey }; seeded?: HotkeyAction[] }
 export type ImportStage = "Probing" | "Converting" | "Finalizing" | "Complete" | "Failed"
 export type ImportedAudioTrack = { 
 /**
@@ -839,7 +844,6 @@ export type KeyboardTrackSegment = { id: string; start: number; end: number; dis
 export type LogicalBounds = { position: LogicalPosition; size: LogicalSize }
 export type LogicalPosition = { x: number; y: number }
 export type LogicalSize = { width: number; height: number }
-export type MacOSVersionInfo = { major: number; minor: number; patch: number; displayName: string; buildNumber: string; isAppleSilicon: boolean }
 export type MainWindowRecordingStartBehaviour = "close" | "minimise"
 export type MaskKeyframes = { position?: MaskVectorKeyframe[]; size?: MaskVectorKeyframe[]; intensity?: MaskScalarKeyframe[] }
 export type MaskKind = "sensitive" | "highlight"
@@ -907,11 +911,12 @@ export type RecordingSettingsStore = { target: ScreenCaptureTarget | null; micNa
 export type RecordingStarted = null
 export type RecordingStatus = "pending" | "recording"
 export type RecordingStopped = null
-export type RecordingTargetMode = "display" | "window" | "area" | "camera"
+export type RecordingTargetMode = "display" | "window" | "area" | "camera" | "ocr"
 export type RecordingsMigrationFailure = { name: string; error: string }
 export type RecordingsMigrationProgress = { total: number; done: number; current: string | null }
 export type RecordingsMigrationSummary = { moved: number; skippedInUse: number; failed: RecordingsMigrationFailure[] }
 export type RenderFrameEvent = { frame_number: number; fps: number; resolution_base: XY<number> }
+export type RenderingStatus = { isUsingSoftwareRendering: boolean; isUsingBasicRenderDriver: boolean; hardwareEncodingAvailable: boolean; warningMessage: string | null }
 export type RequestOpenRecordingPicker = { target_mode: RecordingTargetMode | null }
 export type RequestOpenSettings = { page: string }
 export type RequestScreenCapturePrewarm = { force?: boolean }
@@ -956,7 +961,7 @@ export type StereoMode = "stereo" | "monoL" | "monoR"
 export type StudioRecordingMeta = { segment: SingleSegment } | { inner: MultipleSegments }
 export type StudioRecordingQuality = "compatibility" | "balanced" | "ultra"
 export type StudioRecordingStatus = { status: "InProgress" } | { status: "NeedsRemux" } | { status: "Failed"; error: string } | { status: "Complete" }
-export type SystemDiagnostics = { macosVersion: MacOSVersionInfo | null; availableEncoders: string[]; screenCaptureSupported: boolean; metalSupported: boolean; gpuName: string | null }
+export type SystemDiagnostics = { windowsVersion: WindowsVersionInfo | null; gpuInfo: GpuInfoDiag | null; allGpus: AllGpusInfo | null; renderingStatus: RenderingStatus; availableEncoders: string[]; graphicsCaptureSupported: boolean; d3D11VideoProcessorAvailable: boolean }
 export type TargetUnderCursor = { display_id: DisplayId | null; window: WindowUnderCursor | null }
 export type TextSegment = { start: number; end: number; track?: number; enabled?: boolean; content?: string; center?: XY<number>; size?: XY<number>; fontFamily?: string; fontSize?: number; fontWeight?: number; italic?: boolean; color?: string; fadeDuration?: number }
 export type TimelineConfiguration = { segments: TimelineSegment[]; transitions: ClipTransition[]; zoomSegments: ZoomSegment[]; sceneSegments?: SceneSegment[]; maskSegments?: MaskSegment[]; textSegments?: TextSegment[]; captionSegments?: CaptionTrackSegment[]; keyboardSegments?: KeyboardTrackSegment[]; audioSegments?: AudioTrackSegment[] }
@@ -981,6 +986,7 @@ export type WindowExclusion = { bundleIdentifier?: string | null; ownerName?: st
 export type WindowId = string
 export type WindowPosition = { x: number; y: number; displayId?: DisplayId | null }
 export type WindowUnderCursor = { id: WindowId; app_name: string; bounds: LogicalBounds }
+export type WindowsVersionInfo = { major: number; minor: number; build: number; displayName: string; meetsRequirements: boolean; isWindows11: boolean }
 export type XY<T> = { x: T; y: T }
 export type ZoomMode = "auto" | { manual: { x: number; y: number } }
 export type ZoomSegment = { start: number; end: number; amount: number; mode: ZoomMode; glideDirection?: GlideDirection; glideSpeed?: number; instantAnimation?: boolean; edgeSnapRatio?: number }

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -62,6 +62,11 @@ async takeScreenshot(target: ScreenCaptureTarget) : Promise<string> {
 async captureOcrText(target: ScreenCaptureTarget) : Promise<string> {
     return await TAURI_INVOKE("capture_ocr_text", { target });
 },
+/**
+ * Captures a window while scrolling it, stitching the frames into one tall
+ * image. The window must be under the cursor so the injected wheel events
+ * reach it.
+ */
 async captureScrollingWindow(windowId: WindowId) : Promise<string> {
     return await TAURI_INVOKE("capture_scrolling_window", { windowId });
 },


### PR DESCRIPTION
## Summary

Adds scrolling capture: a new hotkey action ("Scrolling capture of window under cursor", unbound by default) that captures an entire scrollable window — not just the visible part — by scrolling it and stitching the frames into one tall screenshot, saved as a normal Cap screenshot project.

How it works (`scrolling_capture.rs`):

```
capture window frame
loop (≤60 steps, ≤16000px):
    inject 2 wheel notches at the cursor (SendInput on Windows,
    CGEventCreateScrollWheelEvent2 on macOS) → wait 600ms for
    smooth-scroll to settle → capture next frame
    → detect vertical offset: minimal mean-absolute-difference over
      overlapping rows (top 20% skipped for sticky headers, ≥25%
      overlap required, 1px granularity)
    → offset == 0 (bottom reached) or no match → stop
    → append the frame's new bottom rows to the stitched image
```

- The hotkey targets the window under the cursor (same pattern as the existing "Screenshot current window" action), so the injected wheel events reach the right window.
- The stitched image goes through the normal screenshot-project save path: same toast, automations, editor-open behavior, library entry.
- No new dependencies; the stitching is a few dozen lines over `image` buffers.
- Known cosmetic limitation: sticky *side* columns (e.g. Wikipedia's TOC panel) repeat down the image — only top-anchored sticky content is compensated.

## Showcase

A 60-section page captured into one 1280x7404 image:

![Stitched 7404px-tall capture](https://raw.githubusercontent.com/x1xhlol/Cap/assets/pr-media/media/scroll-10-showcase-tall-paint.png)

Bottom of the stitch — capture stops at the page footer with no repeated content:

![Footer reached, no repeats](https://raw.githubusercontent.com/x1xhlol/Cap/assets/pr-media/media/scroll-12-footer-slice.png)

## Testing (Windows, end-to-end on a live dev build)

| Test | Result |
|---|---|
| 60-section long page → 1280x7404 stitch, all sections in order, zero seam artifacts | ✅ |
| Stops at page bottom (footer present, nothing repeated) | ✅ |
| Wikipedia article → 1280x12680 continuous stitch (hit the 60-frame cap on a very long article) | ✅ |
| Non-scrolling window → single frame in ~5s, no hang | ✅ |
| Toast + normal `.cap` screenshot project on every run | ✅ |
| Regression: normal screenshot flow unaffected | ✅ |

macOS compiles the same capture/stitch path with a CoreGraphics scroll-event injector; runtime-tested on Windows only.

Builds on #2095 (OCR text capture — shares its capture/save helpers); the scrolling-capture change itself is the top two commits.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds window scrolling capture, OCR area capture, associated hotkeys and settings, and refactors screenshot capture/saving into reusable backend helpers.
- Adds platform-specific synthetic scrolling and frame stitching for whole-window screenshots.
- Adds OCR selection, clipboard, notification, and optional screenshot-preservation flows.
- Extends persisted settings, hotkey actions, target-selection UI, window handling, and Tauri IPC bindings.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until scrolling captures are capped before appending oversized strips and the Linux action is either implemented or disabled.

Near-limit captures can produce images rejected by the screenshot editor, while Linux exposes an action whose scroll injector performs no operation and therefore cannot capture off-screen content.

**Files Needing Attention:** apps/desktop/src-tauri/src/scrolling_capture.rs, apps/desktop/src/routes/(window-chrome)/settings/hotkeys.tsx, apps/desktop/src/utils/tauri.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/scrolling_capture.rs | Implements scrolling and stitching, but can exceed the image-height cap and silently degenerates to a single-frame capture on Linux. |
| apps/desktop/src-tauri/src/hotkeys.rs | Adds OCR and scrolling-capture actions plus default OCR hotkey seeding; the scrolling action reaches the unsupported Linux implementation. |
| apps/desktop/src-tauri/src/recording.rs | Refactors image capture and project saving and adds OCR capture while preserving the existing asynchronous PNG-save behavior. |
| apps/desktop/src/routes/target-select-overlay.tsx | Adds OCR area-selection capture and explicit success/error overlay lifecycle handling. |
| apps/desktop/src/utils/tauri.ts | Updates generated IPC bindings, contrary to the repository rule prohibiting direct changes to generated tauri.ts files. |
| apps/desktop/src-tauri/src/general_settings.rs | Adds backward-compatible defaulted OCR preferences. |
| apps/desktop/src-tauri/src/lib.rs | Correctly registers the new commands and scrolling-capture module. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/desktop/src-tauri/src/scrolling_capture.rs:74-83
**Height cap checked too late**

When a capture is near 16,000 pixels, the full next strip is appended before the cap is checked, allowing the result to exceed the screenshot editor's 16,384-pixel limit and fail to open.

```suggestion
        let remaining_height = MAX_STITCHED_HEIGHT.saturating_sub(stitched_height);
        let new_rows = offset.min(frame_height).min(remaining_height);
        if new_rows == 0 {
            debug!("Stitched image reached the height cap; stopping");
            break;
        }

        let strip = frame.crop_imm(0, frame_height - new_rows, frame_width, new_rows);
        stitched.push(strip);
        stitched_height += new_rows;
        prev = cur;

        if stitched_height >= MAX_STITCHED_HEIGHT {
            debug!("Stitched image reached the height cap; stopping");
            break;
        }
```

### Issue 2
apps/desktop/src-tauri/src/scrolling_capture.rs:158-187
**Linux scroll injection is absent**

When a Linux user invokes the exposed scrolling-capture hotkey, `inject_scroll` performs no operation, so the loop waits once and saves only the initially visible frame instead of capturing off-screen content.

### Issue 3
apps/desktop/src/utils/tauri.ts:59-70
**Generated bindings changed directly**

This directly modifies the generated `tauri.ts` IPC surface and includes unrelated generated type churn. These changes can be overwritten during regeneration and leave the checked-in bindings out of sync; regenerate the file from the Rust command definitions instead.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Tune scrolling capture stepping and matc..."](https://github.com/capsoftware/cap/commit/c5af970312dfda93cb8323e8f1d3a640a535cbae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50877424)</sub>

> Greptile also left **3 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - AGENTS.md ([source](https://github.com/capsoftware/cap/blob/main/AGENTS.md))
- Knowledge Base — [Desktop Tauri App (Rust Backend)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-tauri-app.md)
- Knowledge Base — [Desktop Frontend (apps/desktop/src)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-frontend.md)
</details>

<!-- /greptile_comment -->