### PR TITLE
Text segments v2: styles, animations, and takeover layouts

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -194,6 +194,8 @@ pub struct GeneralSettingsStore {
     pub enable_native_camera_preview: bool,
     #[serde(default = "default_true")]
     pub auto_zoom_on_clicks: bool,
+    #[serde(default)]
+    pub default_zoom_amount: Option<f64>,
     /// `None` until [`init`] seeds it from whether this machine has a notched
     /// display. From then on it is the user's preference and nothing re-reads
     /// the hardware, so moving between machines can't silently flip it.
@@ -328,6 +330,7 @@ impl Default for GeneralSettingsStore {
             // Keep aligned with the field's serde `default_true`: auto zooms
             // are on by default, matching configs that never stored the key.
             auto_zoom_on_clicks: true,
+            default_zoom_amount: None,
             macbook_notch_overlay: None,
             capture_keyboard_events: cap_recording::DEFAULT_CAPTURE_KEYBOARD_EVENTS,
             post_deletion_behaviour: PostDeletionBehaviour::DoNothing,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4875,45 +4875,8 @@ fn configure_camera_blur_recovery(
     }
 }
 
-#[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
-    // Arm the unexpected-termination sentinel before anything else can crash, and
-    // report any previous session that died without a clean shutdown.
-    let previous_termination = crash_sentinel::init(&logs_dir, env!("CARGO_PKG_VERSION"));
-    configure_windows_graphics_recovery(previous_termination);
-
-    // Keep the sentinel's blur marker in sync with live BlurProcessor instances
-    // (camera preview and editor render alike), so a native blur crash is
-    // attributable on the next launch.
-    cap_camera_effects::set_blur_session_observer(|active| {
-        if active {
-            crash_sentinel::enter_blur_session();
-        } else {
-            crash_sentinel::exit_blur_session();
-        }
-    });
-
-    ffmpeg::init()
-        .map_err(|e| {
-            error!("Failed to initialize ffmpeg: {e}");
-        })
-        .ok();
-
-    // Detect the camera-preview quality profile once from total RAM. On low-RAM
-    // machines (<= 8GB) this opts the preview into a cheaper profile (smaller
-    // textures, 30fps, no background blur); higher-spec machines keep the exact
-    // current behaviour. Only the preview is affected — recording is untouched.
-    {
-        let mut system = sysinfo::System::new();
-        system.refresh_memory();
-        camera::init_preview_profile(system.total_memory());
-    }
-
-    telemetry::init();
-
-    let tauri_context = tauri::generate_context!();
-
-    let specta_builder = tauri_specta::Builder::new()
+fn specta_builder() -> tauri_specta::Builder {
+    tauri_specta::Builder::new()
         .commands(tauri_specta::collect_commands![
             set_mic_input,
             set_camera_input,
@@ -5130,7 +5093,48 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
         .typ::<cap_automation::ClipboardSource>()
         .typ::<cap_automation::ExportFormat>()
         .typ::<cap_automation::AutomationExportCompression>()
-        .typ::<cap_automation::ExportDestination>();
+        .typ::<cap_automation::ExportDestination>()
+}
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
+    // Arm the unexpected-termination sentinel before anything else can crash, and
+    // report any previous session that died without a clean shutdown.
+    let previous_termination = crash_sentinel::init(&logs_dir, env!("CARGO_PKG_VERSION"));
+    configure_windows_graphics_recovery(previous_termination);
+
+    // Keep the sentinel's blur marker in sync with live BlurProcessor instances
+    // (camera preview and editor render alike), so a native blur crash is
+    // attributable on the next launch.
+    cap_camera_effects::set_blur_session_observer(|active| {
+        if active {
+            crash_sentinel::enter_blur_session();
+        } else {
+            crash_sentinel::exit_blur_session();
+        }
+    });
+
+    ffmpeg::init()
+        .map_err(|e| {
+            error!("Failed to initialize ffmpeg: {e}");
+        })
+        .ok();
+
+    // Detect the camera-preview quality profile once from total RAM. On low-RAM
+    // machines (<= 8GB) this opts the preview into a cheaper profile (smaller
+    // textures, 30fps, no background blur); higher-spec machines keep the exact
+    // current behaviour. Only the preview is affected — recording is untouched.
+    {
+        let mut system = sysinfo::System::new();
+        system.refresh_memory();
+        camera::init_preview_profile(system.total_memory());
+    }
+
+    telemetry::init();
+
+    let tauri_context = tauri::generate_context!();
+
+    let specta_builder = specta_builder();
 
     #[cfg(debug_assertions)]
     {
@@ -6918,5 +6922,18 @@ mod screenshot_share_cache_tests {
         let link = screenshot_share_link_for_hash(Some(&sharing(None)), "hash-a");
 
         assert!(link.is_none());
+    }
+}
+
+#[cfg(test)]
+mod typescript_bindings_tests {
+    #[test]
+    fn export_typescript_bindings() {
+        let bindings_path = std::path::Path::new("../src/utils/tauri.ts");
+        if bindings_path.parent().is_some_and(|parent| parent.exists()) {
+            super::specta_builder()
+                .export(specta_typescript::Typescript::default(), bindings_path)
+                .expect("failed to export TypeScript bindings");
+        }
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3459,6 +3459,15 @@ async fn list_audio_devices() -> Result<Vec<String>, ()> {
     Ok(MicrophoneFeed::list_names())
 }
 
+#[tauri::command]
+#[specta::specta]
+#[instrument]
+async fn list_system_fonts() -> Vec<String> {
+    tokio::task::spawn_blocking(cap_rendering::system_font_families)
+        .await
+        .unwrap_or_default()
+}
+
 #[derive(Serialize, Type, Debug, Clone)]
 pub struct UploadProgress {
     progress: f64,
@@ -4935,6 +4944,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             windows::refresh_window_content_protection,
             general_settings::get_default_excluded_windows,
             list_audio_devices,
+            list_system_fonts,
             close_recordings_overlay_window,
             fake_window::set_fake_window_bounds,
             fake_window::remove_fake_window,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3380,14 +3380,22 @@ async fn update_project_config_in_memory(
 
 #[tauri::command]
 #[specta::specta]
-#[instrument(skip(editor_instance))]
+#[instrument(skip(app, editor_instance))]
 async fn generate_zoom_segments_from_clicks(
+    app: AppHandle,
     editor_instance: WindowEditorInstance,
 ) -> Result<Vec<ZoomSegment>, String> {
     let meta = editor_instance.meta();
     let recordings = &editor_instance.recordings;
 
-    let zoom_segments = recording::generate_zoom_segments_for_project(meta, recordings);
+    let zoom_amount = GeneralSettingsStore::get(&app)
+        .ok()
+        .flatten()
+        .and_then(|settings| settings.default_zoom_amount)
+        .unwrap_or(recording::DEFAULT_AUTO_ZOOM_AMOUNT);
+
+    let zoom_segments =
+        recording::generate_zoom_segments_for_project(meta, recordings, zoom_amount);
 
     Ok(zoom_segments)
 }

--- a/apps/desktop/src-tauri/src/recording.rs
+++ b/apps/desktop/src-tauri/src/recording.rs
@@ -3701,10 +3701,13 @@ async fn finalize_studio_recording(
     Ok(())
 }
 
+pub const DEFAULT_AUTO_ZOOM_AMOUNT: f64 = 2.0;
+
 fn generate_zoom_segments_from_clicks_impl(
     mut clicks: Vec<CursorClickEvent>,
     _moves: Vec<CursorMoveEvent>,
     max_duration: f64,
+    zoom_amount: f64,
 ) -> Vec<ZoomSegment> {
     const MS_PER_SECOND: f64 = 1000.0;
     const START_MIN_MS: f64 = 1.0;
@@ -3713,7 +3716,6 @@ fn generate_zoom_segments_from_clicks_impl(
     const CLICK_END_CLAMP_PADDING_MS: f64 = 800.0;
     const TRAILING_CLICK_IGNORE_MS: f64 = 1000.0;
     const MERGE_GAP_MS: f64 = 2500.0;
-    const AUTO_ZOOM_AMOUNT: f64 = 2.0;
 
     if max_duration <= 0.0 {
         return Vec::new();
@@ -3769,7 +3771,7 @@ fn generate_zoom_segments_from_clicks_impl(
         .map(|(start, end)| ZoomSegment {
             start: start.round() / MS_PER_SECOND,
             end: end.round() / MS_PER_SECOND,
-            amount: AUTO_ZOOM_AMOUNT,
+            amount: zoom_amount,
             mode: ZoomMode::Auto,
             glide_direction: GlideDirection::None,
             glide_speed: 0.5,
@@ -3784,6 +3786,7 @@ fn generate_zoom_segments_from_clicks_impl(
 pub fn generate_zoom_segments_from_clicks(
     recording: &studio_recording::CompletedRecording,
     recordings: &ProjectRecordingsMeta,
+    zoom_amount: f64,
 ) -> Vec<ZoomSegment> {
     // Build a temporary RecordingMeta so we can use the common implementation
     let recording_meta = RecordingMeta {
@@ -3795,7 +3798,7 @@ pub fn generate_zoom_segments_from_clicks(
         upload: None,
     };
 
-    generate_zoom_segments_for_project(&recording_meta, recordings)
+    generate_zoom_segments_for_project(&recording_meta, recordings, zoom_amount)
 }
 
 /// Generates zoom segments from clicks for an existing project.
@@ -3803,6 +3806,7 @@ pub fn generate_zoom_segments_from_clicks(
 pub fn generate_zoom_segments_for_project(
     recording_meta: &RecordingMeta,
     recordings: &ProjectRecordingsMeta,
+    zoom_amount: f64,
 ) -> Vec<ZoomSegment> {
     let RecordingMetaInner::Studio(studio_meta) = &recording_meta.inner else {
         return Vec::new();
@@ -3835,7 +3839,12 @@ pub fn generate_zoom_segments_for_project(
         }
     }
 
-    generate_zoom_segments_from_clicks_impl(all_clicks, all_moves, recordings.duration())
+    generate_zoom_segments_from_clicks_impl(
+        all_clicks,
+        all_moves,
+        recordings.duration(),
+        zoom_amount,
+    )
 }
 
 fn project_config_from_recording(
@@ -3898,7 +3907,13 @@ fn project_config_from_recording(
         .collect::<Vec<_>>();
 
     let zoom_segments = if settings.auto_zoom_on_clicks {
-        generate_zoom_segments_from_clicks(completed_recording, recordings)
+        generate_zoom_segments_from_clicks(
+            completed_recording,
+            recordings,
+            settings
+                .default_zoom_amount
+                .unwrap_or(DEFAULT_AUTO_ZOOM_AMOUNT),
+        )
     } else {
         Vec::new()
     };
@@ -4271,8 +4286,12 @@ mod tests {
 
     #[test]
     fn skips_trailing_stop_click() {
-        let segments =
-            generate_zoom_segments_from_clicks_impl(vec![click_event(11_900.0)], vec![], 12.0);
+        let segments = generate_zoom_segments_from_clicks_impl(
+            vec![click_event(11_900.0)],
+            vec![],
+            12.0,
+            DEFAULT_AUTO_ZOOM_AMOUNT,
+        );
 
         assert!(
             segments.is_empty(),
@@ -4289,7 +4308,8 @@ mod tests {
             move_event(1_940.0, 0.74, 0.78),
         ];
 
-        let segments = generate_zoom_segments_from_clicks_impl(clicks, moves, 20.0);
+        let segments =
+            generate_zoom_segments_from_clicks_impl(clicks, moves, 20.0, DEFAULT_AUTO_ZOOM_AMOUNT);
 
         assert!(
             !segments.is_empty(),
@@ -4317,7 +4337,12 @@ mod tests {
             move_event(19_364.0, 0.44, 0.95),
         ];
 
-        let segments = generate_zoom_segments_from_clicks_impl(clicks, moves, 19.436_667);
+        let segments = generate_zoom_segments_from_clicks_impl(
+            clicks,
+            moves,
+            19.436_667,
+            DEFAULT_AUTO_ZOOM_AMOUNT,
+        );
 
         assert_eq!(segments.len(), 2);
         assert_eq!(segments[0].start, 1.971);
@@ -4330,7 +4355,8 @@ mod tests {
     fn extends_segment_until_after_mouse_up() {
         let clicks = vec![click_event(1_000.0), click_up_event(2_500.0)];
 
-        let segments = generate_zoom_segments_from_clicks_impl(clicks, vec![], 10.0);
+        let segments =
+            generate_zoom_segments_from_clicks_impl(clicks, vec![], 10.0, DEFAULT_AUTO_ZOOM_AMOUNT);
 
         assert_eq!(segments.len(), 1);
         assert_eq!(segments[0].start, 0.7);
@@ -4341,7 +4367,8 @@ mod tests {
     fn clamps_zoom_end_before_recording_end() {
         let clicks = vec![click_event(8_999.0), click_event(9_000.0)];
 
-        let segments = generate_zoom_segments_from_clicks_impl(clicks, vec![], 10.0);
+        let segments =
+            generate_zoom_segments_from_clicks_impl(clicks, vec![], 10.0, DEFAULT_AUTO_ZOOM_AMOUNT);
 
         assert_eq!(segments.len(), 1);
         assert_eq!(segments[0].start, 8.699);
@@ -4358,7 +4385,12 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let segments = generate_zoom_segments_from_clicks_impl(Vec::new(), jitter_moves, 15.0);
+        let segments = generate_zoom_segments_from_clicks_impl(
+            Vec::new(),
+            jitter_moves,
+            15.0,
+            DEFAULT_AUTO_ZOOM_AMOUNT,
+        );
 
         assert!(
             segments.is_empty(),

--- a/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/settings/general.tsx
@@ -25,7 +25,7 @@ import toast from "solid-toast";
 import themePreviewAuto from "~/assets/theme-previews/auto.jpg";
 import themePreviewDark from "~/assets/theme-previews/dark.jpg";
 import themePreviewLight from "~/assets/theme-previews/light.jpg";
-import { Input } from "~/routes/editor/ui";
+import { Input, Slider } from "~/routes/editor/ui";
 import {
 	authStore,
 	generalSettingsStore,
@@ -662,6 +662,26 @@ function Inner(props: {
 							value={!!settings.autoZoomOnClicks}
 							onChange={(value) => handleChange("autoZoomOnClicks", value)}
 						/>
+						<SettingItem
+							label="Default zoom amount"
+							description="Zoom level for newly created and auto-generated zoom segments."
+						>
+							<div class="flex gap-2 items-center w-52">
+								<Slider
+									class="flex-1"
+									value={[settings.defaultZoomAmount ?? 1.5]}
+									onChange={(v) => setSettings("defaultZoomAmount", v[0])}
+									onChangeEnd={(v) => handleChange("defaultZoomAmount", v[0])}
+									minValue={1}
+									maxValue={4.5}
+									step={0.1}
+									formatTooltip="x"
+								/>
+								<span class="w-9 text-xs text-right text-gray-11 tabular-nums">
+									{`${(settings.defaultZoomAmount ?? 1.5).toFixed(1)}x`}
+								</span>
+							</div>
+						</SettingItem>
 						<ToggleSettingItem
 							label="Capture keyboard presses"
 							description="Record key presses so you can add keyboard overlays in the editor."

--- a/apps/desktop/src/routes/editor/CaptionsTab.tsx
+++ b/apps/desktop/src/routes/editor/CaptionsTab.tsx
@@ -289,6 +289,8 @@ export function CaptionsTab(props: {
 					recordingSegments,
 					timeline.transitions ?? [],
 					sourceRange,
+					"outgoing",
+					timeline.textSegments,
 				);
 				const end = mapEditedTimeToSource(
 					timelineSegment.end,
@@ -296,6 +298,8 @@ export function CaptionsTab(props: {
 					recordingSegments,
 					timeline.transitions ?? [],
 					sourceRange,
+					"outgoing",
+					timeline.textSegments,
 				);
 				if (start !== null) source.start = start;
 				if (end !== null) source.end = end;

--- a/apps/desktop/src/routes/editor/ConfigSidebar.tsx
+++ b/apps/desktop/src/routes/editor/ConfigSidebar.tsx
@@ -50,6 +50,7 @@ import imageBg from "~/assets/illustrations/image.webp";
 import transparentBg from "~/assets/illustrations/transparent.webp";
 import { Toggle } from "~/components/Toggle";
 import { generalSettingsStore } from "~/store";
+import { listSystemFonts } from "~/utils/fonts";
 import { normalizeOpaqueHexColor } from "~/utils/hex-color";
 import {
 	createSelectedOrganization,
@@ -64,7 +65,6 @@ import {
 	type CameraYPosition,
 	type CaptionTrackSegment,
 	type ClipOffsets,
-	type ClipSpeedAudioMode,
 	type CursorAnimationStyle,
 	type CursorType,
 	commands,
@@ -78,6 +78,9 @@ import {
 	type XY,
 	type ZoomSegment,
 } from "~/utils/tauri";
+import IconLucideAlignCenter from "~icons/lucide/align-center";
+import IconLucideAlignLeft from "~icons/lucide/align-left";
+import IconLucideAlignRight from "~icons/lucide/align-right";
 import IconLucideArrowLeftRight from "~icons/lucide/arrow-left-right";
 import IconLucideBoxSelect from "~icons/lucide/box-select";
 import IconLucideColumns2 from "~icons/lucide/columns-2";
@@ -86,6 +89,7 @@ import IconLucideFlipHorizontal2 from "~icons/lucide/flip-horizontal-2";
 import IconLucideFlipVertical2 from "~icons/lucide/flip-vertical-2";
 import IconLucideGrid from "~icons/lucide/grid";
 import IconLucideImageOff from "~icons/lucide/image-off";
+import IconLucideItalic from "~icons/lucide/italic";
 import IconLucideKeyboard from "~icons/lucide/keyboard";
 import IconLucideLaptop from "~icons/lucide/laptop";
 import IconLucideMonitor from "~icons/lucide/monitor";
@@ -110,8 +114,10 @@ import {
 import { BrandColorsDropdown } from "./BrandColorsDropdown";
 import { ColorCorrectionSection } from "./ColorCorrectionSection";
 import { syncCaptionWordsWithText } from "./captions";
+import { type ClipTransition, clipSourceTimeAt } from "./clip-transitions";
 import { getColorPreviewBorderColor, hexToRgb, RgbInput } from "./color-utils";
 import { type CornerRoundingType, useEditorContext } from "./context";
+import { FontPicker } from "./FontPicker";
 import { GradientEditor } from "./GradientEditor";
 import { KeyboardTab } from "./KeyboardTab";
 import {
@@ -136,8 +142,20 @@ import { TextInput } from "./TextInput";
 import {
 	TEXT_FONT_SIZE_MAX,
 	TEXT_FONT_SIZE_MIN,
+	type TextAlign,
+	type TextLayout,
 	type TextSegment,
 } from "./text";
+import {
+	applyTextPreset,
+	matchTextPreset,
+	TEXT_PRESETS,
+	type TextPreset,
+} from "./text-presets";
+import {
+	TEXT_ANIMATION_OPTIONS,
+	TEXT_SEGMENT_WEIGHT_OPTIONS,
+} from "./text-style";
 import {
 	ANGLE_PRESETS,
 	anglePresetMotion,
@@ -173,6 +191,7 @@ import {
 	matchAnglePreset,
 	setMotion,
 } from "./three-d";
+import { heldTimeBefore, holdWindows } from "./timeline-holds";
 import {
 	ComingSoonTooltip,
 	EditorButton,
@@ -186,6 +205,7 @@ import {
 	topSlideAnimateClasses,
 } from "./ui";
 import { formatTime } from "./utils";
+import { ZoomModeHelper } from "./ZoomModeHelper";
 
 // Split out of the sidebar chunk: the captions tab is not visible at first
 // paint (Kobalte only mounts the selected tab), and its code is heavy. The
@@ -552,12 +572,19 @@ export function ConfigSidebar() {
 			| "captions",
 	});
 
+	// Clip selection is a timeline-only affordance (highlight, Delete key,
+	// multi-select); it must not swap the sidebar away from the current tab.
+	const sidebarSelection = () => {
+		const selection = editorState.timeline.selection;
+		return selection && selection.type !== "clip" ? selection : null;
+	};
+
 	let scrollRef!: HTMLDivElement;
 
 	return (
 		<KTabs
 			value={
-				editorState.timeline.selection ||
+				sidebarSelection() ||
 				editorState.timeline.audioPicker !== null ||
 				editorState.timeline.camera3dSetup !== null
 					? undefined
@@ -598,13 +625,13 @@ export function ConfigSidebar() {
 							value={item.id}
 							class={cx(
 								"flex relative z-10 flex-1 justify-center items-center px-4 py-2 transition-colors group disabled:opacity-50 focus:outline-hidden",
-								editorState.timeline.selection
+								sidebarSelection()
 									? "text-gray-11"
 									: "text-gray-11 data-selected:text-gray-12",
 							)}
 							onClick={() => {
 								// Clear any active selection first
-								if (editorState.timeline.selection) {
+								if (sidebarSelection()) {
 									setEditorState("timeline", "selection", null);
 								}
 								if (editorState.timeline.audioPicker !== null) {
@@ -639,7 +666,7 @@ export function ConfigSidebar() {
 				{/** Center the indicator with the icon */}
 				<Show
 					when={
-						!editorState.timeline.selection &&
+						!sidebarSelection() &&
 						editorState.timeline.audioPicker === null &&
 						editorState.timeline.camera3dSetup === null
 					}
@@ -657,7 +684,7 @@ export function ConfigSidebar() {
 				class="custom-scroll overflow-x-hidden overflow-y-scroll text-[0.875rem] flex-1 min-h-0"
 				classList={{
 					hidden:
-						!!editorState.timeline.selection ||
+						!!sidebarSelection() ||
 						editorState.timeline.audioPicker !== null ||
 						editorState.timeline.audioReplace !== null ||
 						editorState.timeline.camera3dSetup !== null,
@@ -786,6 +813,7 @@ export function ConfigSidebar() {
 							/>
 						</Field>
 					)}
+					<SyncOffsetsConfig />
 				</KTabs.Content>
 				<KTabs.Content
 					value="cursor"
@@ -1053,12 +1081,12 @@ export function ConfigSidebar() {
 				class="custom-scroll p-4 top-16 left-0 right-0 bottom-0 text-[0.875rem] space-y-4 bg-gray-1 dark:bg-gray-2 z-50"
 				classList={{
 					hidden:
-						!editorState.timeline.selection &&
+						!sidebarSelection() &&
 						editorState.timeline.audioPicker === null &&
 						editorState.timeline.audioReplace === null &&
 						editorState.timeline.camera3dSetup === null,
 					"animate-in slide-in-from-bottom-2 fade-in":
-						!!editorState.timeline.selection ||
+						!!sidebarSelection() ||
 						editorState.timeline.audioPicker !== null ||
 						editorState.timeline.audioReplace !== null ||
 						editorState.timeline.camera3dSetup !== null,
@@ -1067,7 +1095,7 @@ export function ConfigSidebar() {
 				<Show
 					when={
 						editorState.timeline.audioPicker !== null &&
-						!editorState.timeline.selection &&
+						!sidebarSelection() &&
 						editorState.timeline.audioReplace === null
 					}
 				>
@@ -1081,7 +1109,7 @@ export function ConfigSidebar() {
 				</Show>
 				<Show
 					when={
-						!editorState.timeline.selection &&
+						!sidebarSelection() &&
 						editorState.timeline.audioPicker === null &&
 						editorState.timeline.audioReplace === null
 							? editorState.timeline.camera3dSetup
@@ -1117,7 +1145,7 @@ export function ConfigSidebar() {
 				<Show
 					when={
 						editorState.timeline.audioReplace === null
-							? editorState.timeline.selection
+							? sidebarSelection()
 							: null
 					}
 				>
@@ -1496,68 +1524,89 @@ export function ConfigSidebar() {
 									return { selection: zoomSelection, segments };
 								})()}
 							>
-								{(value) => (
-									<div class="space-y-4">
-										<div class="flex flex-row justify-between items-center">
-											<div class="flex gap-2 items-center">
-												<EditorButton
-													onClick={() =>
-														setEditorState("timeline", "selection", null)
-													}
-													leftIcon={<IconLucideCheck />}
-												>
-													Done
-												</EditorButton>
-												<span class="text-sm text-gray-10">
-													{value().segments.length} zoom{" "}
-													{value().segments.length === 1
-														? "segment"
-														: "segments"}{" "}
-													selected
-												</span>
-											</div>
-											<EditorButton
-												variant="danger"
-												onClick={() => {
-													projectActions.deleteZoomSegments(
-														value().segments.map((s) => s.index),
-													);
-												}}
-												leftIcon={<IconCapTrash />}
-											>
-												Delete
-											</EditorButton>
-										</div>
-										<Show
-											when={value().segments.length === 1}
-											fallback={
-												<div class="grid grid-cols-3 gap-4">
-													<Index each={value().segments}>
-														{(item, index) => (
-															<div class="p-2.5 rounded-lg border border-gray-4 bg-gray-3">
-																<ZoomSegmentPreview
-																	segment={item().segment}
-																	segmentIndex={index}
-																/>
-															</div>
-														)}
-													</Index>
+								{(value) => {
+									const totalZoomSegments = () =>
+										project.timeline?.zoomSegments?.length ?? 0;
+
+									// The sidebar header is narrow, so the count stays terse and
+									// "Select all" is an inline text action rather than a third
+									// full button, which would wrap.
+									const selectionLabel = () => {
+										const count = value().segments.length;
+										const total = totalZoomSegments();
+										if (total > 1 && count === total)
+											return `All ${total} selected`;
+										if (total > 1) return `${count} of ${total} selected`;
+										return `${count} selected`;
+									};
+
+									return (
+										<div class="space-y-4">
+											<div class="flex flex-row justify-between items-center">
+												<div class="flex gap-2 items-center min-w-0">
+													<EditorButton
+														onClick={() =>
+															setEditorState("timeline", "selection", null)
+														}
+														leftIcon={<IconLucideCheck />}
+													>
+														Done
+													</EditorButton>
+													<span class="text-sm text-gray-10 whitespace-nowrap">
+														{selectionLabel()}
+													</span>
+													<Show
+														when={value().segments.length < totalZoomSegments()}
+													>
+														<button
+															type="button"
+															class="text-sm font-medium whitespace-nowrap text-blue-11 hover:underline outline-hidden focus-visible:underline"
+															onClick={() =>
+																setEditorState("timeline", "selection", {
+																	type: "zoom",
+																	indices: Array.from(
+																		{ length: totalZoomSegments() },
+																		(_, i) => i,
+																	),
+																})
+															}
+														>
+															Select all
+														</button>
+													</Show>
 												</div>
-											}
-										>
-											<For each={value().segments}>
-												{(item) => (
-													<div class="p-4 rounded-lg border border-gray-200">
-														<ZoomSegmentConfig
-															segment={item.segment}
-															segmentIndex={item.index}
-														/>
-													</div>
-												)}
-											</For>
-										</Show>
-									</div>
-								)}
+												<EditorButton
+													variant="danger"
+													onClick={() => {
+														projectActions.deleteZoomSegments(
+															value().segments.map((s) => s.index),
+														);
+													}}
+													leftIcon={<IconCapTrash />}
+												>
+													Delete
+												</EditorButton>
+											</div>
+											<Show
+												when={value().segments.length === 1}
+												fallback={
+													<ZoomMultiSegmentConfig segments={value().segments} />
+												}
+											>
+												<For each={value().segments}>
+													{(item) => (
+														<div class="p-4 rounded-lg border border-gray-200">
+															<ZoomSegmentConfig
+																segment={item.segment}
+																segmentIndex={item.index}
+															/>
+														</div>
+													)}
+												</For>
+											</Show>
+										</div>
+									);
+								}}
 							</Show>
 							<Show
 								when={(() => {
@@ -1692,79 +1741,6 @@ export function ConfigSidebar() {
 																	.sort((a, b) => b - a)
 																	.forEach((idx) => {
 																		projectActions.deleteSceneSegment(idx);
-																	});
-															}}
-															leftIcon={<IconCapTrash />}
-														>
-															Delete
-														</EditorButton>
-													</div>
-												</div>
-											</Show>
-										)}
-									</Show>
-								)}
-							</Show>
-							<Show
-								when={(() => {
-									const clipSelection = selection();
-									if (clipSelection.type !== "clip") return;
-
-									const segments = clipSelection.indices
-										.map((idx) => ({
-											segment: project.timeline?.segments?.[idx],
-											index: idx,
-										}))
-										.filter(
-											(s): s is { segment: TimelineSegment; index: number } =>
-												s.segment !== undefined,
-										);
-
-									if (segments.length === 0) return;
-									return { selection: clipSelection, segments };
-								})()}
-							>
-								{(value) => (
-									<Show when={value().segments[0]}>
-										{(firstSegment) => (
-											<Show
-												when={value().segments.length > 1}
-												fallback={
-													<ClipSegmentConfig
-														segment={firstSegment().segment}
-														segmentIndex={firstSegment().index}
-													/>
-												}
-											>
-												<div class="space-y-4">
-													<div class="flex flex-row justify-between items-center">
-														<div class="flex gap-2 items-center">
-															<EditorButton
-																onClick={() =>
-																	setEditorState("timeline", "selection", null)
-																}
-																leftIcon={<IconLucideCheck />}
-															>
-																Done
-															</EditorButton>
-															<span class="text-sm text-gray-10">
-																{value().segments.length} clip{" "}
-																{value().segments.length === 1
-																	? "segment"
-																	: "segments"}{" "}
-																selected
-															</span>
-														</div>
-														<EditorButton
-															variant="danger"
-															onClick={() => {
-																const indices = value().selection.indices;
-
-																// Delete segments in reverse order to maintain indices
-																[...indices]
-																	.sort((a, b) => b - a)
-																	.forEach((idx) => {
-																		projectActions.deleteClipSegment(idx);
 																	});
 															}}
 															leftIcon={<IconCapTrash />}
@@ -3488,12 +3464,161 @@ function HexColorInput(props: {
 	);
 }
 
+function TextStyleSelect<T extends string | number>(props: {
+	options: { label: string; value: T }[];
+	value: T;
+	onChange: (value: T) => void;
+	fallbackLabel?: (value: T) => string;
+}) {
+	const selected = () =>
+		props.options.find((option) => option.value === props.value) ?? {
+			label: props.fallbackLabel?.(props.value) ?? String(props.value),
+			value: props.value,
+		};
+
+	return (
+		<KSelect
+			options={props.options}
+			optionValue="value"
+			optionTextValue="label"
+			value={selected()}
+			onChange={(option) => {
+				if (option) props.onChange(option.value);
+			}}
+			itemComponent={(selectItemProps) => (
+				<MenuItem<typeof KSelect.Item>
+					as={KSelect.Item}
+					item={selectItemProps.item}
+				>
+					<KSelect.ItemLabel class="flex-1">
+						{selectItemProps.item.rawValue.label}
+					</KSelect.ItemLabel>
+					<KSelect.ItemIndicator class="ml-auto text-blue-9">
+						<IconCapCircleCheck />
+					</KSelect.ItemIndicator>
+				</MenuItem>
+			)}
+		>
+			<KSelect.Trigger class="flex w-full items-center justify-between rounded-md border border-gray-3 bg-gray-2 px-3 py-2 text-sm text-gray-12 transition-colors hover:border-gray-4 hover:bg-gray-3 focus:border-blue-9 focus:outline-hidden focus:ring-1 focus:ring-blue-9">
+				<KSelect.Value<{ label: string; value: T }> class="truncate">
+					{(state) => state.selectedOption()?.label ?? selected().label}
+				</KSelect.Value>
+				<KSelect.Icon>
+					<IconCapChevronDown class="size-4 shrink-0 transform transition-transform data-expanded:rotate-180 text-(--gray-500)" />
+				</KSelect.Icon>
+			</KSelect.Trigger>
+			<KSelect.Portal>
+				<PopperContent<typeof KSelect.Content>
+					as={KSelect.Content}
+					class={cx(topSlideAnimateClasses, "z-50")}
+				>
+					<MenuItemList<typeof KSelect.Listbox>
+						class="overflow-y-auto max-h-52"
+						as={KSelect.Listbox}
+					/>
+				</PopperContent>
+			</KSelect.Portal>
+		</KSelect>
+	);
+}
+
+const TEXT_PRESET_HOVER_FX: Record<string, string> = {
+	fade: "group-hover:opacity-70",
+	slideUp: "group-hover:-translate-y-1",
+	slideDown: "group-hover:translate-y-1",
+	pop: "group-hover:scale-110",
+	typewriter: "",
+	none: "",
+};
+
+function TextPresetCard(props: {
+	preset: TextPreset;
+	active: boolean;
+	onApply: () => void;
+}) {
+	const style = () => props.preset.style;
+	const stackCss = () =>
+		style()
+			.fontStack.map((family) =>
+				["sans-serif", "serif", "monospace"].includes(family)
+					? family
+					: `"${family}"`,
+			)
+			.join(", ");
+
+	return (
+		<button
+			type="button"
+			onClick={() => props.onApply()}
+			class={cx(
+				"group relative flex h-16 flex-col items-center justify-center overflow-hidden rounded-lg border px-2 pb-3 transition-colors",
+				props.active
+					? "border-blue-9 ring-1 ring-blue-9"
+					: "border-gray-3 hover:border-gray-5",
+			)}
+			style={{
+				background: "linear-gradient(135deg, #17181c 0%, #2a2c33 100%)",
+			}}
+		>
+			<span
+				class={cx(
+					"max-w-full truncate text-white transition-all duration-200",
+					TEXT_PRESET_HOVER_FX[style().animationIn],
+				)}
+				style={{
+					"font-family": stackCss(),
+					"font-weight": String(style().fontWeight),
+					"font-style": style().italic ? "italic" : "normal",
+					"font-size": `${Math.min(Math.max(style().fontSize * 0.22, 11), 24)}px`,
+					"letter-spacing": `${style().letterSpacing * 0.35}px`,
+					"line-height": 1.1,
+					"text-shadow":
+						style().shadow > 0
+							? `0 1px 3px rgba(0, 0, 0, ${0.45 + style().shadow * 0.4})`
+							: "none",
+				}}
+			>
+				{props.preset.sample}
+			</span>
+			<span class="absolute inset-x-0 bottom-1 text-center text-[10px] font-medium text-white/50">
+				{props.preset.name}
+			</span>
+		</button>
+	);
+}
+
+// The renderer also supports splitLeft/splitRight takeovers; only these two
+// are exposed for now.
+const TEXT_LAYOUT_OPTIONS: {
+	value: TextLayout;
+	label: string;
+	icon: ValidComponent;
+}[] = [
+	{ value: "overlay", label: "Overlay", icon: IconLucideBoxSelect },
+	{ value: "fullscreen", label: "Fullscreen", icon: IconLucideMaximize },
+];
+
+const TEXT_LAYOUT_CENTERS: Partial<
+	Record<TextLayout, { x: number; y: number }>
+> = {
+	fullscreen: { x: 0.5, y: 0.5 },
+};
+
+const TEXT_ALIGN_OPTIONS: { value: TextAlign; icon: ValidComponent }[] = [
+	{ value: "left", icon: IconLucideAlignLeft },
+	{ value: "center", icon: IconLucideAlignCenter },
+	{ value: "right", icon: IconLucideAlignRight },
+];
+
 function TextSegmentConfig(props: {
 	segmentIndex: number;
 	segment: TextSegment;
 	brandColorSwatches: OrganizationBrandColorSwatch[];
 }) {
 	const { setProject } = useEditorContext();
+	const [installedFonts] = createResource(listSystemFonts, {
+		initialValue: [],
+	});
 	const clampNumber = (value: number, min: number, max: number) =>
 		Math.min(Math.max(Number.isFinite(value) ? value : min, min), max);
 
@@ -3508,6 +3633,24 @@ function TextSegmentConfig(props: {
 			}),
 		);
 	};
+
+	const activePresetId = createMemo(() =>
+		matchTextPreset(props.segment, installedFonts()),
+	);
+
+	const setAnimationDuration = (
+		key: "animationInDuration" | "animationOutDuration",
+		value: number,
+	) =>
+		updateSegment((segment) => {
+			segment[key] = clampNumber(value, 0, 3);
+			// Old builds only know fadeDuration; keep it tracking the slower
+			// edge so a project opened there still fades sensibly.
+			segment.fadeDuration = Math.max(
+				segment.animationInDuration ?? 0.15,
+				segment.animationOutDuration ?? 0.15,
+			);
+		});
 
 	return (
 		<div class="space-y-4">
@@ -3538,148 +3681,318 @@ function TextSegmentConfig(props: {
 					</div>
 				</div>
 			</Field>
-			<Field name="Size" icon={<IconCapEnlarge class="size-4" />}>
-				<Slider
-					value={[
-						clampNumber(
-							props.segment.fontSize,
-							TEXT_FONT_SIZE_MIN,
-							TEXT_FONT_SIZE_MAX,
-						),
-					]}
-					onChange={([value]) =>
-						updateSegment((segment) => {
-							const newFontSize = clampNumber(
-								value,
-								TEXT_FONT_SIZE_MIN,
-								TEXT_FONT_SIZE_MAX,
-							);
-							const oldFontSize = segment.fontSize || 48;
-							const scale = newFontSize / oldFontSize;
-
-							segment.fontSize = newFontSize;
-
-							// Scale the box with the font so line wrapping is
-							// preserved; keep the top edge fixed since the renderer
-							// anchors text at the top of the box (the canvas overlay
-							// re-hugs the box to the exact glyph bounds when visible).
-							if (segment.size && segment.center) {
-								const topEdge = segment.center.y - segment.size.y / 2;
-								segment.size.x = Math.min(segment.size.x * scale, 1);
-								segment.size.y = segment.size.y * scale;
-								segment.center.y = topEdge + segment.size.y / 2;
-							}
-						})
-					}
-					minValue={TEXT_FONT_SIZE_MIN}
-					maxValue={TEXT_FONT_SIZE_MAX}
-					step={1}
-				/>
+			<Field name="Layout" icon={<IconLucideBoxSelect class="size-4" />}>
+				<div class="flex flex-col gap-3">
+					<div class="grid grid-cols-2 gap-1 rounded-lg border border-gray-3 bg-gray-2 p-1">
+						<For each={TEXT_LAYOUT_OPTIONS}>
+							{(option) => (
+								<button
+									type="button"
+									title={option.label}
+									class={cx(
+										"flex flex-col items-center gap-1 rounded-md py-1.5 transition-colors",
+										(props.segment.layout ?? "overlay") === option.value
+											? "bg-gray-5 text-gray-12"
+											: "text-gray-10 hover:text-gray-12",
+									)}
+									onClick={() =>
+										updateSegment((segment) => {
+											if ((segment.layout ?? "overlay") === option.value)
+												return;
+											segment.layout = option.value;
+											// A takeover layout implies where the text
+											// belongs; place it there so the result reads
+											// immediately (still draggable afterwards).
+											const center = TEXT_LAYOUT_CENTERS[option.value];
+											if (center) segment.center = { ...center };
+										})
+									}
+								>
+									<Dynamic component={option.icon} class="size-4" />
+									<span class="text-[9px] font-medium leading-none">
+										{option.label}
+									</span>
+								</button>
+							)}
+						</For>
+					</div>
+					<Show when={(props.segment.layout ?? "overlay") === "fullscreen"}>
+						<p class="text-xs leading-snug text-gray-10">
+							Pauses the video while the text is shown, then resumes where it
+							left off.
+						</p>
+					</Show>
+					<Show when={(props.segment.layout ?? "overlay") !== "overlay"}>
+						<div class="flex flex-col gap-1">
+							<span class="text-xs text-gray-11">Screen transition</span>
+							<Slider
+								value={[
+									clampNumber(props.segment.layoutTransition ?? 0.5, 0.1, 1.5),
+								]}
+								onChange={([value]) =>
+									updateSegment((segment) => {
+										segment.layoutTransition = clampNumber(value, 0.1, 1.5);
+									})
+								}
+								minValue={0.1}
+								maxValue={1.5}
+								step={0.05}
+								formatTooltip="s"
+							/>
+						</div>
+					</Show>
+				</div>
 			</Field>
-			<Field name="Style" icon={<IconLucideSparkles class="size-4" />}>
-				<div class="flex flex-col gap-2">
-					<KSelect
-						options={[
-							{ label: "Normal", value: 400 },
-							{ label: "Medium", value: 500 },
-							{ label: "Bold", value: 700 },
-						]}
-						optionValue="value"
-						optionTextValue="label"
-						value={{
-							label: "Custom",
-							value: props.segment.fontWeight,
-						}}
-						onChange={(value) => {
-							if (!value) return;
-							updateSegment((segment) => {
-								segment.fontWeight = value.value;
-							});
-						}}
-						itemComponent={(selectItemProps) => (
-							<MenuItem<typeof KSelect.Item>
-								as={KSelect.Item}
-								item={selectItemProps.item}
-							>
-								<KSelect.ItemLabel class="flex-1">
-									{selectItemProps.item.rawValue.label}
-								</KSelect.ItemLabel>
-								<KSelect.ItemIndicator class="ml-auto text-blue-9">
-									<IconCapCircleCheck />
-								</KSelect.ItemIndicator>
-							</MenuItem>
+			<Field name="Templates" icon={<IconLucideSparkles class="size-4" />}>
+				<div class="grid grid-cols-2 gap-2">
+					<For each={TEXT_PRESETS}>
+						{(preset) => (
+							<TextPresetCard
+								preset={preset}
+								active={activePresetId() === preset.id}
+								onApply={() =>
+									updateSegment((segment) =>
+										applyTextPreset(segment, preset, installedFonts()),
+									)
+								}
+							/>
 						)}
-					>
-						<KSelect.Trigger class="flex w-full items-center justify-between rounded-md border border-gray-3 bg-gray-2 px-3 py-2 text-sm text-gray-12 transition-colors hover:border-gray-4 hover:bg-gray-3 focus:border-blue-9 focus:outline-hidden focus:ring-1 focus:ring-blue-9">
-							<KSelect.Value<{ label: string; value: number }> class="truncate">
-								{(state) => {
-									const selected = state.selectedOption();
-									if (selected) return selected.label;
-									const weight = props.segment.fontWeight;
-									const option = [
-										{ label: "Normal", value: 400 },
-										{ label: "Medium", value: 500 },
-										{ label: "Bold", value: 700 },
-									].find((o) => o.value === weight);
-									if (option) return option.label;
-									if (weight != null) return `Custom (${weight})`;
-									return "Normal";
-								}}
-							</KSelect.Value>
-							<KSelect.Icon>
-								<IconCapChevronDown class="size-4 shrink-0 transform transition-transform data-expanded:rotate-180 text-(--gray-500)" />
-							</KSelect.Icon>
-						</KSelect.Trigger>
-						<KSelect.Portal>
-							<PopperContent<typeof KSelect.Content>
-								as={KSelect.Content}
-								class={cx(topSlideAnimateClasses, "z-50")}
-							>
-								<MenuItemList<typeof KSelect.Listbox>
-									class="overflow-y-auto max-h-40"
-									as={KSelect.Listbox}
-								/>
-							</PopperContent>
-						</KSelect.Portal>
-					</KSelect>
-
-					<div class="flex items-center justify-between pt-1">
-						<span class="text-xs text-gray-11">Italic</span>
-						<Toggle
-							checked={props.segment.italic}
-							onChange={(value) =>
+					</For>
+				</div>
+			</Field>
+			<Field name="Font" icon={<IconLucideType class="size-4" />}>
+				<div class="flex flex-col gap-2">
+					<FontPicker
+						value={props.segment.fontFamily ?? "sans-serif"}
+						onChange={(family) =>
+							updateSegment((segment) => {
+								segment.fontFamily = family;
+							})
+						}
+					/>
+					<div class="flex items-center gap-2">
+						<div class="flex-1">
+							<TextStyleSelect
+								options={TEXT_SEGMENT_WEIGHT_OPTIONS}
+								value={props.segment.fontWeight}
+								onChange={(value) =>
+									updateSegment((segment) => {
+										segment.fontWeight = value;
+									})
+								}
+								fallbackLabel={(value) => `Custom (${value})`}
+							/>
+						</div>
+						<button
+							type="button"
+							title="Italic"
+							class={cx(
+								"flex size-9 shrink-0 items-center justify-center rounded-md border transition-colors",
+								props.segment.italic
+									? "border-blue-9 bg-blue-9/10 text-blue-9"
+									: "border-gray-3 bg-gray-2 text-gray-11 hover:bg-gray-3",
+							)}
+							onClick={() =>
 								updateSegment((segment) => {
-									segment.italic = value;
+									segment.italic = !segment.italic;
 								})
 							}
+						>
+							<IconLucideItalic class="size-4" />
+						</button>
+					</div>
+					<div class="flex flex-col gap-1">
+						<span class="text-xs text-gray-11">Size</span>
+						<Slider
+							value={[
+								clampNumber(
+									props.segment.fontSize,
+									TEXT_FONT_SIZE_MIN,
+									TEXT_FONT_SIZE_MAX,
+								),
+							]}
+							onChange={([value]) =>
+								updateSegment((segment) => {
+									const newFontSize = clampNumber(
+										value,
+										TEXT_FONT_SIZE_MIN,
+										TEXT_FONT_SIZE_MAX,
+									);
+									const oldFontSize = segment.fontSize || 48;
+									const scale = newFontSize / oldFontSize;
+
+									segment.fontSize = newFontSize;
+
+									// Scale the box with the font so line wrapping is
+									// preserved; keep the top edge fixed since the renderer
+									// anchors text at the top of the box (the canvas overlay
+									// re-hugs the box to the exact glyph bounds when visible).
+									if (segment.size && segment.center) {
+										const topEdge = segment.center.y - segment.size.y / 2;
+										segment.size.x = Math.min(segment.size.x * scale, 1);
+										segment.size.y = segment.size.y * scale;
+										segment.center.y = topEdge + segment.size.y / 2;
+									}
+								})
+							}
+							minValue={TEXT_FONT_SIZE_MIN}
+							maxValue={TEXT_FONT_SIZE_MAX}
+							step={1}
+						/>
+					</div>
+				</div>
+			</Field>
+			<Field name="Layout" icon={<IconLucideAlignCenter class="size-4" />}>
+				<div class="flex flex-col gap-3">
+					<div class="grid grid-cols-3 gap-1 rounded-lg border border-gray-3 bg-gray-2 p-1">
+						<For each={TEXT_ALIGN_OPTIONS}>
+							{(option) => (
+								<button
+									type="button"
+									class={cx(
+										"flex items-center justify-center rounded-md py-1.5 transition-colors",
+										(props.segment.align ?? "center") === option.value
+											? "bg-gray-5 text-gray-12"
+											: "text-gray-10 hover:text-gray-12",
+									)}
+									onClick={() =>
+										updateSegment((segment) => {
+											segment.align = option.value;
+										})
+									}
+								>
+									<Dynamic component={option.icon} class="size-4" />
+								</button>
+							)}
+						</For>
+					</div>
+					<div class="flex flex-col gap-1">
+						<span class="text-xs text-gray-11">Line height</span>
+						<Slider
+							value={[clampNumber(props.segment.lineHeight ?? 1.2, 0.8, 2)]}
+							onChange={([value]) =>
+								updateSegment((segment) => {
+									segment.lineHeight = clampNumber(value, 0.8, 2);
+								})
+							}
+							minValue={0.8}
+							maxValue={2}
+							step={0.05}
+						/>
+					</div>
+					<div class="flex flex-col gap-1">
+						<span class="text-xs text-gray-11">Letter spacing</span>
+						<Slider
+							value={[clampNumber(props.segment.letterSpacing ?? 0, -2, 20)]}
+							onChange={([value]) =>
+								updateSegment((segment) => {
+									segment.letterSpacing = clampNumber(value, -2, 20);
+								})
+							}
+							minValue={-2}
+							maxValue={20}
+							step={0.5}
+							formatTooltip="px"
 						/>
 					</div>
 				</div>
 			</Field>
 			<Field name="Color" icon={<IconLucidePalette class="size-4" />}>
-				<HexColorInput
-					value={props.segment.color}
-					brandColorSwatches={props.brandColorSwatches}
-					onChange={(value) =>
-						updateSegment((segment) => {
-							segment.color = value;
-						})
-					}
-				/>
+				<div class="flex flex-col gap-3">
+					<HexColorInput
+						value={props.segment.color}
+						brandColorSwatches={props.brandColorSwatches}
+						onChange={(value) =>
+							updateSegment((segment) => {
+								segment.color = value;
+							})
+						}
+					/>
+					<div class="flex flex-col gap-1">
+						<span class="text-xs text-gray-11">Opacity</span>
+						<Slider
+							value={[clampNumber(props.segment.opacity ?? 1, 0, 1)]}
+							onChange={([value]) =>
+								updateSegment((segment) => {
+									segment.opacity = clampNumber(value, 0, 1);
+								})
+							}
+							minValue={0}
+							maxValue={1}
+							step={0.01}
+						/>
+					</div>
+					<div class="flex flex-col gap-1">
+						<span class="text-xs text-gray-11">Shadow</span>
+						<Slider
+							value={[clampNumber(props.segment.shadow ?? 0, 0, 1)]}
+							onChange={([value]) =>
+								updateSegment((segment) => {
+									segment.shadow = clampNumber(value, 0, 1);
+								})
+							}
+							minValue={0}
+							maxValue={1}
+							step={0.01}
+						/>
+					</div>
+				</div>
 			</Field>
-			<Field name="Fade Duration" icon={<IconLucideTimer class="size-4" />}>
-				<Slider
-					value={[clampNumber(props.segment.fadeDuration ?? 0.15, 0, 1)]}
-					onChange={([value]) =>
-						updateSegment((segment) => {
-							segment.fadeDuration = clampNumber(value, 0, 1);
-						})
-					}
-					minValue={0}
-					maxValue={1}
-					step={0.01}
-					formatTooltip="s"
-				/>
+			<Field name="Animation" icon={<IconLucideTimer class="size-4" />}>
+				<div class="flex flex-col gap-3">
+					<div class="flex flex-col gap-2">
+						<span class="text-xs text-gray-11">In</span>
+						<TextStyleSelect
+							options={TEXT_ANIMATION_OPTIONS}
+							value={props.segment.animationIn ?? "fade"}
+							onChange={(value) =>
+								updateSegment((segment) => {
+									segment.animationIn = value;
+								})
+							}
+						/>
+						<Show when={(props.segment.animationIn ?? "fade") !== "none"}>
+							<Slider
+								value={[
+									clampNumber(props.segment.animationInDuration ?? 0.15, 0, 3),
+								]}
+								onChange={([value]) =>
+									setAnimationDuration("animationInDuration", value)
+								}
+								minValue={0}
+								maxValue={3}
+								step={0.05}
+								formatTooltip="s"
+							/>
+						</Show>
+					</div>
+					<div class="flex flex-col gap-2">
+						<span class="text-xs text-gray-11">Out</span>
+						<TextStyleSelect
+							options={TEXT_ANIMATION_OPTIONS}
+							value={props.segment.animationOut ?? "fade"}
+							onChange={(value) =>
+								updateSegment((segment) => {
+									segment.animationOut = value;
+								})
+							}
+						/>
+						<Show when={(props.segment.animationOut ?? "fade") !== "none"}>
+							<Slider
+								value={[
+									clampNumber(props.segment.animationOutDuration ?? 0.15, 0, 3),
+								]}
+								onChange={([value]) =>
+									setAnimationDuration("animationOutDuration", value)
+								}
+								minValue={0}
+								maxValue={3}
+								step={0.05}
+								formatTooltip="s"
+							/>
+						</Show>
+					</div>
+				</div>
 			</Field>
 		</div>
 	);
@@ -5116,32 +5429,57 @@ function Camera3DSegmentConfig(props: {
 	);
 }
 
+// Maps a zoom segment's start (held-output time on the edited timeline) to
+// the recording-segment file and the time within it whose frame is on screen
+// at that moment. Split/trimmed timelines mean neither can be read off the
+// zoom segment directly.
+function zoomPreviewSource(
+	timeline:
+		| {
+				segments: TimelineSegment[];
+				transitions?: ClipTransition[];
+				textSegments?: TextSegment[];
+		  }
+		| null
+		| undefined,
+	editedTime: number,
+): { recordingSegment: number; sourceTime: number } {
+	const gapless =
+		editedTime -
+		heldTimeBefore(holdWindows(timeline?.textSegments), editedTime);
+	return (
+		clipSourceTimeAt(
+			timeline?.segments ?? [],
+			timeline?.transitions ?? [],
+			gapless,
+		) ?? { recordingSegment: 0, sourceTime: gapless }
+	);
+}
+
+// The mapping memos return fresh objects; compare by value so unrelated
+// timeline edits don't restart the preview <video>.
+const zoomPreviewSourceEquals = (
+	a: { recordingSegment: number; sourceTime: number },
+	b: { recordingSegment: number; sourceTime: number },
+) => a.recordingSegment === b.recordingSegment && a.sourceTime === b.sourceTime;
+
 function ZoomSegmentPreview(props: {
 	segmentIndex: number;
 	segment: ZoomSegment;
 }) {
 	const { project, editorInstance } = useEditorContext();
 
-	const start = createMemo(() => props.segment.start);
-
-	const clipSegment = createMemo(() => {
-		const st = start();
-		return project.timeline?.segments.find((s) => s.start <= st && s.end > st);
-	});
-
-	const relativeTime = createMemo(() => {
-		const st = start();
-		const segment = clipSegment();
-		if (!segment) return 0;
-		return Math.max(0, st - segment.start);
-	});
+	const source = createMemo(
+		() => zoomPreviewSource(project.timeline, props.segment.start),
+		undefined,
+		{ equals: zoomPreviewSourceEquals },
+	);
 
 	const video = document.createElement("video");
 	createEffect(() => {
-		// TODO: make this not hardcoded
 		const path = convertFileSrc(
 			`${editorInstance.path}/content/segments/segment-${
-				clipSegment()?.recordingSegment ?? 0
+				source().recordingSegment
 			}/display.mp4`,
 		);
 		video.src = path;
@@ -5150,8 +5488,7 @@ function ZoomSegmentPreview(props: {
 	});
 
 	createEffect(() => {
-		const t = relativeTime();
-		if (t === undefined) return;
+		const t = source().sourceTime;
 
 		if (video.readyState >= 2) {
 			video.currentTime = t;
@@ -5173,7 +5510,10 @@ function ZoomSegmentPreview(props: {
 		ctx.imageSmoothingEnabled = false;
 		ctx.clearRect(0, 0, canvasRef.width, canvasRef.height);
 
-		const raw = editorInstance.recordings.segments[0].display;
+		const raw = (
+			editorInstance.recordings.segments[source().recordingSegment] ??
+			editorInstance.recordings.segments[0]
+		).display;
 		const croppedPosition = project.background.crop?.position || { x: 0, y: 0 };
 		const croppedSize = project.background.crop?.size || {
 			x: raw.width,
@@ -5304,6 +5644,17 @@ function ZoomSegmentConfig(props: {
 							<div class="flex-1 bg-gray-3" />
 						</KTabs.Indicator>
 					</KTabs.List>
+					<div class="space-y-3">
+						<Show when={!generalSettings.data?.custom_cursor_capture2}>
+							<p class="text-xs text-gray-11">
+								Auto mode needs cursor capture. Enable "Custom cursor capture
+								(Studio)" in Settings → General.
+							</p>
+						</Show>
+						<ZoomModeHelper
+							mode={props.segment.mode === "auto" ? "auto" : "manual"}
+						/>
+					</div>
 					<KTabs.Content value="manual" tabIndex="">
 						<Show
 							when={(() => {
@@ -5314,39 +5665,30 @@ function ZoomSegmentConfig(props: {
 							})()}
 						>
 							{(mode) => {
-								const start = createMemo<number>((prev) => {
-									if (projectHistory.isPaused()) return prev;
+								// Frozen while history is paused so drags don't thrash the
+								// <video> seek.
+								const source = createMemo<{
+									recordingSegment: number;
+									sourceTime: number;
+								}>(
+									(prev) => {
+										if (projectHistory.isPaused()) return prev;
 
-									return props.segment.start;
-								}, 0);
-
-								const segmentIndex = createMemo<number>((prev) => {
-									if (projectHistory.isPaused()) return prev;
-
-									const st = start();
-									const i = project.timeline?.segments.findIndex(
-										(s) => s.start <= st && s.end > st,
-									);
-									if (i === undefined || i === -1) return 0;
-									return i;
-								}, 0);
-
-								// Calculate the time relative to the video segment
-								const relativeTime = createMemo(() => {
-									const st = start();
-									const segment = project.timeline?.segments[segmentIndex()];
-									if (!segment) return 0;
-									// The time within the actual video file
-									return Math.max(0, st - segment.start);
-								});
+										return zoomPreviewSource(
+											project.timeline,
+											props.segment.start,
+										);
+									},
+									{ recordingSegment: 0, sourceTime: 0 },
+									{ equals: zoomPreviewSourceEquals },
+								);
 
 								const video = document.createElement("video");
 								createEffect(() => {
 									const path = convertFileSrc(
-										// TODO: this shouldn't be so hardcoded
-										`${
-											editorInstance.path
-										}/content/segments/segment-${segmentIndex()}/display.mp4`,
+										`${editorInstance.path}/content/segments/segment-${
+											source().recordingSegment
+										}/display.mp4`,
 									);
 									video.src = path;
 									video.preload = "auto";
@@ -5355,8 +5697,7 @@ function ZoomSegmentConfig(props: {
 								});
 
 								createEffect(() => {
-									const t = relativeTime();
-									if (t === undefined) return;
+									const t = source().sourceTime;
 
 									// Ensure video is ready before seeking
 									if (video.readyState >= 2) {
@@ -5429,7 +5770,11 @@ function ZoomSegmentConfig(props: {
 								const [ref, setRef] = createSignal<HTMLDivElement>();
 								const bounds = createElementBounds(ref);
 								const rawSize = () => {
-									const raw = editorInstance.recordings.segments[0].display;
+									const raw = (
+										editorInstance.recordings.segments[
+											source().recordingSegment
+										] ?? editorInstance.recordings.segments[0]
+									).display;
 									return { x: raw.width, y: raw.height };
 								};
 
@@ -5531,192 +5876,303 @@ function ZoomSegmentConfig(props: {
 	);
 }
 
-function ClipSegmentConfig(props: {
-	segmentIndex: number;
-	segment: TimelineSegment;
+// Bulk editor shown when multiple zoom segments are selected: one set of
+// controls that writes to every selected segment, with "Mixed" badges when
+// the selected segments' values differ.
+function ZoomMultiSegmentConfig(props: {
+	segments: { index: number; segment: ZoomSegment }[];
 }) {
-	const { setProject, setEditorState, project, projectActions, meta } =
-		useEditorContext();
+	const generalSettings = generalSettingsStore.createQuery();
+	const { setProject, setEditorState } = useEditorContext();
 
-	// Get current clip configuration
-	const clipConfig = () =>
-		project.clips?.find((c) => c.index === props.segmentIndex);
-	const offsets = () => clipConfig()?.offsets || {};
-	const offsetsAutoCalculated = () =>
-		clipConfig()?.offsetsAutoCalculated === true;
+	const amounts = () => props.segments.map((s) => s.segment.amount);
+	const sharedAmount = () => {
+		const [first, ...rest] = amounts();
+		if (first === undefined) return null;
+		return rest.every((a) => a === first) ? first : null;
+	};
+	const averageAmount = () => {
+		const values = amounts();
+		if (values.length === 0) return 1;
+		return values.reduce((sum, v) => sum + v, 0) / values.length;
+	};
 
-	function setOffset(type: keyof ClipOffsets, offset: number) {
-		if (Number.isNaN(offset)) return;
+	const sharedMode = (): "auto" | "manual" | "mixed" => {
+		const modes = props.segments.map((s) =>
+			s.segment.mode === "auto" ? ("auto" as const) : ("manual" as const),
+		);
+		const [first, ...rest] = modes;
+		if (first === undefined) return "mixed";
+		return rest.every((m) => m === first) ? first : "mixed";
+	};
+
+	const manualPositions = () =>
+		props.segments.map((s) =>
+			s.segment.mode === "auto" ? { x: 0.5, y: 0.5 } : s.segment.mode.manual,
+		);
+
+	const manualPositionsMixed = () => {
+		const [first, ...rest] = manualPositions();
+		if (!first) return false;
+		return rest.some((p) => p.x !== first.x || p.y !== first.y);
+	};
+
+	const averageManualPosition = () => {
+		const positions = manualPositions();
+		if (positions.length === 0) return { x: 0.5, y: 0.5 };
+		return {
+			x: positions.reduce((sum, p) => sum + p.x, 0) / positions.length,
+			y: positions.reduce((sum, p) => sum + p.y, 0) / positions.length,
+		};
+	};
+
+	const setAllAmounts = (amount: number) =>
+		batch(() => {
+			for (const { index } of props.segments)
+				setProject("timeline", "zoomSegments", index, "amount", amount);
+		});
+
+	// Switching to manual keeps each segment's existing focal point; only
+	// segments coming from auto get the centered default.
+	const setAllModes = (mode: "auto" | "manual") =>
+		batch(() => {
+			for (const { index, segment } of props.segments) {
+				if (mode === "auto")
+					setProject("timeline", "zoomSegments", index, "mode", "auto");
+				else if (segment.mode === "auto")
+					setProject("timeline", "zoomSegments", index, "mode", {
+						manual: { x: 0.5, y: 0.5 },
+					});
+			}
+		});
+
+	const setAllManualPositions = (pos: XY<number>) =>
+		batch(() => {
+			for (const { index } of props.segments)
+				setProject("timeline", "zoomSegments", index, "mode", {
+					manual: { ...pos },
+				});
+		});
+
+	const removeFromSelection = (segmentIndex: number) => {
+		const remaining = props.segments
+			.map((s) => s.index)
+			.filter((index) => index !== segmentIndex);
+		setEditorState(
+			"timeline",
+			"selection",
+			remaining.length > 0 ? { type: "zoom", indices: remaining } : null,
+		);
+	};
+
+	const modeButtonClass =
+		"flex-1 py-2.5 rounded-[0.6rem] text-gray-11 transition-colors duration-100 outline-hidden data-[selected='true']:bg-gray-3 data-[selected='true']:text-gray-12 not-data-[selected='true']:hover:text-gray-12 disabled:opacity-40 disabled:cursor-not-allowed";
+
+	return (
+		<div class="space-y-4">
+			<div class="flex flex-col gap-6 p-4 rounded-lg border border-gray-200">
+				<Field
+					name="Zoom Amount"
+					icon={<IconLucideSearch />}
+					value={
+						<Show when={sharedAmount() === null}>
+							<span class="text-[10px] px-1.5 py-0.5 bg-gray-3 rounded-full text-gray-11 font-medium">
+								Mixed
+							</span>
+						</Show>
+					}
+				>
+					<Slider
+						value={[sharedAmount() ?? averageAmount()]}
+						onChange={(v) => setAllAmounts(v[0])}
+						minValue={1}
+						maxValue={4.5}
+						step={0.001}
+						formatTooltip="x"
+					/>
+				</Field>
+				<Field
+					name="Zoom Mode"
+					icon={<IconCapSettings />}
+					value={
+						<Show when={sharedMode() === "mixed"}>
+							<span class="text-[10px] px-1.5 py-0.5 bg-gray-3 rounded-full text-gray-11 font-medium">
+								Mixed
+							</span>
+						</Show>
+					}
+				>
+					<div class="flex flex-row items-center p-px rounded-lg border">
+						<button
+							type="button"
+							disabled={!generalSettings.data?.custom_cursor_capture2}
+							data-selected={sharedMode() === "auto"}
+							onClick={() => setAllModes("auto")}
+							class={modeButtonClass}
+						>
+							Auto
+						</button>
+						<button
+							type="button"
+							data-selected={sharedMode() === "manual"}
+							onClick={() => setAllModes("manual")}
+							class={modeButtonClass}
+						>
+							Manual
+						</button>
+					</div>
+					<Show when={!generalSettings.data?.custom_cursor_capture2}>
+						<p class="text-xs text-gray-11">
+							Auto mode needs cursor capture. Enable "Custom cursor capture
+							(Studio)" in Settings → General.
+						</p>
+					</Show>
+					<Show
+						when={(() => {
+							const mode = sharedMode();
+							return mode === "mixed" ? null : mode;
+						})()}
+					>
+						{(mode) => <ZoomModeHelper mode={mode()} />}
+					</Show>
+					<Show when={sharedMode() === "manual"}>
+						<div class="space-y-1.5">
+							<PositionPad
+								value={averageManualPosition}
+								onChange={setAllManualPositions}
+							/>
+							<Show when={manualPositionsMixed()}>
+								<p class="text-xs text-gray-10">
+									Segments zoom into different spots. Drag to move them all to
+									the same one.
+								</p>
+							</Show>
+						</div>
+					</Show>
+				</Field>
+			</div>
+			<div class="grid grid-cols-3 gap-4">
+				<Index each={[...props.segments].sort((a, b) => a.index - b.index)}>
+					{(item) => (
+						<div class="relative p-2.5 rounded-lg border border-gray-4 bg-gray-3 group">
+							<button
+								type="button"
+								class="hidden absolute top-1.5 right-1.5 z-10 justify-center items-center rounded-full transition-colors group-hover:flex bg-gray-5 hover:bg-gray-6 text-gray-11 hover:text-gray-12 size-5"
+								aria-label="Remove from selection"
+								onClick={() => removeFromSelection(item().index)}
+							>
+								<IconLucideX class="size-3" />
+							</button>
+							<ZoomSegmentPreview
+								segment={item().segment}
+								segmentIndex={item().index}
+							/>
+						</div>
+					)}
+				</Index>
+			</div>
+		</div>
+	);
+}
+
+// A/V sync offsets are per recording segment (project.clips is keyed by
+// recording segment index), so they live with the audio settings rather
+// than any one timeline segment.
+function SyncOffsetsConfig() {
+	const { project, setProject, editorInstance, meta } = useEditorContext();
+
+	const clipConfig = (recordingIndex: number) =>
+		project.clips?.find((c) => c.index === recordingIndex);
+
+	const hasAnySource = () =>
+		meta().hasSystemAudio || meta().hasMicrophone || meta().hasCamera;
+
+	function setOffset(
+		recordingIndex: number,
+		type: keyof ClipOffsets,
+		offsetMs: number,
+	) {
+		if (Number.isNaN(offsetMs)) return;
 
 		setProject(
 			produce((proj) => {
 				if (!proj.clips) proj.clips = [];
-				const clips = proj.clips;
-				let clip = clips.find(
-					(clip) => clip.index === (props.segment.recordingSegment ?? 0),
-				);
+				let clip = proj.clips.find((c) => c.index === recordingIndex);
 				if (!clip) {
-					clip = { index: 0, offsets: {} };
-					clips.push(clip);
+					clip = { index: recordingIndex, offsets: {} };
+					proj.clips.push(clip);
 				}
 
-				clip.offsets[type] = offset / 1000;
+				clip.offsets[type] = offsetMs / 1000;
 				clip.offsetsAutoCalculated = false;
 			}),
 		);
 	}
 
-	function setSpeedAudioMode(value: string) {
-		if (
-			value === "mute" ||
-			value === "maintainPitch" ||
-			value === "matchSpeed"
-		) {
-			projectActions.setClipSegmentSpeedAudioMode(
-				props.segmentIndex,
-				value satisfies ClipSpeedAudioMode,
-			);
-		}
-	}
-
 	return (
-		<>
-			<div class="flex flex-row justify-between items-center">
-				<div class="flex gap-2 items-center">
-					<EditorButton
-						onClick={() => setEditorState("timeline", "selection", null)}
-						leftIcon={<IconLucideCheck />}
-					>
-						Done
-					</EditorButton>
-				</div>
-				<EditorButton
-					variant="danger"
-					onClick={() => {
-						projectActions.deleteClipSegment(props.segmentIndex);
-					}}
-					disabled={(project.timeline?.segments.length ?? 0) < 2}
-					leftIcon={<IconCapTrash />}
-				>
-					Delete
-				</EditorButton>
-			</div>
-
-			<div class="space-y-0.5">
-				<h3 class="font-medium text-gray-12">Segment Settings</h3>
-				<p class="text-gray-11">
-					These settings apply to only the selected segment
-				</p>
-			</div>
-
-			<Field name="Speed" icon={<IconLucideFastForward class="size-4" />}>
-				<KRadioGroup
-					class="flex flex-row gap-1.5 -mt-1"
-					value={props.segment.timescale.toString()}
-					onChange={(v) => {
-						projectActions.setClipSegmentTimescale(
-							props.segmentIndex,
-							parseFloat(v),
-						);
-					}}
-				>
-					<For each={[0.25, 0.5, 1, 1.5, 2, 4, 8]}>
-						{(mult) => (
-							<KRadioGroup.Item value={mult.toString()}>
-								<KRadioGroup.ItemControl class="px-2 py-1 text-gray-11 hover:text-gray-12 bg-gray-1 border border-gray-3 rounded-md data-checked:bg-gray-3 data-checked:border-gray-4 data-checked:text-gray-12">
-									{mult}x
-								</KRadioGroup.ItemControl>
-							</KRadioGroup.Item>
-						)}
-					</For>
-				</KRadioGroup>
-
-				<Show when={props.segment.timescale !== 1}>
-					<div class="space-y-2 pt-2">
-						<p class="text-gray-11">
-							Mute is fastest. Maintain pitch keeps voices natural, while Match
-							speed raises or lowers pitch with playback speed.
-						</p>
-						<KRadioGroup
-							class="grid grid-cols-3 gap-1.5"
-							value={props.segment.speedAudioMode ?? "mute"}
-							onChange={setSpeedAudioMode}
-						>
-							<For
-								each={[
-									{ value: "mute", label: "Mute" },
-									{ value: "maintainPitch", label: "Maintain pitch" },
-									{ value: "matchSpeed", label: "Match speed" },
-								]}
-							>
-								{(option) => (
-									<KRadioGroup.Item value={option.value}>
-										<KRadioGroup.ItemControl class="w-full px-2 py-1.5 text-xs text-gray-11 hover:text-gray-12 bg-gray-1 border border-gray-3 rounded-md data-checked:bg-gray-3 data-checked:border-gray-4 data-checked:text-gray-12">
-											{option.label}
-										</KRadioGroup.ItemControl>
-									</KRadioGroup.Item>
-								)}
-							</For>
-						</KRadioGroup>
-					</div>
-				</Show>
-			</Field>
-
-			<div class="space-y-0.5 pt-2">
-				<h3 class="font-medium text-gray-12">Clip Settings</h3>
-				<p class="text-gray-11">
-					These settings apply to all segments for the current clip
-				</p>
-				<Show when={offsetsAutoCalculated()}>
+		<Show when={hasAnySource()}>
+			<div class="flex flex-col gap-6">
+				<div class="space-y-0.5">
+					<h3 class="font-medium text-gray-12">Sync</h3>
 					<p class="text-gray-11">
-						Cap calculated these offsets automatically to keep audio in sync
-						with the video. Adjust them if anything still sounds off.
+						Fine-tune source offsets if audio or camera drifts out of sync with
+						the screen recording.
 					</p>
-				</Show>
+				</div>
+
+				<For each={editorInstance.recordings.segments}>
+					{(_, index) => (
+						<div class="flex flex-col gap-6">
+							<Show when={editorInstance.recordings.segments.length > 1}>
+								<span class="font-medium text-gray-12">Clip {index()}</span>
+							</Show>
+							<Show when={clipConfig(index())?.offsetsAutoCalculated === true}>
+								<p class="text-gray-11">
+									Cap calculated these offsets automatically to keep audio in
+									sync with the video. Adjust them if anything still sounds off.
+								</p>
+							</Show>
+							{meta().hasSystemAudio && (
+								<SourceOffsetField
+									name="System Audio Offset"
+									value={clipConfig(index())?.offsets.system_audio}
+									autoCalculated={
+										clipConfig(index())?.offsetsAutoCalculated === true
+									}
+									onChange={(offset) => {
+										setOffset(index(), "system_audio", offset);
+									}}
+								/>
+							)}
+							{meta().hasMicrophone && (
+								<SourceOffsetField
+									name="Microphone Offset"
+									value={clipConfig(index())?.offsets.mic}
+									autoCalculated={
+										clipConfig(index())?.offsetsAutoCalculated === true
+									}
+									onChange={(offset) => {
+										setOffset(index(), "mic", offset);
+									}}
+								/>
+							)}
+							{meta().hasCamera && (
+								<SourceOffsetField
+									name="Camera Offset"
+									value={clipConfig(index())?.offsets.camera}
+									autoCalculated={
+										clipConfig(index())?.offsetsAutoCalculated === true
+									}
+									onChange={(offset) => {
+										setOffset(index(), "camera", offset);
+									}}
+								/>
+							)}
+						</div>
+					)}
+				</For>
 			</div>
-
-			{meta().hasSystemAudio && (
-				<SourceOffsetField
-					name="System Audio Offset"
-					value={offsets().system_audio}
-					autoCalculated={offsetsAutoCalculated()}
-					onChange={(offset) => {
-						setOffset("system_audio", offset);
-					}}
-				/>
-			)}
-			{meta().hasMicrophone && (
-				<SourceOffsetField
-					name="Microphone Offset"
-					value={offsets().mic}
-					autoCalculated={offsetsAutoCalculated()}
-					onChange={(offset) => {
-						setOffset("mic", offset);
-					}}
-				/>
-			)}
-			{meta().hasCamera && (
-				<SourceOffsetField
-					name="Camera Offset"
-					value={offsets().camera}
-					autoCalculated={offsetsAutoCalculated()}
-					onChange={(offset) => {
-						setOffset("camera", offset);
-					}}
-				/>
-			)}
-
-			{/*<ComingSoonTooltip>
-			<Field name="Hide Cursor" disabled value={<Toggle disabled />} />
-		</ComingSoonTooltip>
-		<ComingSoonTooltip>
-			<Field
-				name="Disable Smooth Cursor Movement"
-				disabled
-				value={<Toggle disabled />}
-			/>
-		</ComingSoonTooltip>*/}
-		</>
+		</Show>
 	);
 }
 

--- a/apps/desktop/src/routes/editor/FontPicker.tsx
+++ b/apps/desktop/src/routes/editor/FontPicker.tsx
@@ -1,0 +1,96 @@
+import { Combobox as KCombobox } from "@kobalte/core/combobox";
+import { cx } from "cva";
+import { createMemo, createResource } from "solid-js";
+import {
+	cssFontFamily,
+	fontFamilyLabel,
+	GENERIC_FONT_OPTIONS,
+	listSystemFonts,
+} from "~/utils/fonts";
+import {
+	MenuItem,
+	MenuItemList,
+	PopperContent,
+	topSlideAnimateClasses,
+} from "./ui";
+
+type FontOption = { value: string; label: string };
+
+export function FontPicker(props: {
+	value: string;
+	onChange: (family: string) => void;
+}) {
+	const [installedFonts] = createResource(listSystemFonts);
+
+	const options = createMemo<FontOption[]>(() => [
+		...GENERIC_FONT_OPTIONS,
+		...(installedFonts() ?? []).map((name) => ({ value: name, label: name })),
+	]);
+
+	const selected = createMemo<FontOption>(
+		() =>
+			options().find((option) => option.value === props.value) ?? {
+				value: props.value,
+				label: fontFamilyLabel(props.value),
+			},
+	);
+
+	return (
+		<KCombobox<FontOption>
+			options={options()}
+			optionValue="value"
+			optionTextValue="label"
+			optionLabel="label"
+			value={selected()}
+			onChange={(option) => {
+				if (option) props.onChange(option.value);
+			}}
+			defaultFilter="contains"
+			placeholder="Search fonts…"
+			itemComponent={(itemProps) => (
+				<MenuItem<typeof KCombobox.Item>
+					as={KCombobox.Item}
+					item={itemProps.item}
+				>
+					<KCombobox.ItemLabel
+						class="flex-1 truncate"
+						style={{
+							"font-family": cssFontFamily(itemProps.item.rawValue.value),
+						}}
+					>
+						{itemProps.item.rawValue.label}
+					</KCombobox.ItemLabel>
+					<KCombobox.ItemIndicator class="ml-auto text-blue-9">
+						<IconCapCircleCheck />
+					</KCombobox.ItemIndicator>
+				</MenuItem>
+			)}
+		>
+			<KCombobox.Control class="flex w-full items-center justify-between rounded-md border border-gray-3 bg-gray-2 px-3 py-2 text-sm text-gray-12 transition-colors hover:border-gray-4 hover:bg-gray-3 focus-within:border-blue-9 focus-within:ring-1 focus-within:ring-blue-9">
+				<KCombobox.Input
+					class="flex-1 min-w-0 bg-transparent outline-hidden text-gray-12 placeholder:text-gray-10"
+					style={{ "font-family": cssFontFamily(props.value) }}
+				/>
+				<KCombobox.Trigger class="shrink-0 ml-2 text-(--gray-500)">
+					<KCombobox.Icon>
+						<IconCapChevronDown class="size-4 transform transition-transform data-expanded:rotate-180" />
+					</KCombobox.Icon>
+				</KCombobox.Trigger>
+			</KCombobox.Control>
+			<KCombobox.Portal>
+				<PopperContent<typeof KCombobox.Content>
+					as={KCombobox.Content}
+					class={cx(
+						topSlideAnimateClasses,
+						"z-50 w-(--kb-popper-anchor-width)",
+					)}
+				>
+					<MenuItemList<typeof KCombobox.Listbox>
+						class="overflow-y-auto max-h-64"
+						as={KCombobox.Listbox}
+					/>
+				</PopperContent>
+			</KCombobox.Portal>
+		</KCombobox>
+	);
+}

--- a/apps/desktop/src/routes/editor/TextOverlay.tsx
+++ b/apps/desktop/src/routes/editor/TextOverlay.tsx
@@ -23,6 +23,7 @@ import {
 	TEXT_FONT_SIZE_MAX,
 	TEXT_FONT_SIZE_MIN,
 	TEXT_REFERENCE_HEIGHT,
+	type TextAlign,
 	type TextSegment,
 } from "./text";
 
@@ -264,9 +265,16 @@ type SegmentWithDefaults = {
 	fontWeight: number;
 	italic: boolean;
 	color: string;
+	align: TextAlign;
+	letterSpacing: number;
+	lineHeight: number;
 };
 
 function normalizeSegment(segment: TauriTextSegment): SegmentWithDefaults {
+	// The generated bindings lag behind the Rust schema until the next debug
+	// run regenerates them; the style fields are always present at runtime.
+	const styled = segment as TauriTextSegment &
+		Partial<Pick<TextSegment, "align" | "letterSpacing" | "lineHeight">>;
 	return {
 		start: segment.start,
 		end: segment.end,
@@ -279,6 +287,9 @@ function normalizeSegment(segment: TauriTextSegment): SegmentWithDefaults {
 		fontWeight: segment.fontWeight ?? 700,
 		italic: segment.italic ?? false,
 		color: segment.color ?? "#ffffff",
+		align: styled.align ?? "center",
+		letterSpacing: styled.letterSpacing ?? 0,
+		lineHeight: styled.lineHeight ?? 1.2,
 	};
 }
 
@@ -358,9 +369,10 @@ function TextSegmentOverlay(props: {
 	};
 
 	// Fit the stored box to the measured text. The box adapts to the glyphs,
-	// never the other way around: the top edge and horizontal center stay
-	// fixed (the renderer anchors text at the top of the box and centers each
-	// line), so a hug never moves pixels on screen.
+	// never the other way around: the top edge stays fixed (the renderer
+	// anchors text at the top of the box) and the horizontal edge the text is
+	// aligned to stays pinned — center for centered text, left/right edge for
+	// left/right-aligned — so a hug never moves pixels on screen.
 	const applyHug = () => {
 		const ink = measureInk();
 		if (!ink) return;
@@ -372,8 +384,16 @@ function TextSegmentOverlay(props: {
 			Math.abs(ink.y - seg.size.y) < epsY
 		)
 			return;
+		const align = seg.align;
 		props.updateSegment((s) => {
 			const topEdge = s.center.y - s.size.y / 2;
+			if (align === "left") {
+				const leftEdge = s.center.x - s.size.x / 2;
+				s.center.x = leftEdge + ink.x / 2;
+			} else if (align === "right") {
+				const rightEdge = s.center.x + s.size.x / 2;
+				s.center.x = rightEdge - ink.x / 2;
+			}
 			s.size.x = ink.x;
 			s.size.y = ink.y;
 			s.center.y = topEdge + ink.y / 2;
@@ -388,6 +408,9 @@ function TextSegmentOverlay(props: {
 				fontWeight: segment().fontWeight,
 				fontFamily: segment().fontFamily,
 				italic: segment().italic,
+				align: segment().align,
+				letterSpacing: segment().letterSpacing,
+				lineHeight: segment().lineHeight,
 				width: props.size.width,
 				height: props.size.height,
 			}),
@@ -695,12 +718,18 @@ function TextSegmentOverlay(props: {
 		top: rect().top >= 28 ? "-24px" : `${Math.max(6, 6 - rect().top)}px`,
 	});
 
+	// Letter spacing is authored in px at the 1080p reference height, like
+	// fontSize; scale it to preview px the same way.
+	const letterSpacingPx = () =>
+		(segment().letterSpacing * props.size.height) / TEXT_REFERENCE_HEIGHT;
+
 	const textStyle = () => ({
 		"font-family": segment().fontFamily,
 		"font-size": `${fontPx()}px`,
 		"font-weight": segment().fontWeight,
 		"font-style": segment().italic ? "italic" : "normal",
-		"line-height": 1.2,
+		"line-height": segment().lineHeight,
+		"letter-spacing": `${letterSpacingPx()}px`,
 	});
 
 	return (
@@ -765,9 +794,10 @@ function TextSegmentOverlay(props: {
 				<Show when={editing()}>
 					<textarea
 						ref={textareaRef}
-						class="absolute inset-0 p-0 text-center bg-transparent border-none outline-none resize-none overflow-hidden"
+						class="absolute inset-0 p-0 bg-transparent border-none outline-none resize-none overflow-hidden"
 						style={{
 							...textStyle(),
+							"text-align": segment().align,
 							color: segment().color,
 							"caret-color": segment().color,
 							"white-space": "pre-wrap",

--- a/apps/desktop/src/routes/editor/Timeline/AudioTrack.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/AudioTrack.tsx
@@ -10,6 +10,7 @@ import { useTimelineContext } from "./context";
 import {
 	SegmentContent,
 	SegmentHandle,
+	SegmentLabel,
 	SegmentRoot,
 	TrackRoot,
 	useSetPreviewTime,
@@ -456,6 +457,7 @@ export function AudioTrack(props: {
 								!segment.enabled && "opacity-50",
 							)}
 							innerClass="ring-emerald-8"
+							title={segment.name || "Audio"}
 							segment={segment}
 							onMouseDown={(e) => {
 								e.stopPropagation();
@@ -527,12 +529,24 @@ export function AudioTrack(props: {
 									},
 								)}
 							>
-								<div class="flex z-10 gap-1.5 items-center w-full min-w-0 text-xs text-white/95 drop-shadow-sm">
-									<IconLucideMusic class="size-3 shrink-0 opacity-90" />
-									<span class="max-w-full font-medium truncate">
-										{segment.name || "Audio"}
-									</span>
-								</div>
+								<SegmentLabel
+									compactAt={24}
+									full={() => (
+										<div class="flex z-10 gap-1.5 items-center max-w-full text-xs text-white/95 drop-shadow-sm">
+											<IconLucideMusic class="size-3 shrink-0 opacity-90" />
+											<span class="max-w-full font-medium truncate">
+												{segment.name || "Audio"}
+											</span>
+										</div>
+									)}
+									compact={() => (
+										<div class="flex z-10 items-center max-w-full text-xs text-white/95 drop-shadow-sm">
+											<span class="max-w-full font-medium truncate">
+												{segment.name || "Audio"}
+											</span>
+										</div>
+									)}
+								/>
 							</SegmentContent>
 							<SegmentHandle
 								position="end"

--- a/apps/desktop/src/routes/editor/Timeline/CaptionsTrack.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/CaptionsTrack.tsx
@@ -4,7 +4,13 @@ import { createMemo, createRoot, For } from "solid-js";
 
 import { useEditorContext } from "../context";
 import { useTimelineContext } from "./context";
-import { SegmentContent, SegmentHandle, SegmentRoot, TrackRoot } from "./Track";
+import {
+	SegmentContent,
+	SegmentHandle,
+	SegmentLabel,
+	SegmentRoot,
+	TrackRoot,
+} from "./Track";
 
 export type CaptionSegmentDragState =
 	| { type: "idle" }
@@ -164,6 +170,16 @@ export function CaptionsTrack(props: {
 					const segmentWidth = () =>
 						Math.min(segment.end, totalDuration()) - segment.start;
 
+					// Truncation degrades gracefully, so the same row serves both the
+					// full and compact tiers; it just clips against a smaller box.
+					const captionLabel = () => (
+						<div class="flex gap-1 justify-center items-center text-[10px] text-gray-1 dark:text-gray-12">
+							<span class="truncate max-w-full opacity-80">
+								{segment.text || "Caption"}
+							</span>
+						</div>
+					);
+
 					return (
 						<SegmentRoot
 							data-caption-segment
@@ -174,6 +190,7 @@ export function CaptionsTrack(props: {
 								isSelected() ? "border-green-7" : "border-transparent",
 							)}
 							innerClass="ring-green-6"
+							title={segment.text || "Caption"}
 							segment={{
 								start: segment.start,
 								end: Math.min(segment.end, totalDuration()),
@@ -248,13 +265,11 @@ export function CaptionsTrack(props: {
 									},
 								)}
 							>
-								<div class="flex flex-col gap-0.5 justify-center items-center text-xs text-gray-1 dark:text-gray-12 w-full min-w-0 overflow-hidden">
-									<div class="flex gap-1 items-center text-[10px] w-full min-w-0 justify-center">
-										<span class="truncate max-w-full opacity-80">
-											{segment.text || "Caption"}
-										</span>
-									</div>
-								</div>
+								<SegmentLabel
+									compactAt={24}
+									full={captionLabel}
+									compact={captionLabel}
+								/>
 							</SegmentContent>
 							<SegmentHandle
 								position="end"

--- a/apps/desktop/src/routes/editor/Timeline/ClipTrack.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/ClipTrack.tsx
@@ -8,6 +8,7 @@ import {
 	createMemo,
 	createRoot,
 	createSignal,
+	For,
 	Index,
 	Match,
 	onCleanup,
@@ -17,7 +18,7 @@ import {
 } from "solid-js";
 import { produce } from "solid-js/store";
 
-import type { TimelineSegment } from "~/utils/tauri";
+import type { ClipSpeedAudioMode, TimelineSegment } from "~/utils/tauri";
 import {
 	clampTransitionDuration,
 	clipTimelineDuration,
@@ -29,11 +30,14 @@ import {
 	maxTransitionDuration,
 } from "../clip-transitions";
 import { useEditorContext } from "../context";
+import { effectiveToOutput, holdWindows } from "../timeline-holds";
 import { useSegmentContext, useTimelineContext } from "./context";
 import { getSectionMarker } from "./sectionMarker";
+import { SPLIT_SNAP_PX, snapSplitTime } from "./split-snapping";
 import {
 	SegmentContent,
 	SegmentHandle,
+	SegmentLabel,
 	SegmentRoot,
 	TrackRoot,
 	useSegmentTranslateX,
@@ -59,15 +63,19 @@ function gainToScale(gain?: number) {
 
 const MAX_WAVEFORM_SAMPLES = 6000;
 
+// `range` is in output (timeline) time; `sourceTimeAt` maps an output time to
+// recording time, or null while a fullscreen-text hold has the clock paused —
+// the mixer renders silence there, so the waveform drops to the baseline.
 function createWaveformPath(
-	segment: { start: number; end: number },
+	range: { start: number; end: number },
 	waveform: number[] | undefined,
 	targetSamples: number,
+	sourceTimeAt: (outputTime: number) => number | null,
 ) {
 	if (typeof Path2D === "undefined") return;
 	if (!waveform || waveform.length === 0) return;
 
-	const duration = Math.max(segment.end - segment.start, WAVEFORM_SAMPLE_STEP);
+	const duration = Math.max(range.end - range.start, WAVEFORM_SAMPLE_STEP);
 	if (!Number.isFinite(duration) || duration <= 0) return;
 
 	const nativeSamples = Math.ceil(duration / WAVEFORM_SAMPLE_STEP) + 1;
@@ -82,7 +90,9 @@ function createWaveformPath(
 	const path = new Path2D();
 	path.moveTo(0, 1);
 
-	const amplitudeAt = (time: number) => {
+	const amplitudeAt = (outputTime: number) => {
+		const time = sourceTimeAt(outputTime);
+		if (time === null) return 0;
 		const index = Math.floor(time * 10);
 		const sample = waveform[index];
 		const db =
@@ -97,10 +107,10 @@ function createWaveformPath(
 	const controlStep = Math.min(WAVEFORM_CONTROL_STEP / duration, 0.25);
 
 	for (let i = 0; i <= numSamples; i++) {
-		const time = segment.start + i * timeStep;
-		const normalizedX = (time - segment.start) / duration;
+		const time = range.start + i * timeStep;
+		const normalizedX = (time - range.start) / duration;
 		const prevTime = time - timeStep;
-		const prevX = Math.max(0, (prevTime - segment.start) / duration);
+		const prevX = Math.max(0, (prevTime - range.start) / duration);
 		const y = 1 - amplitudeAt(time);
 		const prevY = 1 - amplitudeAt(prevTime);
 		const cpX1 = prevX + controlStep / 2;
@@ -109,7 +119,7 @@ function createWaveformPath(
 	}
 
 	const closingX =
-		(segment.end + WAVEFORM_PADDING_SECONDS - segment.start) / duration;
+		(range.end + WAVEFORM_PADDING_SECONDS - range.start) / duration;
 	path.lineTo(closingX, 1);
 	path.closePath();
 
@@ -138,6 +148,7 @@ function WaveformCanvas(props: {
 	micWaveform?: number[];
 	segment: { start: number; end: number };
 	segmentOffset: number;
+	holds: ReadonlyArray<[number, number]>;
 }) {
 	const { project, editorState } = useEditorContext();
 	const { width } = useSegmentContext();
@@ -153,19 +164,40 @@ function WaveformCanvas(props: {
 		const ctx = canvas.getContext("2d");
 		if (!ctx) return;
 
-		const segmentDuration = props.segment.end - props.segment.start;
+		// Hold windows relative to the clip's box; the box is stretched across
+		// them, so the canvas spans output time, not source time.
+		const holds = props.holds.map(([start, end]): [number, number] => [
+			start - props.segmentOffset,
+			end - props.segmentOffset,
+		]);
+		const heldDuration = holds.reduce(
+			(sum, [start, end]) => sum + end - start,
+			0,
+		);
+		const outputDuration =
+			props.segment.end - props.segment.start + heldDuration;
 		const fullSegmentWidth = width();
 
-		if (fullSegmentWidth < 1 || segmentDuration <= 0) {
+		if (fullSegmentWidth < 1 || outputDuration <= 0) {
 			return;
 		}
+
+		const sourceTimeAt = (outputTime: number): number | null => {
+			let held = 0;
+			for (const [start, end] of holds) {
+				if (outputTime >= end) held += end - start;
+				else if (outputTime > start) return null;
+				else break;
+			}
+			return props.segment.start + outputTime - held;
+		};
 
 		const useVirtualization = fullSegmentWidth > MAX_CANVAS_WIDTH;
 
 		let canvasWidth: number;
 		let leftOffsetPx: number;
 		let renderWidth: number;
-		let renderSegment: { start: number; end: number };
+		let renderRange: { start: number; end: number };
 
 		if (useVirtualization) {
 			const viewportWidth = timelineBounds.width ?? 800;
@@ -174,7 +206,7 @@ function WaveformCanvas(props: {
 			const viewEnd = viewStart + transform.zoom;
 
 			const segStart = props.segmentOffset;
-			const segEnd = segStart + segmentDuration;
+			const segEnd = segStart + outputDuration;
 
 			const visibleStart = Math.max(viewStart, segStart);
 			const visibleEnd = Math.min(viewEnd, segEnd);
@@ -189,7 +221,7 @@ function WaveformCanvas(props: {
 			const visibleStartInSegment = visibleStart - segStart;
 			const visibleEndInSegment = visibleEnd - segStart;
 
-			const pxPerSec = fullSegmentWidth / segmentDuration;
+			const pxPerSec = fullSegmentWidth / outputDuration;
 			const visibleWidthPx = Math.min(
 				(visibleEndInSegment - visibleStartInSegment) * pxPerSec,
 				viewportWidth + 200,
@@ -201,24 +233,24 @@ function WaveformCanvas(props: {
 			);
 			leftOffsetPx = visibleStartInSegment * pxPerSec;
 			renderWidth = visibleWidthPx;
-			renderSegment = {
-				start: props.segment.start + visibleStartInSegment,
-				end: props.segment.start + visibleEndInSegment,
+			renderRange = {
+				start: visibleStartInSegment,
+				end: visibleEndInSegment,
 			};
 		} else {
 			canvasWidth = Math.max(Math.ceil(fullSegmentWidth), 1);
 			leftOffsetPx = 0;
 			renderWidth = fullSegmentWidth;
-			renderSegment = {
-				start: props.segment.start,
-				end: props.segment.end,
-			};
+			renderRange = { start: 0, end: outputDuration };
 		}
 
 		const micScale = gainToScale(project.audio.micVolumeDb);
 		const systemScale = gainToScale(project.audio.systemVolumeDb);
 
-		const renderKey = `${canvasWidth}-${renderSegment.start.toFixed(2)}-${renderSegment.end.toFixed(2)}-${micScale.toFixed(2)}-${systemScale.toFixed(2)}`;
+		const holdsKey = holds
+			.map(([start, end]) => `${start.toFixed(2)}:${end.toFixed(2)}`)
+			.join(",");
+		const renderKey = `${canvasWidth}-${props.segment.start.toFixed(2)}-${renderRange.start.toFixed(2)}-${renderRange.end.toFixed(2)}-${holdsKey}-${micScale.toFixed(2)}-${systemScale.toFixed(2)}`;
 		if (renderKey === lastRenderKey) {
 			return;
 		}
@@ -241,7 +273,12 @@ function WaveformCanvas(props: {
 			color: string,
 			gain?: number,
 		) => {
-			const path = createWaveformPath(renderSegment, waveform, numSamples);
+			const path = createWaveformPath(
+				renderRange,
+				waveform,
+				numSamples,
+				sourceTimeAt,
+			);
 			if (!path) return;
 			const scale = gainToScale(gain);
 			if (scale <= 0) return;
@@ -272,6 +309,8 @@ function WaveformCanvas(props: {
 		editorState.timeline.transform.zoom;
 		props.segment.start;
 		props.segment.end;
+		props.segmentOffset;
+		props.holds;
 		props.micWaveform;
 		props.systemWaveform;
 		project.audio.micVolumeDb;
@@ -308,6 +347,89 @@ function WaveformCanvas(props: {
 			style={{ left: "0px" }}
 			height={CANVAS_HEIGHT}
 		/>
+	);
+}
+
+// The speed chip is rendered once per label tier so an open popover survives
+// the segment shrinking past a tier boundary; the menu itself lives here so
+// it isn't duplicated per tier.
+function ClipSpeedControl(props: {
+	timescale: number;
+	speedAudioMode?: ClipSpeedAudioMode | null;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	triggerClass?: string;
+	onSetTimescale: (timescale: number) => void;
+	onSetSpeedAudioMode: (mode: ClipSpeedAudioMode) => void;
+}) {
+	return (
+		<Popover
+			placement="top"
+			gutter={8}
+			open={props.open}
+			onOpenChange={props.onOpenChange}
+		>
+			<Popover.Trigger
+				class={cx(
+					"pointer-events-auto flex items-center gap-0.5 rounded-full bg-black/30 px-1.5 py-0.5 text-[10px] font-medium text-white transition-colors hover:bg-black/50",
+					props.triggerClass,
+				)}
+				aria-label={`Clip speed: ${props.timescale}x`}
+				onMouseDown={(event) => event.stopPropagation()}
+			>
+				<IconLucideFastForward class="size-2.5" />
+				{props.timescale}x
+			</Popover.Trigger>
+			<Popover.Portal>
+				<Popover.Content
+					onMouseDown={(event) => event.stopPropagation()}
+					class="z-50 flex w-max flex-col gap-1.5 rounded-xl border border-gray-3 bg-gray-1 p-2 text-gray-12 shadow-xl outline-hidden animate-in fade-in slide-in-from-bottom-2"
+				>
+					<div class="flex items-center gap-1 rounded-lg bg-gray-2 p-1">
+						{[0.25, 0.5, 1, 1.5, 2, 4, 8].map((mult) => (
+							<button
+								type="button"
+								aria-pressed={props.timescale === mult}
+								class={cx(
+									"rounded-md px-2 py-1 text-xs whitespace-nowrap transition-colors",
+									props.timescale === mult
+										? "bg-gray-4 text-gray-12"
+										: "text-gray-10 hover:text-gray-12",
+								)}
+								onClick={() => props.onSetTimescale(mult)}
+							>
+								{mult}x
+							</button>
+						))}
+					</div>
+					<Show when={props.timescale !== 1}>
+						<div class="flex items-center gap-1 rounded-lg bg-gray-2 p-1">
+							{(
+								[
+									["mute", "Mute"],
+									["maintainPitch", "Maintain pitch"],
+									["matchSpeed", "Match speed"],
+								] as const
+							).map(([value, label]) => (
+								<button
+									type="button"
+									aria-pressed={(props.speedAudioMode ?? "mute") === value}
+									class={cx(
+										"flex-1 rounded-md px-2 py-1 text-xs whitespace-nowrap transition-colors",
+										(props.speedAudioMode ?? "mute") === value
+											? "bg-gray-4 text-gray-12"
+											: "text-gray-10 hover:text-gray-12",
+									)}
+									onClick={() => props.onSetSpeedAudioMode(value)}
+								>
+									{label}
+								</button>
+							))}
+						</div>
+					</Show>
+				</Popover.Content>
+			</Popover.Portal>
+		</Popover>
 	);
 }
 
@@ -381,15 +503,42 @@ export function ClipTrack(
 		};
 	};
 
+	// Fullscreen text segments pause the recording clock, stretching the clip
+	// that contains them across the held window on the output timeline.
+	const heldWindows = createMemo(() =>
+		holdWindows(project.timeline?.textSegments),
+	);
+
+	const selectedHoldWindows = createMemo(() => {
+		const selection = editorState.timeline.selection;
+		if (selection?.type !== "text") return null;
+		const texts = project.timeline?.textSegments;
+		if (!texts) return null;
+		const windows = selection.indices
+			.map((index) => texts[index])
+			.filter(
+				(segment) =>
+					segment &&
+					segment.enabled !== false &&
+					segment.layout === "fullscreen",
+			)
+			.map((segment): [number, number] => [segment.start, segment.end]);
+		return windows.length > 0 ? windows : null;
+	});
+
 	const visibleSegmentIndices = createMemo(() => {
 		const segs = segments();
 		const offsets = segmentOffsets();
+		const holds = heldWindows();
 		const draggedIndex = transitionDrag()?.index;
 		const visible: number[] = [];
 		for (let i = 0; i < segs.length; i++) {
 			const seg = segs[i];
-			const segStart = offsets[i];
-			const segEnd = segStart + (seg.end - seg.start) / seg.timescale;
+			const segStart = effectiveToOutput(holds, offsets[i]);
+			const segEnd = effectiveToOutput(
+				holds,
+				offsets[i] + (seg.end - seg.start) / seg.timescale,
+			);
 			if (i === draggedIndex || isSegmentVisible(segStart, segEnd)) {
 				visible.push(i);
 			}
@@ -413,6 +562,10 @@ export function ClipTrack(
 		editorInstance.recordings.segments.length > 1;
 
 	const split = () => editorState.timeline.interactMode === "split";
+
+	createEffect(() => {
+		if (!split()) setEditorState("timeline", "splitPreview", null);
+	});
 
 	function selectClip(currentIndex: number, event: MouseEvent) {
 		const selection = editorState.timeline.selection;
@@ -450,12 +603,29 @@ export function ClipTrack(
 		<TrackRoot
 			ref={props.ref}
 			onMouseEnter={() => setEditorState("timeline", "hoveredTrack", "clip")}
-			onMouseLeave={() => setEditorState("timeline", "hoveredTrack", null)}
+			onMouseLeave={() => {
+				setEditorState("timeline", "hoveredTrack", null);
+				setEditorState("timeline", "splitPreview", null);
+			}}
 		>
 			<Index each={visibleSegmentIndices()}>
 				{(segmentIndex) => {
 					const i = segmentIndex;
 					const segment = () => segments()[i()];
+					const [speedOpen, setSpeedOpen] = createSignal(false);
+
+					const clipName = () =>
+						hasMultipleRecordingSegments()
+							? `Clip ${segment().recordingSegment}`
+							: "Clip";
+
+					const clipTitle = () => {
+						const seg = segment();
+						const parts = [clipName(), formatTime(seg.end - seg.start)];
+						if (seg.timescale !== 1) parts.push(`${seg.timescale}x`);
+						return parts.join(" · ");
+					};
+
 					const [startHandleDrag, setStartHandleDrag] = createSignal<null | {
 						offset: number;
 						initialStart: number;
@@ -467,19 +637,55 @@ export function ClipTrack(
 						const ds = startHandleDrag();
 						const offset = ds?.offset ?? 0;
 						const seg = segment();
+						const holds = heldWindows();
 
 						return {
-							start: Math.max(prevDuration() + offset, 0),
-							end:
+							start: Math.max(
+								effectiveToOutput(holds, prevDuration() + offset),
+								0,
+							),
+							end: effectiveToOutput(
+								holds,
 								prevDuration() +
-								(offset + (seg.end - seg.start)) / seg.timescale,
+									(offset + (seg.end - seg.start)) / seg.timescale,
+							),
 							timescale: seg.timescale,
 							recordingSegment: seg.recordingSegment,
 						};
 					});
 
+					// Held (paused) windows inside this clip's on-screen box.
+					const segmentHolds = createMemo(() => {
+						const { start, end } = relativeSegment();
+						return heldWindows()
+							.map(([holdStart, holdEnd]): [number, number] => [
+								Math.max(holdStart, start),
+								Math.min(holdEnd, end),
+							])
+							.filter(([holdStart, holdEnd]) => holdEnd > holdStart);
+					});
+
 					const segmentX = useSegmentTranslateX(relativeSegment);
 					const segmentWidth = useSegmentWidth(relativeSegment);
+
+					const splitTimeAt = (e: {
+						clientX: number;
+						altKey: boolean;
+						currentTarget: HTMLDivElement;
+					}) => {
+						const rect = e.currentTarget.getBoundingClientRect();
+						const seg = relativeSegment();
+						const raw = seg.start + (e.clientX - rect.left) * secsPerPixel();
+						if (e.altKey) return { time: raw, snapped: null };
+						return snapSplitTime(
+							raw,
+							seg.start,
+							seg.end,
+							SPLIT_SNAP_PX * secsPerPixel(),
+							project.timeline,
+							editorState.playbackTime,
+						);
+					};
 
 					const segmentRecording = (s = i()) =>
 						editorInstance.recordings.segments[
@@ -617,7 +823,20 @@ export function ClipTrack(
 									isSelected() ? "border-gray-12" : "border-transparent",
 								)}
 								innerClass="ring-blue-9"
+								title={clipTitle()}
 								segment={relativeSegment()}
+								onMouseMove={(e) => {
+									if (editorState.timeline.interactMode !== "split") return;
+									const result = splitTimeAt(e);
+									setEditorState("timeline", "splitPreview", {
+										time: result.time,
+										snapped: result.snapped !== null,
+									});
+								}}
+								onMouseLeave={() => {
+									if (editorState.timeline.splitPreview)
+										setEditorState("timeline", "splitPreview", null);
+								}}
 								onMouseDown={(e) => {
 									e.stopPropagation();
 									if (e.button !== 0) return;
@@ -629,17 +848,10 @@ export function ClipTrack(
 										return;
 
 									if (editorState.timeline.interactMode === "split") {
-										const rect = e.currentTarget.getBoundingClientRect();
-										const fraction = (e.clientX - rect.left) / rect.width;
-										const seg = segment();
-
-										const splitTime =
-											(fraction * (seg.end - seg.start)) / seg.timescale;
-
-										projectActions.splitClipSegment(
-											prevDuration() + splitTime,
-											i(),
-										);
+										// The box is in output time (it stretches across any
+										// held windows); splitClipSegment converts back to the
+										// recording-flow domain itself.
+										projectActions.splitClipSegment(splitTimeAt(e).time, i());
 									} else {
 										const index = i();
 										const initialTransition = getClipTransition(
@@ -733,11 +945,61 @@ export function ClipTrack(
 										micWaveform={micWaveform()}
 										systemWaveform={systemAudioWaveform()}
 										segment={segment()}
-										segmentOffset={prevDuration()}
+										segmentOffset={relativeSegment().start}
+										holds={segmentHolds()}
 									/>
 								)}
 
-								<Markings segment={segment()} prevDuration={prevDuration()} />
+								<Markings
+									segment={segment()}
+									prevDuration={relativeSegment().start}
+									holds={segmentHolds()}
+								/>
+
+								<For each={segmentHolds()}>
+									{(hold) => {
+										// Light up when the fullscreen text causing this hold
+										// is selected, so cause and effect read as one thing.
+										const causeSelected = () =>
+											selectedHoldWindows()?.some(
+												([start, end]) => start < hold[1] && end > hold[0],
+											) ?? false;
+										const holdWidth = () =>
+											(hold[1] - hold[0]) / secsPerPixel();
+										return (
+											<div
+												class={cx(
+													"absolute inset-y-0 z-[3] flex items-center justify-center gap-1 overflow-hidden bg-black/45 backdrop-saturate-50 border-x transition-colors",
+													causeSelected() ? "border-blue-9" : "border-white/25",
+												)}
+												style={{
+													left: `${(hold[0] - relativeSegment().start) / secsPerPixel()}px`,
+													width: `${holdWidth()}px`,
+													"background-image":
+														"repeating-linear-gradient(-45deg, rgba(255,255,255,0.07) 0px, rgba(255,255,255,0.07) 4px, transparent 4px, transparent 8px)",
+												}}
+												title="Video paused while the fullscreen text is shown"
+											>
+												<IconLucidePause
+													class={cx(
+														"size-3 shrink-0",
+														causeSelected() ? "text-blue-9" : "text-white/70",
+													)}
+												/>
+												<Show when={holdWidth() >= 64}>
+													<span
+														class={cx(
+															"text-[10px] font-medium whitespace-nowrap",
+															causeSelected() ? "text-blue-9" : "text-white/70",
+														)}
+													>
+														Paused
+													</span>
+												</Show>
+											</div>
+										);
+									}}
+								</For>
 
 								<Show when={i() > 0 && !transitionAt(i())}>
 									<button
@@ -971,28 +1233,50 @@ export function ClipTrack(
 								/>
 								<SegmentContent class="relative justify-center items-center">
 									{(() => {
-										const ctx = useSegmentContext();
 										const seg = segment();
 
+										const speedControl = (triggerClass?: string) => (
+											<ClipSpeedControl
+												timescale={seg.timescale}
+												speedAudioMode={seg.speedAudioMode}
+												open={speedOpen()}
+												onOpenChange={setSpeedOpen}
+												triggerClass={triggerClass}
+												onSetTimescale={(mult) =>
+													projectActions.setClipSegmentTimescale(i(), mult)
+												}
+												onSetSpeedAudioMode={(mode) =>
+													projectActions.setClipSegmentSpeedAudioMode(i(), mode)
+												}
+											/>
+										);
+
 										return (
-											<Show when={ctx.width() > 100}>
-												<div class="flex flex-col gap-1 justify-center items-center text-xs whitespace-nowrap text-gray-12">
-													<span class="text-white/70">
-														{hasMultipleRecordingSegments()
-															? `Clip ${seg.recordingSegment}`
-															: "Clip"}
-													</span>
-													<div class="flex gap-1 items-center text-md dark:text-gray-12 text-gray-1">
-														<IconLucideClock class="size-3.5" />{" "}
-														{formatTime(seg.end - seg.start)}
-														<Show when={seg.timescale !== 1}>
-															<div class="w-0.5" />
-															<IconLucideFastForward class="size-3" />
-															{seg.timescale}x
-														</Show>
+											<SegmentLabel
+												full={() => (
+													<div class="flex flex-col gap-1 justify-center items-center text-xs whitespace-nowrap text-gray-12">
+														<span class="text-white/70">{clipName()}</span>
+														<div class="flex gap-1 items-center text-md dark:text-gray-12 text-gray-1">
+															<IconLucideClock class="size-3.5" />{" "}
+															{formatTime(seg.end - seg.start)}
+															{speedControl()}
+														</div>
 													</div>
-												</div>
-											</Show>
+												)}
+												compact={() => (
+													<div class="flex gap-1 items-center text-[10px] whitespace-nowrap dark:text-gray-12 text-gray-1">
+														{speedControl("shrink-0")}
+														<span class="truncate">
+															{formatTime(seg.end - seg.start)}
+														</span>
+													</div>
+												)}
+												glyph={
+													seg.timescale !== 1
+														? () => speedControl("shrink-0")
+														: undefined
+												}
+											/>
 										);
 									})()}
 								</SegmentContent>
@@ -1138,7 +1422,11 @@ export function ClipTrack(
 	);
 }
 
-function Markings(props: { segment: TimelineSegment; prevDuration: number }) {
+function Markings(props: {
+	segment: TimelineSegment;
+	prevDuration: number;
+	holds: ReadonlyArray<[number, number]>;
+}) {
 	const { editorState } = useEditorContext();
 	const { secsPerPixel, markingResolution } = useTimelineContext();
 
@@ -1163,8 +1451,16 @@ function Markings(props: { segment: TimelineSegment; prevDuration: number }) {
 		<Index each={Array.from({ length: markingParams().count })}>
 			{(_, index) => {
 				const marking = () => getMarkingTime(index);
-				const translateX = () =>
-					(marking() - props.segment.start) / secsPerPixel();
+				// Markings live in recording time; push each past the holds the
+				// stretched box inserts before it.
+				const translateX = () => {
+					const holdsRel = props.holds.map(([start, end]): [number, number] => [
+						start - props.prevDuration,
+						end - props.prevDuration,
+					]);
+					const effective = marking() - props.segment.start;
+					return effectiveToOutput(holdsRel, effective) / secsPerPixel();
+				};
 
 				return (
 					<div

--- a/apps/desktop/src/routes/editor/Timeline/KeyboardTrack.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/KeyboardTrack.tsx
@@ -4,7 +4,13 @@ import { createMemo, createRoot, For } from "solid-js";
 
 import { useEditorContext } from "../context";
 import { useTimelineContext } from "./context";
-import { SegmentContent, SegmentHandle, SegmentRoot, TrackRoot } from "./Track";
+import {
+	SegmentContent,
+	SegmentHandle,
+	SegmentLabel,
+	SegmentRoot,
+	TrackRoot,
+} from "./Track";
 
 export type KeyboardSegmentDragState =
 	| { type: "idle" }
@@ -156,6 +162,16 @@ export function KeyboardTrack(props: {
 					const segmentWidth = () =>
 						Math.min(segment.end, totalDuration()) - segment.start;
 
+					// Truncation degrades gracefully, so the same row serves both the
+					// full and compact tiers; it just clips against a smaller box.
+					const keysLabel = () => (
+						<div class="flex gap-1 justify-center items-center font-mono text-[10px] text-gray-1 dark:text-gray-12">
+							<span class="truncate max-w-full opacity-80">
+								{segment.displayText || "⌨"}
+							</span>
+						</div>
+					);
+
 					return (
 						<SegmentRoot
 							data-keyboard-segment
@@ -166,6 +182,7 @@ export function KeyboardTrack(props: {
 								isSelected() ? "border-sky-7" : "border-transparent",
 							)}
 							innerClass="ring-sky-6"
+							title={segment.displayText || "Keyboard"}
 							segment={{
 								start: segment.start,
 								end: Math.min(segment.end, totalDuration()),
@@ -240,13 +257,16 @@ export function KeyboardTrack(props: {
 									},
 								)}
 							>
-								<div class="flex flex-col gap-0.5 justify-center items-center text-xs text-gray-1 dark:text-gray-12 w-full min-w-0 overflow-hidden">
-									<div class="flex gap-1 items-center text-[10px] w-full min-w-0 justify-center font-mono">
-										<span class="truncate max-w-full opacity-80">
-											{segment.displayText || "⌨"}
+								<SegmentLabel
+									compactAt={24}
+									full={keysLabel}
+									compact={keysLabel}
+									glyph={() => (
+										<span class="font-mono text-[10px] text-gray-1 opacity-80 dark:text-gray-12">
+											⌨
 										</span>
-									</div>
-								</div>
+									)}
+								/>
 							</SegmentContent>
 							<SegmentHandle
 								position="end"

--- a/apps/desktop/src/routes/editor/Timeline/MaskTrack.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/MaskTrack.tsx
@@ -10,6 +10,7 @@ import { useTimelineContext } from "./context";
 import {
 	SegmentContent,
 	SegmentHandle,
+	SegmentLabel,
 	SegmentRoot,
 	TrackRoot,
 	useSetPreviewTime,
@@ -362,6 +363,7 @@ export function MaskTrack(props: {
 									: "border border-transparent",
 							)}
 							innerClass="ring-red-5"
+							title={`Mask · ${contentLabel()}`}
 							segment={segment}
 							onMouseEnter={(e) => {
 								setHoveredSegmentState(e, index, segment);
@@ -476,16 +478,21 @@ export function MaskTrack(props: {
 									},
 								)}
 							>
-								{(() => {
-									return (
+								<SegmentLabel
+									full={() => (
 										<div class="flex flex-col gap-0.5 justify-center items-center text-xs whitespace-nowrap text-gray-1 dark:text-gray-12">
 											<span class="opacity-70">Mask</span>
 											<div class="flex gap-1 items-center text-md">
 												<span>{contentLabel()}</span>
 											</div>
 										</div>
-									);
-								})()}
+									)}
+									compact={() => (
+										<div class="flex gap-1 items-center text-xs whitespace-nowrap text-gray-1 dark:text-gray-12">
+											<span class="truncate">{contentLabel()}</span>
+										</div>
+									)}
+								/>
 							</SegmentContent>
 							<SegmentHandle
 								position="end"

--- a/apps/desktop/src/routes/editor/Timeline/Minimap.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/Minimap.tsx
@@ -1,0 +1,135 @@
+import { createElementBounds } from "@solid-primitives/bounds";
+import { createEventListenerMap } from "@solid-primitives/event-listener";
+import { cx } from "cva";
+import { createMemo, createRoot, createSignal, For, onCleanup } from "solid-js";
+
+import { clipTimelineOffsets } from "../clip-transitions";
+import { useEditorContext } from "../context";
+
+const MIN_CHIP_WIDTH = 20;
+
+export function Minimap() {
+	const { project, editorState, setEditorState, totalDuration } =
+		useEditorContext();
+	const transform = () => editorState.timeline.transform;
+
+	const [barRef, setBarRef] = createSignal<HTMLDivElement>();
+	const barBounds = createElementBounds(barRef);
+
+	const total = () => Math.max(totalDuration(), 0.001);
+	const barWidth = () => Math.max(barBounds.width ?? 0, 1);
+	const pxPerSec = () => barWidth() / total();
+	const zoomedIn = () => total() - transform().zoom > 0.01;
+
+	const chipWidth = () =>
+		Math.min(
+			Math.max(transform().zoom * pxPerSec(), MIN_CHIP_WIDTH),
+			barWidth(),
+		);
+	const chipLeft = () => {
+		const maxPosition = Math.max(total() - transform().zoom, 0.001);
+		const fraction = Math.min(transform().position / maxPosition, 1);
+		return fraction * Math.max(barWidth() - chipWidth(), 0);
+	};
+
+	const clipBoundaries = createMemo(() => {
+		const timeline = project.timeline;
+		if (!timeline || timeline.segments.length < 2) return [];
+		return clipTimelineOffsets(timeline.segments, timeline.transitions ?? [])
+			.slice(1)
+			.filter((offset) => offset > 0 && offset < total());
+	});
+
+	function beginDrag(downEvent: MouseEvent, mode: "move" | "left" | "right") {
+		if (downEvent.button !== 0) return;
+		downEvent.stopPropagation();
+
+		const startX = downEvent.clientX;
+		const startPosition = transform().position;
+		const startZoom = transform().zoom;
+		const anchorStart = startPosition;
+		const anchorEnd = startPosition + startZoom;
+		const moveScale =
+			(total() - startZoom) / Math.max(barWidth() - chipWidth(), 1);
+
+		createRoot((dispose) => {
+			const previousCursor = document.body.style.cursor;
+			document.body.style.cursor = mode === "move" ? "grabbing" : "col-resize";
+			onCleanup(() => {
+				document.body.style.cursor = previousCursor;
+			});
+
+			createEventListenerMap(window, {
+				mousemove: (event) => {
+					setEditorState("previewTime", null);
+					const deltaX = event.clientX - startX;
+					if (mode === "move") {
+						transform().setPosition(startPosition + deltaX * moveScale);
+					} else if (mode === "left") {
+						// Anchoring the zoom at the opposite edge keeps that edge
+						// pinned exactly: updateZoom's origin math resolves to
+						// originPercentage 1 (left handle) or 0 (right handle).
+						transform().updateZoom(startZoom - deltaX / pxPerSec(), anchorEnd);
+					} else {
+						transform().updateZoom(
+							startZoom + deltaX / pxPerSec(),
+							anchorStart,
+						);
+					}
+				},
+				mouseup: () => dispose(),
+				blur: () => dispose(),
+			});
+		});
+	}
+
+	function handleBarMouseDown(downEvent: MouseEvent) {
+		if (downEvent.button !== 0) return;
+		downEvent.stopPropagation();
+
+		const bar = barRef();
+		if (!bar) return;
+		const rect = bar.getBoundingClientRect();
+		const clickTime = ((downEvent.clientX - rect.left) / barWidth()) * total();
+		transform().setPosition(clickTime - transform().zoom / 2);
+		beginDrag(downEvent, "move");
+	}
+
+	return (
+		<div
+			ref={setBarRef}
+			class={cx(
+				"relative w-full h-full overflow-hidden rounded-full border border-gray-4 bg-gray-3/80 transition-opacity duration-200",
+				zoomedIn() ? "opacity-100" : "pointer-events-none opacity-0",
+			)}
+			onMouseDown={handleBarMouseDown}
+			onMouseMove={(e) => {
+				e.stopPropagation();
+				setEditorState("previewTime", null);
+			}}
+		>
+			<For each={clipBoundaries()}>
+				{(offset) => (
+					<div
+						class="absolute inset-y-0 w-px bg-gray-6/50"
+						style={{ left: `${(offset / total()) * 100}%` }}
+					/>
+				)}
+			</For>
+			<div
+				class="absolute inset-y-0 rounded-full border border-gray-7/80 bg-gray-6/70 transition-colors duration-150 cursor-grab hover:bg-gray-7/70 active:cursor-grabbing"
+				style={{ left: `${chipLeft()}px`, width: `${chipWidth()}px` }}
+				onMouseDown={(e) => beginDrag(e, "move")}
+			>
+				<div
+					class="absolute inset-y-0 left-0 w-2 cursor-col-resize"
+					onMouseDown={(e) => beginDrag(e, "left")}
+				/>
+				<div
+					class="absolute inset-y-0 right-0 w-2 cursor-col-resize"
+					onMouseDown={(e) => beginDrag(e, "right")}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/routes/editor/Timeline/SceneTrack.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/SceneTrack.tsx
@@ -15,14 +15,11 @@ import {
 import { produce } from "solid-js/store";
 
 import { useEditorContext } from "../context";
-import {
-	useSegmentContext,
-	useTimelineContext,
-	useTrackContext,
-} from "./context";
+import { useTimelineContext, useTrackContext } from "./context";
 import {
 	SegmentContent,
 	SegmentHandle,
+	SegmentLabel,
 	SegmentRoot,
 	TrackRoot,
 	useSetPreviewTime,
@@ -424,6 +421,7 @@ export function SceneTrack(props: {
 								isSelected() ? "border-gray-12" : "border-transparent",
 							)}
 							innerClass="ring-blue-5"
+							title={`Scene · ${getSceneLabel(segment.mode)}`}
 							segment={segment}
 							onMouseEnter={() => {
 								setHoveringSegment(true);
@@ -542,25 +540,30 @@ export function SceneTrack(props: {
 									},
 								)}
 							>
-								{(() => {
-									const ctx = useSegmentContext();
-
-									return (
-										<Show when={ctx.width() > 80}>
-											<div class="flex flex-col gap-1 justify-center items-center text-xs whitespace-nowrap text-gray-1 dark:text-gray-12 animate-in fade-in">
-												<span class="opacity-70">Scene</span>
-												<div class="flex gap-1 items-center text-md">
-													{getSceneIcon(segment.mode)}
-													{ctx.width() > 120 && (
-														<span class="text-xs">
-															{getSceneLabel(segment.mode)}
-														</span>
-													)}
-												</div>
+								<SegmentLabel
+									full={() => (
+										<div class="flex flex-col gap-1 justify-center items-center text-xs whitespace-nowrap text-gray-1 dark:text-gray-12 animate-in fade-in">
+											<span class="opacity-70">Scene</span>
+											<div class="flex gap-1 items-center text-md">
+												{getSceneIcon(segment.mode)}
+												<span class="text-xs">
+													{getSceneLabel(segment.mode)}
+												</span>
 											</div>
-										</Show>
-									);
-								})()}
+										</div>
+									)}
+									compact={() => (
+										<div class="flex gap-1 items-center text-md whitespace-nowrap text-gray-1 dark:text-gray-12">
+											{getSceneIcon(segment.mode)}
+											<span class="text-xs">{getSceneLabel(segment.mode)}</span>
+										</div>
+									)}
+									glyph={() => (
+										<div class="flex justify-center items-center text-gray-1 dark:text-gray-12">
+											{getSceneIcon(segment.mode)}
+										</div>
+									)}
+								/>
 							</SegmentContent>
 							<SegmentHandle
 								position="end"

--- a/apps/desktop/src/routes/editor/Timeline/TextTrack.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/TextTrack.tsx
@@ -3,6 +3,7 @@ import { cx } from "cva";
 import { createMemo, createRoot, createSignal, For, Show } from "solid-js";
 import { produce } from "solid-js/store";
 
+import { cssFontFamily } from "~/utils/fonts";
 import { useEditorContext } from "../context";
 import { autoTextColorAt, defaultTextSegment } from "../text";
 import { getSegmentTrack, sortTrackSegments } from "../timelineTracks";
@@ -10,6 +11,7 @@ import { useTimelineContext } from "./context";
 import {
 	SegmentContent,
 	SegmentHandle,
+	SegmentLabel,
 	SegmentRoot,
 	TrackRoot,
 	useSetPreviewTime,
@@ -322,6 +324,36 @@ export function TextTrack(props: {
 
 					const segmentWidth = () => segment.end - segment.start;
 
+					const textContentRow = () => (
+						<div class="flex gap-1.5 justify-center items-center max-w-full text-md">
+							<span
+								class="size-2 shrink-0 rounded-full border border-white/40"
+								style={{
+									"background-color": segment.color ?? "#ffffff",
+								}}
+							/>
+							<span
+								class="truncate max-w-full"
+								style={{
+									"font-family": cssFontFamily(
+										segment.fontFamily ?? "sans-serif",
+									),
+									"font-style": segment.italic ? "italic" : "normal",
+									"font-weight": segment.fontWeight ?? 700,
+								}}
+							>
+								{segment.content || "Label"}
+							</span>
+						</div>
+					);
+
+					const textTitle = () => {
+						const base = `Text · ${segment.content || "Label"}`;
+						return segment.layout === "fullscreen"
+							? `${base} · Fullscreen: pauses the video while shown`
+							: base;
+					};
+
 					return (
 						<SegmentRoot
 							data-text-segment
@@ -333,6 +365,7 @@ export function TextTrack(props: {
 								!segment.enabled && "opacity-60",
 							)}
 							innerClass="ring-blue-6"
+							title={textTitle()}
 							segment={segment}
 							onMouseDown={(e) => {
 								e.stopPropagation();
@@ -423,14 +456,31 @@ export function TextTrack(props: {
 									},
 								)}
 							>
-								<div class="flex flex-col gap-0.5 justify-center items-center text-xs text-gray-1 dark:text-gray-12 w-full min-w-0 overflow-hidden">
-									<span class="opacity-70">Text</span>
-									<div class="flex gap-1 items-center text-md w-full min-w-0 justify-center">
-										<span class="truncate max-w-full">
-											{segment.content || "Label"}
-										</span>
-									</div>
-								</div>
+								<SegmentLabel
+									full={() => (
+										<div class="flex flex-col gap-0.5 justify-center items-center text-xs text-gray-1 dark:text-gray-12">
+											<span class="flex gap-1 items-center opacity-70">
+												Text
+												<Show when={segment.layout === "fullscreen"}>
+													<IconLucidePause class="size-2.5" />
+												</Show>
+											</span>
+											{textContentRow()}
+										</div>
+									)}
+									compact={() => (
+										<div class="flex justify-center items-center text-xs text-gray-1 dark:text-gray-12">
+											{textContentRow()}
+										</div>
+									)}
+									glyph={
+										segment.layout === "fullscreen"
+											? () => (
+													<IconLucidePause class="size-2.5 text-gray-1 opacity-70 dark:text-gray-12" />
+												)
+											: undefined
+									}
+								/>
 							</SegmentContent>
 							<SegmentHandle
 								position="end"

--- a/apps/desktop/src/routes/editor/Timeline/ThreeDTrack.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/ThreeDTrack.tsx
@@ -7,9 +7,7 @@ import {
 	createRoot,
 	createSignal,
 	Index,
-	Match,
 	Show,
-	Switch,
 } from "solid-js";
 import { produce } from "solid-js/store";
 import { useEditorContext } from "../context";
@@ -19,17 +17,15 @@ import {
 	fitCamera3DMotionToSegment,
 	hasCamera3DMotion,
 } from "../three-d";
-import {
-	useSegmentContext,
-	useTimelineContext,
-	useTrackContext,
-} from "./context";
+import { useTimelineContext, useTrackContext } from "./context";
 import {
 	SegmentContent,
 	SegmentHandle,
+	SegmentLabel,
 	SegmentRoot,
 	TrackRoot,
 	useSegmentTranslateX,
+	useSegmentVisibleBox,
 	useSegmentWidth,
 	useSetPreviewTime,
 } from "./Track";
@@ -367,6 +363,9 @@ export function ThreeDTrack(props: {
 						const camera3dSegments = () =>
 							project.timeline?.camera3dSegments ?? [];
 
+						const motionLabel = () =>
+							hasCamera3DMotion(segment()) ? "Motion" : "Still";
+
 						// Double-clicking a handle expands the segment as far as it can go
 						// in that direction (up to the neighbouring segment / timeline edge).
 						const fillStart = () => {
@@ -541,6 +540,7 @@ export function ThreeDTrack(props: {
 									isSelected() ? "border-gray-12" : "border-transparent",
 								)}
 								innerClass="ring-red-5"
+								title={`3D Perspective · ${motionLabel()}`}
 								segment={segment()}
 								onMouseDown={(e) => {
 									e.stopPropagation();
@@ -649,33 +649,20 @@ export function ThreeDTrack(props: {
 									)}
 								>
 									{(() => {
-										const ctx = useSegmentContext();
+										const visibleBox = useSegmentVisibleBox();
 
 										return (
-											<Switch>
-												<Match when={ctx.width() < 40}>
-													<div class="flex justify-center items-center">
-														<IconLucideRotate3d class="size-3.5 text-gray-1 dark:text-gray-12" />
-													</div>
-												</Match>
-												<Match when={ctx.width() < 100}>
-													<div class="flex gap-1 items-center text-xs whitespace-nowrap text-gray-1 dark:text-gray-12">
-														<IconLucideRotate3d class="size-3" />
-														<span>3D</span>
-													</div>
-												</Match>
-												<Match when={true}>
+											<SegmentLabel
+												full={() => (
 													<div class="flex flex-col gap-1 justify-center items-center text-xs whitespace-nowrap text-gray-1 dark:text-gray-12 animate-in fade-in">
 														<span class="opacity-70">
-															{ctx.width() >= 140 ? "3D Perspective" : "3D"}
+															{visibleBox().width >= 140
+																? "3D Perspective"
+																: "3D"}
 														</span>
 														<div class="flex gap-1 items-center text-md">
 															<IconLucideRotate3d class="size-3.5" />
-															<span>
-																{hasCamera3DMotion(segment())
-																	? "Motion"
-																	: "Still"}
-															</span>
+															<span>{motionLabel()}</span>
 															{/* Presentation only: the arrow says the shot
 															    moves from its start pose to its end pose. */}
 															<Show when={hasCamera3DMotion(segment())}>
@@ -683,8 +670,19 @@ export function ThreeDTrack(props: {
 															</Show>
 														</div>
 													</div>
-												</Match>
-											</Switch>
+												)}
+												compact={() => (
+													<div class="flex gap-1 items-center text-xs whitespace-nowrap text-gray-1 dark:text-gray-12">
+														<IconLucideRotate3d class="size-3" />
+														<span>3D</span>
+													</div>
+												)}
+												glyph={() => (
+													<div class="flex justify-center items-center">
+														<IconLucideRotate3d class="size-3.5 text-gray-1 dark:text-gray-12" />
+													</div>
+												)}
+											/>
 										);
 									})()}
 								</SegmentContent>

--- a/apps/desktop/src/routes/editor/Timeline/Track.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/Track.tsx
@@ -1,10 +1,14 @@
 import { mergeRefs } from "@solid-primitives/refs";
 import { cx } from "cva";
 import {
+	type Accessor,
 	type ComponentProps,
 	createMemo,
 	createSignal,
+	type JSX,
+	Match,
 	Show,
+	Switch,
 	splitProps,
 } from "solid-js";
 import { useEditorContext } from "../context";
@@ -95,7 +99,7 @@ export function SegmentRoot(
 
 	return (
 		<Show when={visible()}>
-			<SegmentContextProvider width={width}>
+			<SegmentContextProvider width={width} segment={() => local.segment}>
 				<div
 					{...rest}
 					class={cx(
@@ -130,6 +134,88 @@ export function SegmentRoot(
 				</div>
 			</SegmentContextProvider>
 		</Show>
+	);
+}
+
+export const SEGMENT_LABEL_FULL_PX = 100;
+export const SEGMENT_LABEL_COMPACT_PX = 48;
+
+// Pixel box of the segment's intersection with the viewport, in
+// segment-local coordinates, with a clamped center for label anchoring.
+// A zoomed-in segment can extend well past the viewport, so its true
+// centre is often off-screen; labels anchor to this instead.
+export function useSegmentVisibleBox(): Accessor<{
+	width: number;
+	centerX: number;
+}> {
+	const { width, segment } = useSegmentContext();
+	const { secsPerPixel } = useTrackContext();
+	const { editorState } = useEditorContext();
+
+	return createMemo(() => {
+		const segmentWidth = width();
+		const { transform } = editorState.timeline;
+
+		const leftPx = (segment().start - transform.position) / secsPerPixel();
+		const viewportPx = transform.zoom / secsPerPixel();
+
+		const visibleStart = Math.max(0, -leftPx);
+		const visibleEnd = Math.min(segmentWidth, viewportPx - leftPx);
+		const visibleWidth = Math.max(0, visibleEnd - visibleStart);
+
+		// Keep the label inside the segment box, but when only a small slice
+		// of a wide segment is on screen the margin must shrink with it, or
+		// the clamp would push the label out of view past the viewport edge.
+		const margin = Math.min(
+			60,
+			segmentWidth / 2,
+			Math.max(visibleWidth / 2, 4),
+		);
+		const centerX = Math.min(
+			Math.max((visibleStart + visibleEnd) / 2, margin),
+			segmentWidth - margin,
+		);
+
+		return { width: visibleWidth, centerX };
+	});
+}
+
+// Progressive disclosure for segment labels: the label degrades from its
+// full form down to a compact row and then to a state glyph as the visible
+// slice of the segment shrinks, rather than vanishing at a hard cliff.
+export function SegmentLabel(props: {
+	full: () => JSX.Element;
+	compact?: () => JSX.Element;
+	glyph?: () => JSX.Element;
+	fullAt?: number;
+	compactAt?: number;
+}) {
+	const visibleBox = useSegmentVisibleBox();
+
+	const fullAt = () => props.fullAt ?? SEGMENT_LABEL_FULL_PX;
+	const compactAt = () => props.compactAt ?? SEGMENT_LABEL_COMPACT_PX;
+
+	return (
+		<div
+			class="absolute pointer-events-none"
+			style={{
+				left: `${visibleBox().centerX}px`,
+				top: "50%",
+				transform: "translate(-50%, -50%)",
+				"max-width": `${Math.max(0, visibleBox().width - 8)}px`,
+				overflow: "hidden",
+			}}
+		>
+			<Switch>
+				<Match when={visibleBox().width >= fullAt()}>{props.full()}</Match>
+				<Match when={visibleBox().width >= compactAt() && !!props.compact}>
+					{props.compact?.()}
+				</Match>
+				<Match when={visibleBox().width >= 16 && !!props.glyph}>
+					{props.glyph?.()}
+				</Match>
+			</Switch>
+		</div>
 	);
 }
 

--- a/apps/desktop/src/routes/editor/Timeline/ZoomTrack.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/ZoomTrack.tsx
@@ -10,23 +10,20 @@ import {
 	createRoot,
 	createSignal,
 	Index,
-	Match,
 	Show,
-	Switch,
 } from "solid-js";
 import { produce } from "solid-js/store";
+import { generalSettingsStore } from "~/store";
 import { commands } from "~/utils/tauri";
 import { useEditorContext } from "../context";
-import {
-	useSegmentContext,
-	useTimelineContext,
-	useTrackContext,
-} from "./context";
+import { useTimelineContext, useTrackContext } from "./context";
 import {
 	SegmentContent,
 	SegmentHandle,
+	SegmentLabel,
 	SegmentRoot,
 	TrackRoot,
+	useSegmentVisibleBox,
 	useSetPreviewTime,
 } from "./Track";
 
@@ -56,6 +53,7 @@ export function ZoomTrack(props: {
 
 	const { duration, secsPerPixel } = useTimelineContext();
 	const setPreviewTime = useSetPreviewTime();
+	const generalSettings = generalSettingsStore.createQuery();
 
 	const [creatingSegmentViaDrag, setCreatingSegmentViaDrag] =
 		createSignal(false);
@@ -225,7 +223,7 @@ export function ZoomTrack(props: {
 									zoomSegments.splice(index, 0, {
 										start: baseSegment.start,
 										end: Math.max(minEndTime, endTime),
-										amount: 1.5,
+										amount: generalSettings.data?.defaultZoomAmount ?? 1.5,
 										mode: "auto",
 									});
 
@@ -346,6 +344,9 @@ export function ZoomTrack(props: {
 							const amount = segment().amount;
 							return `${amount.toFixed(1)}x`;
 						};
+
+						const zoomModeLabel = () =>
+							segment().mode === "auto" ? "Automatic Zoom" : "Manual Zoom";
 
 						const zoomSegments = () => project.timeline?.zoomSegments ?? [];
 
@@ -525,6 +526,7 @@ export function ZoomTrack(props: {
 									isSelected() ? "border-gray-12" : "border-transparent",
 								)}
 								innerClass="ring-red-5"
+								title={`${zoomModeLabel()} · ${zoomPercentage()}`}
 								segment={segment()}
 								onMouseDown={(e) => {
 									e.stopPropagation();
@@ -538,6 +540,58 @@ export function ZoomTrack(props: {
 
 										projectActions.splitZoomSegment(i, splitTime);
 									}
+								}}
+								onContextMenu={async (e: MouseEvent) => {
+									e.preventDefault();
+									e.stopPropagation();
+
+									// Right-clicking an unselected segment selects it first,
+									// so the menu always acts on what's highlighted.
+									const selection = editorState.timeline.selection;
+									const targetIndices =
+										selection?.type === "zoom" && selection.indices.includes(i)
+											? [...selection.indices]
+											: [i];
+									if (
+										targetIndices.length === 1 &&
+										!selectedZoomIndices()?.has(i)
+									)
+										setEditorState("timeline", "selection", {
+											type: "zoom",
+											indices: [i],
+										});
+
+									// `Array` here is effect's module, so derive the index
+									// list from the segments themselves.
+									const allIndices = (project.timeline?.zoomSegments ?? []).map(
+										(_, idx) => idx,
+									);
+
+									const menu = await Menu.new({
+										id: "zoom-segment-options",
+										items: [
+											{
+												id: "selectAllZoomSegments",
+												text: "Select all zoom segments",
+												enabled: allIndices.length > 1,
+												action: () =>
+													setEditorState("timeline", "selection", {
+														type: "zoom",
+														indices: allIndices,
+													}),
+											},
+											{
+												id: "deleteZoomSegments",
+												text:
+													targetIndices.length > 1
+														? `Delete ${targetIndices.length} zoom segments`
+														: "Delete zoom segment",
+												action: () =>
+													projectActions.deleteZoomSegments(targetIndices),
+											},
+										],
+									});
+									menu.popup();
 								}}
 							>
 								<SegmentHandle
@@ -637,28 +691,15 @@ export function ZoomTrack(props: {
 									)}
 								>
 									{(() => {
-										const ctx = useSegmentContext();
+										const visibleBox = useSegmentVisibleBox();
 
 										return (
-											<Switch>
-												<Match when={ctx.width() < 40}>
-													<div class="flex justify-center items-center">
-														<IconLucideSearch class="size-3.5 text-gray-1 dark:text-gray-12" />
-													</div>
-												</Match>
-												<Match when={ctx.width() < 100}>
-													<div class="flex gap-1 items-center text-xs whitespace-nowrap text-gray-1 dark:text-gray-12">
-														<IconLucideSearch class="size-3" />
-														<span>{zoomPercentage()}</span>
-													</div>
-												</Match>
-												<Match when={true}>
+											<SegmentLabel
+												full={() => (
 													<div class="flex flex-col gap-1 justify-center items-center text-xs whitespace-nowrap text-gray-1 dark:text-gray-12 animate-in fade-in">
 														<span class="opacity-70">
-															{ctx.width() >= 140
-																? segment().mode === "auto"
-																	? "Automatic Zoom"
-																	: "Manual Zoom"
+															{visibleBox().width >= 140
+																? zoomModeLabel()
 																: "Zoom"}
 														</span>
 														<div class="flex gap-1 items-center text-md">
@@ -666,8 +707,19 @@ export function ZoomTrack(props: {
 															{zoomPercentage()}
 														</div>
 													</div>
-												</Match>
-											</Switch>
+												)}
+												compact={() => (
+													<div class="flex gap-1 items-center text-xs whitespace-nowrap text-gray-1 dark:text-gray-12">
+														<IconLucideSearch class="size-3" />
+														<span>{zoomPercentage()}</span>
+													</div>
+												)}
+												glyph={() => (
+													<div class="flex justify-center items-center">
+														<IconLucideSearch class="size-3.5 text-gray-1 dark:text-gray-12" />
+													</div>
+												)}
+											/>
 										);
 									})()}
 								</SegmentContent>

--- a/apps/desktop/src/routes/editor/Timeline/context.ts
+++ b/apps/desktop/src/routes/editor/Timeline/context.ts
@@ -35,6 +35,7 @@ type TrackContextValue = {
 
 type SegmentContextValue = {
 	width: Accessor<number>;
+	segment: Accessor<{ start: number; end: number }>;
 };
 
 export const [TimelineContextProvider, useTimelineContext] =
@@ -102,7 +103,10 @@ export const [TrackContextProvider, useTrackContext] = createContextProvider(
 
 export const [SegmentContextProvider, useSegmentContext] =
 	createContextProvider(
-		(props: { width: Accessor<number> }) => {
+		(props: {
+			width: Accessor<number>;
+			segment: Accessor<{ start: number; end: number }>;
+		}) => {
 			return props;
 		},
 		null as unknown as SegmentContextValue,

--- a/apps/desktop/src/routes/editor/Timeline/index.tsx
+++ b/apps/desktop/src/routes/editor/Timeline/index.tsx
@@ -1,5 +1,8 @@
 import { createElementBounds } from "@solid-primitives/bounds";
-import { createEventListener } from "@solid-primitives/event-listener";
+import {
+	createEventListener,
+	createEventListenerMap,
+} from "@solid-primitives/event-listener";
 import { LogicalPosition } from "@tauri-apps/api/dpi";
 import { Menu, MenuItem } from "@tauri-apps/api/menu";
 import { platform } from "@tauri-apps/plugin-os";
@@ -49,6 +52,7 @@ import { ClipTrack } from "./ClipTrack";
 import { TimelineContextProvider, useTimelineContext } from "./context";
 import { type KeyboardSegmentDragState, KeyboardTrack } from "./KeyboardTrack";
 import { type MaskSegmentDragState, MaskTrack } from "./MaskTrack";
+import { Minimap } from "./Minimap";
 import { type SceneSegmentDragState, SceneTrack } from "./SceneTrack";
 import { type TextSegmentDragState, TextTrack } from "./TextTrack";
 import { type ThreeDSegmentDragState, ThreeDTrack } from "./ThreeDTrack";
@@ -812,8 +816,44 @@ export function Timeline(props: {
 		};
 	}
 
-	async function handleUpdatePlayhead(e: MouseEvent) {
+	function timelineTimeFromClientX(clientX: number) {
 		const metrics = getTimelineContentMetrics();
+		if (!metrics) return null;
+		const rawTime =
+			secsPerPixel() * (clientX - metrics.left) + transform().position;
+		// Snap to the very start when the cursor lands within a few pixels
+		// of the timeline origin so hitting exactly 0:00 isn't a battle
+		const snappedTime = rawTime / secsPerPixel() <= START_SNAP_PX ? 0 : rawTime;
+		return Math.min(Math.max(0, snappedTime), totalDuration());
+	}
+
+	async function seekPlayheadTo(newTime: number) {
+		// If playing, some backends require restart to seek reliably
+		if (editorState.playing) {
+			try {
+				await commands.stopPlayback();
+
+				// Round to nearest frame to prevent off-by-one drift
+				const targetFrame = Math.round(newTime * FPS);
+				await commands.seekTo(targetFrame);
+
+				// If the user paused during these async ops, bail out without restarting
+				if (!editorState.playing) {
+					setEditorState("playbackTime", newTime);
+					return;
+				}
+
+				await commands.startPlayback(FPS, previewResolutionBase());
+				setEditorState("playing", true);
+			} catch (err) {
+				console.error("Failed to seek during playback:", err);
+			}
+		}
+
+		setEditorState("playbackTime", newTime);
+	}
+
+	async function handleUpdatePlayhead(e: MouseEvent) {
 		if (
 			zoomSegmentDragState.type !== "moving" &&
 			sceneSegmentDragState.type !== "moving" &&
@@ -824,39 +864,100 @@ export function Timeline(props: {
 			keyboardSegmentDragState.type !== "moving" &&
 			threeDSegmentDragState.type !== "moving"
 		) {
-			if (!metrics) return;
-			const rawTime =
-				secsPerPixel() * (e.clientX - metrics.left) + transform().position;
-			// Snap to the very start when the cursor lands within a few pixels
-			// of the timeline origin so hitting exactly 0:00 isn't a battle
-			const snappedTime =
-				rawTime / secsPerPixel() <= START_SNAP_PX ? 0 : rawTime;
-			const newTime = Math.min(Math.max(0, snappedTime), totalDuration());
-
-			// If playing, some backends require restart to seek reliably
-			if (editorState.playing) {
-				try {
-					await commands.stopPlayback();
-
-					// Round to nearest frame to prevent off-by-one drift
-					const targetFrame = Math.round(newTime * FPS);
-					await commands.seekTo(targetFrame);
-
-					// If the user paused during these async ops, bail out without restarting
-					if (!editorState.playing) {
-						setEditorState("playbackTime", newTime);
-						return;
-					}
-
-					await commands.startPlayback(FPS, previewResolutionBase());
-					setEditorState("playing", true);
-				} catch (err) {
-					console.error("Failed to seek during playback:", err);
-				}
-			}
-
-			setEditorState("playbackTime", newTime);
+			const newTime = timelineTimeFromClientX(e.clientX);
+			if (newTime === null) return;
+			await seekPlayheadTo(newTime);
 		}
+	}
+
+	function beginRulerScrub(downEvent: MouseEvent) {
+		if (downEvent.button !== 0) return;
+		downEvent.stopPropagation();
+
+		let lastClientX = downEvent.clientX;
+		let seekInFlight = false;
+		let seekQueued = false;
+		let panRafId: number | null = null;
+
+		const contentEdges = () => {
+			const metrics = getTimelineContentMetrics();
+			if (!metrics || metrics.width <= 0) return null;
+			return { left: metrics.left, right: metrics.left + metrics.width };
+		};
+
+		// While playing, each seek is a stop/seek/restart round-trip, so scrub
+		// updates are coalesced to one in-flight seek with the latest position
+		// applied once it settles.
+		const applyScrub = () => {
+			const edges = contentEdges();
+			const clientX = edges
+				? Math.min(Math.max(lastClientX, edges.left), edges.right)
+				: lastClientX;
+			const newTime = timelineTimeFromClientX(clientX);
+			if (newTime === null) return;
+			if (seekInFlight) {
+				seekQueued = true;
+				return;
+			}
+			seekInFlight = true;
+			void seekPlayheadTo(newTime).finally(() => {
+				seekInFlight = false;
+				if (seekQueued) {
+					seekQueued = false;
+					applyScrub();
+				}
+			});
+		};
+
+		const stepEdgePan = () => {
+			panRafId = null;
+			const edges = contentEdges();
+			if (!edges) return;
+			const overshoot =
+				lastClientX < edges.left
+					? lastClientX - edges.left
+					: lastClientX > edges.right
+						? lastClientX - edges.right
+						: 0;
+			if (overshoot === 0) return;
+			const panPx =
+				Math.sign(overshoot) * Math.min(Math.abs(overshoot) * 0.2, 12);
+			transform().setPosition(transform().position + panPx * secsPerPixel());
+			applyScrub();
+			panRafId = requestAnimationFrame(stepEdgePan);
+		};
+
+		const ensureEdgePan = () => {
+			if (panRafId === null) panRafId = requestAnimationFrame(stepEdgePan);
+		};
+
+		applyScrub();
+		ensureEdgePan();
+
+		createRoot((dispose) => {
+			onCleanup(() => {
+				if (panRafId !== null) {
+					cancelAnimationFrame(panRafId);
+					panRafId = null;
+				}
+			});
+			createEventListenerMap(window, {
+				mousemove: (event) => {
+					lastClientX = event.clientX;
+					applyScrub();
+					ensureEdgePan();
+				},
+				mouseup: () => {
+					batch(() => {
+						setEditorState("timeline", "selection", null);
+						setEditorState("timeline", "audioPicker", null);
+						setEditorState("timeline", "camera3dSetup", null);
+					});
+					dispose();
+				},
+				blur: () => dispose(),
+			});
+		});
 	}
 
 	createEventListener(window, "keydown", (e) => {
@@ -915,6 +1016,36 @@ export function Timeline(props: {
 			setEditorState("timeline", "selection", null);
 			setEditorState("timeline", "audioPicker", null);
 			setEditorState("timeline", "camera3dSetup", null);
+		} else if (
+			e.code === "KeyA" &&
+			(e.metaKey || e.ctrlKey) &&
+			!e.shiftKey &&
+			!e.altKey
+		) {
+			// Cmd/Ctrl+A expands the current selection to every segment on the
+			// same track.
+			const selection = editorState.timeline.selection;
+			if (!selection || selection.type === "transition") return;
+
+			const timeline = project.timeline;
+			const segmentCount = {
+				clip: timeline?.segments.length ?? 0,
+				zoom: timeline?.zoomSegments?.length ?? 0,
+				scene: timeline?.sceneSegments?.length ?? 0,
+				mask: timeline?.maskSegments?.length ?? 0,
+				caption: timeline?.captionSegments?.length ?? 0,
+				keyboard: timeline?.keyboardSegments?.length ?? 0,
+				text: timeline?.textSegments?.length ?? 0,
+				audio: timeline?.audioSegments?.length ?? 0,
+				"3d": timeline?.camera3dSegments?.length ?? 0,
+			}[selection.type];
+			if (!segmentCount) return;
+
+			e.preventDefault();
+			setEditorState("timeline", "selection", {
+				type: selection.type,
+				indices: Array.from({ length: segmentCount }, (_, i) => i),
+			});
 		}
 	});
 
@@ -1076,6 +1207,17 @@ export function Timeline(props: {
 				}}
 			>
 				<div
+					class="absolute z-30"
+					style={{
+						top: "2px",
+						left: `${TIMELINE_PADDING + TRACK_GUTTER}px`,
+						right: `${TIMELINE_PADDING}px`,
+						height: "12px",
+					}}
+				>
+					<Minimap />
+				</div>
+				<div
 					class="relative z-20"
 					style={{ height: `${TIMELINE_HEADER_HEIGHT}px` }}
 				>
@@ -1092,10 +1234,20 @@ export function Timeline(props: {
 							onAdd={handleAddTrack}
 						/>
 					</div>
+					{/* Scrub surface for the ruler. It reaches START_SNAP_PX left of
+					    the timeline origin so the snap-to-zero zone always places the
+					    playhead instead of hitting the "Add track" trigger beneath. */}
+					<div
+						class="absolute inset-y-0 right-0 z-40"
+						style={{ left: `${TRACK_GUTTER - START_SNAP_PX}px` }}
+						onMouseDown={beginRulerScrub}
+					/>
 				</div>
 				<Show
 					when={
-						!editorState.playing && editorState.previewTime !== null
+						!editorState.playing &&
+						editorState.previewTime !== null &&
+						editorState.timeline.splitPreview === null
 							? { time: editorState.previewTime }
 							: null
 					}
@@ -1141,6 +1293,27 @@ export function Timeline(props: {
 				>
 					<div class="size-3 bg-[rgb(226,64,64)] rounded-full -mt-2 -ml-[calc(0.37rem-0.5px)]" />
 				</div>
+				<Show when={split() ? editorState.timeline.splitPreview : null}>
+					{(preview) => (
+						<div
+							class={cx(
+								"absolute bottom-0 z-20 w-px pointer-events-none",
+								preview().snapped ? "bg-blue-9" : "bg-gray-10/70",
+							)}
+							style={{
+								left: `${TIMELINE_PADDING + TRACK_GUTTER}px`,
+								top: `${PLAYHEAD_TOP_OFFSET}px`,
+								transform: `translateX(${
+									(preview().time - transform().position) / secsPerPixel()
+								}px)`,
+							}}
+						>
+							<Show when={preview().snapped}>
+								<div class="absolute top-0 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rotate-45 rounded-[1px] bg-blue-9" />
+							</Show>
+						</div>
+					)}
+				</Show>
 				<div
 					class="relative flex-1 min-h-0"
 					style={{

--- a/apps/desktop/src/routes/editor/Timeline/split-snapping.ts
+++ b/apps/desktop/src/routes/editor/Timeline/split-snapping.ts
@@ -1,0 +1,66 @@
+// Pure geometry for split-mode snapping on the timeline. All times are in
+// output (rendered) time, the domain every non-clip track stores directly and
+// the clip track draws in; the caller converts the pixel snap radius via
+// secsPerPixel. Targets within EDGE_EPSILON of the hovered clip's edges are
+// rejected — snapping there would cut off a near-zero-length piece.
+
+import type { TimelineConfiguration } from "~/utils/tauri";
+
+export const SPLIT_SNAP_PX = 7;
+export const SPLIT_EDGE_EPSILON = 0.05;
+
+export type SplitSnapResult = {
+	time: number;
+	snapped: { time: number } | null;
+};
+
+const BOUNDARY_TRACKS = [
+	"zoomSegments",
+	"sceneSegments",
+	"camera3dSegments",
+	"textSegments",
+	"maskSegments",
+	"captionSegments",
+	"keyboardSegments",
+	"audioSegments",
+] as const;
+
+export function snapSplitTime(
+	raw: number,
+	clipStart: number,
+	clipEnd: number,
+	radius: number,
+	timeline: TimelineConfiguration | null | undefined,
+	playhead: number,
+): SplitSnapResult {
+	const min = clipStart + SPLIT_EDGE_EPSILON;
+	const max = clipEnd - SPLIT_EDGE_EPSILON;
+	let best: number | null = null;
+	let bestDist = Number.POSITIVE_INFINITY;
+
+	const consider = (t: number) => {
+		if (t < min || t > max) return;
+		const dist = Math.abs(t - raw);
+		if (dist > radius) return;
+		if (dist < bestDist || (dist === bestDist && best !== null && t < best)) {
+			bestDist = dist;
+			best = t;
+		}
+	};
+
+	consider(playhead);
+	if (timeline) {
+		for (const key of BOUNDARY_TRACKS) {
+			const segments = timeline[key];
+			if (!segments) continue;
+			for (const segment of segments) {
+				consider(segment.start);
+				consider(segment.end);
+			}
+		}
+	}
+
+	return best === null
+		? { time: raw, snapped: null }
+		: { time: best, snapped: { time: best } };
+}

--- a/apps/desktop/src/routes/editor/TranscriptPage.tsx
+++ b/apps/desktop/src/routes/editor/TranscriptPage.tsx
@@ -189,6 +189,7 @@ export function TranscriptPanel() {
 				project.timeline?.transitions ?? [],
 				undefined,
 				"incoming",
+				project.timeline?.textSegments,
 			) ?? outputStart;
 		const end = start + defaultDuration;
 		const text = "New caption";
@@ -273,6 +274,7 @@ export function TranscriptPanel() {
 			project.timeline?.transitions ?? [],
 			undefined,
 			"incoming",
+			project.timeline?.textSegments,
 		);
 		if (sourceTime === null) return -1;
 
@@ -298,6 +300,7 @@ export function TranscriptPanel() {
 				project.timeline?.segments ?? [],
 				recordingSegments(),
 				project.timeline?.transitions ?? [],
+				project.timeline?.textSegments,
 			);
 			if (outputTime === null) return;
 			if (editorState.playing) {

--- a/apps/desktop/src/routes/editor/TranscriptPage.tsx
+++ b/apps/desktop/src/routes/editor/TranscriptPage.tsx
@@ -90,6 +90,7 @@ export function TranscriptPanel() {
 			project.timeline?.segments ?? [],
 			recordingSegments(),
 			project.timeline?.transitions ?? [],
+			project.timeline?.textSegments,
 		),
 	);
 

--- a/apps/desktop/src/routes/editor/ZoomModeHelper.tsx
+++ b/apps/desktop/src/routes/editor/ZoomModeHelper.tsx
@@ -1,0 +1,62 @@
+import { Collapsible as KCollapsible } from "@kobalte/core/collapsible";
+import IconLucideInfo from "~icons/lucide/info";
+
+export function ZoomModeHelper(props: { mode: "auto" | "manual" }) {
+	return (
+		<KCollapsible>
+			<KCollapsible.Trigger class="flex flex-row gap-1.5 items-center w-full text-xs font-medium transition-colors duration-200 group text-gray-11 hover:text-gray-12 outline-hidden">
+				<IconLucideInfo class="size-3.5" />
+				How does it work?
+				<IconCapChevronDown class="ml-auto transition-transform duration-200 size-3.5 group-data-expanded:rotate-180" />
+			</KCollapsible.Trigger>
+			<KCollapsible.Content class="overflow-hidden opacity-0 transition-opacity animate-collapsible-up data-expanded:animate-collapsible-down data-expanded:opacity-100">
+				<div class="pt-2 space-y-1.5">
+					<style>
+						{`
+						@keyframes cap-zoom-mode-helper-path {
+							0% { left: 26%; top: 36%; }
+							30% { left: 72%; top: 30%; }
+							55% { left: 64%; top: 68%; }
+							80% { left: 32%; top: 64%; }
+							100% { left: 26%; top: 36%; }
+						}
+						.cap-zoom-mode-helper-cursor,
+						.cap-zoom-mode-helper-viewport-auto {
+							left: 26%;
+							top: 36%;
+							animation: cap-zoom-mode-helper-path 7s ease-in-out infinite;
+						}
+						.cap-zoom-mode-helper-viewport-auto {
+							animation-delay: 0.35s;
+						}
+						@media (prefers-reduced-motion: reduce) {
+							.cap-zoom-mode-helper-cursor,
+							.cap-zoom-mode-helper-viewport-auto {
+								animation: none;
+							}
+						}
+						`}
+					</style>
+					<div class="overflow-hidden relative w-full rounded-lg border bg-gray-3 border-gray-4 h-[88px]">
+						<div
+							data-visible={props.mode === "auto"}
+							class="cap-zoom-mode-helper-viewport-auto absolute rounded-md border-2 opacity-0 transition-opacity duration-300 -translate-x-1/2 -translate-y-1/2 border-blue-9/60 bg-blue-9/10 w-[42%] h-[55%] data-[visible='true']:opacity-100"
+						/>
+						<div
+							data-visible={props.mode === "manual"}
+							class="absolute left-1/2 top-1/2 rounded-md border-2 opacity-0 transition-opacity duration-300 -translate-x-1/2 -translate-y-1/2 border-blue-9/60 bg-blue-9/10 w-[42%] h-[55%] data-[visible='true']:opacity-100"
+						/>
+						<div class="cap-zoom-mode-helper-cursor absolute">
+							<IconCapCursor class="text-gray-12 size-3.5" />
+						</div>
+					</div>
+					<p class="text-xs text-gray-11">
+						{props.mode === "auto"
+							? "Automatic zoom follows your cursor around the screen."
+							: "Manual zoom stays on a fixed spot you pick below."}
+					</p>
+				</div>
+			</KCollapsible.Content>
+		</KCollapsible>
+	);
+}

--- a/apps/desktop/src/routes/editor/captions-export.ts
+++ b/apps/desktop/src/routes/editor/captions-export.ts
@@ -8,6 +8,7 @@ import {
 	mapCaptionsToEditedTimeline,
 } from "./captions";
 import type { ClipTransition } from "./clip-transitions";
+import type { TextSegment } from "./text";
 
 export type CaptionExportFormat = "srt" | "vtt";
 
@@ -109,12 +110,14 @@ export function createCaptionExportCues(
 	timelineSegments: TimelineSegment[],
 	recordingSegments: SegmentRecordings[],
 	transitions: ClipTransition[] = [],
+	textSegments?: readonly TextSegment[],
 ): CaptionExportCue[] {
 	return mapCaptionsToEditedTimeline(
 		segments,
 		timelineSegments,
 		recordingSegments,
 		transitions,
+		textSegments,
 	)
 		.map(cueFromCaptionSegment)
 		.filter((cue): cue is CaptionExportCue => cue !== null)

--- a/apps/desktop/src/routes/editor/captions.ts
+++ b/apps/desktop/src/routes/editor/captions.ts
@@ -15,6 +15,7 @@ import { type ClipTransition, clipTimelineOffsets } from "./clip-transitions";
 import type { TextSegment } from "./text";
 import {
 	effectiveToOutput,
+	effectiveToOutputEnd,
 	heldTimeBefore,
 	holdWindows,
 } from "./timeline-holds";
@@ -172,6 +173,7 @@ export function mapCaptionsToEditedTimeline(
 	timelineSegments: TimelineSegment[],
 	recordingSegments: SegmentRecordings[],
 	transitions: ClipTransition[] = [],
+	textSegments?: readonly TextSegment[],
 ): CaptionSegment[] {
 	const sanitizedSegments = rawSegments.map(clampCaptionSegmentWords);
 
@@ -185,6 +187,20 @@ export function mapCaptionsToEditedTimeline(
 		transitions,
 	);
 
+	// The edit-list mappings live in the gapless recording-flow domain; the
+	// rendered track is compared against the output clock, which includes
+	// fullscreen-text holds. Land every projected range back in output time
+	// so captions after (or across) a hold stay on their spoken content.
+	const holds = holdWindows(textSegments);
+	const holdAdjusted = (range: MappedTimeRange): MappedTimeRange =>
+		holds.length === 0
+			? range
+			: {
+					...range,
+					start: effectiveToOutput(holds, range.start),
+					end: effectiveToOutputEnd(holds, range.end),
+				};
+
 	const result: CaptionSegment[] = [];
 
 	for (const caption of sanitizedSegments) {
@@ -196,16 +212,16 @@ export function mapCaptionsToEditedTimeline(
 						word.end,
 						mapping,
 					);
+					if (!wordMapped) return [];
 
-					return wordMapped
-						? [
-								{
-									text: word.text,
-									start: wordMapped.start,
-									end: wordMapped.end,
-								},
-							]
-						: [];
+					const adjusted = holdAdjusted(wordMapped);
+					return [
+						{
+							text: word.text,
+							start: adjusted.start,
+							end: adjusted.end,
+						},
+					];
 				});
 
 				if (mappedWords.length === 0) {
@@ -228,17 +244,17 @@ export function mapCaptionsToEditedTimeline(
 				caption.end,
 				mapping,
 			);
+			if (!mappedRange) return [];
 
-			return mappedRange
-				? [
-						{
-							...caption,
-							start: mappedRange.start,
-							end: mappedRange.end,
-							words: caption.words,
-						},
-					]
-				: [];
+			const adjusted = holdAdjusted(mappedRange);
+			return [
+				{
+					...caption,
+					start: adjusted.start,
+					end: adjusted.end,
+					words: caption.words,
+				},
+			];
 		});
 
 		mappedCaptionSegments.forEach((segment, index) => {
@@ -310,6 +326,7 @@ export function deriveCaptionTrackSegments(
 	recordingSegments: SegmentRecordings[],
 	previousTrack: CaptionTrackSegment[] = [],
 	transitions: ClipTransition[] = [],
+	textSegments?: readonly TextSegment[],
 ): CaptionTrackSegment[] {
 	const overridesBySourceId = new Map<string, CaptionTrackOverrides>();
 	for (const segment of previousTrack) {
@@ -331,6 +348,7 @@ export function deriveCaptionTrackSegments(
 		timelineSegments,
 		recordingSegments,
 		transitions,
+		textSegments,
 	);
 
 	return mapped
@@ -461,6 +479,7 @@ export function applyCaptionResultToProject<
 					segments: TimelineSegment[];
 					captionSegments?: CaptionTrackSegment[] | null;
 					transitions?: ClipTransition[] | null;
+					textSegments?: TextSegment[] | null;
 			  } & Record<string, unknown>)
 			| null;
 	},
@@ -503,6 +522,7 @@ export function applyCaptionResultToProject<
 		recordingSegments,
 		timeline.captionSegments ?? [],
 		timeline.transitions ?? [],
+		timeline.textSegments ?? [],
 	);
 }
 
@@ -725,6 +745,82 @@ if (import.meta.vitest) {
 			expect(result[0]?.words?.[2]?.end).toBeCloseTo(1.5);
 		});
 
+		it("projects captions into hold-extended output time", () => {
+			const fullscreenText = (start: number, end: number): TextSegment =>
+				({
+					start,
+					end,
+					enabled: true,
+					layout: "fullscreen",
+				}) as TextSegment;
+			const identityTimeline: TimelineSegment[] = [
+				{ start: 0, end: 10, timescale: 1, recordingSegment: 0 },
+			];
+			const recordings = [{ display: { duration: 10 } } as SegmentRecordings];
+
+			// Speech after the hold lands after the inserted pause.
+			const after = mapCaptionsToEditedTimeline(
+				[
+					{
+						id: "caption",
+						start: 4,
+						end: 5,
+						text: "later",
+						words: [{ text: "later", start: 4, end: 5 }],
+					},
+				],
+				identityTimeline,
+				recordings,
+				[],
+				[fullscreenText(2, 5)],
+			);
+			expect(after).toHaveLength(1);
+			expect(after[0]?.start).toBeCloseTo(7);
+			expect(after[0]?.end).toBeCloseTo(8);
+			expect(after[0]?.words?.[0]?.start).toBeCloseTo(7);
+			expect(after[0]?.words?.[0]?.end).toBeCloseTo(8);
+
+			// A caption ending exactly where the hold begins stays before it.
+			const before = mapCaptionsToEditedTimeline(
+				[{ id: "caption", start: 1, end: 2, text: "before", words: [] }],
+				identityTimeline,
+				recordings,
+				[],
+				[fullscreenText(2, 5)],
+			);
+			expect(before[0]?.start).toBeCloseTo(1);
+			expect(before[0]?.end).toBeCloseTo(2);
+
+			// A caption crossing the hold spans the inserted time: the word
+			// before the pause stays put, the word after resumes with the
+			// recording.
+			const across = mapCaptionsToEditedTimeline(
+				[
+					{
+						id: "caption",
+						start: 1,
+						end: 3,
+						text: "across it",
+						words: [
+							{ text: "across", start: 1, end: 2 },
+							{ text: "it", start: 2, end: 3 },
+						],
+					},
+				],
+				identityTimeline,
+				recordings,
+				[],
+				[fullscreenText(2, 5)],
+			);
+			expect(across).toHaveLength(1);
+			expect(across[0]?.start).toBeCloseTo(1);
+			expect(across[0]?.end).toBeCloseTo(6);
+			expect(across[0]?.words?.[0]?.start).toBeCloseTo(1);
+			expect(across[0]?.words?.[0]?.end).toBeCloseTo(2);
+			expect(across[0]?.words?.[1]?.start).toBeCloseTo(5);
+			expect(across[0]?.words?.[1]?.end).toBeCloseTo(6);
+		});
+
 		it("splits captions without word timing across retained timeline ranges", () => {
 			const result = mapCaptionsToEditedTimeline(
 				[
@@ -831,6 +927,32 @@ if (import.meta.vitest) {
 			);
 
 			expect(rederived.find((s) => s.id === "capA")?.fontSizeOverride).toBe(42);
+		});
+
+		it("derives the render track in hold-extended output time", () => {
+			const identity: TimelineSegment[] = [
+				{ start: 0, end: 10, timescale: 1, recordingSegment: 0 },
+			];
+
+			const track = deriveCaptionTrackSegments(
+				sourceSegments,
+				identity,
+				recordings,
+				[],
+				[],
+				[
+					{
+						start: 3,
+						end: 5,
+						enabled: true,
+						layout: "fullscreen",
+					} as TextSegment,
+				],
+			);
+
+			expect(track.find((s) => s.id === "capA")?.start).toBeCloseTo(1);
+			expect(track.find((s) => s.id === "capB")?.start).toBeCloseTo(8);
+			expect(track.find((s) => s.id === "capB")?.end).toBeCloseTo(9);
 		});
 	});
 

--- a/apps/desktop/src/routes/editor/captions.ts
+++ b/apps/desktop/src/routes/editor/captions.ts
@@ -12,6 +12,12 @@ import {
 	type TimelineSegment,
 } from "~/utils/tauri";
 import { type ClipTransition, clipTimelineOffsets } from "./clip-transitions";
+import type { TextSegment } from "./text";
+import {
+	effectiveToOutput,
+	heldTimeBefore,
+	holdWindows,
+} from "./timeline-holds";
 export const DEFAULT_CAPTION_MODEL = "best";
 export const DEFAULT_WHISPER_CAPTION_MODEL = "small";
 export const DEFAULT_CAPTION_LANGUAGE = "auto";
@@ -350,6 +356,7 @@ export function mapSourceTimeToEdited(
 	timelineSegments: TimelineSegment[],
 	recordingSegments: SegmentRecordings[],
 	transitions: ClipTransition[] = [],
+	textSegments?: readonly TextSegment[],
 ): number | null {
 	const mappings = buildSourceToEditedMappings(
 		timelineSegments,
@@ -358,9 +365,12 @@ export function mapSourceTimeToEdited(
 	);
 	for (const mapping of mappings) {
 		if (sourceTime >= mapping.sourceStart && sourceTime <= mapping.sourceEnd) {
-			return (
+			// The mapping is in the gapless recording-flow domain; seeks need
+			// output time, which includes fullscreen-text holds.
+			return effectiveToOutput(
+				holdWindows(textSegments),
 				mapping.editedStart +
-				(sourceTime - mapping.sourceStart) / mapping.timescale
+					(sourceTime - mapping.sourceStart) / mapping.timescale,
 			);
 		}
 	}
@@ -404,7 +414,11 @@ export function mapEditedTimeToSource(
 	transitions: ClipTransition[] = [],
 	sourceRange?: { start: number; end: number },
 	overlapPreference: "outgoing" | "incoming" = "outgoing",
+	textSegments?: readonly TextSegment[],
 ): number | null {
+	// Output time includes fullscreen-text holds; the mappings below live in
+	// the gapless recording-flow domain.
+	editedTime -= heldTimeBefore(holdWindows(textSegments), editedTime);
 	const mappings = buildSourceToEditedMappings(
 		timelineSegments,
 		recordingSegments,

--- a/apps/desktop/src/routes/editor/clip-transitions.ts
+++ b/apps/desktop/src/routes/editor/clip-transitions.ts
@@ -105,6 +105,44 @@ export function clipTimelineOffsets(
 	return offsets;
 }
 
+/**
+ * Maps an edited-timeline timestamp to the recording-segment file and the
+ * time within that file which plays at that moment. Mirrors the Rust
+ * `TimelineConfiguration::get_segment_time` (minus holds); where a transition
+ * overlaps two segments the incoming segment wins. Times outside the timeline
+ * clamp to the nearest edge. Returns null only when there are no segments.
+ */
+export function clipSourceTimeAt(
+	segments: TimelineSegment[],
+	transitions: ClipTransition[],
+	editedTime: number,
+): {
+	segmentIndex: number;
+	recordingSegment: number;
+	sourceTime: number;
+} | null {
+	if (segments.length === 0) return null;
+
+	const offsets = clipTimelineOffsets(segments, transitions);
+
+	for (let index = segments.length - 1; index >= 0; index--) {
+		const segment = segments[index];
+		const local = editedTime - offsets[index];
+		if (local >= 0 || index === 0) {
+			return {
+				segmentIndex: index,
+				recordingSegment: segment.recordingSegment ?? 0,
+				sourceTime:
+					segment.start +
+					Math.min(Math.max(local, 0), clipDuration(segment)) *
+						segment.timescale,
+			};
+		}
+	}
+
+	return null;
+}
+
 export function normalizeClipTransitions(
 	segments: TimelineSegment[],
 	transitions: ClipTransition[],

--- a/apps/desktop/src/routes/editor/context.ts
+++ b/apps/desktop/src/routes/editor/context.ts
@@ -94,6 +94,11 @@ import {
 	setMotion,
 } from "./three-d";
 import {
+	heldTimeBefore,
+	holdWindows,
+	totalHeldDuration,
+} from "./timeline-holds";
+import {
 	getUsedTrackCount,
 	normalizeTrackSegments,
 	sortTrackSegments,
@@ -511,6 +516,9 @@ export const [EditorContextProvider, useEditorContext] = createContextProvider(
 						const timeline = project.timeline;
 						if (!timeline) return;
 						const segments = timeline.segments;
+						// The click position is in held-output time; clip offsets
+						// live in the gapless recording-flow domain.
+						time -= heldTimeBefore(holdWindows(timeline.textSegments), time);
 						const offsets = clipTimelineOffsets(
 							segments,
 							timeline.transitions ?? [],
@@ -1368,7 +1376,7 @@ export const [EditorContextProvider, useEditorContext] = createContextProvider(
 				? clipTimelineDuration(
 						project.timeline.segments,
 						project.timeline.transitions ?? [],
-					)
+					) + totalHeldDuration(holdWindows(project.timeline.textSegments))
 				: props.editorInstance.recordingDuration;
 
 		type State = {

--- a/apps/desktop/src/routes/editor/context.ts
+++ b/apps/desktop/src/routes/editor/context.ts
@@ -1653,7 +1653,12 @@ export const [EditorContextProvider, useEditorContext] = createContextProvider(
 								`${transition.segmentIndex}|${transition.type}|${transition.duration}`,
 						)
 						.join(",");
-					return `${captionsSig}@@${timelineSig}@@${transitionSig}`;
+					// Fullscreen-text holds shift the projected track's output
+					// times, so moving/resizing one must re-derive too.
+					const holdSig = holdWindows(timeline.textSegments)
+						.map(([start, end]) => `${start}|${end}`)
+						.join(",");
+					return `${captionsSig}@@${timelineSig}@@${transitionSig}@@${holdSig}`;
 				},
 				() => {
 					const timeline = project.timeline;
@@ -1665,6 +1670,7 @@ export const [EditorContextProvider, useEditorContext] = createContextProvider(
 						captionRecordingSegments,
 						timeline.captionSegments ?? [],
 						timeline.transitions ?? [],
+						timeline.textSegments,
 					);
 					setProject(
 						"timeline",

--- a/apps/desktop/src/routes/editor/context.ts
+++ b/apps/desktop/src/routes/editor/context.ts
@@ -1437,6 +1437,7 @@ export const [EditorContextProvider, useEditorContext] = createContextProvider(
 			},
 			timeline: {
 				interactMode: "seek" as "seek" | "split",
+				splitPreview: null as null | { time: number; snapped: boolean },
 				selection: null as
 					| null
 					| { type: "zoom"; indices: number[] }

--- a/apps/desktop/src/routes/editor/text-presets.ts
+++ b/apps/desktop/src/routes/editor/text-presets.ts
@@ -1,0 +1,265 @@
+import type { TextAlign, TextAnimation, TextSegment } from "./text";
+
+export type TextPresetStyle = {
+	fontStack: string[];
+	fontSize: number;
+	fontWeight: number;
+	italic: boolean;
+	align: TextAlign;
+	letterSpacing: number;
+	lineHeight: number;
+	shadow: number;
+	animationIn: TextAnimation;
+	animationInDuration: number;
+	animationOut: TextAnimation;
+	animationOutDuration: number;
+};
+
+export type TextPreset = {
+	id: string;
+	name: string;
+	sample: string;
+	style: TextPresetStyle;
+	// Presets that imply placement (e.g. a lower third) reposition the box.
+	center?: { x: number; y: number };
+};
+
+export const TEXT_PRESETS: TextPreset[] = [
+	{
+		id: "title",
+		name: "Title",
+		sample: "Big Title",
+		style: {
+			fontStack: ["Helvetica Neue", "Segoe UI", "Inter", "sans-serif"],
+			fontSize: 96,
+			fontWeight: 700,
+			italic: false,
+			align: "center",
+			letterSpacing: -1,
+			lineHeight: 1.1,
+			shadow: 0.35,
+			animationIn: "slideUp",
+			animationInDuration: 0.35,
+			animationOut: "fade",
+			animationOutDuration: 0.25,
+		},
+	},
+	{
+		id: "subtitle",
+		name: "Subtitle",
+		sample: "A calmer supporting line",
+		style: {
+			fontStack: ["Helvetica Neue", "Segoe UI", "Inter", "sans-serif"],
+			fontSize: 44,
+			fontWeight: 500,
+			italic: false,
+			align: "center",
+			letterSpacing: 0,
+			lineHeight: 1.3,
+			shadow: 0.25,
+			animationIn: "fade",
+			animationInDuration: 0.3,
+			animationOut: "fade",
+			animationOutDuration: 0.25,
+		},
+	},
+	{
+		id: "lower-third",
+		name: "Lower Third",
+		sample: "Name / Context",
+		center: { x: 0.22, y: 0.85 },
+		style: {
+			fontStack: ["Helvetica Neue", "Segoe UI", "Inter", "sans-serif"],
+			fontSize: 40,
+			fontWeight: 600,
+			italic: false,
+			align: "left",
+			letterSpacing: 0,
+			lineHeight: 1.25,
+			shadow: 0.4,
+			animationIn: "slideUp",
+			animationInDuration: 0.3,
+			animationOut: "slideDown",
+			animationOutDuration: 0.25,
+		},
+	},
+	{
+		id: "kicker",
+		name: "Kicker",
+		sample: "NEW FEATURE",
+		style: {
+			fontStack: ["Helvetica Neue", "Segoe UI", "Inter", "sans-serif"],
+			fontSize: 26,
+			fontWeight: 700,
+			italic: false,
+			align: "center",
+			letterSpacing: 6,
+			lineHeight: 1.2,
+			shadow: 0.2,
+			animationIn: "fade",
+			animationInDuration: 0.2,
+			animationOut: "fade",
+			animationOutDuration: 0.2,
+		},
+	},
+	{
+		id: "stat",
+		name: "Big Stat",
+		sample: "128%",
+		style: {
+			fontStack: ["Helvetica Neue", "Segoe UI", "Inter", "sans-serif"],
+			fontSize: 160,
+			fontWeight: 800,
+			italic: false,
+			align: "center",
+			letterSpacing: -2,
+			lineHeight: 1,
+			shadow: 0.3,
+			animationIn: "pop",
+			animationInDuration: 0.4,
+			animationOut: "fade",
+			animationOutDuration: 0.25,
+		},
+	},
+	{
+		id: "quote",
+		name: "Quote",
+		sample: "“Make it feel effortless”",
+		style: {
+			fontStack: ["Georgia", "Times New Roman", "serif"],
+			fontSize: 56,
+			fontWeight: 500,
+			italic: true,
+			align: "center",
+			letterSpacing: 0,
+			lineHeight: 1.35,
+			shadow: 0.2,
+			animationIn: "fade",
+			animationInDuration: 0.4,
+			animationOut: "fade",
+			animationOutDuration: 0.3,
+		},
+	},
+	{
+		id: "code",
+		name: "Code",
+		sample: "$ cap record",
+		style: {
+			fontStack: ["Menlo", "Consolas", "monospace"],
+			fontSize: 36,
+			fontWeight: 400,
+			italic: false,
+			align: "left",
+			letterSpacing: 0,
+			lineHeight: 1.4,
+			shadow: 0,
+			animationIn: "fade",
+			animationInDuration: 0.2,
+			animationOut: "fade",
+			animationOutDuration: 0.2,
+		},
+	},
+	{
+		id: "typewriter",
+		name: "Typewriter",
+		sample: "typing it out…",
+		style: {
+			fontStack: ["Menlo", "Consolas", "monospace"],
+			fontSize: 44,
+			fontWeight: 500,
+			italic: false,
+			align: "left",
+			letterSpacing: 0,
+			lineHeight: 1.3,
+			shadow: 0,
+			animationIn: "typewriter",
+			animationInDuration: 0.8,
+			animationOut: "fade",
+			animationOutDuration: 0.2,
+		},
+	},
+];
+
+// First family of the stack that is actually installed; the generic at the
+// end of every stack is the fallback (the renderer resolves generics itself).
+export function pickFontFamily(stack: string[], installedFonts: string[]) {
+	const installed = new Set(installedFonts.map((name) => name.toLowerCase()));
+	for (const family of stack) {
+		const normalized = family.toLowerCase();
+		if (
+			normalized === "sans-serif" ||
+			normalized === "serif" ||
+			normalized === "monospace"
+		)
+			return normalized;
+		if (installed.has(normalized)) return family;
+	}
+	return stack[stack.length - 1] ?? "sans-serif";
+}
+
+// Everything the preset styles is applied; content, timing, color (kept from
+// the auto black/white pick) and — unless the preset implies placement —
+// position stay the user's.
+export function applyTextPreset(
+	segment: TextSegment,
+	preset: TextPreset,
+	installedFonts: string[],
+) {
+	const style = preset.style;
+	// Scale the box with the font change, top edge fixed, like the Size
+	// slider — the canvas overlay re-hugs to exact glyph bounds when visible.
+	const boxScale = style.fontSize / (segment.fontSize || 48);
+	if (segment.size && segment.center) {
+		const topEdge = segment.center.y - segment.size.y / 2;
+		segment.size.x = Math.min(segment.size.x * boxScale, 1);
+		segment.size.y = segment.size.y * boxScale;
+		segment.center.y = topEdge + segment.size.y / 2;
+	}
+	segment.fontFamily = pickFontFamily(style.fontStack, installedFonts);
+	segment.fontSize = style.fontSize;
+	segment.fontWeight = style.fontWeight;
+	segment.italic = style.italic;
+	segment.align = style.align;
+	segment.letterSpacing = style.letterSpacing;
+	segment.lineHeight = style.lineHeight;
+	segment.opacity = 1;
+	segment.shadow = style.shadow;
+	segment.animationIn = style.animationIn;
+	segment.animationOut = style.animationOut;
+	segment.animationInDuration = style.animationInDuration;
+	segment.animationOutDuration = style.animationOutDuration;
+	segment.fadeDuration = Math.max(
+		style.animationInDuration,
+		style.animationOutDuration,
+	);
+	if (preset.center) {
+		segment.center = { ...preset.center };
+	}
+}
+
+const near = (a: number, b: number, eps = 0.011) => Math.abs(a - b) < eps;
+
+export function matchTextPreset(
+	segment: TextSegment,
+	installedFonts: string[],
+): string | null {
+	for (const preset of TEXT_PRESETS) {
+		const style = preset.style;
+		if (
+			segment.fontFamily === pickFontFamily(style.fontStack, installedFonts) &&
+			segment.fontWeight === style.fontWeight &&
+			segment.italic === style.italic &&
+			segment.align === style.align &&
+			near(segment.letterSpacing, style.letterSpacing) &&
+			near(segment.lineHeight, style.lineHeight) &&
+			near(segment.shadow, style.shadow) &&
+			segment.animationIn === style.animationIn &&
+			segment.animationOut === style.animationOut &&
+			near(segment.animationInDuration, style.animationInDuration) &&
+			near(segment.animationOutDuration, style.animationOutDuration)
+		) {
+			return preset.id;
+		}
+	}
+	return null;
+}

--- a/apps/desktop/src/routes/editor/text-style.tsx
+++ b/apps/desktop/src/routes/editor/text-style.tsx
@@ -7,6 +7,7 @@ import type { OrganizationBrandColorSwatch } from "~/utils/organization-branding
 import { BrandColorsDropdown } from "./BrandColorsDropdown";
 import { getColorPreviewBorderColor } from "./color-utils";
 import { TextInput } from "./TextInput";
+import type { TextAnimation } from "./text";
 
 export const FONT_OPTIONS = [
 	{ value: "System Sans-Serif", label: "System Sans-Serif" },
@@ -37,6 +38,28 @@ export const TEXT_WEIGHT_OPTIONS = [
 	{ label: "Normal", value: 400 },
 	{ label: "Medium", value: 500 },
 	{ label: "Bold", value: 700 },
+];
+
+export const TEXT_SEGMENT_WEIGHT_OPTIONS = [
+	{ label: "Light", value: 300 },
+	{ label: "Regular", value: 400 },
+	{ label: "Medium", value: 500 },
+	{ label: "Semibold", value: 600 },
+	{ label: "Bold", value: 700 },
+	{ label: "Extra Bold", value: 800 },
+	{ label: "Black", value: 900 },
+];
+
+export const TEXT_ANIMATION_OPTIONS: {
+	value: TextAnimation;
+	label: string;
+}[] = [
+	{ value: "none", label: "None" },
+	{ value: "fade", label: "Fade" },
+	{ value: "slideUp", label: "Slide up" },
+	{ value: "slideDown", label: "Slide down" },
+	{ value: "pop", label: "Pop" },
+	{ value: "typewriter", label: "Typewriter" },
 ];
 
 export const CAPTION_ANIMATION_OPTIONS = [

--- a/apps/desktop/src/routes/editor/text.ts
+++ b/apps/desktop/src/routes/editor/text.ts
@@ -7,6 +7,18 @@ export const TEXT_REFERENCE_HEIGHT = 1080;
 export const TEXT_FONT_SIZE_MIN = 8;
 export const TEXT_FONT_SIZE_MAX = 400;
 
+export type TextAlign = "left" | "center" | "right";
+
+export type TextAnimation =
+	| "none"
+	| "fade"
+	| "slideUp"
+	| "slideDown"
+	| "pop"
+	| "typewriter";
+
+export type TextLayout = "overlay" | "fullscreen" | "splitLeft" | "splitRight";
+
 export type TextSegment = {
 	start: number;
 	end: number;
@@ -21,6 +33,17 @@ export type TextSegment = {
 	italic: boolean;
 	color: string;
 	fadeDuration: number;
+	align: TextAlign;
+	letterSpacing: number;
+	lineHeight: number;
+	opacity: number;
+	shadow: number;
+	animationIn: TextAnimation;
+	animationOut: TextAnimation;
+	animationInDuration: number;
+	animationOutDuration: number;
+	layout: TextLayout;
+	layoutTransition: number;
 };
 
 // Picks the starting colour for a new text segment by sampling the composited
@@ -98,4 +121,15 @@ export const defaultTextSegment = (
 	italic: false,
 	color: "#ffffff",
 	fadeDuration: 0.15,
+	align: "center",
+	letterSpacing: 0,
+	lineHeight: 1.2,
+	opacity: 1,
+	shadow: 0,
+	animationIn: "fade",
+	animationOut: "fade",
+	animationInDuration: 0.15,
+	animationOutDuration: 0.15,
+	layout: "overlay",
+	layoutTransition: 0.5,
 });

--- a/apps/desktop/src/routes/editor/timeline-holds.ts
+++ b/apps/desktop/src/routes/editor/timeline-holds.ts
@@ -1,0 +1,59 @@
+import type { TextSegment } from "./text";
+
+// Mirrors TimelineConfiguration::hold_windows and friends in
+// crates/project/src/configuration.rs — fullscreen text segments pause the
+// recording clock, inserting their duration into the output timeline. The
+// frontend needs the same arithmetic for the ruler, playhead clamps, clip
+// positions and output<->recording conversions.
+
+export type HoldWindow = [number, number];
+
+export function holdWindows(
+	textSegments: readonly TextSegment[] | null | undefined,
+): HoldWindow[] {
+	if (!textSegments?.length) return [];
+	const windows = textSegments
+		.filter(
+			(segment) =>
+				segment.enabled !== false &&
+				segment.layout === "fullscreen" &&
+				segment.end > segment.start,
+		)
+		.map((segment): HoldWindow => [segment.start, segment.end])
+		.sort((a, b) => a[0] - b[0]);
+	const merged: HoldWindow[] = [];
+	for (const window of windows) {
+		const last = merged[merged.length - 1];
+		if (last && window[0] <= last[1]) {
+			last[1] = Math.max(last[1], window[1]);
+		} else {
+			merged.push([window[0], window[1]]);
+		}
+	}
+	return merged;
+}
+
+export function totalHeldDuration(holds: HoldWindow[]): number {
+	return holds.reduce((sum, [start, end]) => sum + (end - start), 0);
+}
+
+export function heldTimeBefore(holds: HoldWindow[], time: number): number {
+	return holds.reduce(
+		(sum, [start, end]) => sum + Math.max(0, Math.min(time, end) - start),
+		0,
+	);
+}
+
+// Places a gapless (recording-flow) timestamp back into output time, landing
+// after every hold it passed.
+export function effectiveToOutput(
+	holds: HoldWindow[],
+	effective: number,
+): number {
+	let output = effective;
+	for (const [start, end] of holds) {
+		if (output >= start) output += end - start;
+		else break;
+	}
+	return output;
+}

--- a/apps/desktop/src/routes/editor/timeline-holds.ts
+++ b/apps/desktop/src/routes/editor/timeline-holds.ts
@@ -8,8 +8,13 @@ import type { TextSegment } from "./text";
 
 export type HoldWindow = [number, number];
 
+// The slice of TextSegment the hold arithmetic reads; lets callers that only
+// carry plain track rows (start/end plus whatever they know) compute holds.
+export type HoldSourceSegment = Pick<TextSegment, "start" | "end"> &
+	Partial<Pick<TextSegment, "enabled" | "layout">>;
+
 export function holdWindows(
-	textSegments: readonly TextSegment[] | null | undefined,
+	textSegments: readonly HoldSourceSegment[] | null | undefined,
 ): HoldWindow[] {
 	if (!textSegments?.length) return [];
 	const windows = textSegments

--- a/apps/desktop/src/routes/editor/timeline-holds.ts
+++ b/apps/desktop/src/routes/editor/timeline-holds.ts
@@ -57,3 +57,19 @@ export function effectiveToOutput(
 	}
 	return output;
 }
+
+// effectiveToOutput for range *end* timestamps: an end landing exactly on a
+// hold boundary binds to the content before the pause instead of jumping past
+// it, so a range that finishes right where a hold begins doesn't stretch
+// across the inserted time.
+export function effectiveToOutputEnd(
+	holds: HoldWindow[],
+	effective: number,
+): number {
+	let output = effective;
+	for (const [start, end] of holds) {
+		if (output > start) output += end - start;
+		else break;
+	}
+	return output;
+}

--- a/apps/desktop/src/routes/editor/timeline-utils.ts
+++ b/apps/desktop/src/routes/editor/timeline-utils.ts
@@ -5,6 +5,12 @@ import {
 	transitionsAfterClipDelete,
 	transitionsAfterClipSplit,
 } from "./clip-transitions";
+import {
+	effectiveToOutput,
+	effectiveToOutputEnd,
+	type HoldSourceSegment,
+	holdWindows,
+} from "./timeline-holds";
 
 export function shiftTimeAfterCut(
 	time: number,
@@ -151,7 +157,7 @@ export function rippleDeleteAllTracks(
 		zoomSegments?: Array<{ start: number; end: number }> | null;
 		sceneSegments?: Array<{ start: number; end: number }> | null;
 		maskSegments?: Array<{ start: number; end: number }> | null;
-		textSegments?: Array<{ start: number; end: number }> | null;
+		textSegments?: Array<HoldSourceSegment> | null;
 		captionSegments?: Array<{ start: number; end: number }> | null;
 		keyboardSegments?: Array<{ start: number; end: number }> | null;
 		audioSegments?: Array<{ start: number; end: number }> | null;
@@ -160,6 +166,15 @@ export function rippleDeleteAllTracks(
 	cutEnd: number,
 	requestedSegmentIndex?: number,
 ) {
+	// The clip cut below works in the gapless recording-flow domain, but the
+	// overlay tracks live in output time, which includes fullscreen-text
+	// holds. Convert the cut range before touching them, and let the held
+	// time inside the cut leave with the text segments it belongs to (they
+	// sit inside the converted range, so the overlay pass deletes them).
+	const holds = holdWindows(timeline.textSegments);
+	const overlayCutStart = effectiveToOutput(holds, cutStart);
+	const overlayCutEnd = effectiveToOutputEnd(holds, cutEnd);
+
 	const durationBefore = clipTimelineDuration(
 		timeline.segments,
 		timeline.transitions ?? [],
@@ -176,59 +191,115 @@ export function rippleDeleteAllTracks(
 		durationBefore -
 			clipTimelineDuration(timeline.segments, timeline.transitions),
 	);
+	const overlayShift =
+		shiftDuration + (overlayCutEnd - overlayCutStart - (cutEnd - cutStart));
 	if (timeline.zoomSegments)
 		rippleDeleteFromTrack(
 			timeline.zoomSegments,
-			cutStart,
-			cutEnd,
-			shiftDuration,
+			overlayCutStart,
+			overlayCutEnd,
+			overlayShift,
 		);
 	if (timeline.sceneSegments)
 		rippleDeleteFromTrack(
 			timeline.sceneSegments,
-			cutStart,
-			cutEnd,
-			shiftDuration,
+			overlayCutStart,
+			overlayCutEnd,
+			overlayShift,
 		);
 	if (timeline.maskSegments)
 		rippleDeleteFromTrack(
 			timeline.maskSegments,
-			cutStart,
-			cutEnd,
-			shiftDuration,
+			overlayCutStart,
+			overlayCutEnd,
+			overlayShift,
 		);
 	if (timeline.textSegments)
 		rippleDeleteFromTrack(
 			timeline.textSegments,
-			cutStart,
-			cutEnd,
-			shiftDuration,
+			overlayCutStart,
+			overlayCutEnd,
+			overlayShift,
 		);
 	if (timeline.captionSegments)
 		rippleDeleteFromTrack(
 			timeline.captionSegments,
-			cutStart,
-			cutEnd,
-			shiftDuration,
+			overlayCutStart,
+			overlayCutEnd,
+			overlayShift,
 		);
 	if (timeline.keyboardSegments)
 		rippleDeleteFromTrack(
 			timeline.keyboardSegments,
-			cutStart,
-			cutEnd,
-			shiftDuration,
+			overlayCutStart,
+			overlayCutEnd,
+			overlayShift,
 		);
 	if (timeline.audioSegments)
 		rippleDeleteFromTrack(
 			timeline.audioSegments,
-			cutStart,
-			cutEnd,
-			shiftDuration,
+			overlayCutStart,
+			overlayCutEnd,
+			overlayShift,
 		);
 }
 
 if (import.meta.vitest) {
 	const { expect, it } = import.meta.vitest;
+
+	it("ripple-deletes overlay tracks in hold-extended output time", () => {
+		// Fullscreen text at output [2,4] pauses the recording for 2s, so
+		// gapless recording time g >= 2 plays at output g + 2.
+		const timeline = {
+			segments: [{ start: 0, end: 10, timescale: 1 }],
+			transitions: [] as ClipTransition[],
+			textSegments: [
+				{ start: 2, end: 4, enabled: true, layout: "fullscreen" as const },
+			],
+			// Covers recording content 3.5..4.5 — entirely before the cut.
+			zoomSegments: [{ start: 5.5, end: 6.5 }],
+			// Covers recording content 6..7 — entirely after the cut.
+			keyboardSegments: [{ start: 8, end: 9 }],
+		};
+
+		// Delete recording content [5,6], which plays at output [7,8].
+		rippleDeleteAllTracks(timeline, 5, 6);
+
+		expect(timeline.segments).toEqual([
+			{ start: 0, end: 5, timescale: 1 },
+			{ start: 6, end: 10, timescale: 1 },
+		]);
+		// Before the fix the gapless cut range [5,6] was compared against
+		// these output-time positions and mangled the zoom to [5,5.5].
+		expect(timeline.zoomSegments).toEqual([{ start: 5.5, end: 6.5 }]);
+		expect(timeline.keyboardSegments).toEqual([{ start: 7, end: 8 }]);
+		expect(timeline.textSegments).toHaveLength(1);
+	});
+
+	it("deletes a hold inside the cut together with its inserted time", () => {
+		const timeline = {
+			segments: [{ start: 0, end: 10, timescale: 1 }],
+			transitions: [] as ClipTransition[],
+			textSegments: [
+				{ start: 2, end: 4, enabled: true, layout: "fullscreen" as const },
+			],
+			// Covers recording content 6..7, at output [8,9].
+			zoomSegments: [{ start: 8, end: 9 }],
+		};
+
+		// Delete recording content [1,5]: output [1,7], swallowing the hold.
+		rippleDeleteAllTracks(timeline, 1, 5);
+
+		expect(timeline.segments).toEqual([
+			{ start: 0, end: 1, timescale: 1 },
+			{ start: 5, end: 10, timescale: 1 },
+		]);
+		// The fullscreen text sat inside the cut and leaves with it.
+		expect(timeline.textSegments).toEqual([]);
+		// 4s of recording plus the 2s hold left the output timeline, and no
+		// holds remain, so output equals gapless again.
+		expect(timeline.zoomSegments).toEqual([{ start: 2, end: 3 }]);
+	});
 
 	it("cuts the requested overlap source without discarding the adjacent clip", () => {
 		const segments = [

--- a/apps/desktop/src/utils/fonts.ts
+++ b/apps/desktop/src/utils/fonts.ts
@@ -1,0 +1,39 @@
+import { invoke } from "@tauri-apps/api/core";
+
+let fontsPromise: Promise<string[]> | null = null;
+
+// Enumerated Rust-side from the same fontdb the renderer shapes with, so
+// every family returned here is guaranteed resolvable at render time.
+export function listSystemFonts(): Promise<string[]> {
+	fontsPromise ??= invoke<string[]>("list_system_fonts").catch(() => {
+		fontsPromise = null;
+		return [];
+	});
+	return fontsPromise;
+}
+
+export const GENERIC_FONT_OPTIONS = [
+	{ value: "sans-serif", label: "System Sans" },
+	{ value: "serif", label: "System Serif" },
+	{ value: "monospace", label: "System Mono" },
+];
+
+const GENERIC_VALUES = new Set(GENERIC_FONT_OPTIONS.map((o) => o.value));
+
+export function isGenericFontFamily(value: string) {
+	return GENERIC_VALUES.has(value.trim().toLowerCase());
+}
+
+export function fontFamilyLabel(value: string) {
+	const generic = GENERIC_FONT_OPTIONS.find(
+		(option) => option.value === value.trim().toLowerCase(),
+	);
+	return generic ? generic.label : value;
+}
+
+// CSS font-family value for previewing a picked family in the webview.
+export function cssFontFamily(value: string) {
+	const trimmed = value.trim();
+	if (isGenericFontFamily(trimmed)) return trimmed.toLowerCase();
+	return `"${trimmed.replaceAll('"', "")}", sans-serif`;
+}

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -92,6 +92,9 @@ async getDefaultExcludedWindows() : Promise<WindowExclusion[]> {
 async listAudioDevices() : Promise<string[]> {
     return await TAURI_INVOKE("list_audio_devices");
 },
+async listSystemFonts() : Promise<string[]> {
+    return await TAURI_INVOKE("list_system_fonts");
+},
 async closeRecordingsOverlayWindow() : Promise<void> {
     await TAURI_INVOKE("close_recordings_overlay_window");
 },
@@ -955,7 +958,7 @@ export type FrameStyle =
 "macbook"
 export type FrameTheme = "dark" | "light"
 export type FramesRendered = { renderedCount: number; totalFrames: number; type: "FramesRendered" }
-export type GeneralSettingsStore = { instanceId?: string; uploadIndividualFiles?: boolean; hideDockIcon?: boolean; autoCreateShareableLink?: boolean; enableNotifications?: boolean; disableAutoOpenLinks?: boolean; hasCompletedStartup?: boolean; theme?: AppTheme; commercialLicense?: CommercialLicense | null; lastVersion?: string | null; windowTransparency?: boolean; postStudioRecordingBehaviour?: PostStudioRecordingBehaviour; mainWindowRecordingStartBehaviour?: MainWindowRecordingStartBehaviour; custom_cursor_capture2?: boolean; serverUrl?: string; recordingCountdown?: number | null; enableNativeCameraPreview: boolean; autoZoomOnClicks?: boolean; 
+export type GeneralSettingsStore = { instanceId?: string; uploadIndividualFiles?: boolean; hideDockIcon?: boolean; autoCreateShareableLink?: boolean; enableNotifications?: boolean; disableAutoOpenLinks?: boolean; hasCompletedStartup?: boolean; theme?: AppTheme; commercialLicense?: CommercialLicense | null; lastVersion?: string | null; windowTransparency?: boolean; postStudioRecordingBehaviour?: PostStudioRecordingBehaviour; mainWindowRecordingStartBehaviour?: MainWindowRecordingStartBehaviour; custom_cursor_capture2?: boolean; serverUrl?: string; recordingCountdown?: number | null; enableNativeCameraPreview: boolean; autoZoomOnClicks?: boolean; defaultZoomAmount?: number | null; 
 /**
  * `None` until [`init`] seeds it from whether this machine has a notched
  * display. From then on it is the user's preference and nothing re-reads
@@ -1067,7 +1070,14 @@ colorCorrection?: ColorCorrectionConfiguration;
  * `font_size`. The field-level default keeps old files at 0 while
  * `Default::default()` produces the current version.
  */
-textSizeVersion?: number }
+textSizeVersion?: number; 
+/**
+ * 0 (legacy): text segments animate with the single symmetric
+ * `fade_duration`. 1: the enter/exit animation fields drive timing;
+ * legacy configs are migrated on load by seeding both animation
+ * durations from `fade_duration`.
+ */
+textAnimVersion?: number }
 export type ProjectRecordingsMeta = { segments: SegmentRecordings[] }
 export type RecordingAction = "Started" | "InvalidAuthentication" | "UpgradeRequired"
 export type RecordingDeleted = { path: string }
@@ -1132,7 +1142,45 @@ export type StudioRecordingQuality = "compatibility" | "balanced" | "ultra"
 export type StudioRecordingStatus = { status: "InProgress" } | { status: "NeedsRemux" } | { status: "Failed"; error: string } | { status: "Complete" }
 export type SystemDiagnostics = { macosVersion: MacOSVersionInfo | null; availableEncoders: string[]; screenCaptureSupported: boolean; metalSupported: boolean; gpuName: string | null }
 export type TargetUnderCursor = { display_id: DisplayId | null; window: WindowUnderCursor | null }
-export type TextSegment = { start: number; end: number; track?: number; enabled?: boolean; content?: string; center?: XY<number>; size?: XY<number>; fontFamily?: string; fontSize?: number; fontWeight?: number; italic?: boolean; color?: string; fadeDuration?: number }
+export type TextAlign = "left" | "center" | "right"
+export type TextAnimation = "none" | "fade" | "slideUp" | "slideDown" | "pop" | "typewriter"
+/**
+ * How a text segment shares the frame with the display recording. The
+ * variants name where the TEXT sits; the display card makes room for it.
+ */
+export type TextLayout = 
+/**
+ * Text draws over the untouched display (the original behavior).
+ */
+"overlay" | 
+/**
+ * The display card shrinks and fades away; text owns the frame.
+ */
+"fullscreen" | 
+/**
+ * Text in the left half, display card contained in the right half.
+ */
+"splitLeft" | 
+/**
+ * Text in the right half, display card contained in the left half.
+ */
+"splitRight"
+export type TextSegment = { start: number; end: number; track?: number; enabled?: boolean; content?: string; center?: XY<number>; size?: XY<number>; fontFamily?: string; fontSize?: number; fontWeight?: number; italic?: boolean; color?: string; 
+/**
+ * Legacy symmetric fade. Superseded by the animation fields below; kept
+ * so configs written by new builds still fade in old builds. The
+ * `text_anim_version` migration seeds the animation durations from it.
+ */
+fadeDuration?: number; align?: TextAlign; 
+/**
+ * Px at the 1080p reference height, like `font_size`.
+ */
+letterSpacing?: number; lineHeight?: number; opacity?: number; shadow?: number; animationIn?: TextAnimation; animationOut?: TextAnimation; animationInDuration?: number; animationOutDuration?: number; layout?: TextLayout; 
+/**
+ * Seconds the display card takes to morph aside (and back) at the
+ * segment edges when `layout` is not `Overlay`.
+ */
+layoutTransition?: number }
 export type TimelineConfiguration = { segments: TimelineSegment[]; transitions: ClipTransition[]; zoomSegments: ZoomSegment[]; sceneSegments?: SceneSegment[]; maskSegments?: MaskSegment[]; textSegments?: TextSegment[]; captionSegments?: CaptionTrackSegment[]; keyboardSegments?: KeyboardTrackSegment[]; audioSegments?: AudioTrackSegment[]; camera3dSegments?: Camera3DSegment[] }
 export type TimelineSegment = { recordingSegment?: number; timescale: number; start: number; end: number; name?: string | null; speedAudioMode?: ClipSpeedAudioMode | null }
 export type TranscriptionEngine = "Whisper" | "Parakeet"

--- a/apps/web/actions/loom.ts
+++ b/apps/web/actions/loom.ts
@@ -405,10 +405,7 @@ async function importLoomVideoForOwner({
 		fetchLoomOEmbed(loomVideoId),
 	]);
 
-	const writableResult = await Storage.getWritableAccessForUser(
-		ownerId,
-		orgId,
-	)
+	const writableResult = await Storage.getWritableAccessForUser(ownerId, orgId)
 		.pipe(runPromise)
 		.then(
 			(value) => ({ ok: true as const, value }),

--- a/apps/web/components/pages/seo/AsyncVideoCodeReviewsPage.tsx
+++ b/apps/web/components/pages/seo/AsyncVideoCodeReviewsPage.tsx
@@ -278,7 +278,8 @@ export const asyncVideoCodeReviewsContent: SeoPageContent = {
 	video: {
 		iframe: {
 			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
-			title: "Cap async video code review demo showing screen recording of a pull request walkthrough with timestamped comments",
+			title:
+				"Cap async video code review demo showing screen recording of a pull request walkthrough with timestamped comments",
 		},
 	},
 

--- a/apps/web/components/pages/seo/BestScreenRecorderPage.tsx
+++ b/apps/web/components/pages/seo/BestScreenRecorderPage.tsx
@@ -254,7 +254,8 @@ export const bestScreenRecorderContent: SeoPageContent = {
 	video: {
 		iframe: {
 			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
-			title: "Cap screen recorder demo showing 4K capture, webcam overlay, and instant sharing",
+			title:
+				"Cap screen recorder demo showing 4K capture, webcam overlay, and instant sharing",
 		},
 	},
 

--- a/apps/web/components/pages/seo/DeveloperDocumentationVideosPage.tsx
+++ b/apps/web/components/pages/seo/DeveloperDocumentationVideosPage.tsx
@@ -277,7 +277,8 @@ export const developerDocumentationVideosContent: SeoPageContent = {
 	video: {
 		iframe: {
 			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
-			title: "Cap developer documentation video demo showing screen recording of an API walkthrough with narration and instant share link",
+			title:
+				"Cap developer documentation video demo showing screen recording of an API walkthrough with narration and instant share link",
 		},
 	},
 

--- a/apps/web/components/pages/seo/HipaaCompliantScreenRecordingPage.tsx
+++ b/apps/web/components/pages/seo/HipaaCompliantScreenRecordingPage.tsx
@@ -285,7 +285,8 @@ export const hipaaCompliantScreenRecordingContent: SeoPageContent = {
 	video: {
 		iframe: {
 			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
-			title: "Cap HIPAA-compliant screen recording demo showing self-hosted storage configuration and secure sharing",
+			title:
+				"Cap HIPAA-compliant screen recording demo showing self-hosted storage configuration and secure sharing",
 		},
 	},
 

--- a/apps/web/components/pages/seo/MacScreenRecordingWithAudioPage.tsx
+++ b/apps/web/components/pages/seo/MacScreenRecordingWithAudioPage.tsx
@@ -271,7 +271,8 @@ export const macScreenRecordingWithAudioContent: SeoPageContent = {
 	video: {
 		iframe: {
 			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
-			title: "Cap recording Mac screen with system audio and microphone simultaneously",
+			title:
+				"Cap recording Mac screen with system audio and microphone simultaneously",
 		},
 	},
 

--- a/apps/web/components/pages/seo/OpenSourceScreenRecorderPage.tsx
+++ b/apps/web/components/pages/seo/OpenSourceScreenRecorderPage.tsx
@@ -255,7 +255,8 @@ export const openSourceScreenRecorderContent: SeoPageContent = {
 	video: {
 		iframe: {
 			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
-			title: "Cap open source screen recorder demo showing recording, sharing, and self-hosting",
+			title:
+				"Cap open source screen recorder demo showing recording, sharing, and self-hosting",
 		},
 	},
 

--- a/apps/web/components/pages/seo/RecordScreenPage.tsx
+++ b/apps/web/components/pages/seo/RecordScreenPage.tsx
@@ -247,7 +247,8 @@ export const recordScreenContent: SeoPageContent = {
 	video: {
 		iframe: {
 			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
-			title: "Cap screen recording demo showing one-click capture, webcam overlay, and instant sharing",
+			title:
+				"Cap screen recording demo showing one-click capture, webcam overlay, and instant sharing",
 		},
 	},
 

--- a/apps/web/components/pages/seo/ScreenRecorderPage.tsx
+++ b/apps/web/components/pages/seo/ScreenRecorderPage.tsx
@@ -107,7 +107,8 @@ export const screenRecorderContent: SeoPageContent = {
 	video: {
 		iframe: {
 			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
-			title: "Cap screen recorder demo showing high-quality and user-friendly features",
+			title:
+				"Cap screen recorder demo showing high-quality and user-friendly features",
 		},
 	},
 

--- a/apps/web/components/pages/seo/ScreenRecordingPage.tsx
+++ b/apps/web/components/pages/seo/ScreenRecordingPage.tsx
@@ -191,7 +191,8 @@ export const screenRecordingContent: SeoPageContent = {
 	video: {
 		iframe: {
 			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
-			title: "Cap screen recording demo showing HD capture, webcam overlay, and instant sharing",
+			title:
+				"Cap screen recording demo showing HD capture, webcam overlay, and instant sharing",
 		},
 	},
 

--- a/apps/web/components/pages/seo/SelfHostedScreenRecordingPage.tsx
+++ b/apps/web/components/pages/seo/SelfHostedScreenRecordingPage.tsx
@@ -273,7 +273,8 @@ export const selfHostedScreenRecordingContent: SeoPageContent = {
 	video: {
 		iframe: {
 			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
-			title: "Cap self-hosted screen recording demo showing S3 storage configuration and instant sharing",
+			title:
+				"Cap self-hosted screen recording demo showing S3 storage configuration and instant sharing",
 		},
 	},
 

--- a/apps/web/components/pages/seo/VideoRecordingSoftwarePage.tsx
+++ b/apps/web/components/pages/seo/VideoRecordingSoftwarePage.tsx
@@ -254,7 +254,8 @@ export const videoRecordingSoftwareContent: SeoPageContent = {
 	video: {
 		iframe: {
 			src: "https://www.rend.so/embed/10512af0-b922-4efa-8974-f8f14fc1886a?accent=3e63dd",
-			title: "Cap video recording software demo showing HD screen capture, webcam overlay, and instant sharing",
+			title:
+				"Cap video recording software demo showing HD screen capture, webcam overlay, and instant sharing",
 		},
 	},
 

--- a/crates/editor/src/audio.rs
+++ b/crates/editor/src/audio.rs
@@ -251,7 +251,9 @@ impl AudioRenderer {
         project: &ProjectConfiguration,
         timeline: &TimelineConfiguration,
     ) -> Option<(usize, Vec<f32>)> {
-        if !timeline.transitions.is_empty() {
+        // Transitions and fullscreen-text holds both need the mapping-driven
+        // path; the accumulation fast path below knows nothing about either.
+        if !timeline.transitions.is_empty() || !timeline.hold_windows().is_empty() {
             return self.render_timeline_transition_frame_raw(samples, project, timeline);
         }
 
@@ -328,7 +330,8 @@ impl AudioRenderer {
                 };
                 let output_end = match mapping {
                     TimelineFrameMapping::Single { output_end, .. }
-                    | TimelineFrameMapping::Transition { output_end, .. } => output_end,
+                    | TimelineFrameMapping::Transition { output_end, .. }
+                    | TimelineFrameMapping::Hold { output_end, .. } => output_end,
                 };
                 let output_end_samples = self.playhead_to_samples(output_end);
                 if output_end_samples > self.elapsed_samples {
@@ -354,6 +357,14 @@ impl AudioRenderer {
                         &mut output,
                     );
                     self.cursor = source_cursor(source, source_samples + chunk_samples);
+                }
+                TimelineFrameMapping::Hold { source, .. } => {
+                    // Recording clock is paused: the chunk stays silent (the
+                    // buffer is zero-filled) and the cursor parks on the
+                    // frozen instant so playback resumes seamlessly. Music
+                    // keeps playing — it mixes in output time on top.
+                    self.cursor =
+                        source_cursor(source, self.playhead_to_samples(source.source_time));
                 }
                 TimelineFrameMapping::Transition {
                     outgoing,

--- a/crates/export/src/lib.rs
+++ b/crates/export/src/lib.rs
@@ -196,7 +196,17 @@ pub fn make_cursor_only_project(mut project_config: ProjectConfiguration) -> Pro
 
     if let Some(timeline) = project_config.timeline.as_mut() {
         timeline.mask_segments.clear();
-        timeline.text_segments.clear();
+        // Fullscreen text segments pause the recording clock (holds), which
+        // shapes the frame count and cursor motion; dropping them would
+        // desync this overlay pass from the main render. Keep them as
+        // invisible placeholders (empty content draws nothing) and only
+        // remove overlay-layout texts.
+        timeline
+            .text_segments
+            .retain(|text| text.layout == cap_project::TextLayout::Fullscreen);
+        for text in &mut timeline.text_segments {
+            text.content.clear();
+        }
         timeline.caption_segments.clear();
         timeline.keyboard_segments.clear();
     }

--- a/crates/project/src/configuration.rs
+++ b/crates/project/src/configuration.rs
@@ -989,6 +989,43 @@ impl MaskSegment {
     }
 }
 
+#[derive(Type, Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum TextAlign {
+    Left,
+    #[default]
+    Center,
+    Right,
+}
+
+#[derive(Type, Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum TextAnimation {
+    None,
+    #[default]
+    Fade,
+    SlideUp,
+    SlideDown,
+    Pop,
+    Typewriter,
+}
+
+/// How a text segment shares the frame with the display recording. The
+/// variants name where the TEXT sits; the display card makes room for it.
+#[derive(Type, Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum TextLayout {
+    /// Text draws over the untouched display (the original behavior).
+    #[default]
+    Overlay,
+    /// The display card shrinks and fades away; text owns the frame.
+    Fullscreen,
+    /// Text in the left half, display card contained in the right half.
+    SplitLeft,
+    /// Text in the right half, display card contained in the left half.
+    SplitRight,
+}
+
 #[derive(Type, Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct TextSegment {
@@ -1014,8 +1051,36 @@ pub struct TextSegment {
     pub italic: bool,
     #[serde(default = "TextSegment::default_color")]
     pub color: String,
+    /// Legacy symmetric fade. Superseded by the animation fields below; kept
+    /// so configs written by new builds still fade in old builds. The
+    /// `text_anim_version` migration seeds the animation durations from it.
     #[serde(default = "TextSegment::default_fade_duration")]
     pub fade_duration: f64,
+    #[serde(default)]
+    pub align: TextAlign,
+    /// Px at the 1080p reference height, like `font_size`.
+    #[serde(default)]
+    pub letter_spacing: f32,
+    #[serde(default = "TextSegment::default_line_height")]
+    pub line_height: f32,
+    #[serde(default = "TextSegment::default_opacity")]
+    pub opacity: f32,
+    #[serde(default)]
+    pub shadow: f32,
+    #[serde(default)]
+    pub animation_in: TextAnimation,
+    #[serde(default)]
+    pub animation_out: TextAnimation,
+    #[serde(default = "TextSegment::default_fade_duration")]
+    pub animation_in_duration: f64,
+    #[serde(default = "TextSegment::default_fade_duration")]
+    pub animation_out_duration: f64,
+    #[serde(default)]
+    pub layout: TextLayout,
+    /// Seconds the display card takes to morph aside (and back) at the
+    /// segment edges when `layout` is not `Overlay`.
+    #[serde(default = "TextSegment::default_layout_transition")]
+    pub layout_transition: f64,
 }
 
 impl TextSegment {
@@ -1053,6 +1118,18 @@ impl TextSegment {
 
     fn default_fade_duration() -> f64 {
         0.15
+    }
+
+    fn default_line_height() -> f32 {
+        1.2
+    }
+
+    fn default_opacity() -> f32 {
+        1.0
+    }
+
+    fn default_layout_transition() -> f64 {
+        0.5
     }
 }
 
@@ -2055,9 +2132,16 @@ pub struct ProjectConfiguration {
     /// `Default::default()` produces the current version.
     #[serde(default)]
     pub text_size_version: u32,
+    /// 0 (legacy): text segments animate with the single symmetric
+    /// `fade_duration`. 1: the enter/exit animation fields drive timing;
+    /// legacy configs are migrated on load by seeding both animation
+    /// durations from `fade_duration`.
+    #[serde(default)]
+    pub text_anim_version: u32,
 }
 
 pub const TEXT_SIZE_VERSION: u32 = 1;
+pub const TEXT_ANIM_VERSION: u32 = 1;
 
 fn camera_config_needs_migration(value: &Value) -> bool {
     value
@@ -2089,6 +2173,7 @@ impl Default for ProjectConfiguration {
             screen_movement_spring: Default::default(),
             color_correction: Default::default(),
             text_size_version: TEXT_SIZE_VERSION,
+            text_anim_version: TEXT_ANIM_VERSION,
         }
     }
 }
@@ -2155,6 +2240,21 @@ impl ProjectConfiguration {
                 }
             }
             config.text_size_version = TEXT_SIZE_VERSION;
+        }
+
+        if config.text_anim_version == 0 {
+            if let Some(timeline) = config.timeline.as_mut() {
+                for segment in &mut timeline.text_segments {
+                    let fade = segment.fade_duration.max(0.0);
+                    segment.animation_in_duration = fade;
+                    segment.animation_out_duration = fade;
+                    if fade == 0.0 {
+                        segment.animation_in = TextAnimation::None;
+                        segment.animation_out = TextAnimation::None;
+                    }
+                }
+            }
+            config.text_anim_version = TEXT_ANIM_VERSION;
         }
 
         config
@@ -2732,6 +2832,17 @@ mod tests {
                     italic: false,
                     color: "#ffffff".to_string(),
                     fade_duration: 0.15,
+                    align: TextAlign::Center,
+                    letter_spacing: 0.0,
+                    line_height: 1.2,
+                    opacity: 1.0,
+                    shadow: 0.0,
+                    animation_in: TextAnimation::Fade,
+                    animation_out: TextAnimation::Fade,
+                    animation_in_duration: 0.15,
+                    animation_out_duration: 0.15,
+                    layout: TextLayout::Overlay,
+                    layout_transition: 0.5,
                 }],
                 caption_segments: Vec::new(),
                 keyboard_segments: Vec::new(),
@@ -2797,6 +2908,110 @@ mod tests {
 
         let segment = &config.timeline.as_ref().unwrap().text_segments[0];
         assert_eq!(segment.font_size, 96.0);
+    }
+
+    fn write_config_with_text_fade(project_path: &std::path::Path, fade_duration: f64) {
+        let mut config = ProjectConfiguration {
+            timeline: Some(TimelineConfiguration {
+                segments: Vec::new(),
+                transitions: Vec::new(),
+                zoom_segments: Vec::new(),
+                scene_segments: Vec::new(),
+                mask_segments: Vec::new(),
+                text_segments: vec![TextSegment {
+                    start: 0.0,
+                    end: 1.0,
+                    track: 0,
+                    enabled: true,
+                    content: "Text".to_string(),
+                    center: XY::new(0.5, 0.5),
+                    size: XY::new(0.35, 0.2),
+                    font_family: "sans-serif".to_string(),
+                    font_size: 48.0,
+                    font_weight: 700.0,
+                    italic: false,
+                    color: "#ffffff".to_string(),
+                    fade_duration,
+                    align: TextAlign::Center,
+                    letter_spacing: 0.0,
+                    line_height: 1.2,
+                    opacity: 1.0,
+                    shadow: 0.0,
+                    animation_in: TextAnimation::Fade,
+                    animation_out: TextAnimation::Fade,
+                    animation_in_duration: 0.15,
+                    animation_out_duration: 0.15,
+                    layout: TextLayout::Overlay,
+                    layout_transition: 0.5,
+                }],
+                caption_segments: Vec::new(),
+                keyboard_segments: Vec::new(),
+                audio_segments: Vec::new(),
+                camera3d_segments: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        config.text_anim_version = 0;
+
+        let mut value = serde_json::to_value(&config).unwrap();
+        let object = value.as_object_mut().unwrap();
+        object.remove("textAnimVersion");
+        // A legacy file predates the animation fields entirely.
+        if let Some(segments) = value
+            .pointer_mut("/timeline/textSegments")
+            .and_then(Value::as_array_mut)
+        {
+            for segment in segments {
+                let object = segment.as_object_mut().unwrap();
+                for key in [
+                    "align",
+                    "letterSpacing",
+                    "lineHeight",
+                    "opacity",
+                    "shadow",
+                    "animationIn",
+                    "animationOut",
+                    "animationInDuration",
+                    "animationOutDuration",
+                ] {
+                    object.remove(key);
+                }
+            }
+        }
+        std::fs::write(
+            project_path.join("project-config.json"),
+            serde_json::to_string(&value).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn legacy_text_fade_seeds_animation_durations() {
+        let dir = tempfile::tempdir().unwrap();
+        write_config_with_text_fade(dir.path(), 0.5);
+
+        let config = ProjectConfiguration::load(dir.path()).unwrap();
+
+        let segment = &config.timeline.as_ref().unwrap().text_segments[0];
+        assert_eq!(segment.animation_in, TextAnimation::Fade);
+        assert_eq!(segment.animation_out, TextAnimation::Fade);
+        assert_eq!(segment.animation_in_duration, 0.5);
+        assert_eq!(segment.animation_out_duration, 0.5);
+        assert_eq!(config.text_anim_version, TEXT_ANIM_VERSION);
+    }
+
+    #[test]
+    fn legacy_text_zero_fade_disables_animation() {
+        let dir = tempfile::tempdir().unwrap();
+        write_config_with_text_fade(dir.path(), 0.0);
+
+        let config = ProjectConfiguration::load(dir.path()).unwrap();
+
+        let segment = &config.timeline.as_ref().unwrap().text_segments[0];
+        assert_eq!(segment.animation_in, TextAnimation::None);
+        assert_eq!(segment.animation_out, TextAnimation::None);
+        assert_eq!(segment.animation_in_duration, 0.0);
+        assert_eq!(segment.animation_out_duration, 0.0);
     }
 
     #[test]

--- a/crates/project/src/configuration.rs
+++ b/crates/project/src/configuration.rs
@@ -1564,6 +1564,14 @@ pub enum TimelineFrameMapping<'a> {
         duration: f64,
         output_end: f64,
     },
+    /// The recording clock is paused under a fullscreen text segment: the
+    /// frozen `source` frame stands until `output_end` (the hold's end in
+    /// output time). Video shows the frozen frame (hidden behind the takeover
+    /// anyway); audio renders silence.
+    Hold {
+        source: TimelineSource<'a>,
+        output_end: f64,
+    },
 }
 
 #[derive(Type, Serialize, Deserialize, Clone, Debug)]
@@ -1628,7 +1636,93 @@ impl TimelineConfiguration {
         })
     }
 
+    /// Output-time windows where a fullscreen text segment pauses the
+    /// recording clock, sorted and merged. Empty for every project without
+    /// fullscreen text — the mapping below then short-circuits to the exact
+    /// pre-hold arithmetic.
+    pub fn hold_windows(&self) -> Vec<(f64, f64)> {
+        let mut windows: Vec<(f64, f64)> = self
+            .text_segments
+            .iter()
+            .filter(|s| s.enabled && s.layout == TextLayout::Fullscreen && s.end > s.start)
+            .map(|s| (s.start, s.end))
+            .collect();
+        if windows.is_empty() {
+            return windows;
+        }
+        windows.sort_by(|a, b| a.0.total_cmp(&b.0));
+        let mut merged: Vec<(f64, f64)> = Vec::with_capacity(windows.len());
+        for window in windows {
+            match merged.last_mut() {
+                Some(last) if window.0 <= last.1 => last.1 = last.1.max(window.1),
+                _ => merged.push(window),
+            }
+        }
+        merged
+    }
+
+    /// Total output seconds inserted by fullscreen text holds.
+    pub fn held_duration(&self) -> f64 {
+        self.hold_windows().iter().map(|(s, e)| e - s).sum()
+    }
+
     pub fn get_frame_mapping(&self, frame_time: f64) -> Option<TimelineFrameMapping<'_>> {
+        let holds = self.hold_windows();
+        if holds.is_empty() {
+            return self.get_frame_mapping_unheld(frame_time);
+        }
+
+        if let Some((hold_start, hold_end)) = active_hold_window(&holds, frame_time) {
+            let effective = hold_start - held_time_before(&holds, hold_start);
+            let source = match self.get_frame_mapping_unheld(effective)? {
+                TimelineFrameMapping::Single { source, .. }
+                | TimelineFrameMapping::Hold { source, .. } => source,
+                TimelineFrameMapping::Transition { incoming, .. } => incoming,
+            };
+            return Some(TimelineFrameMapping::Hold {
+                source,
+                output_end: hold_end,
+            });
+        }
+
+        let effective = frame_time - held_time_before(&holds, frame_time);
+        let next_hold_start = holds
+            .iter()
+            .map(|(start, _)| *start)
+            .find(|start| *start > frame_time);
+        // The base mapping's output_end is in the un-held (gapless) domain;
+        // put it back into output time and stop at the next hold so consumers
+        // (audio chunking) never render contiguous recording samples across a
+        // pause.
+        let clamp_end = |output_end: f64| {
+            let output_end = effective_to_output(&holds, output_end);
+            next_hold_start.map_or(output_end, |hold| output_end.min(hold))
+        };
+        Some(match self.get_frame_mapping_unheld(effective)? {
+            TimelineFrameMapping::Single { source, output_end } => TimelineFrameMapping::Single {
+                source,
+                output_end: clamp_end(output_end),
+            },
+            TimelineFrameMapping::Transition {
+                outgoing,
+                incoming,
+                kind,
+                progress,
+                duration,
+                output_end,
+            } => TimelineFrameMapping::Transition {
+                outgoing,
+                incoming,
+                kind,
+                progress,
+                duration,
+                output_end: clamp_end(output_end),
+            },
+            hold @ TimelineFrameMapping::Hold { .. } => hold,
+        })
+    }
+
+    fn get_frame_mapping_unheld(&self, frame_time: f64) -> Option<TimelineFrameMapping<'_>> {
         if self.transitions.is_empty() {
             return self.get_segment_time_without_transitions(frame_time).map(
                 |(source_time, segment, segment_index, output_end)| TimelineFrameMapping::Single {
@@ -1701,19 +1795,15 @@ impl TimelineConfiguration {
     }
 
     pub fn get_segment_time(&self, frame_time: f64) -> Option<(f64, &TimelineSegment)> {
-        if !self.transitions.is_empty() {
-            return match self.get_frame_mapping(frame_time)? {
-                TimelineFrameMapping::Single { source, .. } => {
-                    Some((source.source_time, source.segment))
-                }
-                TimelineFrameMapping::Transition { incoming, .. } => {
-                    Some((incoming.source_time, incoming.segment))
-                }
-            };
+        match self.get_frame_mapping(frame_time)? {
+            TimelineFrameMapping::Single { source, .. }
+            | TimelineFrameMapping::Hold { source, .. } => {
+                Some((source.source_time, source.segment))
+            }
+            TimelineFrameMapping::Transition { incoming, .. } => {
+                Some((incoming.source_time, incoming.segment))
+            }
         }
-
-        self.get_segment_time_without_transitions(frame_time)
-            .map(|(source_time, segment, _, _)| (source_time, segment))
     }
 
     fn get_segment_time_without_transitions(
@@ -1743,17 +1833,47 @@ impl TimelineConfiguration {
     }
 
     pub fn duration(&self) -> f64 {
-        let segment_duration = self.segments.iter().map(TimelineSegment::duration).sum();
-        if self.transitions.is_empty() {
-            return segment_duration;
-        }
+        let segment_duration: f64 = self.segments.iter().map(TimelineSegment::duration).sum();
+        let segment_duration = if self.transitions.is_empty() {
+            segment_duration
+        } else {
+            segment_duration
+                - (1..self.segments.len())
+                    .filter_map(|segment_index| self.effective_transition(segment_index))
+                    .map(|transition| transition.duration)
+                    .sum::<f64>()
+        };
 
-        segment_duration
-            - (1..self.segments.len())
-                .filter_map(|segment_index| self.effective_transition(segment_index))
-                .map(|transition| transition.duration)
-                .sum::<f64>()
+        segment_duration + self.held_duration()
     }
+}
+
+fn active_hold_window(windows: &[(f64, f64)], time: f64) -> Option<(f64, f64)> {
+    windows
+        .iter()
+        .find(|(start, end)| time >= *start && time < *end)
+        .copied()
+}
+
+fn held_time_before(windows: &[(f64, f64)], time: f64) -> f64 {
+    windows
+        .iter()
+        .map(|(start, end)| (time.min(*end) - start).max(0.0))
+        .sum()
+}
+
+/// Inverse of the held-output -> gapless transform: places a gapless
+/// timestamp back into output time, landing after every hold it passed.
+fn effective_to_output(windows: &[(f64, f64)], effective: f64) -> f64 {
+    let mut output = effective;
+    for (start, end) in windows {
+        if output >= *start {
+            output += end - start;
+        } else {
+            break;
+        }
+    }
+    output
 }
 
 pub const WALLPAPERS_PATH: &str = "assets/backgrounds/macOS";
@@ -2441,6 +2561,111 @@ mod tests {
             audio_segments: Vec::new(),
             camera3d_segments: Vec::new(),
         }
+    }
+
+    fn fullscreen_text(start: f64, end: f64) -> TextSegment {
+        TextSegment {
+            start,
+            end,
+            track: 0,
+            enabled: true,
+            content: "Title".to_string(),
+            center: XY::new(0.5, 0.5),
+            size: XY::new(0.35, 0.2),
+            font_family: "sans-serif".to_string(),
+            font_size: 48.0,
+            font_weight: 700.0,
+            italic: false,
+            color: "#ffffff".to_string(),
+            fade_duration: 0.15,
+            align: TextAlign::Center,
+            letter_spacing: 0.0,
+            line_height: 1.2,
+            opacity: 1.0,
+            shadow: 0.0,
+            animation_in: TextAnimation::Fade,
+            animation_out: TextAnimation::Fade,
+            animation_in_duration: 0.15,
+            animation_out_duration: 0.15,
+            layout: TextLayout::Fullscreen,
+            layout_transition: 0.5,
+        }
+    }
+
+    #[test]
+    fn fullscreen_text_inserts_output_time() {
+        let mut timeline = timeline_with_transitions(Vec::new());
+        timeline.text_segments = vec![fullscreen_text(2.0, 5.0)];
+
+        assert_eq!(timeline.duration(), 13.0);
+
+        // Before the hold: unchanged mapping, but the chunk ends at the hold.
+        assert!(matches!(
+            timeline.get_frame_mapping(1.0),
+            Some(TimelineFrameMapping::Single { source, output_end })
+                if source.source_time == 1.0 && output_end == 2.0
+        ));
+
+        // Inside the hold: frozen at the recording instant where it started.
+        assert!(matches!(
+            timeline.get_frame_mapping(3.5),
+            Some(TimelineFrameMapping::Hold { source, output_end })
+                if source.source_time == 2.0 && output_end == 5.0
+        ));
+        let (frozen, _) = timeline.get_segment_time(3.5).unwrap();
+        assert_eq!(frozen, 2.0);
+
+        // After the hold: resumes exactly where it paused.
+        let (resumed, _) = timeline.get_segment_time(5.0).unwrap();
+        assert_eq!(resumed, 2.0);
+        let (later, segment) = timeline.get_segment_time(7.5).unwrap();
+        assert_eq!(later, 10.5);
+        assert_eq!(segment.recording_clip, 1);
+    }
+
+    #[test]
+    fn overlay_and_disabled_texts_do_not_hold() {
+        let mut timeline = timeline_with_transitions(Vec::new());
+        let mut overlay = fullscreen_text(2.0, 5.0);
+        overlay.layout = TextLayout::Overlay;
+        let mut disabled = fullscreen_text(6.0, 8.0);
+        disabled.enabled = false;
+        timeline.text_segments = vec![overlay, disabled];
+
+        assert_eq!(timeline.duration(), 10.0);
+        assert!(timeline.hold_windows().is_empty());
+        let (time, _) = timeline.get_segment_time(4.5).unwrap();
+        assert_eq!(time, 10.5);
+    }
+
+    #[test]
+    fn overlapping_fullscreen_texts_merge_into_one_hold() {
+        let mut timeline = timeline_with_transitions(Vec::new());
+        timeline.text_segments = vec![fullscreen_text(2.0, 5.0), fullscreen_text(4.0, 6.0)];
+
+        assert_eq!(timeline.hold_windows(), vec![(2.0, 6.0)]);
+        assert_eq!(timeline.duration(), 14.0);
+        let (frozen, _) = timeline.get_segment_time(5.5).unwrap();
+        assert_eq!(frozen, 2.0);
+        let (after, _) = timeline.get_segment_time(6.5).unwrap();
+        assert_eq!(after, 2.5);
+    }
+
+    #[test]
+    fn holds_compose_with_transitions() {
+        let mut timeline = timeline_with_transitions(vec![ClipTransition {
+            segment_index: 1,
+            kind: ClipTransitionType::CrossFade,
+            duration: 1.0,
+        }]);
+        timeline.text_segments = vec![fullscreen_text(1.0, 2.0)];
+
+        assert_eq!(timeline.duration(), 10.0);
+        // 6.0 output = 5.0 effective = 2.0s into the second clip (whose
+        // output start is 3.0 after the 1s cross-fade overlap).
+        let (time, segment) = timeline.get_segment_time(6.0).unwrap();
+        assert_eq!(segment.recording_clip, 1);
+        assert_eq!(time, 12.0);
     }
 
     #[test]

--- a/crates/rendering/src/layers/blur.rs
+++ b/crates/rendering/src/layers/blur.rs
@@ -6,13 +6,24 @@ use crate::ProjectUniforms;
 pub struct BlurLayer {
     pub blur_amount: f64,
     sampler: wgpu::Sampler,
-    uniforms_buffer: wgpu::Buffer,
+    uniforms_buffer_h: wgpu::Buffer,
+    uniforms_buffer_v: wgpu::Buffer,
     pipeline: BlurPipeline,
     cached_uniforms: Option<BlurUniforms>,
 }
 
 impl BlurLayer {
     pub fn new(device: &wgpu::Device) -> Self {
+        let make_buffer = |direction: f32| {
+            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("BackgroundBlur Uniform Buffer"),
+                contents: bytemuck::cast_slice(&[BlurUniforms {
+                    direction,
+                    ..Default::default()
+                }]),
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            })
+        };
         Self {
             blur_amount: 0.0,
             sampler: device.create_sampler(&wgpu::SamplerDescriptor {
@@ -24,11 +35,8 @@ impl BlurLayer {
                 mipmap_filter: wgpu::FilterMode::Nearest,
                 ..Default::default()
             }),
-            uniforms_buffer: device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("BackgroundBlur Uniform Buffer"),
-                contents: bytemuck::cast_slice(&[BlurUniforms::default()]),
-                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-            }),
+            uniforms_buffer_h: make_buffer(0.0),
+            uniforms_buffer_v: make_buffer(1.0),
             pipeline: BlurPipeline::new(device),
             cached_uniforms: None,
         }
@@ -44,31 +52,58 @@ impl BlurLayer {
         let blur_uniform = BlurUniforms {
             output_size: [uniforms.output_size.0 as f32, uniforms.output_size.1 as f32],
             blur_strength,
-            _padding: 0.0,
+            direction: 0.0,
         };
 
         if self.cached_uniforms.as_ref() != Some(&blur_uniform) {
             queue.write_buffer(
-                &self.uniforms_buffer,
+                &self.uniforms_buffer_h,
                 0,
                 bytemuck::cast_slice(&[blur_uniform]),
+            );
+            queue.write_buffer(
+                &self.uniforms_buffer_v,
+                0,
+                bytemuck::cast_slice(&[BlurUniforms {
+                    direction: 1.0,
+                    ..blur_uniform
+                }]),
             );
             self.cached_uniforms = Some(blur_uniform);
         }
     }
 
-    pub fn render(
+    pub fn render_h(
         &self,
         pass: &mut wgpu::RenderPass<'_>,
         device: &wgpu::Device,
         source_texture: &wgpu::TextureView,
+    ) {
+        self.render_pass(pass, device, source_texture, &self.uniforms_buffer_h);
+    }
+
+    pub fn render_v(
+        &self,
+        pass: &mut wgpu::RenderPass<'_>,
+        device: &wgpu::Device,
+        source_texture: &wgpu::TextureView,
+    ) {
+        self.render_pass(pass, device, source_texture, &self.uniforms_buffer_v);
+    }
+
+    fn render_pass(
+        &self,
+        pass: &mut wgpu::RenderPass<'_>,
+        device: &wgpu::Device,
+        source_texture: &wgpu::TextureView,
+        uniforms_buffer: &wgpu::Buffer,
     ) {
         pass.set_pipeline(&self.pipeline.render_pipeline);
         pass.set_bind_group(
             0,
             &self
                 .pipeline
-                .bind_group(device, &self.uniforms_buffer, source_texture, &self.sampler),
+                .bind_group(device, uniforms_buffer, source_texture, &self.sampler),
             &[],
         );
         pass.draw(0..4, 0..1);
@@ -80,7 +115,7 @@ impl BlurLayer {
 pub struct BlurUniforms {
     output_size: [f32; 2],
     blur_strength: f32,
-    _padding: f32,
+    direction: f32,
 }
 
 pub struct BlurPipeline {

--- a/crates/rendering/src/layers/captions.rs
+++ b/crates/rendering/src/layers/captions.rs
@@ -534,7 +534,7 @@ impl CaptionsLayer {
             active.segment.start,
             effective_end,
             segment_fade,
-        );
+        ) * uniforms.takeover_overlay_fade();
         if fade_opacity <= 0.0 {
             self.current_text = None;
             return;

--- a/crates/rendering/src/layers/cursor.rs
+++ b/crates/rendering/src/layers/cursor.rs
@@ -616,7 +616,7 @@ impl CursorLayer {
                         crate::lerp_f32(position_size[2], mapped[2], t),
                         crate::lerp_f32(position_size[3], mapped[3], t),
                     ],
-                    cursor_opacity * takeover.cursor_fade,
+                    cursor_opacity * takeover.overlay_fade,
                 )
             }
             _ => (position_size, cursor_opacity),

--- a/crates/rendering/src/layers/cursor.rs
+++ b/crates/rendering/src/layers/cursor.rs
@@ -594,6 +594,34 @@ impl CursorLayer {
             ],
         };
 
+        // A text takeover relocates the display card by a uniform scale +
+        // translate (the takeover target preserves the card's aspect), so the
+        // cursor follows with the same affine map — and fades with the card
+        // when a Fullscreen takeover hides it.
+        let (position_size, cursor_opacity) = match &uniforms.takeover {
+            Some(takeover) if takeover.t > 0.001 => {
+                let from_w = (takeover.from[2] - takeover.from[0]).max(f32::EPSILON);
+                let scale = (takeover.to[2] - takeover.to[0]) / from_w;
+                let mapped = [
+                    takeover.to[0] + (position_size[0] - takeover.from[0]) * scale,
+                    takeover.to[1] + (position_size[1] - takeover.from[1]) * scale,
+                    position_size[2] * scale,
+                    position_size[3] * scale,
+                ];
+                let t = takeover.t;
+                (
+                    [
+                        crate::lerp_f32(position_size[0], mapped[0], t),
+                        crate::lerp_f32(position_size[1], mapped[1], t),
+                        crate::lerp_f32(position_size[2], mapped[2], t),
+                        crate::lerp_f32(position_size[3], mapped[3], t),
+                    ],
+                    cursor_opacity * takeover.cursor_fade,
+                )
+            }
+            _ => (position_size, cursor_opacity),
+        };
+
         let cursor_grade = if uniforms.project.color_correction.grade_cursor {
             uniforms.screen_color_grade
         } else {

--- a/crates/rendering/src/layers/keyboard.rs
+++ b/crates/rendering/src/layers/keyboard.rs
@@ -343,7 +343,7 @@ impl KeyboardLayer {
             active.segment.start,
             active.segment.end,
             segment_fade,
-        );
+        ) * uniforms.takeover_overlay_fade();
 
         if fade_opacity <= 0.0 {
             return;

--- a/crates/rendering/src/layers/text.rs
+++ b/crates/rendering/src/layers/text.rs
@@ -1,3 +1,4 @@
+use cap_project::TextAlign;
 use glyphon::cosmic_text::Align;
 use glyphon::{
     Attrs, Buffer, Cache, Color, Family, FontSystem, Metrics, Resolution, Shaping, Style,
@@ -15,6 +16,24 @@ pub struct TextLayer {
     text_renderer: TextRenderer,
     viewport: Viewport,
     buffers: Vec<Buffer>,
+}
+
+struct AreaSpec {
+    bounds: TextBounds,
+    left: f32,
+    top: f32,
+    scale: f32,
+    color: Color,
+    shadow: Option<(f32, f32, Color)>,
+}
+
+fn shift_bounds(bounds: TextBounds, dx: f32, dy: f32) -> TextBounds {
+    TextBounds {
+        left: bounds.left + dx.floor() as i32,
+        top: bounds.top + dy.floor() as i32,
+        right: bounds.right + dx.ceil() as i32,
+        bottom: bounds.bottom + dy.ceil() as i32,
+    }
 }
 
 impl TextLayer {
@@ -50,7 +69,7 @@ impl TextLayer {
     ) {
         self.buffers.clear();
         self.buffers.reserve(texts.len());
-        let mut text_area_data = Vec::with_capacity(texts.len());
+        let mut specs = Vec::with_capacity(texts.len());
 
         for text in texts {
             let alpha = text.color[3].clamp(0.0, 1.0) * text.opacity.clamp(0.0, 1.0);
@@ -67,18 +86,23 @@ impl TextLayer {
             // Shape with a little more width than the editor-measured box:
             // the webview and cosmic-text can disagree by a few pixels per
             // line, and without slack a line that fit in the editor wraps in
-            // the render. The room is split evenly so centered lines stay
-            // centered. Boxes already spanning the frame keep their exact
-            // width — there the editor genuinely wrapped too.
+            // the render. The room is placed so the aligned edge stays put —
+            // split for centered text, after for left, before for right.
+            // Boxes already spanning the frame keep their exact width — there
+            // the editor genuinely wrapped too.
             let output_width = (output_size.0 as f32).max(1.0);
             let wrap_width = if width < output_width * 0.98 {
                 (width * 1.05 + 4.0).min(output_width.max(width))
             } else {
                 width
             };
-            let wrap_dx = (wrap_width - width) / 2.0;
+            let origin_dx = match text.align {
+                TextAlign::Left => 0.0,
+                TextAlign::Center => (wrap_width - width) / 2.0,
+                TextAlign::Right => wrap_width - width,
+            };
 
-            let metrics = Metrics::new(text.font_size, text.font_size * 1.2);
+            let metrics = Metrics::new(text.font_size, text.font_size * text.line_height);
             let mut buffer = Buffer::new(&mut self.font_system, metrics);
             // The box only constrains wrapping; height is unbounded so every
             // line is laid out even when the configured box is a little
@@ -99,15 +123,22 @@ impl TextLayer {
                 },
             };
             let weight = Weight(text.font_weight.round().clamp(100.0, 900.0) as u16);
-            let attrs = Attrs::new()
+            // Glyph color comes from each area's default_color (not Attrs) so
+            // the shadow pass can re-tint the same shaped buffer.
+            let mut attrs = Attrs::new()
                 .family(family)
-                .color(color)
                 .weight(weight)
                 .style(if text.italic {
                     Style::Italic
                 } else {
                     Style::Normal
                 });
+            if text.letter_spacing != 0.0 {
+                // cosmic-text adds letter_spacing to the em-relative glyph
+                // advance and multiplies by font size at layout (shape.rs), so
+                // the attr is in em — convert from our px value.
+                attrs = attrs.letter_spacing(text.letter_spacing / text.font_size.max(1.0));
+            }
 
             buffer.set_text(
                 &mut self.font_system,
@@ -116,42 +147,85 @@ impl TextLayer {
                 Shaping::Advanced,
             );
 
+            let align = match text.align {
+                TextAlign::Left => Align::Left,
+                TextAlign::Center => Align::Center,
+                TextAlign::Right => Align::Right,
+            };
             for line in buffer.lines.iter_mut() {
-                line.set_align(Some(Align::Center));
+                line.set_align(Some(align));
             }
 
             buffer.shape_until_scroll(&mut self.font_system, false);
+
+            let laid_out_height = buffer.layout_runs().count() as f32 * metrics.line_height;
+
+            // Animation transform: uniform scale about the box center plus a
+            // translation, applied to the buffer origin and clip bounds (the
+            // glyph layout itself is scaled by TextArea::scale from that
+            // origin).
+            let cx = (text.bounds[0] + text.bounds[2]) / 2.0;
+            let cy = (text.bounds[1] + text.bounds[3]) / 2.0;
+            let scale = text.scale.max(0.01);
+            let tx = |x: f32| cx + (x - cx) * scale + text.offset[0];
+            let ty = |y: f32| cy + (y - cy) * scale + text.offset[1];
+
+            let origin_left = tx(text.bounds[0] - origin_dx);
+            let origin_top = ty(text.bounds[1]);
 
             // Clip horizontally at the (slack-expanded) wrap box, but extend
             // the bottom to the laid-out text height so descenders and extra
             // lines never get cut off; glyphon intersects these bounds with
             // the viewport.
-            let laid_out_height = buffer.layout_runs().count() as f32 * metrics.line_height;
             let bounds = TextBounds {
-                left: (text.bounds[0] - wrap_dx).floor() as i32,
-                top: text.bounds[1].floor() as i32,
-                right: (text.bounds[0] + width + wrap_dx).ceil() as i32,
-                bottom: (text.bounds[1] + height.max(laid_out_height)).ceil() as i32,
+                left: origin_left.floor() as i32,
+                top: origin_top.floor() as i32,
+                right: tx(text.bounds[0] - origin_dx + wrap_width).ceil() as i32,
+                bottom: ty(text.bounds[1] + height.max(laid_out_height)).ceil() as i32,
             };
 
+            let shadow = (text.shadow > 0.0).then(|| {
+                let dx = text.font_size * scale * 0.02;
+                let dy = text.font_size * scale * 0.055;
+                let shadow_alpha = alpha * text.shadow.clamp(0.0, 1.0) * 0.85;
+                (dx, dy, Color::rgba(0, 0, 0, (shadow_alpha * 255.0) as u8))
+            });
+
             self.buffers.push(buffer);
-            // The buffer origin shifts left by the slack so centered lines
-            // stay centered on the box.
-            text_area_data.push((bounds, text.bounds[0] - wrap_dx, text.bounds[1], color));
+            specs.push(AreaSpec {
+                bounds,
+                left: origin_left,
+                top: origin_top,
+                scale,
+                color,
+                shadow,
+            });
         }
 
         let text_areas = self
             .buffers
             .iter()
-            .zip(text_area_data)
-            .map(|(buffer, (bounds, left, top, color))| TextArea {
-                buffer,
-                left,
-                top,
-                scale: 1.0,
-                bounds,
-                default_color: color,
-                custom_glyphs: &[],
+            .zip(&specs)
+            .flat_map(|(buffer, spec)| {
+                let shadow_area = spec.shadow.map(|(dx, dy, shadow_color)| TextArea {
+                    buffer,
+                    left: spec.left + dx,
+                    top: spec.top + dy,
+                    scale: spec.scale,
+                    bounds: shift_bounds(spec.bounds, dx, dy),
+                    default_color: shadow_color,
+                    custom_glyphs: &[],
+                });
+                let main_area = TextArea {
+                    buffer,
+                    left: spec.left,
+                    top: spec.top,
+                    scale: spec.scale,
+                    bounds: spec.bounds,
+                    default_color: spec.color,
+                    custom_glyphs: &[],
+                };
+                shadow_area.into_iter().chain(std::iter::once(main_area))
             })
             .collect::<Vec<_>>();
 

--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -2784,13 +2784,15 @@ pub(crate) struct DisplayLayout {
 }
 
 impl ProjectUniforms {
-    /// 0..1 multiplier for recording-anchored overlays (captions, keyboard)
-    /// while a text takeover hides the recording — they would otherwise hang
-    /// frozen over the title card while the recording clock is paused.
+    /// 0..1 multiplier for recording-anchored overlays (captions, keyboard).
+    /// A Fullscreen takeover hides the recording and pauses its clock, so the
+    /// overlays fade with the display — they would otherwise hang frozen over
+    /// the title card. Split takeovers keep the recording visible and playing,
+    /// so the overlays stay.
     pub fn takeover_overlay_fade(&self) -> f32 {
         self.takeover
             .as_ref()
-            .map_or(1.0, |takeover| 1.0 - takeover.t)
+            .map_or(1.0, |takeover| takeover.overlay_fade)
     }
 
     pub fn frame_layout(&self) -> FrameLayout {
@@ -3979,7 +3981,7 @@ impl ProjectUniforms {
                         t: tk.t,
                         from: pre_takeover_bounds,
                         to: target,
-                        cursor_fade: tk.display_fade(),
+                        overlay_fade: tk.display_fade(),
                     }),
             )
         };

--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -71,6 +71,38 @@ pub fn prewarm_fonts() {
     drop(layers::new_font_system());
 }
 
+/// Unique installed font family names, sorted, for the editor's font picker.
+/// Reuses the process-wide font database scan (see [`prewarm_fonts`]).
+/// Dot-prefixed families (macOS-internal UI fonts) are hidden the same way
+/// browser font pickers hide them.
+pub fn system_font_families() -> Vec<String> {
+    let font_system = layers::new_font_system();
+    let mut families = std::collections::BTreeSet::new();
+    for face in font_system.db().faces() {
+        if let Some((name, _)) = face.families.first()
+            && !name.starts_with('.')
+            && !name.is_empty()
+        {
+            families.insert(name.clone());
+        }
+    }
+    families.into_iter().collect()
+}
+
+#[cfg(test)]
+mod font_family_tests {
+    #[test]
+    fn system_font_families_are_deduped_and_visible() {
+        let families = super::system_font_families();
+        assert!(!families.is_empty());
+        assert!(families.iter().all(|name| !name.starts_with('.')));
+        let mut sorted = families.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(families, sorted);
+    }
+}
+
 use camera3d::{Camera3DFrame, interpolate_camera3d};
 pub use cursor_interpolation::PrecomputedCursorTimeline;
 use mask::interpolate_masks;

--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -5792,12 +5792,18 @@ impl RendererLayers {
             self.background.render(&mut pass);
         }
 
+        // Separable gaussian: horizontal into the spare texture, vertical back
+        // into the current one, so the result ends up where it started and no
+        // swap is needed.
         if self.background_blur.blur_amount > 0.0 {
-            let mut pass = render_pass!(session.other_texture_view(), wgpu::LoadOp::Load);
+            {
+                let mut pass = render_pass!(session.other_texture_view(), wgpu::LoadOp::Load);
+                self.background_blur
+                    .render_h(&mut pass, device, session.current_texture_view());
+            }
+            let mut pass = render_pass!(session.current_texture_view(), wgpu::LoadOp::Load);
             self.background_blur
-                .render(&mut pass, device, session.current_texture_view());
-
-            session.swap_textures();
+                .render_v(&mut pass, device, session.other_texture_view());
         }
 
         // Runs before content layers so the screen grade covers the whole

--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -48,6 +48,7 @@ pub mod notch_shape;
 mod project_recordings;
 mod scene;
 pub mod spring_mass_damper;
+mod takeover;
 mod text;
 mod transition;
 pub mod yuv_converter;
@@ -74,6 +75,8 @@ use camera3d::{Camera3DFrame, interpolate_camera3d};
 pub use cursor_interpolation::PrecomputedCursorTimeline;
 use mask::interpolate_masks;
 use scene::*;
+use takeover::InterpolatedTakeover;
+pub use takeover::TakeoverDisplayMorph;
 use text::{PreparedText, prepare_texts};
 use zoom::*;
 pub use zoom_spring::{CursorCropMap, ZoomTransformTimeline};
@@ -2263,6 +2266,10 @@ pub struct ProjectUniforms {
     pub zoom: InterpolatedZoom,
     pub scene: InterpolatedScene,
     pub split: Option<SplitLayoutComputed>,
+    /// Display-card morph driven by a non-Overlay text segment; `None` when
+    /// no takeover is active. The cursor layer follows it the same way it
+    /// follows `split`.
+    pub takeover: Option<TakeoverDisplayMorph>,
     pub resolution_base: XY<u32>,
     pub display_parent_motion_px: XY<f32>,
     pub motion_blur_amount: f32,
@@ -2745,6 +2752,15 @@ pub(crate) struct DisplayLayout {
 }
 
 impl ProjectUniforms {
+    /// 0..1 multiplier for recording-anchored overlays (captions, keyboard)
+    /// while a text takeover hides the recording — they would otherwise hang
+    /// frozen over the title card while the recording clock is paused.
+    pub fn takeover_overlay_fade(&self) -> f32 {
+        self.takeover
+            .as_ref()
+            .map_or(1.0, |takeover| 1.0 - takeover.t)
+    }
+
     pub fn frame_layout(&self) -> FrameLayout {
         FrameLayout {
             display: self.display_outer_bounds,
@@ -3519,8 +3535,23 @@ impl ProjectUniforms {
             None
         };
 
+        // Text-takeover morph: a non-Overlay text segment pushes the display
+        // aside (Fullscreen) or into a padded half (Split*). None on every
+        // frame without such a segment, which leaves all the math below
+        // exactly as it was.
+        let takeover = project.timeline.as_ref().and_then(|timeline| {
+            InterpolatedTakeover::sample(frame_time as f64, &timeline.text_segments)
+        });
+
         let mut camera3d_zoom: Option<camera3d::Camera3DScreenZoom> = None;
-        let (display, display_motion_parent, frame_chrome, display_outer_bounds, notch) = {
+        let (
+            display,
+            display_motion_parent,
+            frame_chrome,
+            display_outer_bounds,
+            notch,
+            takeover_morph,
+        ) = {
             let output_size = XY::new(output_size.0 as f64, output_size.1 as f64);
             let size = [options.screen_size.x as f32, options.screen_size.y as f32];
 
@@ -3615,6 +3646,28 @@ impl ProjectUniforms {
             let final_crop_bounds = split_layout.as_ref().map_or(base_crop_bounds, |s| {
                 s.screen.crop_for(final_target_bounds, split_t)
             });
+
+            // Text takeover composes after the split morph at the same seam:
+            // lerp the (possibly split) rect toward the takeover target. The
+            // target preserves the current rect's aspect, so the crop derived
+            // above stays valid and content never distorts.
+            let takeover_t = takeover.map_or(0.0, |tk| tk.t);
+            let takeover_display_fade = takeover.map_or(1.0, |tk| tk.display_fade());
+            let takeover_accessory_fade = takeover.map_or(1.0, |tk| tk.accessory_fade());
+            let takeover_card_t = takeover.map_or(0.0, |tk| tk.card_style_t());
+            let takeover_padding = output_size.x.min(output_size.y) as f32 * FLOATING_PADDING_FRAC;
+            let pre_takeover_bounds = final_target_bounds;
+            let takeover_target = takeover.map(|tk| {
+                tk.display_target(
+                    pre_takeover_bounds,
+                    (output_size.x as f32, output_size.y as f32),
+                    takeover_padding,
+                )
+            });
+            let final_target_bounds = takeover_target.map_or(final_target_bounds, |target| {
+                lerp_bounds(pre_takeover_bounds, target, takeover_t)
+            });
+
             let final_target_size = [
                 final_target_bounds[2] - final_target_bounds[0],
                 final_target_bounds[3] - final_target_bounds[1],
@@ -3624,6 +3677,9 @@ impl ProjectUniforms {
             let display_rounding_px =
                 (project.background.rounding / 100.0 * 0.5 * final_min_axis) as f32 * split_fade
                     + floating_rounding_px * floating_t;
+            // A split takeover styles the display as a floating card.
+            let display_rounding_px =
+                lerp_f32(display_rounding_px, floating_rounding_px, takeover_card_t);
             let frame_active = frame_config.is_some();
             // With a frame active the card decoration (shadow/border) moves to
             // the chrome pass; the video keeps only the floating-card shadow
@@ -3640,16 +3696,23 @@ impl ProjectUniforms {
             // fades out, so the multipliers relax back to uniform rounding.
             let display_corner_radii = match frame_config.as_ref().map(|f| f.style) {
                 Some(FrameStyle::MacOS | FrameStyle::Windows | FrameStyle::Browser) => {
-                    [split_t, split_t, 1.0, 1.0]
+                    // The chrome bar also fades out under a takeover, so the
+                    // top corners regain their rounding the same way they do
+                    // in a split.
+                    let top = split_t.max(takeover_t);
+                    [top, top, 1.0, 1.0]
                 }
                 _ => [1.0; 4],
             };
+            // The shader draws border and shadow outside the card shape,
+            // unscaled by the opacity uniform — fade them explicitly or they
+            // outlive a Fullscreen takeover's fade.
             let border_color = if let Some(b) = project.background.border.as_ref() {
                 [
                     b.color[0] as f32 / 255.0,
                     b.color[1] as f32 / 255.0,
                     b.color[2] as f32 / 255.0,
-                    (b.opacity / 100.0).clamp(0.0, 1.0),
+                    (b.opacity / 100.0).clamp(0.0, 1.0) * takeover_display_fade,
                 ]
             } else {
                 [0.0, 0.0, 0.0, 0.0]
@@ -3678,6 +3741,9 @@ impl ProjectUniforms {
                 let chrome_bounds = split_layout.as_ref().map_or(base_outer_bounds, |s| {
                     lerp_bounds(base_outer_bounds, s.screen.target, split_t)
                 });
+                let chrome_bounds = takeover_target.map_or(chrome_bounds, |target| {
+                    lerp_bounds(chrome_bounds, target, takeover_t)
+                });
                 let chrome_size = [
                     chrome_bounds[2] - chrome_bounds[0],
                     chrome_bounds[3] - chrome_bounds[1],
@@ -3705,7 +3771,10 @@ impl ProjectUniforms {
                             0.0,
                         ],
                         shadow: if decorated {
-                            project.background.shadow * split_fade * camera3d_shadow_fade
+                            project.background.shadow
+                                * split_fade
+                                * camera3d_shadow_fade
+                                * takeover_accessory_fade
                         } else {
                             0.0
                         },
@@ -3720,13 +3789,14 @@ impl ProjectUniforms {
                             .as_ref()
                             .map_or(18.0, |s| s.opacity)
                             * split_fade
-                            * camera3d_shadow_fade,
+                            * camera3d_shadow_fade
+                            * takeover_accessory_fade,
                         shadow_blur: project
                             .background
                             .advanced_shadow
                             .as_ref()
                             .map_or(50.0, |s| s.blur),
-                        opacity: scene.screen_opacity as f32 * split_fade,
+                        opacity: scene.screen_opacity as f32 * split_fade * takeover_accessory_fade,
                         border_enabled: if decorated && border_on { 1.0 } else { 0.0 },
                         border_width: project.background.border.as_ref().map_or(5.0, |b| b.width),
                         preserve_source_alpha: 1.0,
@@ -3790,9 +3860,12 @@ impl ProjectUniforms {
                             shadow_size: 0.0,
                             shadow_opacity: 0.0,
                             shadow_blur: 0.0,
-                            // Fades out as a split-screen scene morphs in, where
-                            // the geometry above stops describing the pane.
-                            opacity: scene.screen_opacity as f32 * split_fade,
+                            // Fades out as a split-screen scene or a text
+                            // takeover morphs in, where the geometry above
+                            // stops describing the pane.
+                            opacity: scene.screen_opacity as f32
+                                * split_fade
+                                * takeover_accessory_fade,
                             border_enabled: 0.0,
                             border_width: 0.0,
                             _padding1: [0.0; 3],
@@ -3829,7 +3902,8 @@ impl ProjectUniforms {
                     ],
                     shadow: project.background.shadow
                         * display_decoration_fade
-                        * camera3d_shadow_fade,
+                        * camera3d_shadow_fade
+                        * takeover_display_fade,
                     shadow_size: project
                         .background
                         .advanced_shadow
@@ -3841,13 +3915,14 @@ impl ProjectUniforms {
                         .as_ref()
                         .map_or(18.0, |s| s.opacity)
                         * display_decoration_fade
-                        * camera3d_shadow_fade,
+                        * camera3d_shadow_fade
+                        * takeover_display_fade,
                     shadow_blur: project
                         .background
                         .advanced_shadow
                         .as_ref()
                         .map_or(50.0, |s| s.blur),
-                    opacity: scene.screen_opacity as f32,
+                    opacity: scene.screen_opacity as f32 * takeover_display_fade,
                     border_enabled: if border_on && !frame_active { 1.0 } else { 0.0 },
                     border_width: project.background.border.as_ref().map_or(5.0, |b| b.width),
                     preserve_source_alpha: if options.preserve_screen_alpha {
@@ -3866,6 +3941,14 @@ impl ProjectUniforms {
                 frame_chrome,
                 display_outer_bounds,
                 notch,
+                takeover
+                    .zip(takeover_target)
+                    .map(|(tk, target)| TakeoverDisplayMorph {
+                        t: tk.t,
+                        from: pre_takeover_bounds,
+                        to: target,
+                        cursor_fade: tk.display_fade(),
+                    }),
             )
         };
 
@@ -3999,6 +4082,10 @@ impl ProjectUniforms {
                 // Same chrome rule as the display layer: classic split strips
                 // rounding/shadow, the floating card keeps them.
                 let chrome_fade = (1.0 - split_t + floating_t).clamp(0.0, 1.0);
+                // The shader draws the drop shadow outside the card without the
+                // opacity uniform, so a takeover must fade the shadow uniforms
+                // explicitly or it outlives the hidden bubble.
+                let takeover_fade = takeover.map_or(1.0, |tk| tk.accessory_fade());
                 let final_target_bounds = snap_bounds_to_output_pixels(
                     split_layout.as_ref().map_or(target_bounds, |s| {
                         lerp_bounds(target_bounds, s.camera.target, split_t)
@@ -4038,7 +4125,10 @@ impl ProjectUniforms {
                         camera_descriptor.zoom_amount,
                         0.0,
                     ],
-                    shadow: project.camera.shadow * chrome_fade * camera3d_shadow_fade,
+                    shadow: project.camera.shadow
+                        * chrome_fade
+                        * camera3d_shadow_fade
+                        * takeover_fade,
                     shadow_size: project
                         .camera
                         .advanced_shadow
@@ -4050,13 +4140,16 @@ impl ProjectUniforms {
                         .as_ref()
                         .map_or(18.0, |s| s.opacity)
                         * chrome_fade
-                        * camera3d_shadow_fade,
+                        * camera3d_shadow_fade
+                        * takeover_fade,
                     shadow_blur: project
                         .camera
                         .advanced_shadow
                         .as_ref()
                         .map_or(50.0, |s| s.blur),
-                    opacity: scene.regular_camera_transition_opacity() as f32,
+                    // The bubble yields to a text takeover so it can never
+                    // collide with the text's half of the frame.
+                    opacity: scene.regular_camera_transition_opacity() as f32 * takeover_fade,
                     border_enabled: 0.0,
                     border_width: 0.0,
                     preserve_source_alpha: 0.0,
@@ -4156,7 +4249,8 @@ impl ProjectUniforms {
                     shadow_size: 0.0,
                     shadow_opacity: 0.0,
                     shadow_blur: 0.0,
-                    opacity: scene.camera_only_transition_opacity() as f32,
+                    opacity: scene.camera_only_transition_opacity() as f32
+                        * takeover.map_or(1.0, |tk| tk.accessory_fade()),
                     border_enabled: 0.0,
                     border_width: 0.0,
                     preserve_source_alpha: 0.0,
@@ -4209,6 +4303,7 @@ impl ProjectUniforms {
             zoom,
             scene,
             split: split_layout,
+            takeover: takeover_morph,
             interpolated_cursor,
             frame_rate: fps,
             frame_number,
@@ -5822,6 +5917,9 @@ impl RendererLayers {
 
         let should_render_screen = render_display
             && uniforms.scene.should_render_screen()
+            // A fully-faded card (e.g. a held Fullscreen text takeover) draws
+            // nothing visible; skip the pass entirely.
+            && uniforms.display.opacity > 0.001
             && self.display.has_valid_frame();
         let should_render_cursor = if render_display {
             uniforms.scene.should_render_screen()

--- a/crates/rendering/src/shaders/background-blur.wgsl
+++ b/crates/rendering/src/shaders/background-blur.wgsl
@@ -1,7 +1,15 @@
+// Background blur: separable gaussian, run twice (horizontal then vertical).
+//
+// The kernel always spans the full blur radius with evenly spaced taps; when
+// the radius exceeds the tap budget the spacing widens instead of leaving
+// gaps, and linear filtering interpolates between texels. Spacing stays well
+// under sigma, so the widened kernel cannot alias into the comb/grid pattern
+// the old single-pass sparse kernel produced.
+
 struct Uniforms {
     output_size: vec2<f32>,
     blur_strength: f32,
-    _padding: f32,
+    direction: f32, // 0 = horizontal, 1 = vertical
 };
 
 @group(0) @binding(0) var<uniform> u: Uniforms;
@@ -25,34 +33,35 @@ fn vs_main(@builtin(vertex_index) in_vertex_index: u32) -> VertexOutput {
 
 @fragment
 fn fs_main(@location(0) tex_coords: vec2<f32>) -> @location(0) vec4<f32> {
-    // Early return if no blur
-    if (u.blur_strength <= 0.01) {
-        return textureSample(t_background, s_background, tex_coords);
+    if (u.blur_strength <= 0.001) {
+        return textureSampleLevel(t_background, s_background, tex_coords, 0.0);
     }
 
-    // Use smaller kernel for light blur
-    let radius = u.blur_strength * 16.0;
-    let sigma = radius * 0.5;
-    let samples = min(16, max(4, i32(radius * 0.3)));
-    
-    var color = vec4<f32>(0.0);
-    var total_weight = 0.0;
-    
-    for (var y = -samples; y <= samples; y++) {
-        for (var x = -samples; x <= samples; x++) {
-            let offset = vec2<f32>(
-                f32(x) * radius / u.output_size.x,
-                f32(y) * radius / u.output_size.y
-            );
-            
-            let sample_pos = tex_coords + offset;
-            let dist = f32(x * x + y * y);
-            let weight = exp(-dist / (2.0 * sigma * sigma));
-            
-            color += textureSample(t_background, s_background, sample_pos) * weight;
-            total_weight += weight;
-        }
+    // Sigma scales with output height so preview and export look identical;
+    // full strength blurs with a sigma of 2.5% of the frame height.
+    let sigma = u.blur_strength * u.output_size.y * 0.025;
+    let radius = sigma * 3.0;
+    let taps = min(24.0, ceil(radius));
+    let spacing = radius / taps;
+
+    var step = vec2<f32>(spacing / u.output_size.x, 0.0);
+    if (u.direction > 0.5) {
+        step = vec2<f32>(0.0, spacing / u.output_size.y);
     }
-    
+
+    var color = textureSampleLevel(t_background, s_background, tex_coords, 0.0);
+    var total_weight = 1.0;
+    let inv_sigma2 = 1.0 / (2.0 * sigma * sigma);
+    let n = i32(taps);
+
+    for (var i = 1; i <= n; i++) {
+        let dist = f32(i) * spacing;
+        let weight = exp(-dist * dist * inv_sigma2);
+        let offset = step * f32(i);
+        color += textureSampleLevel(t_background, s_background, tex_coords + offset, 0.0) * weight;
+        color += textureSampleLevel(t_background, s_background, tex_coords - offset, 0.0) * weight;
+        total_weight += 2.0 * weight;
+    }
+
     return color / total_weight;
-} 
+}

--- a/crates/rendering/src/takeover.rs
+++ b/crates/rendering/src/takeover.rs
@@ -1,0 +1,285 @@
+use cap_project::{TextLayout, TextSegment};
+
+/// At full takeover a Fullscreen text leaves the display card at this scale
+/// (about its center) as it fades, so the hand-off reads as a push-back
+/// rather than a bare crossfade.
+pub const TAKEOVER_FULLSCREEN_SHRINK: f32 = 0.92;
+const MIN_TRANSITION: f64 = 0.05;
+
+/// Per-frame state of the text-takeover morph: how far (`t`, eased 0..1) the
+/// display has yielded the frame to a non-Overlay text segment, and which
+/// layout it is yielding to. `None` when every active text segment is a plain
+/// overlay — the pipeline then computes exactly what it did before this
+/// feature existed.
+#[derive(Clone, Copy, Debug)]
+pub struct InterpolatedTakeover {
+    pub t: f32,
+    pub layout: TextLayout,
+}
+
+/// Cursor-side view of the display morph: the display card's pre-takeover
+/// rect, its rect at full takeover, and the morph amount. The takeover
+/// target preserves the card's aspect, so the cursor remap is a uniform
+/// scale + translate.
+#[derive(Clone, Copy, Debug)]
+pub struct TakeoverDisplayMorph {
+    pub t: f32,
+    pub from: [f32; 4],
+    pub to: [f32; 4],
+    /// Multiplier for the cursor sprite's opacity (fades with the display in
+    /// Fullscreen, stays 1 for splits where the card remains visible).
+    pub cursor_fade: f32,
+}
+
+impl InterpolatedTakeover {
+    pub fn sample(frame_time: f64, segments: &[TextSegment]) -> Option<Self> {
+        let mut best: Option<(f32, f64, TextLayout)> = None;
+        for segment in segments {
+            if !segment.enabled || segment.layout == TextLayout::Overlay {
+                continue;
+            }
+            if frame_time < segment.start || frame_time > segment.end {
+                continue;
+            }
+            let half = ((segment.end - segment.start) / 2.0).max(MIN_TRANSITION);
+            let duration = segment.layout_transition.clamp(MIN_TRANSITION, half);
+            let progress = ((frame_time - segment.start) / duration)
+                .min((segment.end - frame_time) / duration)
+                .clamp(0.0, 1.0) as f32;
+            if progress <= 0.0 {
+                continue;
+            }
+            let replace = match best {
+                None => true,
+                Some((t, start, _)) => progress > t || (progress == t && segment.start > start),
+            };
+            if replace {
+                best = Some((progress, segment.start, segment.layout));
+            }
+        }
+        best.map(|(progress, _, layout)| {
+            // Same cubic-bezier(0.42, 0, 0.58, 1) the scene transitions use,
+            // so display morphs feel identical across features.
+            let ease_in_out = bezier_easing::bezier_easing(0.42, 0.0, 0.58, 1.0).unwrap();
+            Self {
+                t: ease_in_out(progress),
+                layout,
+            }
+        })
+    }
+
+    /// The display card's rect at FULL takeover (`t == 1`); callers lerp from
+    /// the pre-takeover rect toward it by `t`. Splits contain-fit the card's
+    /// current aspect into the padded opposite half, so the crop — and with
+    /// it the visible content — never distorts mid-morph.
+    pub fn display_target(
+        &self,
+        base: [f32; 4],
+        output_size: (f32, f32),
+        padding: f32,
+    ) -> [f32; 4] {
+        match self.layout {
+            TextLayout::Overlay => base,
+            TextLayout::Fullscreen => shrink_about_center(base, TAKEOVER_FULLSCREEN_SHRINK),
+            TextLayout::SplitLeft | TextLayout::SplitRight => {
+                let (out_w, out_h) = output_size;
+                let mid = out_w * 0.5;
+                let half_box = if self.layout == TextLayout::SplitLeft {
+                    [mid + padding, padding, out_w - padding, out_h - padding]
+                } else {
+                    [padding, padding, mid - padding, out_h - padding]
+                };
+                contain_aspect(base, half_box)
+            }
+        }
+    }
+
+    /// Multiplier for the display card's own opacity, and for the decoration
+    /// (shadow/border) the shader draws OUTSIDE the card shape — the fragment
+    /// returns those unscaled by the opacity uniform, so they must fade here
+    /// or a ghost shadow outlives a Fullscreen takeover.
+    pub fn display_fade(&self) -> f32 {
+        match self.layout {
+            TextLayout::Fullscreen => 1.0 - self.t,
+            _ => 1.0,
+        }
+    }
+
+    /// Multiplier for layers whose geometry stops describing the morphed
+    /// card (notch, frame chrome) or that would collide with the text
+    /// (camera bubble, camera-only plane).
+    pub fn accessory_fade(&self) -> f32 {
+        1.0 - self.t
+    }
+
+    /// 0..1 amount of floating-card styling (rounding) the display picks up;
+    /// only splits become cards — a Fullscreen card keeps its look while it
+    /// fades.
+    pub fn card_style_t(&self) -> f32 {
+        match self.layout {
+            TextLayout::SplitLeft | TextLayout::SplitRight => self.t,
+            _ => 0.0,
+        }
+    }
+}
+
+fn shrink_about_center(bounds: [f32; 4], scale: f32) -> [f32; 4] {
+    let cx = (bounds[0] + bounds[2]) * 0.5;
+    let cy = (bounds[1] + bounds[3]) * 0.5;
+    let hw = (bounds[2] - bounds[0]) * 0.5 * scale;
+    let hh = (bounds[3] - bounds[1]) * 0.5 * scale;
+    [cx - hw, cy - hh, cx + hw, cy + hh]
+}
+
+fn contain_aspect(base: [f32; 4], container: [f32; 4]) -> [f32; 4] {
+    let base_w = (base[2] - base[0]).max(f32::EPSILON);
+    let base_h = (base[3] - base[1]).max(f32::EPSILON);
+    let aspect = base_w / base_h;
+    let box_w = (container[2] - container[0]).max(f32::EPSILON);
+    let box_h = (container[3] - container[1]).max(f32::EPSILON);
+    let (w, h) = if box_w / box_h > aspect {
+        (box_h * aspect, box_h)
+    } else {
+        (box_w, box_w / aspect)
+    };
+    let cx = (container[0] + container[2]) * 0.5;
+    let cy = (container[1] + container[3]) * 0.5;
+    [cx - w * 0.5, cy - h * 0.5, cx + w * 0.5, cy + h * 0.5]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cap_project::{TextAlign, TextAnimation, XY};
+
+    fn segment(layout: TextLayout, start: f64, end: f64) -> TextSegment {
+        TextSegment {
+            start,
+            end,
+            track: 0,
+            enabled: true,
+            content: "Text".to_string(),
+            center: XY::new(0.5, 0.5),
+            size: XY::new(0.35, 0.2),
+            font_family: "sans-serif".to_string(),
+            font_size: 48.0,
+            font_weight: 700.0,
+            italic: false,
+            color: "#ffffff".to_string(),
+            fade_duration: 0.15,
+            align: TextAlign::Center,
+            letter_spacing: 0.0,
+            line_height: 1.2,
+            opacity: 1.0,
+            shadow: 0.0,
+            animation_in: TextAnimation::Fade,
+            animation_out: TextAnimation::Fade,
+            animation_in_duration: 0.15,
+            animation_out_duration: 0.15,
+            layout,
+            layout_transition: 0.5,
+        }
+    }
+
+    #[test]
+    fn overlay_segments_never_produce_a_takeover() {
+        let segments = [segment(TextLayout::Overlay, 0.0, 10.0)];
+        assert!(InterpolatedTakeover::sample(5.0, &segments).is_none());
+    }
+
+    #[test]
+    fn takeover_is_none_outside_the_segment() {
+        let segments = [segment(TextLayout::Fullscreen, 2.0, 4.0)];
+        assert!(InterpolatedTakeover::sample(1.0, &segments).is_none());
+        assert!(InterpolatedTakeover::sample(5.0, &segments).is_none());
+        assert!(InterpolatedTakeover::sample(2.0, &segments).is_none());
+    }
+
+    #[test]
+    fn takeover_ramps_in_and_out() {
+        let segments = [segment(TextLayout::Fullscreen, 0.0, 10.0)];
+        let entering = InterpolatedTakeover::sample(0.25, &segments).unwrap();
+        assert!(entering.t > 0.0 && entering.t < 1.0);
+        let held = InterpolatedTakeover::sample(5.0, &segments).unwrap();
+        assert_eq!(held.t, 1.0);
+        let exiting = InterpolatedTakeover::sample(9.75, &segments).unwrap();
+        assert!(exiting.t > 0.0 && exiting.t < 1.0);
+    }
+
+    #[test]
+    fn disabled_segments_are_ignored() {
+        let mut seg = segment(TextLayout::Fullscreen, 0.0, 10.0);
+        seg.enabled = false;
+        assert!(InterpolatedTakeover::sample(5.0, &[seg]).is_none());
+    }
+
+    #[test]
+    fn dominant_segment_wins() {
+        let fading = segment(TextLayout::Fullscreen, 0.0, 5.1);
+        let entering = segment(TextLayout::SplitLeft, 5.0, 10.0);
+        let sampled = InterpolatedTakeover::sample(5.05, &[fading, entering]).unwrap();
+        // Both are near-zero activity at the crossover; the later start wins
+        // ties, and by 5.4 the entering split clearly dominates.
+        let later = InterpolatedTakeover::sample(
+            5.4,
+            &[
+                segment(TextLayout::Fullscreen, 0.0, 5.1),
+                segment(TextLayout::SplitLeft, 5.0, 10.0),
+            ],
+        )
+        .unwrap();
+        assert_eq!(later.layout, TextLayout::SplitLeft);
+        assert!(sampled.t <= later.t);
+    }
+
+    #[test]
+    fn split_target_preserves_aspect_in_opposite_half() {
+        let takeover = InterpolatedTakeover {
+            t: 1.0,
+            layout: TextLayout::SplitLeft,
+        };
+        let base = [100.0, 100.0, 1820.0, 980.0];
+        let target = takeover.display_target(base, (1920.0, 1080.0), 54.0);
+        let base_aspect = (base[2] - base[0]) / (base[3] - base[1]);
+        let target_aspect = (target[2] - target[0]) / (target[3] - target[1]);
+        assert!((base_aspect - target_aspect).abs() < 1e-3);
+        // Text-left means the card lives entirely in the right half.
+        assert!(target[0] >= 960.0);
+        assert!(target[2] <= 1920.0);
+    }
+
+    #[test]
+    fn fullscreen_target_shrinks_about_center() {
+        let takeover = InterpolatedTakeover {
+            t: 1.0,
+            layout: TextLayout::Fullscreen,
+        };
+        let base = [0.0, 0.0, 1920.0, 1080.0];
+        let target = takeover.display_target(base, (1920.0, 1080.0), 54.0);
+        assert!((target[0] + target[2] - 1920.0).abs() < 1e-3);
+        assert!((target[1] + target[3] - 1080.0).abs() < 1e-3);
+        assert!((target[2] - target[0]) < 1920.0);
+        assert_eq!(takeover.display_fade(), 0.0);
+    }
+
+    #[test]
+    fn split_keeps_display_visible() {
+        let takeover = InterpolatedTakeover {
+            t: 1.0,
+            layout: TextLayout::SplitRight,
+        };
+        assert_eq!(takeover.display_fade(), 1.0);
+        assert_eq!(takeover.accessory_fade(), 0.0);
+        assert_eq!(takeover.card_style_t(), 1.0);
+    }
+
+    #[test]
+    fn transition_clamps_to_half_segment_length() {
+        let mut seg = segment(TextLayout::Fullscreen, 0.0, 0.4);
+        seg.layout_transition = 5.0;
+        // With the transition clamped to 0.2s, the midpoint reaches full
+        // takeover instead of being stuck near zero.
+        let mid = InterpolatedTakeover::sample(0.2, &[seg]).unwrap();
+        assert_eq!(mid.t, 1.0);
+    }
+}

--- a/crates/rendering/src/takeover.rs
+++ b/crates/rendering/src/takeover.rs
@@ -26,9 +26,10 @@ pub struct TakeoverDisplayMorph {
     pub t: f32,
     pub from: [f32; 4],
     pub to: [f32; 4],
-    /// Multiplier for the cursor sprite's opacity (fades with the display in
-    /// Fullscreen, stays 1 for splits where the card remains visible).
-    pub cursor_fade: f32,
+    /// Multiplier for the cursor sprite and recording-anchored overlays
+    /// (captions, keyboard): fades with the display in Fullscreen, stays 1
+    /// for splits where the recording remains visible.
+    pub overlay_fade: f32,
 }
 
 impl InterpolatedTakeover {

--- a/crates/rendering/src/text.rs
+++ b/crates/rendering/src/text.rs
@@ -1,4 +1,4 @@
-use cap_project::{TextSegment, XY};
+use cap_project::{TextAlign, TextAnimation, TextSegment, XY};
 
 /// Text font sizes are authored against a 1080p-tall reference frame and
 /// scaled to the output height, so a project renders identically at every
@@ -19,6 +19,17 @@ pub struct PreparedText {
     pub font_weight: f32,
     pub italic: bool,
     pub opacity: f32,
+    pub align: TextAlign,
+    /// Output px, already scaled from the 1080p reference.
+    pub letter_spacing: f32,
+    /// Multiplier of `font_size`.
+    pub line_height: f32,
+    /// 0..1 drop-shadow strength; 0 disables the shadow pass.
+    pub shadow: f32,
+    /// Animation translation in output px, applied to the whole block.
+    pub offset: [f32; 2],
+    /// Animation scale about the box center.
+    pub scale: f32,
 }
 
 fn parse_color(hex: &str) -> [f32; 4] {
@@ -34,6 +45,100 @@ fn parse_color(hex: &str) -> [f32; 4] {
     }
 
     [1.0, 1.0, 1.0, 1.0]
+}
+
+fn ease_out_cubic(t: f32) -> f32 {
+    let t = t.clamp(0.0, 1.0);
+    1.0 - (1.0 - t).powi(3)
+}
+
+fn ease_out_back(t: f32) -> f32 {
+    let t = t.clamp(0.0, 1.0);
+    let c1 = 1.70158;
+    let c3 = c1 + 1.0;
+    let p = t - 1.0;
+    1.0 + c3 * p * p * p + c1 * p * p
+}
+
+const POP_MIN_SCALE: f32 = 0.8;
+
+#[derive(Debug, Clone, Copy)]
+struct AnimSample {
+    alpha: f32,
+    offset: [f32; 2],
+    scale: f32,
+    /// Fraction of characters visible (typewriter); 1 for other styles.
+    reveal: f32,
+}
+
+const ANIM_REST: AnimSample = AnimSample {
+    alpha: 1.0,
+    offset: [0.0, 0.0],
+    scale: 1.0,
+    reveal: 1.0,
+};
+
+/// `progress` runs 0 → 1 toward fully visible for both edges: time since
+/// start over the enter duration, time until end over the exit duration.
+/// `direction` is +1 entering and -1 exiting so slides continue through the
+/// text's resting position (enter from below, exit above) instead of
+/// retracing themselves.
+fn sample_animation(
+    style: TextAnimation,
+    progress: f32,
+    direction: f32,
+    slide_px: f32,
+) -> AnimSample {
+    if progress >= 1.0 {
+        return ANIM_REST;
+    }
+    let eased = ease_out_cubic(progress);
+
+    match style {
+        TextAnimation::None => ANIM_REST,
+        TextAnimation::Fade => AnimSample {
+            alpha: eased,
+            ..ANIM_REST
+        },
+        TextAnimation::SlideUp => AnimSample {
+            alpha: eased,
+            offset: [0.0, direction * (1.0 - eased) * slide_px],
+            ..ANIM_REST
+        },
+        TextAnimation::SlideDown => AnimSample {
+            alpha: eased,
+            offset: [0.0, -direction * (1.0 - eased) * slide_px],
+            ..ANIM_REST
+        },
+        TextAnimation::Pop => AnimSample {
+            alpha: eased,
+            scale: POP_MIN_SCALE + (1.0 - POP_MIN_SCALE) * ease_out_back(progress),
+            ..ANIM_REST
+        },
+        TextAnimation::Typewriter => AnimSample {
+            reveal: progress,
+            ..ANIM_REST
+        },
+    }
+}
+
+fn edge_progress(elapsed: f64, duration: f64) -> f32 {
+    if duration <= 0.0 {
+        1.0
+    } else {
+        (elapsed / duration).clamp(0.0, 1.0) as f32
+    }
+}
+
+/// Truncates to the first `ceil(reveal * chars)` characters on a char
+/// boundary, so the typewriter reveal never splits a code point.
+fn reveal_content(content: &str, reveal: f32) -> String {
+    if reveal >= 1.0 {
+        return content.to_string();
+    }
+    let total = content.chars().count();
+    let visible = ((total as f32) * reveal.max(0.0)).ceil() as usize;
+    content.chars().take(visible).collect()
 }
 
 pub fn prepare_texts(
@@ -77,30 +182,170 @@ pub fn prepare_texts(
         let right = left + width;
         let bottom = top + height;
 
-        let fade_duration = segment.fade_duration.max(0.0);
-        let opacity = if fade_duration > 0.0 {
-            let time_since_start = (frame_time - segment.start).max(0.0);
-            let time_until_end = (segment.end - frame_time).max(0.0);
+        let font_size = segment.font_size.clamp(MIN_FONT_SIZE, MAX_FONT_SIZE) * height_scale;
+        let slide_px = font_size * 0.5;
 
-            let fade_in = (time_since_start / fade_duration).min(1.0);
-            let fade_out = (time_until_end / fade_duration).min(1.0);
+        let enter = sample_animation(
+            segment.animation_in,
+            edge_progress(frame_time - segment.start, segment.animation_in_duration),
+            1.0,
+            slide_px,
+        );
+        let exit = sample_animation(
+            segment.animation_out,
+            edge_progress(segment.end - frame_time, segment.animation_out_duration),
+            -1.0,
+            slide_px,
+        );
 
-            (fade_in * fade_out) as f32
-        } else {
-            1.0
-        };
+        let opacity = segment.opacity.clamp(0.0, 1.0) * enter.alpha * exit.alpha;
+        if opacity <= 0.0 {
+            continue;
+        }
+
+        let reveal = enter.reveal.min(exit.reveal);
+        let content = reveal_content(&segment.content, reveal);
+        if content.is_empty() {
+            continue;
+        }
 
         prepared.push(PreparedText {
-            content: segment.content.clone(),
+            content,
             bounds: [left, top, right, bottom],
             color: parse_color(&segment.color),
             font_family: segment.font_family.clone(),
-            font_size: segment.font_size.clamp(MIN_FONT_SIZE, MAX_FONT_SIZE) * height_scale,
+            font_size,
             font_weight: segment.font_weight,
             italic: segment.italic,
             opacity,
+            align: segment.align,
+            letter_spacing: segment.letter_spacing.clamp(-24.0, 240.0) * height_scale,
+            line_height: segment.line_height.clamp(0.5, 3.0),
+            shadow: segment.shadow.clamp(0.0, 1.0),
+            offset: [
+                enter.offset[0] + exit.offset[0],
+                enter.offset[1] + exit.offset[1],
+            ],
+            scale: (enter.scale * exit.scale).max(0.01),
         });
     }
 
     prepared
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cap_project::{TextAnimation, TextLayout};
+
+    fn segment(animation_in: TextAnimation, animation_out: TextAnimation) -> TextSegment {
+        TextSegment {
+            start: 0.0,
+            end: 10.0,
+            track: 0,
+            enabled: true,
+            content: "Hello".to_string(),
+            center: XY::new(0.5, 0.5),
+            size: XY::new(0.35, 0.2),
+            font_family: "sans-serif".to_string(),
+            font_size: 48.0,
+            font_weight: 700.0,
+            italic: false,
+            color: "#ffffff".to_string(),
+            fade_duration: 0.15,
+            align: TextAlign::Center,
+            letter_spacing: 0.0,
+            line_height: 1.2,
+            opacity: 1.0,
+            shadow: 0.0,
+            animation_in,
+            animation_out,
+            animation_in_duration: 1.0,
+            animation_out_duration: 1.0,
+            layout: TextLayout::Overlay,
+            layout_transition: 0.5,
+        }
+    }
+
+    fn prepare_one(seg: TextSegment, time: f64) -> Option<PreparedText> {
+        prepare_texts(XY::new(1920, 1080), time, &[seg], &[])
+            .into_iter()
+            .next()
+    }
+
+    #[test]
+    fn resting_text_has_identity_animation_state() {
+        let text = prepare_one(segment(TextAnimation::Fade, TextAnimation::Fade), 5.0).unwrap();
+        assert_eq!(text.opacity, 1.0);
+        assert_eq!(text.offset, [0.0, 0.0]);
+        assert_eq!(text.scale, 1.0);
+        assert_eq!(text.content, "Hello");
+    }
+
+    #[test]
+    fn fade_ramps_in_and_out() {
+        let early = prepare_one(segment(TextAnimation::Fade, TextAnimation::Fade), 0.25).unwrap();
+        assert!(early.opacity > 0.0 && early.opacity < 1.0);
+
+        let late = prepare_one(segment(TextAnimation::Fade, TextAnimation::Fade), 9.75).unwrap();
+        assert!(late.opacity > 0.0 && late.opacity < 1.0);
+    }
+
+    #[test]
+    fn slide_up_enters_from_below_and_exits_above() {
+        let entering = prepare_one(
+            segment(TextAnimation::SlideUp, TextAnimation::SlideUp),
+            0.25,
+        )
+        .unwrap();
+        assert!(entering.offset[1] > 0.0);
+
+        let exiting = prepare_one(
+            segment(TextAnimation::SlideUp, TextAnimation::SlideUp),
+            9.75,
+        )
+        .unwrap();
+        assert!(exiting.offset[1] < 0.0);
+    }
+
+    #[test]
+    fn pop_scales_up_from_min() {
+        let entering = prepare_one(segment(TextAnimation::Pop, TextAnimation::None), 0.05).unwrap();
+        assert!(entering.scale < 1.0);
+        assert!(entering.scale >= POP_MIN_SCALE);
+    }
+
+    #[test]
+    fn typewriter_reveals_characters_over_time() {
+        let seg = segment(TextAnimation::Typewriter, TextAnimation::None);
+        let mid = prepare_one(seg.clone(), 0.5).unwrap();
+        assert!(mid.content.len() < "Hello".len());
+        assert!(mid.content.starts_with(&seg.content[..1]));
+        assert_eq!(mid.opacity, 1.0);
+
+        let done = prepare_one(seg, 2.0).unwrap();
+        assert_eq!(done.content, "Hello");
+    }
+
+    #[test]
+    fn typewriter_start_renders_nothing() {
+        assert!(
+            prepare_one(segment(TextAnimation::Typewriter, TextAnimation::None), 0.0).is_none()
+        );
+    }
+
+    #[test]
+    fn none_animation_shows_instantly() {
+        let text = prepare_one(segment(TextAnimation::None, TextAnimation::None), 0.0).unwrap();
+        assert_eq!(text.opacity, 1.0);
+        assert_eq!(text.scale, 1.0);
+    }
+
+    #[test]
+    fn segment_opacity_multiplies_animation_alpha() {
+        let mut seg = segment(TextAnimation::None, TextAnimation::None);
+        seg.opacity = 0.5;
+        let text = prepare_one(seg, 5.0).unwrap();
+        assert_eq!(text.opacity, 0.5);
+    }
 }

--- a/crates/rendering/src/zoom_spring.rs
+++ b/crates/rendering/src/zoom_spring.rs
@@ -284,7 +284,64 @@ fn build_time_map(timeline: Option<&TimelineConfiguration>) -> Vec<TimeMapSegmen
         });
         accum += duration;
     }
-    map
+
+    let holds = timeline.hold_windows();
+    if holds.is_empty() {
+        return map;
+    }
+
+    // Fullscreen text segments pause the recording clock: re-express the map
+    // in held-output time, splitting entries at each hold and inserting a
+    // timescale-0 (frozen) span so cursor-driven zoom aiming stays aligned
+    // with what the display actually shows.
+    let mut out = Vec::with_capacity(map.len() + holds.len());
+    let mut hold_idx = 0usize;
+    let mut shift = 0.0;
+    for segment in map {
+        let mut piece_start_out = segment.timeline_start + shift;
+        let mut piece_start_rec = segment.recording_start;
+        let mut remaining = segment.timeline_end - segment.timeline_start;
+        while hold_idx < holds.len() {
+            let (hold_start, hold_end) = holds[hold_idx];
+            if hold_start >= piece_start_out + remaining {
+                break;
+            }
+            if hold_start > piece_start_out {
+                let len = hold_start - piece_start_out;
+                out.push(TimeMapSegment {
+                    timeline_start: piece_start_out,
+                    timeline_end: hold_start,
+                    recording_start: piece_start_rec,
+                    timescale: segment.timescale,
+                    recording_clip: segment.recording_clip,
+                });
+                piece_start_rec += len * segment.timescale;
+                remaining -= len;
+                piece_start_out = hold_start;
+            }
+            let hold_len = hold_end - hold_start;
+            out.push(TimeMapSegment {
+                timeline_start: piece_start_out,
+                timeline_end: piece_start_out + hold_len,
+                recording_start: piece_start_rec,
+                timescale: 0.0,
+                recording_clip: segment.recording_clip,
+            });
+            piece_start_out += hold_len;
+            shift += hold_len;
+            hold_idx += 1;
+        }
+        if remaining > 0.0 {
+            out.push(TimeMapSegment {
+                timeline_start: piece_start_out,
+                timeline_end: piece_start_out + remaining,
+                recording_start: piece_start_rec,
+                timescale: segment.timescale,
+                recording_clip: segment.recording_clip,
+            });
+        }
+    }
+    out
 }
 
 /// Maps a timeline timestamp to recording seconds. Identity when no timeline


### PR DESCRIPTION
Text segments v2: richer text styling and a new relationship between text and the recording.

- Text segments gain alignment, letter spacing, line height, opacity, shadow, per-edge enter/exit animations (fade, slide, pop, typewriter), and layout modes. Legacy configs migrate via `textAnimVersion`.
- Non-overlay layouts morph the display card aside (fullscreen or split), with the cursor, camera, captions, and keyboard overlays following the morph. Fullscreen text pauses the recording clock (video holds, audio goes silent, music keeps playing), mirrored in editor playback, seeking, captions, and zoom aiming.
- Editor UI: redesigned text settings sidebar with style presets and a system-font picker, inline overlay editing, timeline ruler scrubbing with a minimap, split snapping, zoom multi-select, a zoom mode explainer, and a configurable default auto-zoom amount.
- Fix: background blur is now a separable two-pass gaussian, removing the comb/grid artifacts of the old sparse kernel.

Validated: `cargo test -p cap-project` (58 passed), `cargo test -p cap-rendering`, `cargo check -p cap-editor -p cap-export -p cap-desktop`, desktop `tsc --noEmit`, Biome clean on all touched TS files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR expands text segments with richer styling, animation, and takeover layouts while making fullscreen text pause recording playback. It also updates editor timeline interactions, caption/time mapping, overlay rendering, configurable auto-zoom, system-font selection, and background blur.
- Projects hold-aware recording, captions, seeking, audio, and overlays onto the extended output timeline.
- Adds fullscreen and split text takeovers with coordinated display, cursor, camera, caption, and keyboard behavior.
- Redesigns text editing and timeline controls, including presets, inline editing, minimap scrubbing, snapping, and zoom controls.
- Replaces the sparse background blur kernel with a separable two-pass Gaussian implementation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported caption synchronization, split-overlay visibility, and transcript-deletion issues are fixed at the current head.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/editor/captions.ts | Caption derivation and time conversion now consistently account for fullscreen holds across rendering, seeking, and export. |
| apps/desktop/src/routes/editor/timeline-utils.ts | Ripple deletion keeps clip edits in gapless time while converting overlay cuts and shifts into hold-extended output time. |
| crates/rendering/src/lib.rs | Takeover compositing now preserves recording-anchored overlays in split layouts while retaining fullscreen fade behavior. |
| crates/project/src/configuration.rs | Extends the persisted text-segment schema and defines shared hold-window time conversions for fullscreen layouts. |
| crates/rendering/src/takeover.rs | Encapsulates takeover geometry and layout-specific display and overlay fading for fullscreen and split modes. |
| crates/rendering/src/layers/blur.rs | Implements the revised separable Gaussian background-blur pipeline. |

<sub>Reviews (3): Last reviewed commit: ["fix(desktop): ripple-delete overlay trac..."](https://github.com/capsoftware/cap/commit/ee5b7e1ad64a4b7dbf9585ab91f19e5723fd4987) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53317692)</sub>

**Context used:**

- Knowledge Base — [Export and Rendering Pipeline](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-export-rendering.md)
- Knowledge Base — [Desktop Frontend (apps/desktop/src)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-frontend.md)

<!-- /greptile_comment -->