### PR TITLE
Fix Turbopack whole-project tracing from ffmpeg spawn calls

### DIFF
--- a/apps/web/lib/audio-extract.ts
+++ b/apps/web/lib/audio-extract.ts
@@ -74,7 +74,9 @@ export async function extractAudioFromUrl(
 	];
 
 	return new Promise((resolve, reject) => {
-		const proc = spawn(ffmpeg, ffmpegArgs, { stdio: ["pipe", "pipe", "pipe"] });
+		const proc = spawn(/*turbopackIgnore: true*/ ffmpeg, ffmpegArgs, {
+			stdio: ["pipe", "pipe", "pipe"],
+		});
 
 		let stderr = "";
 
@@ -124,7 +126,9 @@ export async function extractAudioToBuffer(videoUrl: string): Promise<Buffer> {
 	];
 
 	return new Promise((resolve, reject) => {
-		const proc = spawn(ffmpeg, ffmpegArgs, { stdio: ["pipe", "pipe", "pipe"] });
+		const proc = spawn(/*turbopackIgnore: true*/ ffmpeg, ffmpegArgs, {
+			stdio: ["pipe", "pipe", "pipe"],
+		});
 
 		const chunks: Buffer[] = [];
 		let stderr = "";
@@ -168,7 +172,9 @@ export async function convertWavToMp3(wavBuffer: Buffer): Promise<Buffer> {
 	];
 
 	return new Promise((resolve, reject) => {
-		const proc = spawn(ffmpeg, ffmpegArgs, { stdio: ["pipe", "pipe", "pipe"] });
+		const proc = spawn(/*turbopackIgnore: true*/ ffmpeg, ffmpegArgs, {
+			stdio: ["pipe", "pipe", "pipe"],
+		});
 
 		const chunks: Buffer[] = [];
 		let stderr = "";
@@ -216,7 +222,7 @@ export async function checkHasAudioTrack(videoUrl: string): Promise<boolean> {
 	const ffmpegArgs = ["-i", videoUrl, "-hide_banner"];
 
 	return new Promise((resolve, reject) => {
-		const proc = spawn(ffmpeg, ffmpegArgs, {
+		const proc = spawn(/*turbopackIgnore: true*/ ffmpeg, ffmpegArgs, {
 			stdio: ["pipe", "pipe", "pipe"],
 		});
 

--- a/apps/web/lib/og/poster-frame.ts
+++ b/apps/web/lib/og/poster-frame.ts
@@ -28,7 +28,7 @@ const grabFrame = (
 ) =>
 	new Promise<Buffer>((resolve, reject) => {
 		const proc = spawn(
-			ffmpeg,
+			/*turbopackIgnore: true*/ ffmpeg,
 			[
 				"-hide_banner",
 				"-loglevel",

--- a/apps/web/lib/video-convert.ts
+++ b/apps/web/lib/video-convert.ts
@@ -15,7 +15,9 @@ function runFfmpeg(args: string[]): Promise<void> {
 	const ffmpeg = getFfmpegPath();
 
 	return new Promise((resolve, reject) => {
-		const proc = spawn(ffmpeg, args, { stdio: ["ignore", "ignore", "pipe"] });
+		const proc = spawn(/*turbopackIgnore: true*/ ffmpeg, args, {
+			stdio: ["ignore", "ignore", "pipe"],
+		});
 
 		let stderr = "";
 
@@ -270,7 +272,7 @@ export async function convertRemoteVideoToMp4Buffer(
 	const result = await convertRemoteVideoToMp4(videoUrl);
 
 	try {
-		return await fs.readFile(result.filePath);
+		return await fs.readFile(/*turbopackIgnore: true*/ result.filePath);
 	} finally {
 		await result.cleanup();
 	}


### PR DESCRIPTION
The dynamic ffmpeg path from getFfmpegPath() made Turbopack's output tracer fall back to tracing the entire project (including public/ and all CSS) into the serverless output for /api/tools/loom-download, /api/video/og, and the workflow step route.

This had two consequences:
1. The build warnings pasted in the deploy log (5 spawn call sites plus a dynamic fs.readFile), and bloated serverless functions.
2. The production deploy failure on main: the over-trace pulled app/globals.css and packages/ui/style/styles.css into the App Route module graph, where PostCSS evaluation failed with `TypeError: __turbopack_context__.a is not a function` and killed the build. The failing deploy's import trace shows globals.css reached via lib/video-convert.ts from the loom-download route, which is exactly this over-trace.

Fix: annotate all seven call sites (4 spawns in lib/audio-extract.ts, 1 spawn + 1 readFile in lib/video-convert.ts, 1 spawn in lib/og/poster-frame.ts) with turbopackIgnore. Safe because the ffmpeg binary still ships explicitly via serverExternalPackages + outputFileTracingIncludes in next.config.

Verified with a full local @cap/web build: tracing warnings went from seven to zero.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Turbopack tracing-ignore annotations to dynamic ffmpeg spawn calls and a runtime temporary-file read, preventing whole-project serverless tracing while retaining explicit ffmpeg packaging.
- Annotates four ffmpeg spawn sites in the audio extraction utilities.
- Annotates the poster-frame and video-conversion ffmpeg spawn sites.
- Excludes the runtime-created converted-video path from static output tracing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed code.

The annotations affect build-time output tracing only; runtime spawn arguments remain unchanged, the ignored file is always created dynamically in temporary storage, and explicit ffmpeg packaging remains configured.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/lib/audio-extract.ts | Adds tracing-ignore annotations to four existing dynamic ffmpeg spawn calls without changing their runtime arguments or process handling. |
| apps/web/lib/og/poster-frame.ts | Excludes the dynamic ffmpeg executable from Turbopack tracing while preserving poster-frame extraction behavior. |
| apps/web/lib/video-convert.ts | Excludes the dynamic ffmpeg executable and runtime-created temporary output path from static tracing without altering conversion or cleanup behavior. |

<sub>Reviews (1): Last reviewed commit: ["Fix Turbopack whole-project tracing from..."](https://github.com/capsoftware/cap/commit/e6a85fba93442dd4d4bb5e97741c67ec104436e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53303407)</sub>

<!-- /greptile_comment -->