### PR TITLE
fix: keep folder rename textarea focused after choosing Rename

### DIFF
--- a/apps/web/app/(org)/dashboard/caps/components/FoldersDropdown.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/FoldersDropdown.tsx
@@ -13,7 +13,7 @@ import {
 	faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import type { RefObject } from "react";
+import { type RefObject, useRef } from "react";
 
 interface FoldersDropdownProps {
 	id: string;
@@ -38,6 +38,8 @@ export const FoldersDropdown = ({
 	canMove,
 	onMove,
 }: FoldersDropdownProps) => {
+	const renameRequestedRef = useRef(false);
+
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
@@ -55,7 +57,25 @@ export const FoldersDropdown = ({
 					<FontAwesomeIcon className="text-gray-12 size-4" icon={faEllipsis} />
 				</button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent>
+			<DropdownMenuContent
+				onCloseAutoFocus={(event) => {
+					// Radix restores focus to the trigger on close from a setTimeout(0)
+					// scheduled when the menu unmounts, so it always lands after the
+					// rename focus calls below. That blur makes the textarea's onBlur
+					// exit rename mode instantly (reported as "flashes then can't
+					// type"). Opt out for rename only; other items still restore focus
+					// to the trigger.
+					if (!renameRequestedRef.current) return;
+					renameRequestedRef.current = false;
+					event.preventDefault();
+					// Fallback only: never take focus back off wherever the user has
+					// since clicked.
+					if (document.activeElement === document.body) {
+						nameRef.current?.focus();
+						nameRef.current?.select();
+					}
+				}}
+			>
 				{(() => {
 					type FolderDropdownItem = {
 						label: string;
@@ -67,6 +87,7 @@ export const FoldersDropdown = ({
 							label: "Rename",
 							icon: faPencil,
 							onClick: () => {
+								renameRequestedRef.current = true;
 								setIsRenaming(true);
 								setTimeout(() => {
 									nameRef.current?.focus();


### PR DESCRIPTION
## Problem

Customer report (Chrome, dashboard): choosing Rename from a folder's 3-dot menu makes the name field flash and immediately become uneditable.

Radix's dropdown restores focus to the trigger when the menu closes, from a setTimeout scheduled when the content unmounts - which always lands after the app's own focus calls on the rename textarea. That late focus steal blurs the textarea, and its onBlur exits rename mode instantly. Traced through the installed `@radix-ui/react-dropdown-menu@2.1.19` + `FocusScope@1.1.11` sources: both restore paths gate on `defaultPrevented` of the `onCloseAutoFocus` event.

## Fix

Pass `onCloseAutoFocus` on this one menu's `DropdownMenuContent` that calls `preventDefault()` only when the Rename item was just clicked (tracked via a ref set in Rename's onClick and cleared on the next close). The shared `packages/ui` Dropdown defaults are untouched, and every other item (public/private, copy link, move, delete) plus Escape/outside-click dismissals keep the exact current focus-restore behavior.

## What could have regressed and why it can't

The new code is inert unless Rename was just clicked - the guard ref is only set by that one onClick and cleared on the next close, so no other menu, item, or dismissal path can reach the `preventDefault()`. After Rename, suppressing the restore is the desired end state (focus belongs on the textarea the user asked to edit), and the body-only fallback can never yank focus from anything the user clicked mid-close. Typecheck (`tsc -b`, full project graph) exits 0; no component-mount test harness exists in the repo (node-env vitest only, no RTL/Playwright), so the traced event order above stands in for a DOM regression test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents Radix from restoring focus to the folder menu trigger after Rename is selected, allowing the rename textarea to retain focus.
- Tracks Rename selection with a component-local ref.
- Cancels close autofocus only for the corresponding Rename dismissal.
- Preserves existing focus restoration for other menu actions and dismissals.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete regression identified in the changed focus-management flow.

The Rename path prevents the late trigger-focus restoration that caused the textarea to blur, while existing post-render focus handling mounts and focuses the textarea and all non-Rename close paths retain their prior behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/(org)/dashboard/caps/components/FoldersDropdown.tsx | Adds a narrowly guarded `onCloseAutoFocus` handler that suppresses trigger focus restoration after Rename while resetting its per-instance guard for subsequent menu interactions. |

<sub>Reviews (1): Last reviewed commit: ["fix: keep folder rename textarea focused..."](https://github.com/capsoftware/cap/commit/8dcf64ffdcc62fb855aa56f56b39378fab3bf680) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51129356)</sub>

<!-- /greptile_comment -->