### PR TITLE
fix(windows): shut down IMFMediaSource deterministically to stop fatal 0xC000070A threadpool crash

### DIFF
--- a/crates/camera-mediafoundation/src/lib.rs
+++ b/crates/camera-mediafoundation/src/lib.rs
@@ -10,7 +10,10 @@ use std::{
     ops::{Deref, DerefMut},
     os::windows::ffi::OsStringExt,
     slice::from_raw_parts,
-    sync::mpsc::{Receiver, Sender, channel},
+    sync::{
+        Arc,
+        mpsc::{Receiver, Sender, channel},
+    },
     time::Duration,
 };
 use tracing::error;
@@ -18,7 +21,7 @@ use windows::Win32::{
     Foundation::{S_FALSE, *},
     Media::MediaFoundation::*,
     System::{
-        Com::{CLSCTX_INPROC_SERVER, CoCreateInstance, CoInitialize},
+        Com::{CLSCTX_INPROC_SERVER, CoCreateInstance, CoInitialize, CoTaskMemFree},
         Performance::QueryPerformanceCounter,
     },
 };
@@ -73,6 +76,19 @@ impl DeviceSourcesIterator {
     }
 }
 
+impl Drop for DeviceSourcesIterator {
+    fn drop(&mut self) {
+        // MFEnumDeviceSources allocates the IMFActivate array with CoTaskMemAlloc;
+        // the caller owns both the array and each element's reference.
+        unsafe {
+            for i in 0..self.count as usize {
+                std::ptr::drop_in_place(self.devices.add(i));
+            }
+            CoTaskMemFree(Some(self.devices.cast()));
+        }
+    }
+}
+
 impl Iterator for DeviceSourcesIterator {
     type Item = Device;
 
@@ -102,9 +118,28 @@ impl Iterator for DeviceSourcesIterator {
             };
 
             return Some(Device {
-                media_source,
+                media_source: media_source.clone(),
+                shutdown_guard: Arc::new(MediaSourceGuard(media_source)),
                 activate: device.clone(),
             });
+        }
+    }
+}
+
+/// Enforces Media Foundation's documented teardown contract:
+/// `IMFMediaSource::Shutdown()` must be called before the final COM release.
+///
+/// Without it, teardown only happens when the refcount hits zero, on whatever
+/// thread drops the last reference — which races the KS proxy's registered
+/// threadpool waits and kills the process with a non-catchable 0xC000070A
+/// (handle closed while a threadpool wait is still registered on it).
+struct MediaSourceGuard(IMFMediaSource);
+
+impl Drop for MediaSourceGuard {
+    fn drop(&mut self) {
+        // Shutting down an already-shut-down source returns an error; that's fine.
+        unsafe {
+            let _ = self.0.Shutdown();
         }
     }
 }
@@ -112,7 +147,11 @@ impl Iterator for DeviceSourcesIterator {
 #[derive(Clone)]
 pub struct Device {
     activate: IMFActivate,
-    pub media_source: IMFMediaSource,
+    media_source: IMFMediaSource,
+    /// Shared owner of the media source's shutdown. `Shutdown()` fires when the
+    /// last clone of this `Device` (and any `CaptureHandle` borrowing the
+    /// source) drops.
+    shutdown_guard: Arc<MediaSourceGuard>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -333,7 +372,11 @@ impl Device {
             wait_for_event(&event_rx, CaptureEngineEventVariant::PreviewStarted)
                 .map_err(|v| StartCapturingError::StartPreview(v.into()))?;
 
-            Ok(CaptureHandle { engine, event_rx })
+            Ok(CaptureHandle {
+                engine,
+                event_rx,
+                _source_guard: self.shutdown_guard.clone(),
+            })
         }
     }
 }
@@ -368,6 +411,9 @@ fn retry_on_invalid_request<T>(
 pub struct CaptureHandle {
     event_rx: Receiver<CaptureEngineEvent>,
     engine: IMFCaptureEngine,
+    /// Keeps the media source's shutdown deferred until capture ends, even if
+    /// the originating `Device` is dropped while capturing.
+    _source_guard: Arc<MediaSourceGuard>,
 }
 
 impl CaptureHandle {


### PR DESCRIPTION
Fixes the Windows crash reported in #2115.

### Problem

`0xC000070A` is ntdll's fatal threadpool assertion: a HANDLE was closed while a
threadpool wait was still registered on it. Full-dump analysis (see #2115) places the
dangling wait in Media Foundation's camera kernel-streaming layer (`mfksproxy.dll`,
`mf.dll`/`mfplat.dll` objects adjacent to the failed `TP_WAIT`).

Nothing in the repo ever calls `IMFMediaSource::Shutdown()`. Teardown is left to COM
refcount release, which runs on whatever thread drops the last reference and races the
KS proxy's registered waits. MF documents Shutdown-before-release as the required
teardown order for media sources.

Because camera enumeration runs continuously (`spawn_devices_snapshot_emitter` every
500ms→5s plus the frontend's 5s poll), fresh `IMFMediaSource` objects are created and
refcount-dropped several times a minute for the app's whole lifetime, so the race
window recurs constantly. On the reporting machine this crashed the app 9 times in
about an hour, including 4 seconds after launch, with no camera selected
(`cameraId: null`) — enumeration alone triggers it.

### Fix (`crates/camera-mediafoundation/src/lib.rs`)

1. `MediaSourceGuard` — RAII owner of the `IMFMediaSource` that calls `Shutdown()` on
   drop. Held as `Arc` by `Device` (which derives `Clone`), so shutdown fires exactly
   once, when the last clone drops.
2. `CaptureHandle` holds a clone of the guard, so a source cannot be shut down while a
   capture engine is still using it, even if the originating `Device` drops
   mid-capture.
3. `Drop for DeviceSourcesIterator` — releases each `IMFActivate` and frees the
   `MFEnumDeviceSources` array with `CoTaskMemFree`. Previously the array leaked on
   every enumeration (i.e. every few seconds, forever).

`media_source` also goes from `pub` field to private; external access already went
through `Deref`, so no callers change.

### Verification

- Before: stock 0.5.9 crashed 9× in ~1h on the reporting machine (Windows 11 26200,
  RTX 3070 laptop, one camera in PnP Error state — roster in #2115).
- After: a patched build on the same machine, same device roster (broken virtual
  camera re-enabled deliberately), survived multiple sessions including one ~3-hour
  session of active use (record → edit → export → idle) ending in a clean tray quit:
  zero unclean shutdowns, zero WER events, zero panics in captured logs. WER
  LocalDumps was armed at DumpType=2 the whole time and captured nothing.
- The two captured dumps show both failure flavors expected from this race
  (`STATUS_INVALID_HANDLE` when the slot is empty, `STATUS_ACCESS_DENIED` when the
  handle slot was recycled), consistent with close-while-registered.

Happy to split the iterator leak fix into its own commit if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes Windows Media Foundation camera-source teardown deterministic and fixes enumeration resource leaks.
- Adds an Arc-shared guard that calls IMFMediaSource::Shutdown when the last Device or CaptureHandle owner is released.
- Keeps the source alive throughout active capture.
- Releases IMFActivate entries and the MFEnumDeviceSources allocation when enumeration ends.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with deterministic source shutdown and enumeration cleanup correctly tied to existing ownership lifetimes.

The source remains owned through active capture, Shutdown runs before the guard’s final COM release, and iterator entries are cloned rather than moved so their new centralized cleanup does not double-release them.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/camera-mediafoundation/src/lib.rs | Adds coordinated media-source shutdown ownership and correct cleanup of Media Foundation device-enumeration allocations; no actionable changed-code defect was established. |

<sub>Reviews (1): Last reviewed commit: ["fix(windows): shut down IMFMediaSource d..."](https://github.com/capsoftware/cap/commit/fd1745144dcab3192bdb89bba4707c6776dc019a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52724682)</sub>

**Context used:**

- Knowledge Base — [Desktop Recording Capture Pipeline](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-recording-capture.md)

<!-- /greptile_comment -->