### PR TITLE
fix(desktop): clear overlay restore label on recording mode switch

### DIFF
--- a/apps/desktop/src-tauri/src/recording_settings.rs
+++ b/apps/desktop/src-tauri/src/recording_settings.rs
@@ -7,7 +7,7 @@ use cap_recording::{
     sources::screen_capture::ScreenCaptureTarget,
 };
 use std::collections::HashMap;
-use tauri::{AppHandle, Wry};
+use tauri::{AppHandle, Manager, Wry};
 use tauri_plugin_store::StoreExt;
 
 use crate::tray;
@@ -92,5 +92,15 @@ pub fn camera_key(id: &DeviceOrModelID) -> String {
 pub fn set_recording_mode(app: AppHandle, mode: RecordingMode) -> Result<(), String> {
     RecordingSettingsStore::set_mode(&app, mode)?;
     tray::update_tray_icon_for_mode(&app, mode);
+
+    // A mode switch invalidates any pending "restore this overlay when
+    // Settings closes" instruction — otherwise a stale label can pop the
+    // target-select overlay back up as a screen-wide input-eating surface
+    // after the user has moved on to a different mode. See #1945.
+    if let Some(focus_manager) = app.try_state::<crate::target_select_overlay::WindowFocusManager>()
+    {
+        focus_manager.clear_overlay_restore_labels();
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Switching recording mode while a "restore this overlay when Settings closes" instruction is pending left it stale, so the target-select overlay could pop back up as a screen-wide input-eating surface after the user had already moved to a different mode. Fixes #1945.


Verified with `cargo fmt --all`. Wasn't able to fully build the native 
deps (FFmpeg/whisper.cpp) in my dev environment to run `cargo check` 
end-to-end — happy to iterate if CI or a maintainer spots anything.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR clears pending target-select overlay restoration labels whenever the recording mode changes, preventing Settings from reopening an overlay that belongs to the previous mode.

- Imports Tauri’s `Manager` trait to access managed window-focus state.
- Clears pending overlay restore labels after successfully persisting the new mode and updating the tray icon.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the pending overlay restoration state cleared at the intended recording-mode transition.

The managed focus state is registered during application setup, and clearing its restoration labels after mode persistence prevents Settings-close handling from reviving an overlay associated with the previous mode.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/recording_settings.rs | The recording-mode command now invalidates stale overlay restoration state after a successful mode change; no actionable defect was identified. |

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): clear overlay restore labe..."](https://github.com/capsoftware/cap/commit/199facefb038b00b7b2fdaedbb89c72d6fe82235) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51042371)</sub>

**Context used:**

- Knowledge Base — [Desktop Tauri App (Rust Backend)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-tauri-app.md)

<!-- /greptile_comment -->