### PR TITLE
Handle disconnected mic/camera selections gracefully

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1111,6 +1111,27 @@ async fn set_mic_input(state: MutableState<'_, App>, label: Option<String>) -> R
         let mut app = state.write().await;
         app.ensure_mic_feed_alive().await?;
 
+        // A selected microphone that isn't connected is an expected state
+        // (e.g. undocked laptop), not an error: remember the selection so the
+        // device can be reclaimed when it reappears, and leave the feed empty.
+        if let Some(label) = desired_label.as_ref()
+            && !matches!(app.recording_state, RecordingState::Active(_))
+            && find_mic_by_label_or_fuzzy(&MicrophoneFeed::list_names(), label).is_none()
+        {
+            info!(
+                "Selected microphone '{label}' is not connected; keeping selection with no input"
+            );
+            app.selected_mic_label = desired_label.clone();
+            let mic_feed = app.mic_feed.clone();
+            drop(app);
+            // Best-effort: the feed may be locked by a recording that is still
+            // spinning up (Pending), in which case it must keep its input.
+            if let Err(err) = mic_feed.ask(microphone::RemoveInput).await {
+                warn!("Failed to release microphone input for absent device: {err}");
+            }
+            return Ok(());
+        }
+
         if desired_label == app.selected_mic_label {
             if desired_label.is_some() && !matches!(app.recording_state, RecordingState::Active(_))
             {
@@ -1281,6 +1302,45 @@ async fn set_camera_input(
             .set_camera_feed(None)
             .await
             .map_err(|e| e.to_string())?;
+    }
+
+    // A selected camera that isn't connected is an expected state (e.g. undocked
+    // laptop), not an error: tear down like a deselect but remember the selection
+    // so the device can be reclaimed when it reappears. Running the init/retry
+    // loop instead would flash the preview window and toast an error on every
+    // launch and picker-open while the device is away.
+    if let Some(id) = &id
+        && !is_camera_available(id)
+    {
+        info!(camera = ?id, "Selected camera is not connected; keeping selection with no input");
+        let shutdown_rx = {
+            let app = &mut *state.write().await;
+            app.camera_in_use = false;
+            app.selected_camera_id = Some(id.clone());
+            app.camera_cleanup_done = true;
+            if skip_camera_window {
+                app.camera_preview.begin_shutdown()
+            } else {
+                app.camera_preview.pause();
+                None
+            }
+        };
+
+        // Best-effort: the feed may be locked by a recording that is still
+        // spinning up (Pending), in which case it must keep its input.
+        if let Err(err) = camera_feed.ask(feeds::camera::RemoveInput).await {
+            warn!("Failed to release camera input for absent device: {err}");
+        }
+
+        if let Some(rx) = shutdown_rx {
+            let _ = tokio::time::timeout(Duration::from_millis(500), rx).await;
+        }
+
+        if !skip_camera_window && let Some(window) = CapWindowId::Camera.get(&app_handle) {
+            let _ = window.hide();
+        }
+
+        return Ok(());
     }
 
     match &id {
@@ -2162,7 +2222,10 @@ pub async fn request_app_exit(app: AppHandle) {
     finalize_app_exit(&app, 0);
 }
 
-fn find_mic_by_label_or_fuzzy(devices: &[String], selected_label: &str) -> Option<String> {
+pub(crate) fn find_mic_by_label_or_fuzzy(
+    devices: &[String],
+    selected_label: &str,
+) -> Option<String> {
     if devices.iter().any(|name| name == selected_label) {
         return Some(selected_label.to_string());
     }
@@ -2313,7 +2376,7 @@ fn spawn_camera_watcher(app_handle: AppHandle) {
     });
 }
 
-fn is_camera_available(id: &DeviceOrModelID) -> bool {
+pub(crate) fn is_camera_available(id: &DeviceOrModelID) -> bool {
     let cameras: Vec<_> = cap_camera::list_cameras().collect();
     debug!(
         "is_camera_available: looking for {:?} in {} cameras",

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -1817,6 +1817,29 @@ pub async fn start_recording(
                 )
             };
 
+            // A remembered camera that isn't connected must not abort the
+            // recording (camera-only mode excepted, where it's required):
+            // degrade to no-camera and tell the user once.
+            let selected_camera_id = match selected_camera_id {
+                Some(id)
+                    if !matches!(inputs.capture_target, ScreenCaptureTarget::CameraOnly)
+                        && !crate::is_camera_available(&id) =>
+                {
+                    warn!(
+                        camera = %camera_id_label(&id),
+                        "Selected camera is not connected; recording without camera"
+                    );
+                    let _ = crate::NewNotification {
+                        title: "Recording without camera".to_string(),
+                        body: "The selected camera is not connected, so this recording won't include it.".to_string(),
+                        is_error: true,
+                    }
+                    .emit(&app_handle);
+                    None
+                }
+                other => other,
+            };
+
             let camera_feed = lock_selected_camera(
                 &camera_feed_actor,
                 selected_camera_id,
@@ -1900,7 +1923,34 @@ pub async fn start_recording(
 
             let (done_fut, health_rx) = loop {
                 let actor_result: Result<InProgressRecording, anyhow::Error> = async {
-                    let selected_mic_label = state.selected_mic_label.clone();
+                    // Resolve the remembered microphone against the connected
+                    // devices (fuzzy-matching Bluetooth profile renames like the
+                    // reconnect watcher does). A missing microphone must not
+                    // abort the recording: degrade and tell the user once.
+                    let selected_mic_label = match state.selected_mic_label.clone() {
+                        Some(label) => {
+                            let matched = crate::find_mic_by_label_or_fuzzy(
+                                &microphone::MicrophoneFeed::list_names(),
+                                &label,
+                            );
+                            if matched.is_none() {
+                                warn!(
+                                    mic = %label,
+                                    "Selected microphone is not connected; recording without microphone"
+                                );
+                                let _ = crate::NewNotification {
+                                    title: "Recording without microphone".to_string(),
+                                    body: format!(
+                                        "Microphone '{label}' is not connected, so this recording won't include it."
+                                    ),
+                                    is_error: true,
+                                }
+                                .emit(&app_handle);
+                            }
+                            matched
+                        }
+                        None => None,
+                    };
                     let selected_mic_settings = selected_mic_label
                         .as_ref()
                         .and_then(|label| state.microphone_settings_for_label(label));

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -397,7 +397,11 @@ pub(crate) async fn restore_main_window_inputs(app: &AppHandle) {
                 None
             }
         })
-        .unwrap_or(None);
+        .unwrap_or(None)
+        // A remembered camera that isn't connected must not run the init/retry
+        // loop below: it would flash the preview window and toast an error on
+        // every main-window reveal while the device is away.
+        .filter(crate::is_camera_available);
 
     if let Some(camera_id) = camera_to_restore {
         emit_camera_preview_clear(app);

--- a/apps/desktop/src/routes/(window-chrome)/new-main/CameraSelect.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/CameraSelect.tsx
@@ -35,7 +35,6 @@ export default function CameraSelect(props: {
 	value: CameraInfo | null;
 	selectedLabel?: string | null;
 	isSelected?: boolean;
-	/** The selected camera is remembered but not currently connected. */
 	disconnected?: boolean;
 	onChange: (camera: CameraInfo | null) => void;
 	permissions?: OSPermissionsCheck;

--- a/apps/desktop/src/routes/(window-chrome)/new-main/CameraSelect.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/CameraSelect.tsx
@@ -35,6 +35,8 @@ export default function CameraSelect(props: {
 	value: CameraInfo | null;
 	selectedLabel?: string | null;
 	isSelected?: boolean;
+	/** The selected camera is remembered but not currently connected. */
+	disconnected?: boolean;
 	onChange: (camera: CameraInfo | null) => void;
 	permissions?: OSPermissionsCheck;
 	hidePreviewButton?: boolean;
@@ -93,6 +95,8 @@ export default function CameraSelect(props: {
 		props.permissions.camera === "granted" ||
 		props.permissions.camera === "notNeeded";
 
+	const notConnected = () => !!props.disconnected && permissionGranted();
+
 	const hasSelection = () => props.isSelected ?? props.value !== null;
 
 	const label = () =>
@@ -104,10 +108,14 @@ export default function CameraSelect(props: {
 		props.value !== null &&
 		permissionGranted() &&
 		!cameraWindowOpen() &&
-		!props.hidePreviewButton;
+		!props.hidePreviewButton &&
+		!notConnected();
 
 	const showSettingsShortcut = () =>
-		hasSelection() && permissionGranted() && !!props.onOpenSettings;
+		hasSelection() &&
+		permissionGranted() &&
+		!!props.onOpenSettings &&
+		!notConnected();
 
 	const isDisabled = () => !!currentRecording.data || props.disabled;
 
@@ -127,7 +135,12 @@ export default function CameraSelect(props: {
 				aria-haspopup="menu"
 			>
 				<IconCapCamera class={DEVICE_ROW_ICON_CLASS} />
-				<p class={DEVICE_ROW_LABEL_CLASS}>{label()}</p>
+				<p
+					class={cx(DEVICE_ROW_LABEL_CLASS, notConnected() && "text-gray-10")}
+					title={notConnected() ? "Not connected" : undefined}
+				>
+					{label()}
+				</p>
 				<div class={DEVICE_ROW_TRAILING_CLASS}>
 					<Show when={showHiddenIndicator()}>
 						<button
@@ -160,6 +173,7 @@ export default function CameraSelect(props: {
 					<TargetSelectInfoPill
 						PillComponent={InfoPill}
 						value={hasSelection() ? true : null}
+						disconnected={notConnected()}
 						permissionGranted={permissionGranted()}
 						requestPermission={() =>
 							requestPermission("camera", props.permissions?.camera)

--- a/apps/desktop/src/routes/(window-chrome)/new-main/MicrophoneSelect.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/MicrophoneSelect.tsx
@@ -27,7 +27,6 @@ export default function MicrophoneSelect(props: {
 	disabled?: boolean;
 	options: string[];
 	value: string | null;
-	/** The selected microphone is remembered but not currently connected. */
 	disconnected?: boolean;
 	onChange: (micName: string | null) => void;
 	permissions?: OSPermissionsCheck;

--- a/apps/desktop/src/routes/(window-chrome)/new-main/MicrophoneSelect.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/MicrophoneSelect.tsx
@@ -27,6 +27,8 @@ export default function MicrophoneSelect(props: {
 	disabled?: boolean;
 	options: string[];
 	value: string | null;
+	/** The selected microphone is remembered but not currently connected. */
+	disconnected?: boolean;
 	onChange: (micName: string | null) => void;
 	permissions?: OSPermissionsCheck;
 	onOpen?: () => void;
@@ -42,6 +44,8 @@ export default function MicrophoneSelect(props: {
 		props.permissions === undefined ||
 		props.permissions.microphone === "granted" ||
 		props.permissions.microphone === "notNeeded";
+
+	const notConnected = () => !!props.disconnected && permissionGranted();
 
 	const handleMicrophoneChange = async (name: string | null) => {
 		if (!props.options) return;
@@ -62,10 +66,14 @@ export default function MicrophoneSelect(props: {
 	const audioLevel = () =>
 		(1 - Math.max((dbs() ?? 0) + DB_SCALE, 0) / DB_SCALE) ** 0.5;
 
-	const showLevel = () => props.value !== null && dbs() !== undefined;
+	const showLevel = () =>
+		props.value !== null && dbs() !== undefined && !notConnected();
 
 	const showSettingsShortcut = () =>
-		props.value !== null && permissionGranted() && !!props.onOpenSettings;
+		props.value !== null &&
+		permissionGranted() &&
+		!!props.onOpenSettings &&
+		!notConnected();
 
 	const isDisabled = () => !!currentRecording.data || props.disabled;
 
@@ -95,7 +103,12 @@ export default function MicrophoneSelect(props: {
 					/>
 				</Show>
 				<IconCapMicrophone class={DEVICE_ROW_ICON_CLASS} />
-				<p class={DEVICE_ROW_LABEL_CLASS}>{props.value ?? NO_MICROPHONE}</p>
+				<p
+					class={cx(DEVICE_ROW_LABEL_CLASS, notConnected() && "text-gray-10")}
+					title={notConnected() ? "Not connected" : undefined}
+				>
+					{props.value ?? NO_MICROPHONE}
+				</p>
 				<div class={DEVICE_ROW_TRAILING_CLASS}>
 					<Show when={showSettingsShortcut()}>
 						<button
@@ -116,6 +129,7 @@ export default function MicrophoneSelect(props: {
 					<TargetSelectInfoPill
 						PillComponent={InfoPill}
 						value={props.value}
+						disconnected={notConnected()}
 						permissionGranted={permissionGranted()}
 						requestPermission={() =>
 							requestPermission("microphone", props.permissions?.microphone)

--- a/apps/desktop/src/routes/(window-chrome)/new-main/TargetSelectInfoPill.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/TargetSelectInfoPill.tsx
@@ -5,7 +5,6 @@ import type { InfoPillVariant } from "./InfoPill";
 export default function TargetSelectInfoPill<T>(props: {
 	value: T | null;
 	permissionGranted: boolean;
-	/** The selected device is remembered but not currently connected. */
 	disconnected?: boolean;
 	requestPermission: () => void;
 	onClick: (e: MouseEvent) => void;

--- a/apps/desktop/src/routes/(window-chrome)/new-main/TargetSelectInfoPill.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/TargetSelectInfoPill.tsx
@@ -5,6 +5,8 @@ import type { InfoPillVariant } from "./InfoPill";
 export default function TargetSelectInfoPill<T>(props: {
 	value: T | null;
 	permissionGranted: boolean;
+	/** The selected device is remembered but not currently connected. */
+	disconnected?: boolean;
 	requestPermission: () => void;
 	onClick: (e: MouseEvent) => void;
 	PillComponent: Component<
@@ -13,6 +15,7 @@ export default function TargetSelectInfoPill<T>(props: {
 }) {
 	const variant = (): InfoPillVariant => {
 		if (!props.permissionGranted) return "red";
+		if (props.disconnected) return "gray";
 		return props.value !== null ? "blue" : "gray";
 	};
 
@@ -35,7 +38,13 @@ export default function TargetSelectInfoPill<T>(props: {
 				props.onClick(e);
 			}}
 		>
-			{!props.permissionGranted ? "Allow" : props.value !== null ? "On" : "Off"}
+			{!props.permissionGranted
+				? "Allow"
+				: props.disconnected
+					? "Not connected"
+					: props.value !== null
+						? "On"
+						: "Off"}
 		</Dynamic>
 	);
 }

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -2691,6 +2691,17 @@ function Page() {
 		},
 		micName: () =>
 			devices.microphones.find((m) => m.name === rawOptions.micName),
+		// Selected-but-unplugged devices (e.g. undocked laptop): the selection is
+		// remembered, the row shows "Not connected", and the effects below
+		// re-apply the device when it reappears.
+		cameraDisconnected: () =>
+			rawOptions.cameraID != null &&
+			!devices.isPending &&
+			!findCamera(devices.cameras, rawOptions.cameraID),
+		micDisconnected: () =>
+			rawOptions.micName != null &&
+			!devices.isPending &&
+			!devices.microphones.some((m) => m.name === rawOptions.micName),
 		target: (): ScreenCaptureTarget | undefined => {
 			switch (rawOptions.captureTarget.variant) {
 				case "display": {
@@ -2717,6 +2728,52 @@ function Page() {
 			}
 		},
 	};
+
+	// Re-apply a remembered device when it reappears (e.g. plugging back into a
+	// dock). The mount-time restore quick-fails while the device is away, so
+	// without this the row would claim a device the backend isn't using.
+	let micPresence: { name: string; present: boolean } | undefined;
+	createEffect(() => {
+		const name = rawOptions.micName;
+		if (name == null || devices.isPending) {
+			micPresence = undefined;
+			return;
+		}
+		const present = devices.microphones.some((m) => m.name === name);
+		// Mid-recording device changes are the backend watcher's job; keep the
+		// last idle observation so the reclaim runs once the recording ends.
+		if (isRecording()) return;
+		const previous = micPresence;
+		micPresence = { name, present };
+		if (present && previous?.present === false && previous.name === name) {
+			commands
+				.setMicInput(name)
+				.catch((error) =>
+					console.error("Failed to restore reconnected microphone:", error),
+				);
+		}
+	});
+
+	let cameraPresence: { key: string; present: boolean } | undefined;
+	createEffect(() => {
+		const id = rawOptions.cameraID;
+		if (id == null || devices.isPending) {
+			cameraPresence = undefined;
+			return;
+		}
+		const key = JSON.stringify(id);
+		const present = !!findCamera(devices.cameras, id);
+		if (isRecording()) return;
+		const previous = cameraPresence;
+		cameraPresence = { key, present };
+		if (present && previous?.present === false && previous.key === key) {
+			commands
+				.setCameraInput(id, false)
+				.catch((error) =>
+					console.error("Failed to restore reconnected camera:", error),
+				);
+		}
+	});
 
 	const toggleTargetMode = async (
 		mode: "display" | "window" | "area" | "camera",
@@ -2875,6 +2932,7 @@ function Page() {
 					value={options.camera() ?? null}
 					selectedLabel={rawOptions.cameraLabel}
 					isSelected={rawOptions.cameraID != null}
+					disconnected={options.cameraDisconnected()}
 					onChange={(c) => {
 						if (!c) {
 							setOptions("cameraLabel", null);
@@ -2903,6 +2961,7 @@ function Page() {
 					disabled={enableDeviceQueries() && devices.isPending}
 					options={devices.microphones.map((m) => m.name)}
 					value={rawOptions.micName ?? null}
+					disconnected={options.micDisconnected()}
 					onChange={(v) => setMicInput.mutate(v)}
 					permissions={currentPermissions()}
 					onOpen={() => openMicrophoneMenu(null)}

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -142,6 +142,19 @@ const findCamera = (cameras: CameraWithDetails[], id: DeviceOrModelID) => {
 	});
 };
 
+// Must stay in sync with find_mic_by_label_or_fuzzy in src-tauri: Bluetooth
+// mics can reappear under a slightly different name (profile switch), and the
+// backend accepts case-insensitive containment in either direction.
+const findMicrophone = (microphones: MicrophoneWithDetails[], name: string) => {
+	const exact = microphones.find((m) => m.name === name);
+	if (exact) return exact;
+	const nameLower = name.toLowerCase();
+	return microphones.find((m) => {
+		const deviceLower = m.name.toLowerCase();
+		return deviceLower.includes(nameLower) || nameLower.includes(deviceLower);
+	});
+};
+
 type WindowListItem = Pick<
 	CaptureWindow,
 	"id" | "owner_name" | "name" | "bounds" | "refresh_rate"
@@ -2652,7 +2665,7 @@ function Page() {
 	createEffect(() => {
 		if (!microphoneMenuOpen() || !openMicrophoneSettingsWhenReady()) return;
 		const mic = rawOptions.micName
-			? devices.microphones.find((m) => m.name === rawOptions.micName)
+			? findMicrophone(devices.microphones, rawOptions.micName)
 			: undefined;
 		if (!mic) return;
 		setMicrophoneInitialSettings(mic);
@@ -2690,7 +2703,9 @@ function Page() {
 			return findCamera(devices.cameras, rawOptions.cameraID);
 		},
 		micName: () =>
-			devices.microphones.find((m) => m.name === rawOptions.micName),
+			rawOptions.micName != null
+				? findMicrophone(devices.microphones, rawOptions.micName)
+				: undefined,
 		// Selected-but-unplugged devices (e.g. undocked laptop): the selection is
 		// remembered, the row shows "Not connected", and the effects below
 		// re-apply the device when it reappears.
@@ -2701,7 +2716,7 @@ function Page() {
 		micDisconnected: () =>
 			rawOptions.micName != null &&
 			!devices.isPending &&
-			!devices.microphones.some((m) => m.name === rawOptions.micName),
+			!findMicrophone(devices.microphones, rawOptions.micName),
 		target: (): ScreenCaptureTarget | undefined => {
 			switch (rawOptions.captureTarget.variant) {
 				case "display": {
@@ -2739,15 +2754,25 @@ function Page() {
 			micPresence = undefined;
 			return;
 		}
-		const present = devices.microphones.some((m) => m.name === name);
+		const matched = findMicrophone(devices.microphones, name);
 		// Mid-recording device changes are the backend watcher's job; keep the
 		// last idle observation so the reclaim runs once the recording ends.
 		if (isRecording()) return;
 		const previous = micPresence;
-		micPresence = { name, present };
-		if (present && previous?.present === false && previous.name === name) {
+		micPresence = { name, present: !!matched };
+		const reappeared = previous?.present === false && previous.name === name;
+		if (matched && (reappeared || matched.name !== name)) {
+			// The feed rejects non-exact labels, so a fuzzy match (Bluetooth
+			// rename) must be applied under the connected device's name. The
+			// stored selection converges only after the backend accepts it,
+			// keeping a failed call from retriggering this effect.
+			const matchedName = matched.name;
 			commands
-				.setMicInput(name)
+				.setMicInput(matchedName)
+				.then(() => {
+					if (rawOptions.micName === name && matchedName !== name)
+						setOptions("micName", matchedName);
+				})
 				.catch((error) =>
 					console.error("Failed to restore reconnected microphone:", error),
 				);


### PR DESCRIPTION
Selecting a mic/camera, unplugging them (e.g. undocking a laptop), and relaunching left Cap in a stuck error state: the camera preview window flashed with a persistent "Camera unavailable" error on every launch and picker open, the device rows still showed the missing devices as On, and recording refused to start with "Selected camera is no longer available".

Device selections are now treated as remembered preferences resolved at use time:

- `set_mic_input` / `set_camera_input` quietly keep the selection when the device is not connected instead of running the show-window/retry/toast loop (same for the duplicate restore loop that ran on every main-window reveal).
- Recording start degrades instead of aborting: a missing camera or mic is skipped with a single "Recording without camera/microphone" notification. Camera-only mode still requires its camera. Bluetooth-renamed mics are fuzzy-matched at start instead of failing.
- Main-window rows show the device name with a gray "Not connected" pill instead of a blue "On", and hide the preview/settings shortcuts while disconnected.
- When the device reappears (re-dock), it is re-applied automatically via the existing selection path, restoring the mic meter and camera preview.

Device-present paths are unchanged. Validated with `cargo check`, `cargo test -p cap-desktop --lib` (141 passed), `tsc --noEmit`, and `vitest run` (91 passed).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR treats selected microphones and cameras as remembered preferences that may temporarily be unavailable.
- Recording now omits disconnected optional devices rather than aborting, while camera-only capture continues to require a camera.
- The main window marks unavailable selections as disconnected, hides unusable controls, and restores inputs when devices return.
- Frontend and backend microphone resolution now share fuzzy matching for Bluetooth profile-name changes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/lib.rs | Preserves unavailable device selections, releases idle feeds, and exposes consistent availability and fuzzy-matching helpers. |
| apps/desktop/src-tauri/src/recording.rs | Degrades recording startup gracefully when optional selected camera or microphone devices are unavailable. |
| apps/desktop/src-tauri/src/windows.rs | Avoids retrying camera initialization during main-window restoration when the remembered camera is disconnected. |
| apps/desktop/src/routes/(window-chrome)/new-main/index.tsx | Resolves Bluetooth microphone renames consistently, derives disconnected state, and reapplies devices after reconnection. |
| apps/desktop/src/routes/(window-chrome)/new-main/CameraSelect.tsx | Displays disconnected camera state and suppresses preview and settings shortcuts that cannot work. |
| apps/desktop/src/routes/(window-chrome)/new-main/MicrophoneSelect.tsx | Displays disconnected microphone state and suppresses stale level and settings controls. |
| apps/desktop/src/routes/(window-chrome)/new-main/TargetSelectInfoPill.tsx | Adds the gray Not connected presentation for remembered but unavailable devices. |

<sub>Reviews (2): Last reviewed commit: ["chore: drop redundant disconnected-prop ..."](https://github.com/capsoftware/cap/commit/c978fa938296a9de825bc9a05426d839fc5eaba0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51507997)</sub>

**Context used:**

- Knowledge Base — [Desktop Tauri App (Rust Backend)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-tauri-app.md)
- Knowledge Base — [Desktop Frontend (apps/desktop/src)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-frontend.md)

<!-- /greptile_comment -->