### PR TITLE
Fix broken demo video on SEO pages: use the homepage hero embed

### DIFF
--- a/apps/web/components/pages/seo/AsyncVideoCodeReviewsPage.tsx
+++ b/apps/web/components/pages/seo/AsyncVideoCodeReviewsPage.tsx
@@ -276,9 +276,10 @@ export const asyncVideoCodeReviewsContent: SeoPageContent = {
 	],
 
 	video: {
-		url: "/videos/cap-demo.mp4",
-		thumbnail: "/videos/cap-demo-thumbnail.png",
-		alt: "Cap async video code review demo showing screen recording of a pull request walkthrough with timestamped comments",
+		iframe: {
+			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
+			title: "Cap async video code review demo showing screen recording of a pull request walkthrough with timestamped comments",
+		},
 	},
 
 	cta: {

--- a/apps/web/components/pages/seo/BestScreenRecorderPage.tsx
+++ b/apps/web/components/pages/seo/BestScreenRecorderPage.tsx
@@ -252,9 +252,10 @@ export const bestScreenRecorderContent: SeoPageContent = {
 	],
 
 	video: {
-		url: "/videos/cap-demo.mp4",
-		thumbnail: "/videos/cap-demo-thumbnail.png",
-		alt: "Cap screen recorder demo showing 4K capture, webcam overlay, and instant sharing",
+		iframe: {
+			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
+			title: "Cap screen recorder demo showing 4K capture, webcam overlay, and instant sharing",
+		},
 	},
 
 	cta: {

--- a/apps/web/components/pages/seo/DeveloperDocumentationVideosPage.tsx
+++ b/apps/web/components/pages/seo/DeveloperDocumentationVideosPage.tsx
@@ -275,9 +275,10 @@ export const developerDocumentationVideosContent: SeoPageContent = {
 	],
 
 	video: {
-		url: "/videos/cap-demo.mp4",
-		thumbnail: "/videos/cap-demo-thumbnail.png",
-		alt: "Cap developer documentation video demo showing screen recording of an API walkthrough with narration and instant share link",
+		iframe: {
+			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
+			title: "Cap developer documentation video demo showing screen recording of an API walkthrough with narration and instant share link",
+		},
 	},
 
 	cta: {

--- a/apps/web/components/pages/seo/HipaaCompliantScreenRecordingPage.tsx
+++ b/apps/web/components/pages/seo/HipaaCompliantScreenRecordingPage.tsx
@@ -283,9 +283,10 @@ export const hipaaCompliantScreenRecordingContent: SeoPageContent = {
 	],
 
 	video: {
-		url: "/videos/cap-demo.mp4",
-		thumbnail: "/videos/cap-demo-thumbnail.png",
-		alt: "Cap HIPAA-compliant screen recording demo showing self-hosted storage configuration and secure sharing",
+		iframe: {
+			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
+			title: "Cap HIPAA-compliant screen recording demo showing self-hosted storage configuration and secure sharing",
+		},
 	},
 
 	cta: {

--- a/apps/web/components/pages/seo/HowToScreenRecordPage.tsx
+++ b/apps/web/components/pages/seo/HowToScreenRecordPage.tsx
@@ -212,9 +212,10 @@ export const howToScreenRecordContent: SeoPageContent = {
 	],
 
 	video: {
-		url: "/videos/cap-demo.mp4",
-		thumbnail: "/videos/cap-demo-thumbnail.png",
-		alt: "How to screen record with Cap on Mac and Windows",
+		iframe: {
+			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
+			title: "How to screen record with Cap on Mac and Windows",
+		},
 	},
 
 	cta: {

--- a/apps/web/components/pages/seo/MacScreenRecordingWithAudioPage.tsx
+++ b/apps/web/components/pages/seo/MacScreenRecordingWithAudioPage.tsx
@@ -269,9 +269,10 @@ export const macScreenRecordingWithAudioContent: SeoPageContent = {
 	],
 
 	video: {
-		url: "/videos/cap-demo.mp4",
-		thumbnail: "/videos/cap-demo-thumbnail.png",
-		alt: "Cap recording Mac screen with system audio and microphone simultaneously",
+		iframe: {
+			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
+			title: "Cap recording Mac screen with system audio and microphone simultaneously",
+		},
 	},
 
 	cta: {

--- a/apps/web/components/pages/seo/ObsAlternativePage.tsx
+++ b/apps/web/components/pages/seo/ObsAlternativePage.tsx
@@ -281,9 +281,10 @@ export const obsAlternativeContent: SeoPageContent = {
 	],
 
 	video: {
-		url: "/videos/cap-demo.mp4",
-		thumbnail: "/videos/cap-demo-thumbnail.png",
-		alt: "Cap OBS alternative demo showing instant recording and sharing",
+		iframe: {
+			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
+			title: "Cap OBS alternative demo showing instant recording and sharing",
+		},
 	},
 
 	cta: {

--- a/apps/web/components/pages/seo/OpenSourceScreenRecorderPage.tsx
+++ b/apps/web/components/pages/seo/OpenSourceScreenRecorderPage.tsx
@@ -253,9 +253,10 @@ export const openSourceScreenRecorderContent: SeoPageContent = {
 	],
 
 	video: {
-		url: "/videos/cap-demo.mp4",
-		thumbnail: "/videos/cap-demo-thumbnail.png",
-		alt: "Cap open source screen recorder demo showing recording, sharing, and self-hosting",
+		iframe: {
+			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
+			title: "Cap open source screen recorder demo showing recording, sharing, and self-hosting",
+		},
 	},
 
 	cta: {

--- a/apps/web/components/pages/seo/RecordScreenPage.tsx
+++ b/apps/web/components/pages/seo/RecordScreenPage.tsx
@@ -245,9 +245,10 @@ export const recordScreenContent: SeoPageContent = {
 	],
 
 	video: {
-		url: "/videos/cap-demo.mp4",
-		thumbnail: "/videos/cap-demo-thumbnail.png",
-		alt: "Cap screen recording demo showing one-click capture, webcam overlay, and instant sharing",
+		iframe: {
+			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
+			title: "Cap screen recording demo showing one-click capture, webcam overlay, and instant sharing",
+		},
 	},
 
 	cta: {

--- a/apps/web/components/pages/seo/ScreenRecorderPage.tsx
+++ b/apps/web/components/pages/seo/ScreenRecorderPage.tsx
@@ -105,9 +105,10 @@ export const screenRecorderContent: SeoPageContent = {
 	],
 
 	video: {
-		url: "/videos/cap-demo.mp4",
-		thumbnail: "/videos/cap-demo-thumbnail.png",
-		alt: "Cap screen recorder demo showing high-quality and user-friendly features",
+		iframe: {
+			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
+			title: "Cap screen recorder demo showing high-quality and user-friendly features",
+		},
 	},
 
 	cta: {

--- a/apps/web/components/pages/seo/ScreenRecordingPage.tsx
+++ b/apps/web/components/pages/seo/ScreenRecordingPage.tsx
@@ -189,9 +189,10 @@ export const screenRecordingContent: SeoPageContent = {
 	],
 
 	video: {
-		url: "/videos/cap-demo.mp4",
-		thumbnail: "/videos/cap-demo-thumbnail.png",
-		alt: "Cap screen recording demo showing HD capture, webcam overlay, and instant sharing",
+		iframe: {
+			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
+			title: "Cap screen recording demo showing HD capture, webcam overlay, and instant sharing",
+		},
 	},
 
 	cta: {

--- a/apps/web/components/pages/seo/SelfHostedScreenRecordingPage.tsx
+++ b/apps/web/components/pages/seo/SelfHostedScreenRecordingPage.tsx
@@ -271,9 +271,10 @@ export const selfHostedScreenRecordingContent: SeoPageContent = {
 	],
 
 	video: {
-		url: "/videos/cap-demo.mp4",
-		thumbnail: "/videos/cap-demo-thumbnail.png",
-		alt: "Cap self-hosted screen recording demo showing S3 storage configuration and instant sharing",
+		iframe: {
+			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
+			title: "Cap self-hosted screen recording demo showing S3 storage configuration and instant sharing",
+		},
 	},
 
 	cta: {

--- a/apps/web/components/pages/seo/VideoRecordingSoftwarePage.tsx
+++ b/apps/web/components/pages/seo/VideoRecordingSoftwarePage.tsx
@@ -252,9 +252,10 @@ export const videoRecordingSoftwareContent: SeoPageContent = {
 	],
 
 	video: {
-		url: "/videos/cap-demo.mp4",
-		thumbnail: "/videos/cap-demo-thumbnail.png",
-		alt: "Cap video recording software demo showing HD screen capture, webcam overlay, and instant sharing",
+		iframe: {
+			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
+			title: "Cap video recording software demo showing HD screen capture, webcam overlay, and instant sharing",
+		},
 	},
 
 	cta: {


### PR DESCRIPTION
The "See Cap in Action" sections on 13 SEO pages pointed at /videos/cap-demo.mp4 and /videos/cap-demo-thumbnail.png, but public/videos/ does not exist, so every one of them rendered a broken player.

This swaps each page's video block to the same rend.so embed the homepage hero modal uses (embed 10512af0-b922-4efa-8974-f8f14fc1886a with the brand accent), via the iframe shape SeoPageTemplate already supports. The modal-only autoplay/mute params are omitted since these embeds render inline.

Pages fixed: async-video-code-reviews, best-screen-recorder, developer-documentation-videos, hipaa-compliant-screen-recording, how-to-screen-record, mac-screen-recording-with-audio, obs-alternative, open-source-screen-recorder, record-screen, screen-recorder, screen-recording, self-hosted-screen-recording, video-recording-software.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces broken local demo-video references on 13 public SEO landing pages with the rend.so embed already used by the homepage.
- Migrates each page from `url`/`thumbnail`/`alt` metadata to the supported `iframe.src`/`iframe.title` shape.
- Reuses one branded demo embed without the homepage modal’s autoplay and mute parameters.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking iframe-permission omission that limits picture-in-picture on the new embeds.

The iframe data shape is supported, the same embed is already used by the homepage, and no blocking rendering or build failure remains; only the template branch’s missing picture-in-picture delegation affects the migrated pages.

**Files Needing Attention:** apps/web/components/pages/seo/AsyncVideoCodeReviewsPage.tsx and the other 12 migrated SEO page definitions

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/components/pages/seo/AsyncVideoCodeReviewsPage.tsx | Migrates the demo to the shared external iframe; the selected template branch omits picture-in-picture permission. |
| apps/web/components/pages/seo/BestScreenRecorderPage.tsx | Applies the same supported iframe migration and inherits the shared capability limitation. |
| apps/web/components/pages/seo/DeveloperDocumentationVideosPage.tsx | Applies the same supported iframe migration and inherits the shared capability limitation. |
| apps/web/components/pages/seo/HipaaCompliantScreenRecordingPage.tsx | Replaces the broken local media references without changing the page’s compliance copy. |
| apps/web/components/pages/seo/HowToScreenRecordPage.tsx | Applies the shared inline rend.so embed using the supported content shape. |
| apps/web/components/pages/seo/MacScreenRecordingWithAudioPage.tsx | Applies the shared inline rend.so embed using the supported content shape. |
| apps/web/components/pages/seo/ObsAlternativePage.tsx | Applies the shared inline rend.so embed using the supported content shape. |
| apps/web/components/pages/seo/OpenSourceScreenRecorderPage.tsx | Applies the shared inline rend.so embed using the supported content shape. |
| apps/web/components/pages/seo/RecordScreenPage.tsx | Applies the shared inline rend.so embed using the supported content shape. |
| apps/web/components/pages/seo/ScreenRecorderPage.tsx | Applies the shared inline rend.so embed using the supported content shape. |
| apps/web/components/pages/seo/ScreenRecordingPage.tsx | Applies the shared inline rend.so embed using the supported content shape. |
| apps/web/components/pages/seo/SelfHostedScreenRecordingPage.tsx | Applies the shared inline rend.so embed using the supported content shape. |
| apps/web/components/pages/seo/VideoRecordingSoftwarePage.tsx | Applies the shared inline rend.so embed using the supported content shape. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/components/pages/seo/AsyncVideoCodeReviewsPage.tsx:278-281
**Iframe omits picture-in-picture permission**

These pages now select `SeoPageTemplate`’s iframe branch, which does not delegate picture-in-picture permission even though the canonical homepage player does. As a result, the newly embedded demos lose picture-in-picture support across all 13 migrated SEO pages.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix broken demo video on SEO pages: use ..."](https://github.com/capsoftware/cap/commit/e271d9ed64a0b0536cb816c632b7992d0fc8f6af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53298542)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-app.md)

<!-- /greptile_comment -->