### PR TITLE
fix(web): read org-wide shares on the space page sharing dialog

### DIFF
--- a/apps/web/app/(org)/dashboard/spaces/[spaceId]/page.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/[spaceId]/page.tsx
@@ -25,9 +25,10 @@ import {
 	type ImageUpload,
 	type Organisation,
 	Space,
+	type User,
 	Video,
 } from "@cap/web-domain";
-import { and, count, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, count, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import { Effect } from "effect";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
@@ -163,9 +164,17 @@ type SharedSpaceEntry = Omit<SharedSpaceRow, "videoId" | "iconUrl"> & {
 // Sharing is stored in two places: `space_videos` for named spaces and
 // `shared_videos` for the org-wide "All <Org>" entry. Both have to be read
 // here, otherwise the sharing dialog opens with the org-wide entry unchecked
-// and saving would drop it.
+// and saving would drop it. The `shared_videos` read is limited to the page's
+// organization plus the viewer's own memberships so other organizations'
+// metadata never reaches the client, while an owner's dialog seed still covers
+// every org share `shareCap` is able to preserve (it drops orgs the saver
+// left, regardless of what was submitted).
 async function fetchSharedSpacesForVideos(
 	videoIds: Video.VideoId[],
+	viewer: {
+		userId: User.UserId;
+		organizationId: Organisation.OrganisationId;
+	},
 ): Promise<Record<string, SharedSpaceEntry[]>> {
 	if (videoIds.length === 0) return {};
 
@@ -196,7 +205,21 @@ async function fetchSharedSpacesForVideos(
 				organizations,
 				eq(sharedVideos.organizationId, organizations.id),
 			)
-			.where(inArray(sharedVideos.videoId, videoIds)),
+			.where(
+				and(
+					inArray(sharedVideos.videoId, videoIds),
+					or(
+						eq(sharedVideos.organizationId, viewer.organizationId),
+						inArray(
+							sharedVideos.organizationId,
+							db()
+								.select({ organizationId: organizationMembers.organizationId })
+								.from(organizationMembers)
+								.where(eq(organizationMembers.userId, viewer.userId)),
+						),
+					),
+				),
+			),
 	]);
 
 	const rows: SharedSpaceRow[] = [
@@ -367,6 +390,7 @@ export default async function SharedCapsPage(props: {
 		);
 		const sharedSpacesMap = await fetchSharedSpacesForVideos(
 			spaceVideoData.map((video) => Video.VideoId.make(video.id)),
+			{ userId: user.id, organizationId: space.organizationId },
 		);
 		const [organizationSettingsRow] = await db()
 			.select({ settings: organizations.settings })
@@ -503,6 +527,7 @@ export default async function SharedCapsPage(props: {
 		const { videos: orgVideoData, totalCount } = organizationVideos;
 		const sharedSpacesMap = await fetchSharedSpacesForVideos(
 			orgVideoData.map((video) => Video.VideoId.make(video.id)),
+			{ userId: user.id, organizationId: organization.id },
 		);
 		const [organizationSettingsRow] = await db()
 			.select({ settings: organizations.settings })

--- a/apps/web/app/(org)/dashboard/spaces/[spaceId]/page.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/[spaceId]/page.tsx
@@ -145,32 +145,91 @@ const fetchOrganizationMembers = Effect.fn(function* (
 		);
 });
 
-async function fetchSharedSpacesForVideos(videoIds: Video.VideoId[]) {
+type SharedSpaceRow = {
+	videoId: string;
+	id: string;
+	name: string;
+	organizationId: string;
+	isOrg: boolean;
+	iconUrl: ImageUpload.ImageUrlOrKey | null;
+	settings: (typeof spaces.$inferSelect)["settings"] | null;
+	hasPassword: boolean;
+};
+
+type SharedSpaceEntry = Omit<SharedSpaceRow, "videoId" | "iconUrl"> & {
+	iconUrl: ImageUpload.ImageUrl | null;
+};
+
+// Sharing is stored in two places: `space_videos` for named spaces and
+// `shared_videos` for the org-wide "All <Org>" entry. Both have to be read
+// here, otherwise the sharing dialog opens with the org-wide entry unchecked
+// and saving would drop it.
+async function fetchSharedSpacesForVideos(
+	videoIds: Video.VideoId[],
+): Promise<Record<string, SharedSpaceEntry[]>> {
 	if (videoIds.length === 0) return {};
 
-	const rows = await db()
-		.select({
-			videoId: spaceVideos.videoId,
-			id: spaces.id,
-			name: spaces.name,
-			organizationId: spaces.organizationId,
-			iconUrl: spaces.iconUrl,
-			settings: spaces.settings,
-			hasPassword: sql`${spaces.password} IS NOT NULL`.mapWith(Boolean),
-		})
-		.from(spaceVideos)
-		.innerJoin(spaces, eq(spaceVideos.spaceId, spaces.id))
-		.where(inArray(spaceVideos.videoId, videoIds));
+	const [spaceRows, organizationRows] = await Promise.all([
+		db()
+			.select({
+				videoId: spaceVideos.videoId,
+				id: spaces.id,
+				name: spaces.name,
+				organizationId: spaces.organizationId,
+				iconUrl: spaces.iconUrl,
+				settings: spaces.settings,
+				hasPassword: sql`${spaces.password} IS NOT NULL`.mapWith(Boolean),
+			})
+			.from(spaceVideos)
+			.innerJoin(spaces, eq(spaceVideos.spaceId, spaces.id))
+			.where(inArray(spaceVideos.videoId, videoIds)),
+		db()
+			.select({
+				videoId: sharedVideos.videoId,
+				id: organizations.id,
+				name: organizations.name,
+				organizationId: organizations.id,
+				iconUrl: organizations.iconUrl,
+			})
+			.from(sharedVideos)
+			.innerJoin(
+				organizations,
+				eq(sharedVideos.organizationId, organizations.id),
+			)
+			.where(inArray(sharedVideos.videoId, videoIds)),
+	]);
+
+	const rows: SharedSpaceRow[] = [
+		...spaceRows.map((row) => ({
+			videoId: row.videoId,
+			id: row.id,
+			name: row.name,
+			organizationId: row.organizationId,
+			isOrg: false,
+			iconUrl: row.iconUrl ?? null,
+			settings: row.settings ?? null,
+			hasPassword: row.hasPassword,
+		})),
+		...organizationRows.map((row) => ({
+			videoId: row.videoId,
+			id: row.id,
+			name: row.name,
+			organizationId: row.organizationId,
+			isOrg: true,
+			iconUrl: row.iconUrl ?? null,
+			settings: null,
+			hasPassword: false,
+		})),
+	];
 
 	const resolvedRows = await Effect.gen(function* () {
 		const imageUploads = yield* ImageUploads;
 
 		return yield* Effect.all(
 			rows.map(
-				Effect.fn(function* (row) {
+				Effect.fn(function* (row: SharedSpaceRow) {
 					return {
 						...row,
-						isOrg: false as const,
 						iconUrl: row.iconUrl
 							? yield* imageUploads.resolveImageUrl(row.iconUrl)
 							: null,
@@ -180,13 +239,11 @@ async function fetchSharedSpacesForVideos(videoIds: Video.VideoId[]) {
 		);
 	}).pipe(runPromise);
 
-	return resolvedRows.reduce<
-		Record<string, Omit<(typeof resolvedRows)[number], "videoId">[]>
-	>((acc, row) => {
-		const spaces = acc[row.videoId] ?? [];
-		acc[row.videoId] = spaces;
-		const { videoId: _videoId, ...space } = row;
-		spaces.push(space);
+	return resolvedRows.reduce<Record<string, SharedSpaceEntry[]>>((acc, row) => {
+		const entries = acc[row.videoId] ?? [];
+		acc[row.videoId] = entries;
+		const { videoId: _videoId, ...entry } = row;
+		entries.push(entry);
 		return acc;
 	}, {});
 }
@@ -324,7 +381,9 @@ export default async function SharedCapsPage(props: {
 			const rules = resolveEffectiveVideoRules({
 				videoSettings: video.settings,
 				organizationSettings,
-				spaces: sharedSpaces,
+				// Org-wide entries are not spaces; their rules already come in
+				// through `organizationSettings`.
+				spaces: sharedSpaces.filter((space) => !space.isOrg),
 			});
 			return {
 				...videoWithoutEffectiveDate,
@@ -458,7 +517,9 @@ export default async function SharedCapsPage(props: {
 			const rules = resolveEffectiveVideoRules({
 				videoSettings: video.settings,
 				organizationSettings,
-				spaces: sharedSpaces,
+				// Org-wide entries are not spaces; their rules already come in
+				// through `organizationSettings`.
+				spaces: sharedSpaces.filter((space) => !space.isOrg),
 			});
 			return {
 				...videoWithoutEffectiveDate,


### PR DESCRIPTION
## Problem

Video sharing lives in two tables: `space_videos` (named spaces) and `shared_videos` (the org-wide "All <Org>" entry). The My Caps page reads both when building the sharing dialog's initial state, but the space page's `fetchSharedSpacesForVideos` read only `space_videos`. Opening the sharing dialog from any space page therefore always showed the org-wide entry unchecked - and because `shareCap` is a full-replace write, saving that dialog for any reason silently deleted the org-wide `shared_videos` row. Customer-reported as: a video shared to both the org-wide space and a sub-space shows different checked states depending on the page, and org members lose access after an innocent save.

## Fix

Read-side completeness only: `fetchSharedSpacesForVideos` now also queries `shared_videos` joined to `organizations` and merges those entries with `isOrg: true`, copying the exact field shape the My Caps page already produces (verified side by side). The two `resolveEffectiveVideoRules` call sites on the page filter out the new org entries, matching the existing pattern on My Caps and `lib/folder.ts`, so inherited settings/password badges are unchanged. `shareCap`'s replace semantics are deliberately untouched.

## What could have regressed and why it can't

The change is read-only and additive; the added entries have the same shape, id semantics and null fields the dialog and cards already consume from the My Caps path (all nine downstream consumers audited - dialog seed, inherited-password panel, org-tile ring, card status, counts). The only consumer where extra entries could alter computed output is `resolveEffectiveVideoRules`, and they are filtered out there. Net visible delta: the org-wide tile now renders checked on space pages when a `shared_videos` row exists, which also stops the destructive save path. Typecheck (`tsc -b` full graph) exits 0, with a deliberate error injection proving the file is in the compilation.

## Follow-up (not this PR)

`shareCap` remains a destructive full-replace keyed on the submitted set; worth hardening independently (diff payload or scoping deletes to ids the client rendered) so no future incomplete read path can revoke access as a side effect.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR completes the space-page sharing-dialog seed by loading organization-wide video shares while preventing unrelated organizations’ metadata from reaching the client.
- Queries named-space and organization-wide share records in parallel.
- Restricts organization-wide records to the active organization or the viewer’s organization memberships.
- Marks organization entries explicitly and excludes them from space-specific effective-rule resolution.
- Passes authenticated viewer context into both space and organization page data paths.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/(org)/dashboard/spaces/[spaceId]/page.tsx | Adds membership-scoped organization-wide share loading and keeps organization entries out of space-specific rule resolution; the previously reported unscoped lookup is resolved. |

<sub>Reviews (2): Last reviewed commit: ["fix(web): scope the space-page org-share..."](https://github.com/capsoftware/cap/commit/c753c02ff88888d4c2fde70c5c2e76ec760aff10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51129464)</sub>

**Context used:**

- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-app.md)

<!-- /greptile_comment -->