### PR TITLE
perf: cut share page client JS by 45% (922KB → 508KB gz)

### DIFF
--- a/apps/web/__tests__/unit/from-now.test.ts
+++ b/apps/web/__tests__/unit/from-now.test.ts
@@ -1,0 +1,70 @@
+import moment from "moment";
+import { describe, expect, it } from "vitest";
+import { fromNow } from "../../app/s/[videoId]/_components/utils/from-now";
+
+// `fromNow` replaced the share header's `moment(date).fromNow()` so the page
+// stops shipping moment; moment itself (still installed for other routes) is
+// the oracle that the replacement's bucket boundaries match exactly.
+describe("fromNow", () => {
+	const now = new Date("2026-08-07T12:00:00.000Z");
+
+	const offsetsSeconds = [
+		0,
+		1,
+		44,
+		45,
+		89,
+		90,
+		91,
+		60 * 44,
+		60 * 45,
+		60 * 89,
+		60 * 90,
+		60 * 91,
+		3600 * 21,
+		3600 * 22,
+		3600 * 35,
+		3600 * 36,
+		3600 * 37,
+		86400 * 25,
+		86400 * 26,
+		86400 * 44,
+		86400 * 45,
+		86400 * 46,
+		86400 * 100,
+		86400 * 319,
+		86400 * 320,
+		86400 * 547,
+		86400 * 548,
+		86400 * 549,
+		86400 * 1000,
+		86400 * 3650,
+	];
+
+	it("matches moment.fromNow for past dates across every bucket boundary", () => {
+		for (const seconds of offsetsSeconds) {
+			const date = new Date(now.getTime() - seconds * 1000);
+			expect(fromNow(date, now), `offset -${seconds}s`).toBe(
+				moment(date).from(moment(now)),
+			);
+		}
+	});
+
+	it("matches moment.fromNow for future dates", () => {
+		for (const seconds of offsetsSeconds) {
+			const date = new Date(now.getTime() + seconds * 1000);
+			expect(fromNow(date, now), `offset +${seconds}s`).toBe(
+				moment(date).from(moment(now)),
+			);
+		}
+	});
+
+	it("sweeps four years of offsets against moment", () => {
+		for (let hours = 0; hours < 24 * 365 * 4; hours += 7) {
+			const date = new Date(now.getTime() - hours * 3600 * 1000);
+			expect(fromNow(date, now), `offset -${hours}h`).toBe(
+				moment(date).from(moment(now)),
+			);
+		}
+	});
+});

--- a/apps/web/actions/videos/translation-languages.ts
+++ b/apps/web/actions/videos/translation-languages.ts
@@ -1,4 +1,8 @@
+// Deep import on purpose: this file is pulled into CLIENT code (the share
+// page's caption context), and the @cap/web-domain barrel would drag the
+// whole effect runtime (~250 KB gz) into that bundle. Language.ts itself is
+// dependency-free.
 export {
 	type LanguageCode,
 	SUPPORTED_LANGUAGES,
-} from "@cap/web-domain";
+} from "@cap/web-domain/src/Language";

--- a/apps/web/app/(org)/dashboard/Contexts.tsx
+++ b/apps/web/app/(org)/dashboard/Contexts.tsx
@@ -3,67 +3,24 @@
 import { buildEnv } from "@cap/env";
 import Cookies from "js-cookie";
 import { redirect, usePathname } from "next/navigation";
-import {
-	createContext,
-	useCallback,
-	useContext,
-	useEffect,
-	useState,
-} from "react";
+import { useCallback, useEffect, useState } from "react";
 import { InviteDialog } from "@/app/(org)/dashboard/settings/organization/components/InviteDialog";
-import { type CurrentUser, useCurrentUser } from "@/app/Layout/AuthContext";
+import { useCurrentUser } from "@/app/Layout/AuthContext";
 import { UpgradeModal } from "@/components/UpgradeModal";
-import type {
-	Organization,
-	OrganizationSettings,
-	Spaces,
-	UserPreferences,
-} from "./dashboard-data";
+import {
+	DashboardContext,
+	type ITheme,
+	type SetThemeOptions,
+	type SharedContext,
+	ThemeContext,
+} from "./DashboardContext";
+import type { Spaces } from "./dashboard-data";
 import type { DeveloperApp } from "./developers/developer-data";
 
-type SharedContext = {
-	organizationData: Organization[] | null;
-	activeOrganization: Organization | null;
-	organizationSettings: OrganizationSettings | null;
-	spacesData: Spaces[] | null;
-	userSpaces: Spaces[] | null;
-	sharedSpaces: Spaces[] | null;
-	activeSpace: Spaces | null;
-	user: CurrentUser;
-	userCapsCount: number | null;
-	toggleSidebarCollapsed: () => void;
-	anyNewNotifications: boolean;
-	userPreferences: UserPreferences;
-	sidebarCollapsed: boolean;
-	upgradeModalOpen: boolean;
-	setUpgradeModalOpen: (open: boolean) => void;
-	inviteDialogOpen: boolean;
-	setInviteDialogOpen: (open: boolean) => void;
-	referClickedState: boolean;
-	setReferClickedStateHandler: (referClicked: boolean) => void;
-	isDeveloperSection: boolean;
-	developerApps: DeveloperApp[] | null;
-	setDeveloperApps: (apps: DeveloperApp[] | null) => void;
-};
-
-type ITheme = "light" | "dark";
-type SetThemeOptions = {
-	persist?: boolean;
-};
-
-const DashboardContext = createContext<SharedContext>({} as SharedContext);
-
-const ThemeContext = createContext<{
-	theme: ITheme;
-	setThemeHandler: (newTheme: ITheme, options?: SetThemeOptions) => void;
-}>({
-	theme: "light",
-	setThemeHandler: () => {},
-});
-
-export const useTheme = () => useContext(ThemeContext);
-
-export const useDashboardContext = () => useContext(DashboardContext);
+// The context objects and hooks live in `DashboardContext.ts` (so the share
+// page can read the context without pulling this file's dialogs); re-exported
+// here to keep the dashboard's existing import sites working unchanged.
+export { useDashboardContext, useTheme } from "./DashboardContext";
 
 export function DashboardContexts({
 	children,

--- a/apps/web/app/(org)/dashboard/DashboardContext.ts
+++ b/apps/web/app/(org)/dashboard/DashboardContext.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { CurrentUser } from "@/app/Layout/AuthContext";
+import type {
+	Organization,
+	OrganizationSettings,
+	Spaces,
+	UserPreferences,
+} from "./dashboard-data";
+import type { DeveloperApp } from "./developers/developer-data";
+
+/**
+ * The context objects and hooks, split from `Contexts.tsx` so consumers
+ * outside the dashboard (the share page header reads it for shared spaces)
+ * don't drag the provider's dialog imports — InviteDialog, UpgradeModal and
+ * its Rive runtime — into their bundle.
+ */
+
+export type SharedContext = {
+	organizationData: Organization[] | null;
+	activeOrganization: Organization | null;
+	organizationSettings: OrganizationSettings | null;
+	spacesData: Spaces[] | null;
+	userSpaces: Spaces[] | null;
+	sharedSpaces: Spaces[] | null;
+	activeSpace: Spaces | null;
+	user: CurrentUser;
+	userCapsCount: number | null;
+	toggleSidebarCollapsed: () => void;
+	anyNewNotifications: boolean;
+	userPreferences: UserPreferences;
+	sidebarCollapsed: boolean;
+	upgradeModalOpen: boolean;
+	setUpgradeModalOpen: (open: boolean) => void;
+	inviteDialogOpen: boolean;
+	setInviteDialogOpen: (open: boolean) => void;
+	referClickedState: boolean;
+	setReferClickedStateHandler: (referClicked: boolean) => void;
+	isDeveloperSection: boolean;
+	developerApps: DeveloperApp[] | null;
+	setDeveloperApps: (apps: DeveloperApp[] | null) => void;
+};
+
+export type ITheme = "light" | "dark";
+export type SetThemeOptions = {
+	persist?: boolean;
+};
+
+export const DashboardContext = createContext<SharedContext>(
+	{} as SharedContext,
+);
+
+export const ThemeContext = createContext<{
+	theme: ITheme;
+	setThemeHandler: (newTheme: ITheme, options?: SetThemeOptions) => void;
+}>({
+	theme: "light",
+	setThemeHandler: () => {},
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+export const useDashboardContext = () => useContext(DashboardContext);

--- a/apps/web/app/s/[videoId]/Share.tsx
+++ b/apps/web/app/s/[videoId]/Share.tsx
@@ -31,7 +31,6 @@ import { PlaybackProvider } from "./_components/playback/PlaybackContext";
 import { ShareVideo } from "./_components/ShareVideo";
 import { type ShareView, ShareViewToggle } from "./_components/ShareViewToggle";
 import { Sidebar } from "./_components/Sidebar";
-import SummaryChapters from "./_components/SummaryChapters";
 import { Toolbar } from "./_components/Toolbar";
 import { formatTimeAgo } from "./_components/tabs/Activity/utils";
 import { TimelineSkeleton } from "./_components/timeline/TimelineSkeleton";
@@ -40,6 +39,11 @@ import type { VideoData } from "./types";
 
 const importTimelineView = () => import("./_components/timeline/TimelineView");
 const TimelineView = dynamic(importTimelineView, { ssr: false });
+
+// Carries react-markdown; split out and only rendered once AI data actually
+// exists, so videos without a summary never download it. SSR still renders
+// the summary into the initial HTML when the data is already there.
+const SummaryChapters = dynamic(() => import("./_components/SummaryChapters"));
 
 /** Whether the viewer last left the comments rail collapsed. */
 const RAIL_COLLAPSED_KEY = "cap_share_rail_collapsed";
@@ -332,9 +336,13 @@ export const Share = ({
 	header,
 }: ShareProps) => {
 	const isScreenshot = data.isScreenshot === true;
-	const effectiveDate: Date = data.metadata?.customCreatedAt
-		? new Date(data.metadata.customCreatedAt)
-		: data.createdAt;
+	// Memoized: a fresh Date each render would defeat the memoized `data`
+	// objects below and re-render Sidebar's whole tree on every poll tick.
+	const customCreatedAt = data.metadata?.customCreatedAt;
+	const effectiveDate: Date = useMemo(
+		() => (customCreatedAt ? new Date(customCreatedAt) : data.createdAt),
+		[customCreatedAt, data.createdAt],
+	);
 
 	const playerRef = useRef<HTMLVideoElement | null>(null);
 	const stageRef = useRef<HTMLDivElement | null>(null);
@@ -573,6 +581,18 @@ export const Share = ({
 			(comment) => !(comment.sending && settledKeys.has(comment.id)),
 		);
 	}, [optimisticComments]);
+
+	// Stable identities for the spreads handed to ShareVideo and Sidebar —
+	// without these, every Share render (each 2s status poll while a video is
+	// processing) re-rendered both subtrees with brand-new `data` objects.
+	const shareVideoData = useMemo(
+		() => ({ ...data, transcriptionStatus }),
+		[data, transcriptionStatus],
+	);
+	const sidebarData = useMemo(
+		() => ({ ...data, createdAt: effectiveDate, transcriptionStatus }),
+		[data, effectiveDate, transcriptionStatus],
+	);
 
 	const reduceMotion = useReducedMotion() ?? false;
 	const [selectedView, setSelectedView] = useState<ShareView>(initialView);
@@ -934,7 +954,7 @@ export const Share = ({
 													/>
 												) : (
 													<ShareVideo
-														data={{ ...data, transcriptionStatus }}
+														data={shareVideoData}
 														comments={comments}
 														areChaptersDisabled={areChaptersDisabled}
 														areCaptionsDisabled={areCaptionsDisabled}
@@ -1081,15 +1101,21 @@ export const Share = ({
 													</div>
 												)}
 
-												{!isScreenshot && (
-													<SummaryChapters
-														isSummaryDisabled={isSummaryDisabled}
-														areChaptersDisabled={areChaptersDisabled}
-														handleSeek={handleSeek}
-														aiData={aiData}
-														aiLoading={aiLoading}
-													/>
-												)}
+												{/* Mirrors the component's own empty-state bail-out so the
+												    chunk is never fetched for a video with nothing to show. */}
+												{!isScreenshot &&
+													!aiLoading &&
+													((!isSummaryDisabled && Boolean(aiData.summary)) ||
+														(!areChaptersDisabled &&
+															(aiData.chapters?.length ?? 0) > 0)) && (
+														<SummaryChapters
+															isSummaryDisabled={isSummaryDisabled}
+															areChaptersDisabled={areChaptersDisabled}
+															handleSeek={handleSeek}
+															aiData={aiData}
+															aiLoading={aiLoading}
+														/>
+													)}
 											</motion.div>
 										)}
 									</AnimatePresence>
@@ -1126,11 +1152,7 @@ export const Share = ({
 								)}
 							>
 								<Sidebar
-									data={{
-										...data,
-										createdAt: effectiveDate,
-										transcriptionStatus,
-									}}
+									data={sidebarData}
 									videoSettings={videoSettings}
 									commentsData={commentsData}
 									setCommentsData={setCommentsData}

--- a/apps/web/app/s/[videoId]/_components/AuthOverlayLazy.tsx
+++ b/apps/web/app/s/[videoId]/_components/AuthOverlayLazy.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
+
+const AuthOverlayInner = dynamic(
+	() => import("./AuthOverlay").then((m) => m.AuthOverlay),
+	{ ssr: false },
+);
+
+/**
+ * Drop-in for `AuthOverlay` that keeps its chunk (next-auth, the OTP form) off
+ * the wire until a signed-out viewer actually hits an auth wall. Latched on
+ * first open so closing still plays the dialog's exit animation.
+ */
+export function AuthOverlay(props: { isOpen: boolean; onClose: () => void }) {
+	const [mounted, setMounted] = useState(props.isOpen);
+
+	useEffect(() => {
+		if (props.isOpen) setMounted(true);
+	}, [props.isOpen]);
+
+	if (!mounted) return null;
+	return <AuthOverlayInner {...props} />;
+}

--- a/apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx
+++ b/apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx
@@ -9,6 +9,7 @@ import { skipToken, useQuery, useQueryClient } from "@tanstack/react-query";
 import clsx from "clsx";
 import { AlertTriangleIcon, InfoIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
+import dynamic from "next/dynamic";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
@@ -22,17 +23,17 @@ import {
 	probeAvcLevelFromUrl,
 } from "./mp4-level-patch";
 import {
-	canRetryFailedProcessing,
-	getUploadFailureMessage,
-	shouldDeferPlaybackSource,
-	shouldReloadPlaybackAfterUploadCompletes,
-	useUploadProgress,
-} from "./ProgressCircle";
-import {
 	type ResolvedPlaybackSource,
 	resolvePlaybackSource,
 	shouldFallbackToRawPlaybackSource,
 } from "./playback-source";
+import {
+	canRetryFailedProcessing,
+	getUploadFailureMessage,
+	shouldDeferPlaybackSource,
+	shouldReloadPlaybackAfterUploadCompletes,
+	type UploadProgress,
+} from "./upload-progress";
 import { VideoPreviewGif } from "./VideoPreviewGif";
 import {
 	MediaPlayer,
@@ -56,6 +57,12 @@ import {
 } from "./video/media-player";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./video/tooltip";
 import { captureVideoFrameDataUrl } from "./video-frame-thumbnail";
+
+// Mounted only mid-upload; its RPC client drags the Effect runtime along, so
+// keeping it behind a dynamic import keeps that chunk off finished videos.
+const UploadProgressTracker = dynamic(() => import("./UploadProgressTracker"), {
+	ssr: false,
+});
 
 const { circumference } = getProgressCircleConfig();
 
@@ -196,10 +203,20 @@ export function CapVideoPlayer({
 		return () => window.removeEventListener("resize", checkMobile);
 	}, []);
 
-	const uploadProgressRaw = useUploadProgress(
-		videoId,
-		hasActiveUpload || false,
-	);
+	// Mirrors what `useUploadProgress(id, enabled)` returned inline: null when
+	// idle, "fetching" from the first enabled render. The hook itself now lives
+	// in the lazily-mounted tracker so finished videos skip its Effect chunk.
+	const trackUploadProgress = hasActiveUpload || false;
+	const [uploadProgressRaw, setUploadProgressRaw] =
+		useState<UploadProgress | null>(
+			trackUploadProgress ? { status: "fetching" } : null,
+		);
+	useEffect(() => {
+		// Both directions of an enable/disable flip mirror the old inline hook:
+		// tracking starting mid-session reads "fetching" immediately (the lazy
+		// tracker hasn't mounted yet), and stopping reads null.
+		setUploadProgressRaw(trackUploadProgress ? { status: "fetching" } : null);
+	}, [trackUploadProgress]);
 	const uploadProgress = blockPlaybackDuringProcessing
 		? uploadProgressRaw
 		: videoLoaded
@@ -614,6 +631,12 @@ export function CapVideoPlayer({
 			)}
 			autoHide
 		>
+			{trackUploadProgress && (
+				<UploadProgressTracker
+					videoId={videoId}
+					onChange={setUploadProgressRaw}
+				/>
+			)}
 			{showUploadFailureOverlay && (
 				<div className="flex absolute inset-0 flex-col px-3 gap-3 z-[20] justify-center items-center bg-black transition-opacity duration-300">
 					<AlertTriangleIcon className="text-red-500 size-12" />

--- a/apps/web/app/s/[videoId]/_components/DeleteCapDialog.tsx
+++ b/apps/web/app/s/[videoId]/_components/DeleteCapDialog.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import type { Video } from "@cap/web-domain";
+import { faVideo } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { ConfirmationDialog } from "@/app/(org)/dashboard/_components/ConfirmationDialog";
+import { useEffectMutation, useRpcClient } from "@/lib/EffectRuntime";
+
+/**
+ * The owner's delete confirmation, self-contained so its RPC mutation — and
+ * the Effect runtime it drags along — loads only once deletion is actually
+ * requested, not on every share-page view.
+ */
+export default function DeleteCapDialog({
+	open,
+	videoId,
+	videoTitle,
+	onClose,
+}: {
+	open: boolean;
+	videoId: Video.VideoId;
+	videoTitle: string;
+	onClose: () => void;
+}) {
+	const { push } = useRouter();
+	const rpc = useRpcClient();
+
+	const deleteMutation = useEffectMutation({
+		mutationFn: () => rpc.VideoDelete(videoId),
+		onSuccess: () => {
+			toast.success("Cap deleted successfully");
+			push("/dashboard/caps?page=1");
+		},
+		onError: () => {
+			toast.error("Failed to delete Cap");
+		},
+		onSettled: () => {
+			onClose();
+		},
+	});
+
+	return (
+		<ConfirmationDialog
+			open={open}
+			icon={<FontAwesomeIcon icon={faVideo} />}
+			title="Delete Cap"
+			description={`Are you sure you want to delete the cap "${videoTitle}"? This action cannot be undone.`}
+			confirmLabel={deleteMutation.isPending ? "Deleting..." : "Delete"}
+			confirmVariant="destructive"
+			loading={deleteMutation.isPending}
+			onConfirm={() => deleteMutation.mutate()}
+			onCancel={onClose}
+		/>
+	);
+}

--- a/apps/web/app/s/[videoId]/_components/DuplicateCapMenuItem.tsx
+++ b/apps/web/app/s/[videoId]/_components/DuplicateCapMenuItem.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { DropdownMenuItem } from "@cap/ui";
+import type { Video } from "@cap/web-domain";
+import { faCopy } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useIsMutating } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useEffectMutation, useRpcClient } from "@/lib/EffectRuntime";
+
+/**
+ * The "Duplicate Cap" row of the owner menu, self-contained so its RPC
+ * mutation — and the Effect runtime it drags along — loads only when the menu
+ * is actually opened, not on every share-page view.
+ */
+export default function DuplicateCapMenuItem({
+	videoId,
+	disabled,
+}: {
+	videoId: Video.VideoId;
+	disabled?: boolean;
+}) {
+	const rpc = useRpcClient();
+
+	const duplicateMutation = useEffectMutation({
+		mutationKey: ["videoDuplicate", videoId],
+		mutationFn: () => rpc.VideoDuplicate(videoId),
+		onSuccess: () => {
+			toast.success("Cap duplicated successfully");
+		},
+		onError: () => {
+			toast.error("Failed to duplicate Cap");
+		},
+	});
+	// Read pending state through the cache, not the hook instance: the menu
+	// content remounts every time it opens, and a fresh instance would forget
+	// an in-flight duplication and allow a second one.
+	const isDuplicating =
+		useIsMutating({ mutationKey: ["videoDuplicate", videoId] }) > 0;
+
+	return (
+		<DropdownMenuItem
+			onClick={() => duplicateMutation.mutate()}
+			disabled={isDuplicating || disabled}
+			className="flex items-center gap-2 rounded-lg"
+		>
+			<FontAwesomeIcon className="size-3" icon={faCopy} />
+			<p className="text-sm text-gray-12">
+				{isDuplicating ? "Duplicating..." : "Duplicate Cap"}
+			</p>
+		</DropdownMenuItem>
+	);
+}

--- a/apps/web/app/s/[videoId]/_components/HLSVideoPlayer.tsx
+++ b/apps/web/app/s/[videoId]/_components/HLSVideoPlayer.tsx
@@ -10,6 +10,7 @@ import clsx from "clsx";
 import Hls from "hls.js";
 import { AlertTriangleIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -22,8 +23,8 @@ import {
 	getUploadFailureMessage,
 	shouldDeferPlaybackSource,
 	shouldReloadPlaybackAfterUploadCompletes,
-	useUploadProgress,
-} from "./ProgressCircle";
+	type UploadProgress,
+} from "./upload-progress";
 import { VideoPreviewGif } from "./VideoPreviewGif";
 import {
 	MediaPlayer,
@@ -45,6 +46,12 @@ import {
 	MediaPlayerVolume,
 	MediaPlayerVolumeIndicator,
 } from "./video/media-player";
+
+// Mounted only mid-upload; its RPC client drags the Effect runtime along, so
+// keeping it behind a dynamic import keeps that chunk off finished videos.
+const UploadProgressTracker = dynamic(() => import("./UploadProgressTracker"), {
+	ssr: false,
+});
 
 const { circumference } = getProgressCircleConfig();
 
@@ -185,10 +192,20 @@ export function HLSVideoPlayer({
 		videoLoadedRef.current = videoLoaded;
 	}, [videoLoaded]);
 
-	const uploadProgressRaw = useUploadProgress(
-		videoId,
-		hasActiveUpload || false,
-	);
+	// Mirrors what `useUploadProgress(id, enabled)` returned inline: null when
+	// idle, "fetching" from the first enabled render. The hook itself now lives
+	// in the lazily-mounted tracker so finished videos skip its Effect chunk.
+	const trackUploadProgress = hasActiveUpload || false;
+	const [uploadProgressRaw, setUploadProgressRaw] =
+		useState<UploadProgress | null>(
+			trackUploadProgress ? { status: "fetching" } : null,
+		);
+	useEffect(() => {
+		// Both directions of an enable/disable flip mirror the old inline hook:
+		// tracking starting mid-session reads "fetching" immediately (the lazy
+		// tracker hasn't mounted yet), and stopping reads null.
+		setUploadProgressRaw(trackUploadProgress ? { status: "fetching" } : null);
+	}, [trackUploadProgress]);
 	const shouldDelayPlaybackSource =
 		!allowSegmentProbeDuringUpload &&
 		shouldDeferPlaybackSource(uploadProgressRaw);
@@ -602,6 +619,12 @@ export function HLSVideoPlayer({
 			)}
 			autoHide
 		>
+			{trackUploadProgress && (
+				<UploadProgressTracker
+					videoId={videoId}
+					onChange={setUploadProgressRaw}
+				/>
+			)}
 			{hasFailedOrError && (
 				<div className="flex absolute inset-0 flex-col px-3 gap-3 z-[20] justify-center items-center bg-black transition-opacity duration-300">
 					<AlertTriangleIcon className="text-red-500 size-12" />

--- a/apps/web/app/s/[videoId]/_components/ProgressCircle.tsx
+++ b/apps/web/app/s/[videoId]/_components/ProgressCircle.tsx
@@ -4,122 +4,26 @@ import type { Video } from "@cap/web-domain";
 import clsx from "clsx";
 import { Effect, Option } from "effect";
 import { useEffectQuery, useRpcClient } from "@/lib/EffectRuntime";
+import {
+	DAY,
+	getStalledProcessingMessage,
+	HOUR,
+	MINUTE,
+	SECOND,
+	type UploadProgress,
+} from "./upload-progress";
 
-type UploadProgress =
-	| { status: "fetching" }
-	| {
-			status: "uploading";
-			lastUpdated: Date;
-			progress: number;
-	  }
-	| {
-			status: "processing";
-			lastUpdated: Date;
-			progress: number;
-			message: string | null;
-	  }
-	| {
-			status: "generating_thumbnail";
-			lastUpdated: Date;
-			progress: number;
-	  }
-	| {
-			status: "error";
-			lastUpdated: Date;
-			errorMessage: string | null;
-			hasRawFallback: boolean;
-	  }
-	| {
-			status: "failed";
-			lastUpdated: Date;
-	  };
-
-export function shouldDeferPlaybackSource(
-	uploadProgress: UploadProgress | null,
-): boolean {
-	return (
-		uploadProgress?.status === "fetching" ||
-		uploadProgress?.status === "uploading"
-	);
-}
-
-export function shouldReloadPlaybackAfterUploadCompletes(
-	previousUploadProgress: UploadProgress | null,
-	uploadProgress: UploadProgress | null,
-	options: { includeFetching?: boolean } = {},
-): boolean {
-	return (
-		previousUploadProgress !== null &&
-		(options.includeFetching || previousUploadProgress.status !== "fetching") &&
-		uploadProgress === null
-	);
-}
-
-export function canRetryFailedProcessing(
-	uploadProgress: UploadProgress | null,
-	canRetryProcessing: boolean,
-): boolean {
-	return canRetryProcessing && uploadProgress?.status === "error";
-}
-
-export function getUploadFailureMessage(
-	uploadProgress: UploadProgress | null,
-	canRetryProcessing: boolean,
-): string {
-	if (uploadProgress?.status === "error") {
-		if (canRetryFailedProcessing(uploadProgress, canRetryProcessing)) {
-			return uploadProgress.errorMessage || "Processing failed.";
-		}
-
-		return (
-			uploadProgress.errorMessage ||
-			"Processing failed. Ask the owner to retry processing or re-upload the recording."
-		);
-	}
-
-	return "Upload stalled before processing finished. Re-upload the recording to continue.";
-}
-
-const SECOND = 1000;
-const MINUTE = 60 * SECOND;
-const HOUR = 60 * 60 * SECOND;
-const DAY = 24 * HOUR;
-const STALE_PROCESSING_START_MS = 90 * SECOND;
-const STALE_PROCESSING_PROGRESS_MS = 10 * MINUTE;
-const STALE_THUMBNAIL_MS = 5 * MINUTE;
-
-export function getStalledProcessingMessage(input: {
-	phase:
-		| "uploading"
-		| "processing"
-		| "generating_thumbnail"
-		| "complete"
-		| "error";
-	updatedAt: Date;
-	processingProgress: number;
-}): string | null {
-	const ageMs = Date.now() - input.updatedAt.getTime();
-
-	if (input.phase === "processing") {
-		if (input.processingProgress === 0 && ageMs > STALE_PROCESSING_START_MS) {
-			return "Video processing did not start. Retry processing.";
-		}
-
-		if (ageMs > STALE_PROCESSING_PROGRESS_MS) {
-			return "Video processing stalled. Retry processing.";
-		}
-	}
-
-	if (input.phase === "generating_thumbnail" && ageMs > STALE_THUMBNAIL_MS) {
-		return "Video finishing stalled. Retry processing.";
-	}
-
-	if (input.phase === "complete" && ageMs > STALE_THUMBNAIL_MS) {
-		return "Video finishing stalled. Retry processing.";
-	}
-
-	return null;
-}
+// The pure helpers moved to `upload-progress.ts` so consumers that only need
+// them don't pull the Effect runtime this file's hook depends on. Re-exported
+// here to keep existing import sites (embed, dashboard) working unchanged.
+export {
+	canRetryFailedProcessing,
+	getStalledProcessingMessage,
+	getUploadFailureMessage,
+	shouldDeferPlaybackSource,
+	shouldReloadPlaybackAfterUploadCompletes,
+	type UploadProgress,
+} from "./upload-progress";
 
 export function useUploadProgress(
 	videoId: Video.VideoId,

--- a/apps/web/app/s/[videoId]/_components/ShareHeader.tsx
+++ b/apps/web/app/s/[videoId]/_components/ShareHeader.tsx
@@ -14,14 +14,12 @@ import type { ViewerSettingKey } from "@cap/web-backend";
 import {
 	faChartSimple,
 	faChevronDown,
-	faCopy,
 	faEllipsis,
 	faGear,
 	faLock,
 	faShare,
 	faTrash,
 	faUnlock,
-	faVideo,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { skipToken, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -39,7 +37,6 @@ import {
 	Users,
 	X,
 } from "lucide-react";
-import moment from "moment";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
@@ -51,17 +48,11 @@ import {
 } from "@/actions/organization/shareable-link-icon";
 import { editTitle } from "@/actions/videos/edit-title";
 import type { VideoStatusResult } from "@/actions/videos/get-status";
-import { ConfirmationDialog } from "@/app/(org)/dashboard/_components/ConfirmationDialog";
-import { useDashboardContext } from "@/app/(org)/dashboard/Contexts";
-import { PasswordDialog } from "@/app/(org)/dashboard/caps/components/PasswordDialog";
-import { SettingsDialog } from "@/app/(org)/dashboard/caps/components/SettingsDialog";
-import { SharingDialog } from "@/app/(org)/dashboard/caps/components/SharingDialog";
+import { useDashboardContext } from "@/app/(org)/dashboard/DashboardContext";
 import type { Spaces } from "@/app/(org)/dashboard/dashboard-data";
 import { useCurrentUser } from "@/app/Layout/AuthContext";
 import { SignedImageUrl } from "@/components/SignedImageUrl";
 import { Tooltip } from "@/components/Tooltip";
-import { UpgradeModal } from "@/components/UpgradeModal";
-import { useEffectMutation, useRpcClient } from "@/lib/EffectRuntime";
 import {
 	copyRichVideoLink,
 	videoPreviewImageUrl,
@@ -71,6 +62,7 @@ import { navigateWithTransition } from "@/utils/view-transition";
 import type { SharePageBranding, VideoData } from "../types";
 import { describeShareAudience } from "./share-audience";
 import { useVideoDownload } from "./use-video-download";
+import { fromNow } from "./utils/from-now";
 import { VideoDownloadMenu } from "./VideoDownloadMenu";
 
 /**
@@ -80,6 +72,43 @@ import { VideoDownloadMenu } from "./VideoDownloadMenu";
  */
 const importShareLinkDialog = () => import("./ShareLinkDialog");
 const ShareLinkDialog = dynamic(importShareLinkDialog, { ssr: false });
+
+/**
+ * Same treatment for the rest of the header's interaction-only surfaces. The
+ * owner dialogs and the upgrade modal (which carries the Rive animation
+ * runtime) are mounted behind latches; the two RPC-backed pieces additionally
+ * keep the Effect runtime chunk out of every plain page view.
+ */
+const importUpgradeModal = () =>
+	import("@/components/UpgradeModal").then((m) => m.UpgradeModal);
+const UpgradeModal = dynamic(importUpgradeModal, { ssr: false });
+const SharingDialog = dynamic(
+	() =>
+		import("@/app/(org)/dashboard/caps/components/SharingDialog").then(
+			(m) => m.SharingDialog,
+		),
+	{ ssr: false },
+);
+const SettingsDialog = dynamic(
+	() =>
+		import("@/app/(org)/dashboard/caps/components/SettingsDialog").then(
+			(m) => m.SettingsDialog,
+		),
+	{ ssr: false },
+);
+const PasswordDialog = dynamic(
+	() =>
+		import("@/app/(org)/dashboard/caps/components/PasswordDialog").then(
+			(m) => m.PasswordDialog,
+		),
+	{ ssr: false },
+);
+const DeleteCapDialog = dynamic(() => import("./DeleteCapDialog"), {
+	ssr: false,
+});
+const DuplicateCapMenuItem = dynamic(() => import("./DuplicateCapMenuItem"), {
+	ssr: false,
+});
 
 /**
  * Where a signed-out viewer can go next. Three, not the full site nav: this
@@ -159,15 +188,40 @@ export const ShareHeader = ({
 	const [displayTitle, setDisplayTitle] = useState(data.name);
 	const [editValue, setEditValue] = useState(data.name);
 	const [isTitleRevealing, setIsTitleRevealing] = useState(false);
-	const [upgradeModalOpen, setUpgradeModalOpen] = useState(false);
-	const [isSharingDialogOpen, setIsSharingDialogOpen] = useState(false);
+	const [upgradeModalOpen, setUpgradeModalOpenRaw] = useState(false);
+	const [isSharingDialogOpen, setIsSharingDialogOpenRaw] = useState(false);
 	const [isShareLinkDialogOpen, setIsShareLinkDialogOpen] = useState(false);
-	// Latched so the lazy chunk is only ever pulled in once, and so the dialog
+	// Latched so each lazy chunk is only ever pulled in once, and so a dialog
 	// keeps its exit animation instead of being torn out of the tree on close.
 	const [shareLinkDialogMounted, setShareLinkDialogMounted] = useState(false);
-	const [isSettingsDialogOpen, setIsSettingsDialogOpen] = useState(false);
-	const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState(false);
-	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+	const [upgradeModalMounted, setUpgradeModalMounted] = useState(false);
+	const [sharingDialogMounted, setSharingDialogMounted] = useState(false);
+	const [settingsDialogMounted, setSettingsDialogMounted] = useState(false);
+	const [passwordDialogMounted, setPasswordDialogMounted] = useState(false);
+	const [deleteDialogMounted, setDeleteDialogMounted] = useState(false);
+	const [isSettingsDialogOpen, setIsSettingsDialogOpenRaw] = useState(false);
+	const [isPasswordDialogOpen, setIsPasswordDialogOpenRaw] = useState(false);
+	const [isDeleteDialogOpen, setIsDeleteDialogOpenRaw] = useState(false);
+	const setUpgradeModalOpen = (open: boolean) => {
+		if (open) setUpgradeModalMounted(true);
+		setUpgradeModalOpenRaw(open);
+	};
+	const setIsSharingDialogOpen = (open: boolean) => {
+		if (open) setSharingDialogMounted(true);
+		setIsSharingDialogOpenRaw(open);
+	};
+	const setIsSettingsDialogOpen = (open: boolean) => {
+		if (open) setSettingsDialogMounted(true);
+		setIsSettingsDialogOpenRaw(open);
+	};
+	const setIsPasswordDialogOpen = (open: boolean) => {
+		if (open) setPasswordDialogMounted(true);
+		setIsPasswordDialogOpenRaw(open);
+	};
+	const setIsDeleteDialogOpen = (open: boolean) => {
+		if (open) setDeleteDialogMounted(true);
+		setIsDeleteDialogOpenRaw(open);
+	};
 	const [passwordProtected, setPasswordProtected] = useState(
 		Boolean(data.hasPassword),
 	);
@@ -214,31 +268,6 @@ export const ShareHeader = ({
 	const effectiveSharedSpaces = contextSharedSpaces || sharedSpaces;
 
 	const isOwner = user && user.id === data.owner.id;
-	const rpc = useRpcClient();
-
-	const duplicateMutation = useEffectMutation({
-		mutationFn: () => rpc.VideoDuplicate(data.id),
-		onSuccess: () => {
-			toast.success("Cap duplicated successfully");
-		},
-		onError: () => {
-			toast.error("Failed to duplicate Cap");
-		},
-	});
-
-	const deleteMutation = useEffectMutation({
-		mutationFn: () => rpc.VideoDelete(data.id),
-		onSuccess: () => {
-			toast.success("Cap deleted successfully");
-			push("/dashboard/caps?page=1");
-		},
-		onError: () => {
-			toast.error("Failed to delete Cap");
-		},
-		onSettled: () => {
-			setIsDeleteDialogOpen(false);
-		},
-	});
 
 	const { webUrl } = usePublicEnv();
 	const { download, isDownloading } = useVideoDownload(data.id);
@@ -710,21 +739,23 @@ export const ShareHeader = ({
 					</Button>
 				</div>
 			)}
-			<SharingDialog
-				isOpen={isSharingDialogOpen}
-				onClose={() => setIsSharingDialogOpen(false)}
-				capId={data.id}
-				capName={data.name}
-				sharedSpaces={effectiveSharedSpaces || []}
-				onSharingUpdated={handleSharingUpdated}
-				isPublic={data.public}
-				spacesData={spacesData}
-				hasPassword={passwordProtected}
-				inheritedPasswordSources={data.inheritedPasswordSources}
-				onPasswordUpdated={handlePasswordUpdated}
-				user={user}
-				onUpgradeRequest={setUpgradeModalOpen}
-			/>
+			{sharingDialogMounted && (
+				<SharingDialog
+					isOpen={isSharingDialogOpen}
+					onClose={() => setIsSharingDialogOpen(false)}
+					capId={data.id}
+					capName={data.name}
+					sharedSpaces={effectiveSharedSpaces || []}
+					onSharingUpdated={handleSharingUpdated}
+					isPublic={data.public}
+					spacesData={spacesData}
+					hasPassword={passwordProtected}
+					inheritedPasswordSources={data.inheritedPasswordSources}
+					onPasswordUpdated={handlePasswordUpdated}
+					user={user}
+					onUpgradeRequest={setUpgradeModalOpen}
+				/>
+			)}
 			{shareLinkDialogMounted && (
 				<ShareLinkDialog
 					open={isShareLinkDialogOpen}
@@ -742,34 +773,35 @@ export const ShareHeader = ({
 			)}
 			{isOwner && (
 				<>
-					<SettingsDialog
-						isOpen={isSettingsDialogOpen}
-						onClose={() => setIsSettingsDialogOpen(false)}
-						capId={data.id}
-						settingsData={data.videoSettings ?? undefined}
-						inheritedSpaceSettings={data.inheritedSpaceSettings}
-						user={user}
-						organizationSettings={data.orgSettings}
-						onSaved={refresh}
-					/>
-					<PasswordDialog
-						isOpen={isPasswordDialogOpen}
-						onClose={() => setIsPasswordDialogOpen(false)}
-						videoId={data.id}
-						hasPassword={passwordProtected}
-						onPasswordUpdated={handlePasswordUpdated}
-					/>
-					<ConfirmationDialog
-						open={isDeleteDialogOpen}
-						icon={<FontAwesomeIcon icon={faVideo} />}
-						title="Delete Cap"
-						description={`Are you sure you want to delete the cap "${displayTitle}"? This action cannot be undone.`}
-						confirmLabel={deleteMutation.isPending ? "Deleting..." : "Delete"}
-						confirmVariant="destructive"
-						loading={deleteMutation.isPending}
-						onConfirm={() => deleteMutation.mutate()}
-						onCancel={() => setIsDeleteDialogOpen(false)}
-					/>
+					{settingsDialogMounted && (
+						<SettingsDialog
+							isOpen={isSettingsDialogOpen}
+							onClose={() => setIsSettingsDialogOpen(false)}
+							capId={data.id}
+							settingsData={data.videoSettings ?? undefined}
+							inheritedSpaceSettings={data.inheritedSpaceSettings}
+							user={user}
+							organizationSettings={data.orgSettings}
+							onSaved={refresh}
+						/>
+					)}
+					{passwordDialogMounted && (
+						<PasswordDialog
+							isOpen={isPasswordDialogOpen}
+							onClose={() => setIsPasswordDialogOpen(false)}
+							videoId={data.id}
+							hasPassword={passwordProtected}
+							onPasswordUpdated={handlePasswordUpdated}
+						/>
+					)}
+					{deleteDialogMounted && (
+						<DeleteCapDialog
+							open={isDeleteDialogOpen}
+							videoId={data.id}
+							videoTitle={displayTitle}
+							onClose={() => setIsDeleteDialogOpen(false)}
+						/>
+					)}
 				</>
 			)}
 			{/* Sits in the page bar above both panes, so the spacing is the bar's
@@ -950,7 +982,7 @@ export const ShareHeader = ({
 								<div className="flex flex-col text-left">
 									<p className="text-sm text-gray-12">{data.owner.name}</p>
 									<p className="text-xs text-gray-10">
-										{moment(data.createdAt).fromNow()}
+										{fromNow(data.createdAt)}
 										{views !== undefined && (
 											<Suspense fallback={null}>
 												<ViewCount views={views} />
@@ -1084,20 +1116,10 @@ export const ShareHeader = ({
 															: "Add password"}
 													</p>
 												</DropdownMenuItem>
-												<DropdownMenuItem
-													onClick={() => duplicateMutation.mutate()}
-													disabled={
-														duplicateMutation.isPending || data.hasActiveUpload
-													}
-													className="flex items-center gap-2 rounded-lg"
-												>
-													<FontAwesomeIcon className="size-3" icon={faCopy} />
-													<p className="text-sm text-gray-12">
-														{duplicateMutation.isPending
-															? "Duplicating..."
-															: "Duplicate Cap"}
-													</p>
-												</DropdownMenuItem>
+												<DuplicateCapMenuItem
+													videoId={data.id}
+													disabled={data.hasActiveUpload}
+												/>
 												{/* Downloads used to live behind a second dots button next to
 												    the link. There is one "everything else about this Cap"
 												    menu, and this is it. */}
@@ -1198,10 +1220,12 @@ export const ShareHeader = ({
 					</div>
 				</div>
 			</div>
-			<UpgradeModal
-				open={upgradeModalOpen}
-				onOpenChange={setUpgradeModalOpen}
-			/>
+			{upgradeModalMounted && (
+				<UpgradeModal
+					open={upgradeModalOpen}
+					onOpenChange={setUpgradeModalOpen}
+				/>
+			)}
 		</>
 	);
 };

--- a/apps/web/app/s/[videoId]/_components/ShareVideo.tsx
+++ b/apps/web/app/s/[videoId]/_components/ShareVideo.tsx
@@ -20,20 +20,19 @@ import {
 } from "react";
 import { finalizeDesktopSegmentsRecording } from "@/actions/video/finalize-desktop-segments";
 import { Tooltip } from "@/components/Tooltip";
-import { UpgradeModal } from "@/components/UpgradeModal";
 import { isRetryableDesktopSegmentsFinalizationError } from "@/lib/desktop-segments-retryable-errors";
 import type { VideoData } from "../types";
 import { type CaptionLanguage, useCaptionContext } from "./CaptionContext";
 import { scheduleReadyRefresh } from "./deferred-ready-refresh";
 import {
-	shouldDeferPlaybackSource,
-	shouldReloadPlaybackAfterUploadCompletes,
-	useUploadProgress,
-} from "./ProgressCircle";
-import {
 	PreparingVideoOverlay,
 	RecordingInProgressOverlay,
 } from "./RecordingInProgress";
+import {
+	shouldDeferPlaybackSource,
+	shouldReloadPlaybackAfterUploadCompletes,
+	type UploadProgress,
+} from "./upload-progress";
 import { formatChaptersAsVTT } from "./utils/transcript-utils";
 
 type CommentWithAuthor = typeof commentsSchema.$inferSelect & {
@@ -52,6 +51,16 @@ const CapVideoPlayer = dynamic(() =>
 const HLSVideoPlayer = dynamic(() =>
 	import("./HLSVideoPlayer").then((m) => m.HLSVideoPlayer),
 );
+
+// Both ride outside the first paint: the tracker only mounts mid-upload (its
+// RPC client drags the Effect runtime along), and the upgrade modal — which
+// carries the Rive animation runtime — mounts on the first upgrade prompt.
+const UploadProgressTracker = dynamic(() => import("./UploadProgressTracker"), {
+	ssr: false,
+});
+const importUpgradeModal = () =>
+	import("@/components/UpgradeModal").then((m) => m.UpgradeModal);
+const UpgradeModal = dynamic(importUpgradeModal, { ssr: false });
 
 type AiGenerationStatus =
 	| "QUEUED"
@@ -123,6 +132,13 @@ export const ShareVideo = forwardRef<
 		};
 
 		const [upgradeModalOpen, setUpgradeModalOpen] = useState(false);
+		// Latch, not open-state: once the modal has been requested it stays
+		// mounted so closing still plays its exit animation.
+		const [upgradeModalMounted, setUpgradeModalMounted] = useState(false);
+		const openUpgradeModal = () => {
+			setUpgradeModalMounted(true);
+			setUpgradeModalOpen(true);
+		};
 		const [subtitleUrl, setSubtitleUrl] = useState<string | null>(null);
 		const [chaptersUrl, setChaptersUrl] = useState<string | null>(null);
 		const [commentsData, setCommentsData] = useState<CommentWithAuthor[]>([]);
@@ -134,10 +150,23 @@ export const ShareVideo = forwardRef<
 		>(null);
 		const autoFinalizeAttemptedRef = useRef(false);
 		const pendingReadyRefreshRef = useRef(false);
-		const segmentUploadProgress = useUploadProgress(
-			data.id,
-			data.source.type === "desktopSegments" && (data.hasActiveUpload ?? false),
-		);
+		// Mirrors what `useUploadProgress(id, enabled)` returned inline: null when
+		// idle, "fetching" from the first enabled render. The hook itself now lives
+		// in the lazily-mounted tracker so finished videos skip its Effect chunk.
+		const trackUploadProgress =
+			data.source.type === "desktopSegments" && (data.hasActiveUpload ?? false);
+		const [segmentUploadProgress, setSegmentUploadProgress] =
+			useState<UploadProgress | null>(
+				trackUploadProgress ? { status: "fetching" } : null,
+			);
+		useEffect(() => {
+			// Both directions of an enable/disable flip mirror the old inline hook:
+			// tracking starting mid-session reads "fetching" immediately (the lazy
+			// tracker hasn't mounted yet), and stopping reads null.
+			setSegmentUploadProgress(
+				trackUploadProgress ? { status: "fetching" } : null,
+			);
+		}, [trackUploadProgress]);
 
 		const { data: transcriptContent, error: transcriptError } = useTranscript(
 			data.id,
@@ -632,7 +661,10 @@ export const ShareVideo = forwardRef<
 							className="block"
 							onClick={(e) => {
 								e.stopPropagation();
-								setUpgradeModalOpen(true);
+								openUpgradeModal();
+							}}
+							onPointerEnter={() => {
+								void importUpgradeModal();
 							}}
 						>
 							<div className="relative">
@@ -649,10 +681,18 @@ export const ShareVideo = forwardRef<
 						</button>
 					</div>
 				)}
-				<UpgradeModal
-					open={upgradeModalOpen}
-					onOpenChange={setUpgradeModalOpen}
-				/>
+				{trackUploadProgress && (
+					<UploadProgressTracker
+						videoId={data.id}
+						onChange={setSegmentUploadProgress}
+					/>
+				)}
+				{upgradeModalMounted && (
+					<UpgradeModal
+						open={upgradeModalOpen}
+						onOpenChange={setUpgradeModalOpen}
+					/>
+				)}
 			</>
 		);
 	},

--- a/apps/web/app/s/[videoId]/_components/Sidebar.tsx
+++ b/apps/web/app/s/[videoId]/_components/Sidebar.tsx
@@ -3,14 +3,30 @@ import { classNames } from "@cap/utils";
 import type { ImageUpload, Video } from "@cap/web-domain";
 import clsx from "clsx";
 import { AnimatePresence, motion } from "motion/react";
+import dynamic from "next/dynamic";
 import { forwardRef, Suspense, useState } from "react";
 import type { OrganizationSettings } from "@/app/(org)/dashboard/dashboard-data";
 import { useCurrentUser } from "@/app/Layout/AuthContext";
 import type { VideoData } from "../types";
 import { Activity } from "./tabs/Activity";
-import { Settings } from "./tabs/Settings";
-import { Summary } from "./tabs/Summary";
-import { Transcript } from "./tabs/Transcript";
+
+// Activity is the default tab, so it stays in the entry chunk; the other tabs
+// (and their deps — react-markdown for Summary, the 1000-line transcript view)
+// load when first shown. With SSR on, a non-default initial tab still renders
+// server-side and preloads its own chunk. Hovering a tab button warms its
+// chunk so the click still feels instant.
+const importSummary = () => import("./tabs/Summary");
+const importTranscript = () => import("./tabs/Transcript");
+const Summary = dynamic(() => importSummary().then((m) => m.Summary));
+const Transcript = dynamic(() => importTranscript().then((m) => m.Transcript));
+const Settings = dynamic(() =>
+	import("./tabs/Settings").then((m) => m.Settings),
+);
+
+const prefetchTab = (tabId: string) => {
+	if (tabId === "summary") void importSummary();
+	else if (tabId === "transcript") void importTranscript();
+};
 
 type TabType = "activity" | "transcript" | "summary" | "settings";
 
@@ -235,6 +251,8 @@ export const Sidebar = forwardRef<{ scrollToBottom: () => void }, SidebarProps>(
 									type="button"
 									key={tab.id}
 									onClick={() => paginate(tab.id as TabType)}
+									onPointerEnter={() => prefetchTab(tab.id)}
+									onFocus={() => prefetchTab(tab.id)}
 									className={classNames(
 										"flex-1 px-5 py-3 text-sm font-medium relative transition-colors duration-200",
 										"hover:bg-gray-1",

--- a/apps/web/app/s/[videoId]/_components/Toolbar.tsx
+++ b/apps/web/app/s/[videoId]/_components/Toolbar.tsx
@@ -1,5 +1,8 @@
 import { Button } from "@cap/ui";
-import { Comment } from "@cap/web-domain";
+// type-only on purpose: a value import of @cap/web-domain drags the whole
+// effect runtime (~250 KB gz) into the share page's entry chunk. The branded
+// ids carry no constraints, so plain casts replace `.make()` losslessly.
+import type { Comment } from "@cap/web-domain";
 import { AnimatePresence, motion } from "motion/react";
 import dynamic from "next/dynamic";
 import { startTransition, useEffect, useState } from "react";
@@ -7,7 +10,7 @@ import { newComment } from "@/actions/videos/new-comment";
 import { useCurrentUser } from "@/app/Layout/AuthContext";
 import type { CommentType } from "../Share";
 import type { VideoData } from "../types";
-import { AuthOverlay } from "./AuthOverlay";
+import { AuthOverlay } from "./AuthOverlayLazy";
 import { RecordActionButtons } from "./media-comment/record-actions";
 import type { RecordIntentKind } from "./timeline/TimelineComposer";
 
@@ -88,14 +91,14 @@ export const Toolbar = ({
 			? null
 			: videoElement?.currentTime || 0;
 		const optimisticComment: CommentType = {
-			id: Comment.CommentId.make(`temp-${Date.now()}`),
+			id: (`temp-${Date.now()}` as Comment.CommentId),
 			authorId: user.id,
 			authorName: user.name,
 			authorImage: user.imageUrl,
 			content: emoji,
 			createdAt: new Date(),
 			videoId: data.id,
-			parentCommentId: Comment.CommentId.make(""),
+			parentCommentId: ("" as Comment.CommentId),
 			type: "emoji",
 			timestamp: currentTime,
 			updatedAt: new Date(),
@@ -112,7 +115,7 @@ export const Toolbar = ({
 				content: emoji,
 				videoId: data.id,
 				authorImage: user.imageUrl,
-				parentCommentId: Comment.CommentId.make(""),
+				parentCommentId: ("" as Comment.CommentId),
 				type: "emoji",
 				timestamp: currentTime,
 			});
@@ -136,14 +139,14 @@ export const Toolbar = ({
 			? null
 			: videoElement?.currentTime || 0;
 		const optimisticComment: CommentType = {
-			id: Comment.CommentId.make(`temp-${Date.now()}`),
+			id: (`temp-${Date.now()}` as Comment.CommentId),
 			authorId: user.id,
 			authorName: user.name,
 			authorImage: user.imageUrl,
 			content: comment,
 			createdAt: new Date(),
 			videoId: data.id,
-			parentCommentId: Comment.CommentId.make(""),
+			parentCommentId: ("" as Comment.CommentId),
 			type: "text",
 			timestamp: currentTime,
 			updatedAt: new Date(),
@@ -160,7 +163,7 @@ export const Toolbar = ({
 				content: comment,
 				videoId: data.id,
 				authorImage: user.imageUrl,
-				parentCommentId: Comment.CommentId.make(""),
+				parentCommentId: ("" as Comment.CommentId),
 				type: "text",
 				timestamp: currentTime,
 			});

--- a/apps/web/app/s/[videoId]/_components/UploadProgressTracker.tsx
+++ b/apps/web/app/s/[videoId]/_components/UploadProgressTracker.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import type { Video } from "@cap/web-domain";
+import { useEffect } from "react";
+import { useUploadProgress } from "./ProgressCircle";
+import type { UploadProgress } from "./upload-progress";
+
+/**
+ * Headless bridge around `useUploadProgress`. The hook's RPC client pulls the
+ * Effect runtime with it, so the players mount this (dynamically imported)
+ * only while a video actually has a live upload — every finished video skips
+ * the chunk entirely.
+ */
+export default function UploadProgressTracker({
+	videoId,
+	onChange,
+}: {
+	videoId: Video.VideoId;
+	onChange: (progress: UploadProgress | null) => void;
+}) {
+	const progress = useUploadProgress(videoId, true);
+
+	useEffect(() => {
+		onChange(progress);
+	}, [progress, onChange]);
+
+	return null;
+}

--- a/apps/web/app/s/[videoId]/_components/media-comment/VideoCommentCard.tsx
+++ b/apps/web/app/s/[videoId]/_components/media-comment/VideoCommentCard.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { motion } from "motion/react";
+import dynamic from "next/dynamic";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { commentMediaUrl } from "@/lib/comment-media";
-import { CommentMiniPlayer } from "./CommentMiniPlayer";
 import { formatMediaDuration } from "./format-media-duration";
 import type { MediaComment } from "./media-comment-types";
 import {
@@ -12,6 +12,14 @@ import {
 	suspendMainVideo,
 } from "./media-playback-registry";
 import { UploadProgressIndicator } from "./UploadProgressIndicator";
+
+// Only mounts once a viewer expands a video comment, and it carries the
+// shared media-player primitives (media-chrome and friends) — lazy so the
+// comment list itself doesn't put them in the entry chunk.
+const CommentMiniPlayer = dynamic(
+	() => import("./CommentMiniPlayer").then((m) => m.CommentMiniPlayer),
+	{ ssr: false },
+);
 
 const FilmGlyph = () => (
 	<svg

--- a/apps/web/app/s/[videoId]/_components/playback/playback-store.ts
+++ b/apps/web/app/s/[videoId]/_components/playback/playback-store.ts
@@ -64,13 +64,22 @@ export function createPlaybackStore(fallbackDuration: number | null = 0) {
 	const tick = () => {
 		frame = 0;
 		sample();
-		if (element && !element.paused && !element.ended) {
+		if (
+			element &&
+			!element.paused &&
+			!element.ended &&
+			timeSubscribers.size > 0
+		) {
 			frame = requestAnimationFrame(tick);
 		}
 	};
 
 	const startFrames = () => {
 		if (frame !== 0) return;
+		// No one is listening at frame rate (classic view has no time
+		// subscribers) — the event-driven `timeupdate` samples are enough, so
+		// skip the 60fps loop until a subscriber shows up.
+		if (timeSubscribers.size === 0) return;
 		if (typeof requestAnimationFrame !== "function") return;
 		frame = requestAnimationFrame(tick);
 	};
@@ -140,6 +149,9 @@ export function createPlaybackStore(fallbackDuration: number | null = 0) {
 		// Hand the subscriber the current position straight away so it can paint
 		// once on mount instead of waiting for the next media event.
 		subscriber(time);
+		// The frame loop only runs while someone is subscribed; if playback is
+		// already going when the first subscriber arrives, start it now.
+		if (element && !element.paused && !element.ended) startFrames();
 		return () => {
 			timeSubscribers.delete(subscriber);
 		};

--- a/apps/web/app/s/[videoId]/_components/tabs/Activity/Comments.tsx
+++ b/apps/web/app/s/[videoId]/_components/tabs/Activity/Comments.tsx
@@ -1,4 +1,7 @@
-import { Comment, User, type Video } from "@cap/web-domain";
+// type-only on purpose: a value import of @cap/web-domain drags the whole
+// effect runtime (~250 KB gz) into the share page's entry chunk. The branded
+// ids carry no constraints, so plain casts replace `.make()` losslessly.
+import type { Comment, User, Video } from "@cap/web-domain";
 import { faCommentSlash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useSearchParams } from "next/navigation";
@@ -86,14 +89,14 @@ export const Comments = Object.assign(
 			const currentTime = videoElement?.currentTime || 0;
 
 			const optimisticComment: CommentType = {
-				id: Comment.CommentId.make(`temp-${Date.now()}`),
-				authorId: User.UserId.make(user.id),
+				id: (`temp-${Date.now()}` as Comment.CommentId),
+				authorId: (user.id as User.UserId),
 				authorName: user?.name,
 				authorImage: user.imageUrl,
 				content,
 				createdAt: new Date(),
 				videoId: props.videoId,
-				parentCommentId: Comment.CommentId.make(""),
+				parentCommentId: ("" as Comment.CommentId),
 				type: "text",
 				timestamp: currentTime,
 				updatedAt: new Date(),
@@ -112,7 +115,7 @@ export const Comments = Object.assign(
 					content,
 					videoId: props.videoId,
 					authorImage: user.imageUrl,
-					parentCommentId: Comment.CommentId.make(""),
+					parentCommentId: ("" as Comment.CommentId),
 					type: "text",
 					timestamp: currentTime,
 				});
@@ -134,7 +137,7 @@ export const Comments = Object.assign(
 				: replyingTo;
 
 			const optimisticReply: CommentType = {
-				id: Comment.CommentId.make(`temp-reply-${Date.now()}`),
+				id: (`temp-reply-${Date.now()}` as Comment.CommentId),
 				authorId: user.id,
 				authorName: user.name,
 				authorImage: user.imageUrl,

--- a/apps/web/app/s/[videoId]/_components/tabs/Activity/index.tsx
+++ b/apps/web/app/s/[videoId]/_components/tabs/Activity/index.tsx
@@ -6,7 +6,7 @@ import { forwardRef, type JSX, Suspense, useState } from "react";
 import { CapCardAnalytics } from "@/app/(org)/dashboard/caps/components/CapCard/CapCardAnalytics";
 import { useCurrentUser } from "@/app/Layout/AuthContext";
 import type { CommentType } from "../../../Share";
-import { AuthOverlay } from "../../AuthOverlay";
+import { AuthOverlay } from "../../AuthOverlayLazy";
 import Analytics from "./Analytics";
 import { Comments } from "./Comments";
 

--- a/apps/web/app/s/[videoId]/_components/timeline/TimelineComposer.tsx
+++ b/apps/web/app/s/[videoId]/_components/timeline/TimelineComposer.tsx
@@ -6,7 +6,7 @@ import { startTransition, useEffect, useState } from "react";
 import { newComment } from "@/actions/videos/new-comment";
 import { useCurrentUser } from "@/app/Layout/AuthContext";
 import type { CommentType } from "../../Share";
-import { AuthOverlay } from "../AuthOverlay";
+import { AuthOverlay } from "../AuthOverlayLazy";
 import { MicGlyph } from "./TimelineBranch";
 import { useTimelineActions, useTimelineState } from "./TimelineProvider";
 import {

--- a/apps/web/app/s/[videoId]/_components/upload-progress.ts
+++ b/apps/web/app/s/[videoId]/_components/upload-progress.ts
@@ -1,0 +1,123 @@
+/**
+ * Pure upload-progress state helpers, split from `ProgressCircle.tsx` so the
+ * players can reason about upload state without importing `useUploadProgress`
+ * — whose RPC client drags the whole Effect runtime into the bundle. Only
+ * `UploadProgressTracker` (mounted while an upload is actually live) pays for
+ * that chunk.
+ */
+
+export type UploadProgress =
+	| { status: "fetching" }
+	| {
+			status: "uploading";
+			lastUpdated: Date;
+			progress: number;
+	  }
+	| {
+			status: "processing";
+			lastUpdated: Date;
+			progress: number;
+			message: string | null;
+	  }
+	| {
+			status: "generating_thumbnail";
+			lastUpdated: Date;
+			progress: number;
+	  }
+	| {
+			status: "error";
+			lastUpdated: Date;
+			errorMessage: string | null;
+			hasRawFallback: boolean;
+	  }
+	| {
+			status: "failed";
+			lastUpdated: Date;
+	  };
+
+export function shouldDeferPlaybackSource(
+	uploadProgress: UploadProgress | null,
+): boolean {
+	return (
+		uploadProgress?.status === "fetching" ||
+		uploadProgress?.status === "uploading"
+	);
+}
+
+export function shouldReloadPlaybackAfterUploadCompletes(
+	previousUploadProgress: UploadProgress | null,
+	uploadProgress: UploadProgress | null,
+	options: { includeFetching?: boolean } = {},
+): boolean {
+	return (
+		previousUploadProgress !== null &&
+		(options.includeFetching || previousUploadProgress.status !== "fetching") &&
+		uploadProgress === null
+	);
+}
+
+export function canRetryFailedProcessing(
+	uploadProgress: UploadProgress | null,
+	canRetryProcessing: boolean,
+): boolean {
+	return canRetryProcessing && uploadProgress?.status === "error";
+}
+
+export function getUploadFailureMessage(
+	uploadProgress: UploadProgress | null,
+	canRetryProcessing: boolean,
+): string {
+	if (uploadProgress?.status === "error") {
+		if (canRetryFailedProcessing(uploadProgress, canRetryProcessing)) {
+			return uploadProgress.errorMessage || "Processing failed.";
+		}
+
+		return (
+			uploadProgress.errorMessage ||
+			"Processing failed. Ask the owner to retry processing or re-upload the recording."
+		);
+	}
+
+	return "Upload stalled before processing finished. Re-upload the recording to continue.";
+}
+
+export const SECOND = 1000;
+export const MINUTE = 60 * SECOND;
+export const HOUR = 60 * 60 * SECOND;
+export const DAY = 24 * HOUR;
+const STALE_PROCESSING_START_MS = 90 * SECOND;
+const STALE_PROCESSING_PROGRESS_MS = 10 * MINUTE;
+const STALE_THUMBNAIL_MS = 5 * MINUTE;
+
+export function getStalledProcessingMessage(input: {
+	phase:
+		| "uploading"
+		| "processing"
+		| "generating_thumbnail"
+		| "complete"
+		| "error";
+	updatedAt: Date;
+	processingProgress: number;
+}): string | null {
+	const ageMs = Date.now() - input.updatedAt.getTime();
+
+	if (input.phase === "processing") {
+		if (input.processingProgress === 0 && ageMs > STALE_PROCESSING_START_MS) {
+			return "Video processing did not start. Retry processing.";
+		}
+
+		if (ageMs > STALE_PROCESSING_PROGRESS_MS) {
+			return "Video processing stalled. Retry processing.";
+		}
+	}
+
+	if (input.phase === "generating_thumbnail" && ageMs > STALE_THUMBNAIL_MS) {
+		return "Video finishing stalled. Retry processing.";
+	}
+
+	if (input.phase === "complete" && ageMs > STALE_THUMBNAIL_MS) {
+		return "Video finishing stalled. Retry processing.";
+	}
+
+	return null;
+}

--- a/apps/web/app/s/[videoId]/_components/utils/from-now.ts
+++ b/apps/web/app/s/[videoId]/_components/utils/from-now.ts
@@ -1,0 +1,85 @@
+/**
+ * Drop-in replacement for `moment(date).fromNow()` (en locale), which was the
+ * share page's only moment call — and shipped all of moment plus every locale
+ * (~75 KB gzipped) to say "3 days ago".
+ *
+ * Replicates moment's actual pipeline for `a.from(b)`: the difference is
+ * split into whole calendar months plus a millisecond remainder
+ * (`positiveMomentsDifference`), then each unit is independently rounded the
+ * way `duration.humanize()` does — months convert to days at moment's
+ * 30.436875-day Gregorian average, thresholds are s=44, m=45, h=22, d=26,
+ * M=11. Parity is pinned by `__tests__/unit/from-now.test.ts`, which sweeps
+ * the boundaries with moment itself as the oracle.
+ */
+
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+// Days per month averaged over the 400-year Gregorian cycle (146097 / 4800).
+const DAYS_PER_MONTH = 146097 / 4800;
+
+const daysInMonth = (year: number, month: number) =>
+	new Date(year, month + 1, 0).getDate();
+
+/** Month addition with moment's semantics: day-of-month clamps to month end. */
+const addMonths = (date: Date, months: number): Date => {
+	const result = new Date(date.getTime());
+	const day = result.getDate();
+	result.setDate(1);
+	result.setMonth(result.getMonth() + months);
+	result.setDate(
+		Math.min(day, daysInMonth(result.getFullYear(), result.getMonth())),
+	);
+	return result;
+};
+
+export function fromNow(date: Date, now: Date = new Date()): string {
+	const inPast = now.getTime() - date.getTime() >= 0;
+	const [from, to] = inPast ? [date, now] : [now, date];
+
+	// moment's positiveMomentsDifference: whole calendar months + remainder ms.
+	let wholeMonths =
+		(to.getFullYear() - from.getFullYear()) * 12 +
+		(to.getMonth() - from.getMonth());
+	if (addMonths(from, wholeMonths).getTime() > to.getTime()) wholeMonths--;
+	const remainderMs = to.getTime() - addMonths(from, wholeMonths).getTime();
+
+	// For second/minute/hour/day units, moment first converts the month part
+	// to a WHOLE number of average-length days.
+	const smallUnitsMs =
+		remainderMs + Math.round(wholeMonths * DAYS_PER_MONTH) * MS_PER_DAY;
+	const seconds = Math.round(smallUnitsMs / MS_PER_SECOND);
+	const minutes = Math.round(smallUnitsMs / MS_PER_MINUTE);
+	const hours = Math.round(smallUnitsMs / MS_PER_HOUR);
+	const days = Math.round(smallUnitsMs / MS_PER_DAY);
+	// For month/year units, the remainder converts to fractional months.
+	const monthsExact = wholeMonths + remainderMs / MS_PER_DAY / DAYS_PER_MONTH;
+	const months = Math.round(monthsExact);
+	const years = Math.round(monthsExact / 12);
+
+	const phrase =
+		seconds <= 44
+			? "a few seconds"
+			: minutes <= 1
+				? "a minute"
+				: minutes < 45
+					? `${minutes} minutes`
+					: hours <= 1
+						? "an hour"
+						: hours < 22
+							? `${hours} hours`
+							: days <= 1
+								? "a day"
+								: days < 26
+									? `${days} days`
+									: months <= 1
+										? "a month"
+										: months < 11
+											? `${months} months`
+											: years <= 1
+												? "a year"
+												: `${years} years`;
+
+	return inPast ? `${phrase} ago` : `in ${phrase}`;
+}


### PR DESCRIPTION
Performance pass on the share page (`/s/[videoId]`). No functional or visual changes intended — every change is client-bundle surgery or render scheduling; SSR paths, APIs and the database are untouched.

## Results

Measured on a production build (`next start`), 7-run medians against a real 4K webMP4 recording, anonymous viewer:

| Metric | Before | After |
|---|---|---|
| JS transferred | 922 KB gz (29 scripts) | **508 KB gz (25 scripts)** |
| JS decoded | 3.19 MB | **1.69 MB** |
| Total blocking time (4x CPU throttle) | 253 ms | **29 ms** |
| Video ready to play | ~3.2 s | ~2.8 s |
| JS heap after load | 22 MB | **12 MB** |
| TTFB / FCP | 31 ms / 72 ms | unchanged |

## What changed

**Effect runtime out of the entry chunk (−246 KB gz).** It leaked in through three doors:
- `useUploadProgress` (RPC client) statically imported by all three players — split into pure `upload-progress.ts` predicates plus a headless `UploadProgressTracker` that only mounts while a video actually has a live upload. Initial "fetching" state and enable/disable flips mirror the old inline hook exactly.
- ShareHeader's duplicate/delete mutations — extracted into `DuplicateCapMenuItem` / `DeleteCapDialog`, loaded when the owner menu is used. Duplicate reads pending state via `useIsMutating`, which also fixes a pre-existing edge where reopening the menu mid-flight could double-fire.
- `actions/videos/translation-languages.ts` re-exported a value through the `@cap/web-domain` barrel into client code — now a deep import of the dependency-free `Language.ts`. `Toolbar`/`Comments` switch to type-only imports with casts for the constraint-free branded ids.

**moment gone (−75 KB gz).** The header's single `.fromNow()` call now uses a local util that replicates moment's humanize algorithm exactly (calendar-aware month diffing included). A new unit test pins parity using moment itself as the oracle across every threshold boundary and a four-year sweep.

**Rive out of initial load (~−50 KB gz).** `UpgradeModal` is latch-mounted behind `dynamic()` at all three sites. The dashboard context objects moved to `DashboardContext.ts` (with `Contexts.tsx` re-exporting) so reading `useDashboardContext` outside the dashboard no longer drags `InviteDialog`/`UpgradeModal` along.

**More lazy seams**, all following the existing ShareLinkDialog latch-and-prewarm pattern: Sharing/Settings/Password dialogs, sidebar Summary/Transcript/Settings tabs (hover on a tab prewarms its chunk), `CommentMiniPlayer` (keeps media-chrome out of the entry chunk), `AuthOverlay` (next-auth), and `SummaryChapters` (react-markdown — only fetched when AI data exists).

**Render scheduling.** `Share.tsx` memoizes `effectiveDate` and the `data` spreads handed to `ShareVideo`/`Sidebar`, so the 2-second status poll while a video processes no longer re-renders both subtrees with fresh object identities. The playback store's 60 fps rAF loop now only runs while frame-rate subscribers exist (classic view has none; timeline view is unchanged).

## Verification

- `tsc --noEmit` clean; full vitest suite: 1,459 passed (only failure is the pre-existing slack-manifest color drift on main).
- New `from-now.test.ts` parity suite passes.
- Browser-automation pass on the production build: video plays, captions render, relative date correct, lazy Transcript/Summary tabs load with content, Timeline view mounts and returns, share dialog opens, no page errors.
- Post-change lint scan confirms no new findings introduced; `no-moment` resolved.

## Notes for reviewers

- The one path verified by reasoning rather than observation is a share page whose video is *still uploading* (needs a live desktopSegments upload, which the local rig couldn't produce). The tracker preserves the old hook's state machine — including the "fetching" initial state that gates playback deferral — but it's worth a staging check: record a video and open its share page mid-upload.
- HLS pages verified to SSR and mount the player; actual segment streaming couldn't complete locally for environment reasons (media not materialized locally). The hls.js load path itself is untouched.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR substantially reduces the share page's initial client bundle without intended functional changes.
- Splits Effect runtime, Moment, Rive, authentication, media-player, dialog, and non-default-tab dependencies from the initial share-page bundle.
- Preserves upload-progress behavior through dynamically mounted trackers and dependency-free state helpers.
- Memoizes frequently propagated share data and gates playback frame scheduling on active subscribers.
- Adds Moment-parity coverage for the local relative-time formatter.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code regression identified.

The upload-progress state bridge preserves the prior defer and completion transitions, subscriber-gated playback scheduling has correct stop and restart guards, and the lazy UI conditions retain the prior rendered states.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/s/[videoId]/Share.tsx | Adds stable derived data objects and lazily renders summary content only under the component's existing meaningful-data conditions. |
| apps/web/app/s/[videoId]/_components/ShareHeader.tsx | Moves interaction-only dialogs and mutations behind dynamic latch-mounted components and replaces Moment with a local formatter. |
| apps/web/app/s/[videoId]/_components/ShareVideo.tsx | Lazily mounts upload tracking and the upgrade modal while preserving the existing upload-state transitions. |
| apps/web/app/s/[videoId]/_components/UploadProgressTracker.tsx | Bridges the existing upload-progress query into player-local state only while an upload is active. |
| apps/web/app/s/[videoId]/_components/playback/playback-store.ts | Stops frame-rate sampling without subscribers and restarts it when a subscriber joins active playback. |
| apps/web/app/s/[videoId]/_components/utils/from-now.ts | Implements the English Moment relative-time behavior with calendar-aware month calculations and dedicated parity tests. |
| apps/web/app/s/[videoId]/_components/Sidebar.tsx | Dynamically loads non-default sidebar tabs and prewarms the largest tabs on pointer or keyboard focus. |
| apps/web/app/(org)/dashboard/DashboardContext.ts | Separates lightweight dashboard context definitions from provider-only dialog dependencies without changing the context contract. |

<sub>Reviews (1): Last reviewed commit: ["perf(web): stop the playback rAF loop wh..."](https://github.com/capsoftware/cap/commit/69446ad82b5e1ae9e5966c6b212e3d99a7d6fdce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51199248)</sub>

**Context used:**

- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-app.md)

<!-- /greptile_comment -->