### PR TITLE
fix(web): emit share metadata on the verified custom domain

### DIFF
--- a/apps/web/__tests__/unit/share-video-metadata.test.ts
+++ b/apps/web/__tests__/unit/share-video-metadata.test.ts
@@ -22,6 +22,26 @@ describe("share video metadata", () => {
 		);
 	});
 
+	it("advertises a custom domain but keeps the player and oEmbed canonical", () => {
+		const urls = getShareVideoUrls({
+			videoId: "video123",
+			sourceType: "desktopMP4",
+			webUrl: "https://looms.example.com",
+			canonicalWebUrl: "https://cap.so",
+		});
+
+		expect(urls.shareUrl).toBe("https://looms.example.com/s/video123");
+		expect(urls.previewImageUrl).toContain("https://looms.example.com/");
+		expect(urls.ogImageUrl).toContain("https://looms.example.com/");
+		expect(urls.streamUrl).toContain("https://looms.example.com/");
+		// `/embed/` redirects off a custom domain and `/api/oembed` rejects a
+		// custom domain `url`, so both stay on the default origin.
+		expect(urls.playerUrl).toBe("https://cap.so/embed/video123");
+		expect(urls.oEmbedUrl).toBe(
+			"https://cap.so/api/oembed?url=https%3A%2F%2Fcap.so%2Fs%2Fvideo123&format=json",
+		);
+	});
+
 	it("emits video metadata used by Open Graph and Twitter players", () => {
 		const metadata = buildShareVideoMetadata({
 			videoId: "video123",

--- a/apps/web/__tests__/unit/share-web-url.test.ts
+++ b/apps/web/__tests__/unit/share-web-url.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+	isDefaultShareHostname,
+	requestShareHostname,
+} from "@/lib/share-web-url";
+
+const headersFrom = (init: Record<string, string>) => new Headers(init);
+
+describe("requestShareHostname", () => {
+	it("reads the host header", () => {
+		expect(requestShareHostname(headersFrom({ host: "cap.so" }))).toBe("cap.so");
+	});
+
+	it("prefers the forwarded host set by the proxy", () => {
+		const headers = headersFrom({
+			host: "cap-web.vercel.app",
+			"x-forwarded-host": "looms.example.com",
+		});
+
+		expect(requestShareHostname(headers)).toBe("looms.example.com");
+	});
+
+	it("takes the first entry of a forwarded host list", () => {
+		const headers = headersFrom({
+			"x-forwarded-host": "looms.example.com, cap.so",
+		});
+
+		expect(requestShareHostname(headers)).toBe("looms.example.com");
+	});
+
+	it("lowercases the host and drops the port", () => {
+		expect(requestShareHostname(headersFrom({ host: "LocalHost:3000" }))).toBe(
+			"localhost",
+		);
+	});
+
+	it("returns an empty string when no host header is present", () => {
+		expect(requestShareHostname(headersFrom({}))).toBe("");
+	});
+});
+
+describe("isDefaultShareHostname", () => {
+	it.each(["cap.so", "cap.link", "localhost", "127.0.0.1"])(
+		"treats %s as a default host",
+		(hostname) => {
+			expect(isDefaultShareHostname(hostname, "https://cap.so")).toBe(true);
+		},
+	);
+
+	it("matches the configured web URL host", () => {
+		expect(isDefaultShareHostname("cap.example.com", "https://cap.example.com")).toBe(
+			true,
+		);
+	});
+
+	it("rejects a custom domain", () => {
+		expect(isDefaultShareHostname("looms.example.com", "https://cap.so")).toBe(
+			false,
+		);
+	});
+
+	it("falls back to the default host when the host is missing", () => {
+		expect(isDefaultShareHostname("", "https://cap.so")).toBe(true);
+	});
+
+	it("falls back to the default host when the web URL is unparsable", () => {
+		expect(isDefaultShareHostname("looms.example.com", "not-a-url")).toBe(true);
+	});
+});

--- a/apps/web/__tests__/unit/share-web-url.test.ts
+++ b/apps/web/__tests__/unit/share-web-url.test.ts
@@ -8,7 +8,9 @@ const headersFrom = (init: Record<string, string>) => new Headers(init);
 
 describe("requestShareHostname", () => {
 	it("reads the host header", () => {
-		expect(requestShareHostname(headersFrom({ host: "cap.so" }))).toBe("cap.so");
+		expect(requestShareHostname(headersFrom({ host: "cap.so" }))).toBe(
+			"cap.so",
+		);
 	});
 
 	it("prefers the forwarded host set by the proxy", () => {
@@ -48,9 +50,20 @@ describe("isDefaultShareHostname", () => {
 	);
 
 	it("matches the configured web URL host", () => {
-		expect(isDefaultShareHostname("cap.example.com", "https://cap.example.com")).toBe(
-			true,
-		);
+		expect(
+			isDefaultShareHostname("cap.example.com", "https://cap.example.com"),
+		).toBe(true);
+	});
+
+	it.each([
+		["a bare deployment host", "cap-git-main.vercel.app"],
+		["a deployment host given as a URL", "https://cap-git-main.vercel.app"],
+	])("treats %s as a default host", (_label, deploymentHost) => {
+		expect(
+			isDefaultShareHostname("cap-git-main.vercel.app", "https://cap.so", [
+				deploymentHost,
+			]),
+		).toBe(true);
 	});
 
 	it("rejects a custom domain", () => {

--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -14,7 +14,7 @@ import {
 	videoUploads,
 } from "@cap/database/schema";
 import type { VideoMetadata } from "@cap/database/types";
-import { serverEnv } from "@cap/env";
+import { buildEnv, serverEnv } from "@cap/env";
 import { Logo } from "@cap/ui";
 import { userIsPro } from "@cap/utils";
 import {
@@ -262,6 +262,7 @@ export async function generateMetadata(
 							name: video.name,
 							sourceType: video.source.type,
 							webUrl,
+							canonicalWebUrl: buildEnv.NEXT_PUBLIC_WEB_URL,
 							advertiseIframelyPlayer: shouldAdvertiseIframelyPlayer,
 						}),
 						robots: canRenderSocialPreview

--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -14,7 +14,7 @@ import {
 	videoUploads,
 } from "@cap/database/schema";
 import type { VideoMetadata } from "@cap/database/types";
-import { buildEnv, serverEnv } from "@cap/env";
+import { serverEnv } from "@cap/env";
 import { Logo } from "@cap/ui";
 import { userIsPro } from "@cap/utils";
 import {
@@ -56,6 +56,7 @@ import * as EffectRuntime from "@/lib/server";
 import { runPromise } from "@/lib/server";
 import { getSharePageBranding } from "@/lib/share-branding";
 import { buildShareVideoMetadata } from "@/lib/share-video-metadata";
+import { resolveShareWebUrl } from "@/lib/share-web-url";
 import {
 	isIframelyCrawlerUserAgent,
 	isSocialCrawlerUserAgent,
@@ -235,6 +236,13 @@ export async function generateMetadata(
 	const shouldAdvertiseIframelyPlayer =
 		isIframelyCrawlerUserAgent(requestUserAgent) &&
 		(await getPublicShareVideo(videoId).catch(() => null)) !== null;
+	// Share pages also serve verified custom domains. Metadata has to point at
+	// the host the visitor used, or Slack drops the preview image.
+	const webUrl = await resolveShareWebUrl(headersList);
+	const ogImageUrl = new URL(
+		`/api/video/og?videoId=${videoId}`,
+		webUrl,
+	).toString();
 
 	return Effect.flatMap(Videos, (v) => v.getByIdForViewing(videoId)).pipe(
 		Effect.map(
@@ -253,7 +261,7 @@ export async function generateMetadata(
 							videoId,
 							name: video.name,
 							sourceType: video.source.type,
-							webUrl: buildEnv.NEXT_PUBLIC_WEB_URL,
+							webUrl,
 							advertiseIframelyPlayer: shouldAdvertiseIframelyPlayer,
 						}),
 						robots: canRenderSocialPreview
@@ -269,16 +277,7 @@ export async function generateMetadata(
 					title: "Cap: This video is restricted",
 					description: "This video has restricted access.",
 					openGraph: {
-						images: [
-							{
-								url: new URL(
-									`/api/video/og?videoId=${videoId}`,
-									buildEnv.NEXT_PUBLIC_WEB_URL,
-								).toString(),
-								width: 1200,
-								height: 630,
-							},
-						],
+						images: [{ url: ogImageUrl, width: 1200, height: 630 }],
 					},
 					robots: "noindex, nofollow",
 				}),
@@ -287,27 +286,13 @@ export async function generateMetadata(
 					title: "Cap: Password Protected Video",
 					description: "This video is password protected.",
 					openGraph: {
-						images: [
-							{
-								url: new URL(
-									`/api/video/og?videoId=${videoId}`,
-									buildEnv.NEXT_PUBLIC_WEB_URL,
-								).toString(),
-								width: 1200,
-								height: 630,
-							},
-						],
+						images: [{ url: ogImageUrl, width: 1200, height: 630 }],
 					},
 					twitter: {
 						card: "summary_large_image",
 						title: "Cap: Password Protected Video",
 						description: "This video is password protected.",
-						images: [
-							new URL(
-								`/api/video/og?videoId=${videoId}`,
-								buildEnv.NEXT_PUBLIC_WEB_URL,
-							).toString(),
-						],
+						images: [ogImageUrl],
 					},
 					robots: "noindex, nofollow",
 				}),

--- a/apps/web/lib/share-video-metadata.ts
+++ b/apps/web/lib/share-video-metadata.ts
@@ -14,13 +14,12 @@ export type ShareVideoMetadataInput = {
 	videoId: string;
 	name: string;
 	sourceType: ShareVideoSourceType;
-	/** The origin the visitor used. A verified custom domain, or the default. */
 	webUrl: string;
 	/**
-	 * The default Cap origin. Two surfaces only answer there: `proxy.ts`
-	 * redirects `/embed/` away from a custom domain, and `parseCapShareUrl`
-	 * accepts share URLs on `cap.so` and `cap.link` alone, so `/api/oembed`
-	 * rejects a custom domain `url`. Defaults to `webUrl`.
+	 * Two surfaces only answer on the default Cap origin: `proxy.ts` redirects
+	 * `/embed/` away from a custom domain, and `parseCapShareUrl` accepts share
+	 * URLs on `cap.so` and `cap.link` alone, so `/api/oembed` rejects a custom
+	 * domain `url`. Defaults to `webUrl`.
 	 */
 	canonicalWebUrl?: string;
 	advertiseIframelyPlayer?: boolean;

--- a/apps/web/lib/share-video-metadata.ts
+++ b/apps/web/lib/share-video-metadata.ts
@@ -14,7 +14,15 @@ export type ShareVideoMetadataInput = {
 	videoId: string;
 	name: string;
 	sourceType: ShareVideoSourceType;
+	/** The origin the visitor used. A verified custom domain, or the default. */
 	webUrl: string;
+	/**
+	 * The default Cap origin. Two surfaces only answer there: `proxy.ts`
+	 * redirects `/embed/` away from a custom domain, and `parseCapShareUrl`
+	 * accepts share URLs on `cap.so` and `cap.link` alone, so `/api/oembed`
+	 * rejects a custom domain `url`. Defaults to `webUrl`.
+	 */
+	canonicalWebUrl?: string;
 	advertiseIframelyPlayer?: boolean;
 };
 
@@ -22,9 +30,17 @@ export const getShareVideoUrls = ({
 	videoId,
 	sourceType,
 	webUrl,
-}: Pick<ShareVideoMetadataInput, "videoId" | "sourceType" | "webUrl">) => {
+	canonicalWebUrl = webUrl,
+}: Pick<
+	ShareVideoMetadataInput,
+	"videoId" | "sourceType" | "webUrl" | "canonicalWebUrl"
+>) => {
 	const shareUrl = new URL(`/s/${videoId}`, webUrl).toString();
-	const playerUrl = new URL(`/embed/${videoId}`, webUrl).toString();
+	const canonicalShareUrl = new URL(
+		`/s/${videoId}`,
+		canonicalWebUrl,
+	).toString();
+	const playerUrl = new URL(`/embed/${videoId}`, canonicalWebUrl).toString();
 	const streamUrl = new URL("/api/playlist", webUrl);
 	streamUrl.searchParams.set("videoId", videoId);
 	let streamContentType = "application/vnd.apple.mpegurl";
@@ -42,8 +58,8 @@ export const getShareVideoUrls = ({
 	previewImageUrl.searchParams.set("fallback", "og");
 	const ogImageUrl = new URL("/api/video/og", webUrl);
 	ogImageUrl.searchParams.set("videoId", videoId);
-	const oEmbedUrl = new URL("/api/oembed", webUrl);
-	oEmbedUrl.searchParams.set("url", shareUrl);
+	const oEmbedUrl = new URL("/api/oembed", canonicalWebUrl);
+	oEmbedUrl.searchParams.set("url", canonicalShareUrl);
 	oEmbedUrl.searchParams.set("format", "json");
 
 	return {
@@ -62,9 +78,15 @@ export const buildShareVideoMetadata = ({
 	name,
 	sourceType,
 	webUrl,
+	canonicalWebUrl,
 	advertiseIframelyPlayer = false,
 }: ShareVideoMetadataInput): Metadata => {
-	const urls = getShareVideoUrls({ videoId, sourceType, webUrl });
+	const urls = getShareVideoUrls({
+		videoId,
+		sourceType,
+		webUrl,
+		canonicalWebUrl,
+	});
 	const title = `${name} | Cap Recording`;
 	const description = "Watch this video on Cap";
 

--- a/apps/web/lib/share-web-url.ts
+++ b/apps/web/lib/share-web-url.ts
@@ -1,0 +1,75 @@
+import { db } from "@cap/database";
+import { organizations } from "@cap/database/schema";
+import { buildEnv } from "@cap/env";
+import { eq } from "drizzle-orm";
+
+/**
+ * Hosts that always serve the default web URL, even when they do not match
+ * `NEXT_PUBLIC_WEB_URL` (preview deployments run on the same origins).
+ */
+const DEFAULT_HOSTNAMES = ["cap.so", "cap.link", "localhost", "127.0.0.1"];
+
+const normalizeHostname = (value: string | null | undefined) => {
+	const first = value?.split(",")[0]?.trim().toLowerCase();
+	if (!first) return "";
+	// Strip the port so `localhost:3000` still matches `localhost`.
+	return first.replace(/:\d+$/, "");
+};
+
+/** The hostname the visitor asked for, taken from the incoming request. */
+export const requestShareHostname = (headersList: Headers) =>
+	normalizeHostname(
+		headersList.get("x-forwarded-host") ?? headersList.get("host"),
+	);
+
+/**
+ * True when the request arrived on the default Cap origin, so share metadata
+ * can use `NEXT_PUBLIC_WEB_URL` without a database lookup.
+ */
+export const isDefaultShareHostname = (
+	hostname: string,
+	defaultWebUrl: string,
+) => {
+	if (!hostname) return true;
+	if (DEFAULT_HOSTNAMES.includes(hostname)) return true;
+	try {
+		return new URL(defaultWebUrl).hostname.toLowerCase() === hostname;
+	} catch {
+		return true;
+	}
+};
+
+/**
+ * The public origin that share metadata must advertise.
+ *
+ * A share page on a verified custom domain has to emit `og:url`, `og:image`,
+ * `og:video` and `canonical` on that same domain. Slack drops the preview
+ * image when those values point at another host, so a custom domain link
+ * unfurls as a bare title and description.
+ *
+ * `proxy.ts` already redirects unverified hosts away from `/s/`, so this
+ * lookup is a second check rather than the only one. It returns the default
+ * web URL whenever the host is unknown, unverified, or the query fails.
+ */
+export const resolveShareWebUrl = async (
+	headersList: Headers,
+): Promise<string> => {
+	const defaultWebUrl = buildEnv.NEXT_PUBLIC_WEB_URL;
+	const hostname = requestShareHostname(headersList);
+
+	if (isDefaultShareHostname(hostname, defaultWebUrl)) return defaultWebUrl;
+
+	try {
+		const [organization] = await db()
+			.select({ domainVerified: organizations.domainVerified })
+			.from(organizations)
+			.where(eq(organizations.customDomain, hostname))
+			.limit(1);
+
+		if (!organization?.domainVerified) return defaultWebUrl;
+		return `https://${hostname}`;
+	} catch (error) {
+		console.error("Failed to resolve custom domain for share metadata", error);
+		return defaultWebUrl;
+	}
+};

--- a/apps/web/lib/share-web-url.ts
+++ b/apps/web/lib/share-web-url.ts
@@ -3,20 +3,15 @@ import { organizations } from "@cap/database/schema";
 import { buildEnv, serverEnv } from "@cap/env";
 import { eq } from "drizzle-orm";
 
-/**
- * Hosts that never belong to a customer, so they skip the lookup below.
- * `proxy.ts` treats the same set as a main origin.
- */
 const DEFAULT_HOSTNAMES = ["cap.so", "cap.link", "localhost", "127.0.0.1"];
 
 const normalizeHostname = (value: string | null | undefined) => {
 	const first = value?.split(",")[0]?.trim().toLowerCase();
 	if (!first) return "";
-	// Strip the port so `localhost:3000` still matches `localhost`.
 	return first.replace(/:\d+$/, "");
 };
 
-/** Accepts a bare host (`cap-git-x.vercel.app`) or a full URL. */
+// `WEB_URL` is a full URL while the `VERCEL_*_HOST` values are bare hosts.
 const toHostname = (value: string) => {
 	try {
 		return new URL(value).hostname.toLowerCase();
@@ -25,16 +20,11 @@ const toHostname = (value: string) => {
 	}
 };
 
-/** The hostname the visitor asked for, taken from the incoming request. */
 export const requestShareHostname = (headersList: Headers) =>
 	normalizeHostname(
 		headersList.get("x-forwarded-host") ?? headersList.get("host"),
 	);
 
-/**
- * True when the request arrived on the default Cap origin, so share metadata
- * can use `NEXT_PUBLIC_WEB_URL` without a database lookup.
- */
 export const isDefaultShareHostname = (
 	hostname: string,
 	defaultWebUrl: string,
@@ -52,11 +42,8 @@ export const isDefaultShareHostname = (
 	}
 };
 
-/**
- * The deployment origins that `proxy.ts` treats as main origins. They never
- * belong to a customer, so recognizing them skips a pointless query on every
- * preview deployment.
- */
+// Mirrors the `mainOrigins` list in `proxy.ts`, so a preview deployment does
+// not pay for the organization lookup below.
 const deploymentHostnames = (): string[] => {
 	try {
 		const env = serverEnv();
@@ -72,16 +59,13 @@ const deploymentHostnames = (): string[] => {
 };
 
 /**
- * The public origin that share metadata must advertise.
+ * Slack drops the preview image when `og:url` names a different host than the
+ * link it unfurls, so a share page on a verified custom domain has to advertise
+ * that domain rather than `NEXT_PUBLIC_WEB_URL`. See #2122.
  *
- * A share page on a verified custom domain has to emit `og:url`, `og:image`,
- * `og:video` and `canonical` on that same domain. Slack drops the preview
- * image when those values point at another host, so a custom domain link
- * unfurls as a bare title and description.
- *
- * `proxy.ts` already redirects unverified hosts away from `/s/`, so this
- * lookup is a second check rather than the only one. It returns the default
- * web URL whenever the host is unknown, unverified, or the query fails.
+ * `proxy.ts` already redirects unverified hosts away from `/s/`. This lookup is
+ * a second check, and it falls back whenever the host is unknown, unverified,
+ * or the query throws.
  */
 export const resolveShareWebUrl = async (
 	headersList: Headers,

--- a/apps/web/lib/share-web-url.ts
+++ b/apps/web/lib/share-web-url.ts
@@ -1,11 +1,11 @@
 import { db } from "@cap/database";
 import { organizations } from "@cap/database/schema";
-import { buildEnv } from "@cap/env";
+import { buildEnv, serverEnv } from "@cap/env";
 import { eq } from "drizzle-orm";
 
 /**
- * Hosts that always serve the default web URL, even when they do not match
- * `NEXT_PUBLIC_WEB_URL` (preview deployments run on the same origins).
+ * Hosts that never belong to a customer, so they skip the lookup below.
+ * `proxy.ts` treats the same set as a main origin.
  */
 const DEFAULT_HOSTNAMES = ["cap.so", "cap.link", "localhost", "127.0.0.1"];
 
@@ -14,6 +14,15 @@ const normalizeHostname = (value: string | null | undefined) => {
 	if (!first) return "";
 	// Strip the port so `localhost:3000` still matches `localhost`.
 	return first.replace(/:\d+$/, "");
+};
+
+/** Accepts a bare host (`cap-git-x.vercel.app`) or a full URL. */
+const toHostname = (value: string) => {
+	try {
+		return new URL(value).hostname.toLowerCase();
+	} catch {
+		return normalizeHostname(value);
+	}
 };
 
 /** The hostname the visitor asked for, taken from the incoming request. */
@@ -29,13 +38,36 @@ export const requestShareHostname = (headersList: Headers) =>
 export const isDefaultShareHostname = (
 	hostname: string,
 	defaultWebUrl: string,
+	deploymentHostnames: readonly string[] = [],
 ) => {
 	if (!hostname) return true;
 	if (DEFAULT_HOSTNAMES.includes(hostname)) return true;
+	if (deploymentHostnames.some((value) => toHostname(value) === hostname))
+		return true;
 	try {
 		return new URL(defaultWebUrl).hostname.toLowerCase() === hostname;
 	} catch {
+		// A misconfigured origin must not promote the request host.
 		return true;
+	}
+};
+
+/**
+ * The deployment origins that `proxy.ts` treats as main origins. They never
+ * belong to a customer, so recognizing them skips a pointless query on every
+ * preview deployment.
+ */
+const deploymentHostnames = (): string[] => {
+	try {
+		const env = serverEnv();
+		return [
+			env.WEB_URL,
+			env.VERCEL_URL_HOST,
+			env.VERCEL_BRANCH_URL_HOST,
+			env.VERCEL_PROJECT_PRODUCTION_URL_HOST,
+		].filter((value): value is string => Boolean(value));
+	} catch {
+		return [];
 	}
 };
 
@@ -57,7 +89,8 @@ export const resolveShareWebUrl = async (
 	const defaultWebUrl = buildEnv.NEXT_PUBLIC_WEB_URL;
 	const hostname = requestShareHostname(headersList);
 
-	if (isDefaultShareHostname(hostname, defaultWebUrl)) return defaultWebUrl;
+	if (isDefaultShareHostname(hostname, defaultWebUrl, deploymentHostnames()))
+		return defaultWebUrl;
 
 	try {
 		const [organization] = await db()


### PR DESCRIPTION
Fixes #2122

## The problem

A share page on a verified custom domain builds every absolute URL from `NEXT_PUBLIC_WEB_URL`. The page therefore advertises `cap.so` while the visitor is on the custom domain. Slack drops the preview image when `og:url` names a different host than the link it unfurls, so the same recording renders two different cards.

Both hosts return byte-identical tags today:

```
<meta property="og:url"   content="https://cap.so/s/<id>"/>
<meta property="og:image" content="https://cap.so/api/video/preview?videoId=<id>&fallback=og"/>
<meta property="og:video" content="https://cap.so/api/playlist?videoId=<id>&videoType=mp4"/>
<link rel="canonical"     href="https://cap.so/s/<id>"/>
```

The image endpoints already work on the custom domain. `https://<custom-domain>/api/video/og?videoId=<id>` returns HTTP 200 and `image/png`. Only the advertised URLs were wrong.

The Cap Slack app cannot cover this. `apps/web/slack-app-manifest.json` registers `unfurl_domains` as `cap.so` and `cap.link`, so a custom domain link always falls back to the generic Slack crawler. Open Graph metadata is the only preview path those links have.

## The cause

`generateMetadata` never learns the request host.

1. `apps/web/app/s/[videoId]/page.tsx:256` passed `webUrl: buildEnv.NEXT_PUBLIC_WEB_URL` into `buildShareVideoMetadata`.
2. The `PolicyDenied` and `VerifyVideoPasswordError` branches repeated the same constant.
3. The page component resolves `customDomain` further down, but the result feeds the UI, not the metadata.

## The change

`apps/web/lib/share-web-url.ts` resolves the origin to advertise:

1. Read the host from `x-forwarded-host`, then `host`.
2. Return `NEXT_PUBLIC_WEB_URL` for `cap.so`, `cap.link`, localhost, the configured web URL, and the deployment hosts `proxy.ts` lists as main origins.
3. Otherwise match the host against `organizations.customDomain` and require `domainVerified`.
4. Return `NEXT_PUBLIC_WEB_URL` whenever the host is unknown, unverified, or the query throws.

`generateMetadata` then passes that value through all three branches.

## Two surfaces stay on the default origin

`getShareVideoUrls` takes an optional `canonicalWebUrl` because two endpoints only answer on the default Cap origin. I checked both against a live verified custom domain:

|Request on a custom domain|Result|
|-|-|
|`/api/video/og`, `/api/video/preview`|200, or 302 to the signed CDN URL|
|`/api/playlist`|302 to the signed CDN URL|
|`/embed/<id>`|307 to `cap.so`, sent by `proxy.ts:89`|
|`/api/oembed?url=https://<custom-domain>/s/<id>`|400, `parseCapShareUrl` accepts `cap.so` and `cap.link` alone|

So `og:url`, `canonical`, both images and the stream move to the request host. The Twitter and Iframely player URL, the oEmbed endpoint, and the oEmbed `url` parameter stay canonical. Widening `/embed/` and `parseCapShareUrl` to accept verified custom domains would remove that split, and I am happy to follow up if you want it.

## Security

The host alone decides nothing. It has to match a row in `organizations.customDomain` with `domainVerified` set, so an unknown or spoofed host falls back to `NEXT_PUBLIC_WEB_URL`. The lookup is an indexed point read on `custom_domain_idx`, and it runs only for hosts that are not already a main origin. `generateMetadata` calls `headers()`, which keeps the route dynamic, so there is no shared-cache path that could serve a custom domain response to a `cap.so` visitor.

## Verification

1. `pnpm exec tsc -p apps/web/tsconfig.json --noEmit` passes with 0 errors, after `next typegen`.
2. `apps/web` unit tests pass, 22 of 22 across the two touched files.
3. `biome ci` is clean on all five changed files.
4. Endpoint behavior in the table above comes from live requests, not from reading the code.

One repo-wide `biome ci` failure exists in `apps/web/actions/loom.ts`. That file is untouched here and already fails on `main`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes share-page metadata advertise a verified custom domain while retaining the default Cap origin for embed and oEmbed surfaces that do not support custom-domain URLs.
- Adds request-host normalization and verified custom-domain resolution with safe fallback to the configured web origin.
- Propagates the resolved origin through normal, restricted, and password-protected metadata branches.
- Separates custom-domain share, image, and stream URLs from canonical player and oEmbed URLs.
- Adds focused unit coverage for hostname resolution and metadata URL generation.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only non-blocking cleanup needed for redundant helper comments.

The custom-domain origin is gated by an exact verified-organization lookup, API metadata endpoints remain reachable on custom domains, and unsupported embed and oEmbed surfaces stay on the configured Cap origin.

**Files Needing Attention:** apps/web/lib/share-web-url.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/lib/share-web-url.ts | Adds verified request-host resolution with default-origin fallback; behavior is sound, but several new comments violate the repository’s no-narrative-comments guidance. |
| apps/web/lib/share-video-metadata.ts | Separates the visitor-facing metadata origin from the default origin required by embed and oEmbed endpoints. |
| apps/web/app/s/[videoId]/page.tsx | Resolves the request-specific share origin once and applies it consistently across successful and access-denied metadata branches. |
| apps/web/__tests__/unit/share-web-url.test.ts | Covers forwarded-host precedence, normalization, missing hosts, deployment origins, and fallback behavior. |
| apps/web/__tests__/unit/share-video-metadata.test.ts | Verifies that custom-domain metadata retains canonical Cap URLs for player and oEmbed surfaces. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/lib/share-web-url.ts:25
**Remove narrative helper comments**

The new JSDoc comments above `toHostname`, `requestShareHostname`, `isDefaultShareHostname`, and `deploymentHostnames` restate their names, signatures, or immediately visible behavior. This conflicts with the repository’s comments policy and adds documentation that can drift without preserving non-obvious context.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): keep the player and oEmbed URL..."](https://github.com/capsoftware/cap/commit/df7ed26d58c71d1928abfba011981359abfd680f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53282196)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/capsoftware/cap/blob/main/AGENTS.md))
- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-app.md)

<!-- /greptile_comment -->