### PR TITLE
fix(web): serve public static assets on self-hosted deployments

### DIFF
--- a/apps/web/__tests__/unit/proxy-self-hosted.test.ts
+++ b/apps/web/__tests__/unit/proxy-self-hosted.test.ts
@@ -3,6 +3,12 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("self-hosted proxy routes", () => {
+	it("does not send public assets through the self-hosted login redirect", () => {
+		const source = readFileSync(join(process.cwd(), "proxy.ts"), "utf8");
+		expect(source).toContain("svg");
+		expect(source).toContain("woff2?");
+	});
+
 	it("allows browser-based CLI authorization pages", () => {
 		const source = readFileSync(join(process.cwd(), "proxy.ts"), "utf8");
 		expect(source).toContain('path.startsWith("/cli/")');

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -132,6 +132,6 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
 	matcher: [
-		"/((?!api|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)",
+		"/((?!api|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|.*\\.(?:avif|css|gif|ico|jpe?g|js|map|mp3|mp4|png|svg|webmanifest|webp|woff2?)).*)",
 	],
 };


### PR DESCRIPTION
Self-hosted deployments redirect every non-excluded request to `/login`. Because public assets such as `/logos/browsers/google-chrome.svg` were not excluded from the proxy matcher, authenticated onboarding rendered the Chrome CTA icon as broken. Exclude conventional public asset extensions and add a regression test.\n\nValidation: `corepack pnpm exec biome check apps/web/proxy.ts apps/web/__tests__/unit/proxy-self-hosted.test.ts`; `corepack pnpm --dir apps/web exec vitest run __tests__/unit/proxy-self-hosted.test.ts`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the Next.js proxy matcher so selected public asset extensions bypass self-hosted login redirects and adds a regression test.
- Adds a negative-lookahead extension list to the web proxy matcher.
- Adds source-level assertions intended to cover SVG and web-font assets.
- The exclusion remains incomplete for several public formats already used by the application.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the matcher covers the public asset formats already used by self-hosted pages.

Existing Rive animations and recorder sounds still request omitted extensions, causing those public files to continue through the self-hosted proxy and redirect to `/login`; the added test does not exercise this behavior.

**Files Needing Attention:** apps/web/proxy.ts and apps/web/__tests__/unit/proxy-self-hosted.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/proxy.ts | Adds static-asset exclusions, but omits existing `.riv`, `.ogg`, `.wasm`, and `.otf` assets that remain subject to the self-hosted login redirect. |
| apps/web/__tests__/unit/proxy-self-hosted.test.ts | Adds a regression test, but its unrestricted source-substring assertions do not verify matcher behavior. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/proxy.ts:135
**Existing asset formats remain redirected**

When a self-hosted page requests existing `.riv`, `.ogg`, `.wasm`, or `.otf` public assets, the matcher still sends those requests through the proxy, causing Rive animations, recorder sounds, and related resources to redirect to `/login` instead of loading.

```suggestion
		"/((?!api|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|.*\\.(?:avif|css|gif|ico|jpe?g|js|map|mp3|mp4|ogg|otf|png|riv|svg|wasm|webmanifest|webp|woff2?)).*)",
```

### Issue 2
apps/web/__tests__/unit/proxy-self-hosted.test.ts:7-9
**Substring assertions miss routing regressions**

These assertions only search the entire source file for `svg` and `woff2?`, so they remain green when those strings exist outside a functioning matcher and do not protect the self-hosted asset-routing behavior the test names.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): serve public static assets on ..."](https://github.com/capsoftware/cap/commit/f30a6c1dda0b55bd0aa755fdab3f5d75465762ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53349211)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-app.md)

<!-- /greptile_comment -->