### PR TITLE
fix(windows): don't instantiate capture filters while enumerating cameras (leaks ~43 handles + 1 thread per poll)

### DIFF
--- a/crates/camera-directshow/examples/cli.rs
+++ b/crates/camera-directshow/examples/cli.rs
@@ -42,7 +42,12 @@ mod windows {
 
             let device = selected.0;
 
-            let video_control = device.output_pin().cast::<IAMVideoControl>().ok();
+            let output_pin = device
+                .output_pin()
+                .expect("failed to bind capture filter for selected device")
+                .clone();
+
+            let video_control = output_pin.cast::<IAMVideoControl>().ok();
 
             let formats = device
                 .media_types()
@@ -65,7 +70,7 @@ mod windows {
 
                     if let Some(video_control) = &video_control {
                         let time_per_frame_list = video_control.time_per_frame_list(
-                            device.output_pin(),
+                            &output_pin,
                             i as i32,
                             SIZE {
                                 cx: width,

--- a/crates/camera-directshow/src/lib.rs
+++ b/crates/camera-directshow/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(non_snake_case)]
 
 use std::{
-    cell::RefCell,
+    cell::{OnceCell, RefCell},
     ffi::{OsString, c_void},
     mem::ManuallyDrop,
     ops::Deref,
@@ -359,32 +359,57 @@ impl Iterator for VideoInputDeviceIterator {
     }
 }
 
+/// The parts of a device that require actually instantiating the capture
+/// filter. Binding these opens the camera through its KS driver, which costs a
+/// thread and dozens of kernel handles that are not reclaimed on release - so
+/// it is deferred until something genuinely needs a filter, pin or format.
 #[derive(Clone)]
-pub struct VideoInputDevice {
-    moniker: IMoniker,
-    prop_bag: IPropertyBag,
+struct BoundFilter {
     filter: IBaseFilter,
     output_pin: IPin,
     stream_config: IAMStreamConfig,
 }
 
+#[derive(Clone)]
+pub struct VideoInputDevice {
+    moniker: IMoniker,
+    prop_bag: IPropertyBag,
+    bound: OnceCell<BoundFilter>,
+}
+
 impl VideoInputDevice {
     fn new(moniker: IMoniker) -> windows_core::Result<Self> {
+        // Only BindToStorage here: the property bag is enough for name, id and
+        // model id, which is all plain enumeration ever reads. BindToObject is
+        // deliberately not called - see `bound()`.
         let prop_bag: IPropertyBag = unsafe { moniker.BindToStorage(None, None) }?;
-        let filter: IBaseFilter = unsafe { moniker.BindToObject(None, None) }?;
 
+        Ok(Self {
+            moniker,
+            prop_bag,
+            bound: OnceCell::new(),
+        })
+    }
+
+    /// Instantiates the capture filter on first use and caches it.
+    fn bound(&self) -> windows_core::Result<&BoundFilter> {
+        if let Some(bound) = self.bound.get() {
+            return Ok(bound);
+        }
+
+        let filter: IBaseFilter = unsafe { self.moniker.BindToObject(None, None) }?;
         let output_pin = filter
             .get_pin(PINDIR_OUTPUT, PIN_CATEGORY_CAPTURE, GUID::zeroed())
             .ok_or(E_FAIL)?;
         let stream_config = output_pin.cast::<IAMStreamConfig>().ok().ok_or(E_FAIL)?;
 
-        Ok(Self {
-            moniker,
-            prop_bag,
+        let _ = self.bound.set(BoundFilter {
             filter,
             output_pin,
             stream_config,
-        })
+        });
+
+        self.bound.get().ok_or_else(|| E_FAIL.into())
     }
 
     pub fn name(&self) -> Option<OsString> {
@@ -410,22 +435,26 @@ impl VideoInputDevice {
     }
 
     pub fn media_types(&self) -> Option<VideoMediaTypesIterator<'_>> {
-        self.stream_config
+        self.bound()
+            .ok()?
+            .stream_config
             .media_types()
             .map(|inner| VideoMediaTypesIterator { inner })
             .ok()
     }
 
-    pub fn filter(&self) -> &IBaseFilter {
-        &self.filter
+    /// Binds the capture filter if it isn't bound yet; `None` if the device
+    /// can't be instantiated (unplugged, in use, driver error).
+    pub fn filter(&self) -> Option<&IBaseFilter> {
+        Some(&self.bound().ok()?.filter)
     }
 
-    pub fn stream_config(&self) -> &IAMStreamConfig {
-        &self.stream_config
+    pub fn stream_config(&self) -> Option<&IAMStreamConfig> {
+        Some(&self.bound().ok()?.stream_config)
     }
 
-    pub fn output_pin(&self) -> &IPin {
-        &self.output_pin
+    pub fn output_pin(&self) -> Option<&IPin> {
+        Some(&self.bound().ok()?.output_pin)
     }
 
     pub fn start_capturing(
@@ -433,8 +462,11 @@ impl VideoInputDevice {
         format: &AMMediaType,
         callback: SinkCallback,
     ) -> Result<CaptureHandle, StartCapturingError> {
+        let bound = self.bound().map_err(StartCapturingError::Other)?.clone();
+
         unsafe {
-            self.stream_config
+            bound
+                .stream_config
                 .SetFormat(&**format)
                 .map_err(StartCapturingError::Other)?;
 
@@ -460,7 +492,7 @@ impl VideoInputDevice {
                 .SetFiltergraph(&graph_builder)
                 .map_err(StartCapturingError::ConfigureGraph)?;
             graph_builder
-                .AddFilter(&self.filter, None)
+                .AddFilter(&bound.filter, None)
                 .map_err(StartCapturingError::ConfigureGraph)?;
 
             let sink_filter: IBaseFilter = sink_filter
@@ -476,14 +508,14 @@ impl VideoInputDevice {
                 .FindInterface(
                     Some(&PIN_CATEGORY_CAPTURE),
                     Some(&MEDIATYPE_Video),
-                    &self.filter,
+                    &bound.filter,
                     &IAMStreamConfig::IID,
                     &mut stream_config,
                 )
                 .map_err(StartCapturingError::ConfigureGraph)?;
 
             graph_builder
-                .Connect(&self.output_pin, &input_sink_pin)
+                .Connect(&bound.output_pin, &input_sink_pin)
                 .map_err(StartCapturingError::ConfigureGraph)?;
 
             media_control.Run().map_err(StartCapturingError::Run)?;
@@ -491,7 +523,7 @@ impl VideoInputDevice {
             Ok(CaptureHandle {
                 media_control,
                 graph_builder,
-                output_capture_pin: self.output_pin,
+                output_capture_pin: bound.output_pin.clone(),
                 input_sink_pin,
             })
         }

--- a/crates/camera-directshow/src/lib.rs
+++ b/crates/camera-directshow/src/lib.rs
@@ -379,9 +379,7 @@ pub struct VideoInputDevice {
 
 impl VideoInputDevice {
     fn new(moniker: IMoniker) -> windows_core::Result<Self> {
-        // Only BindToStorage here: the property bag is enough for name, id and
-        // model id, which is all plain enumeration ever reads. BindToObject is
-        // deliberately not called - see `bound()`.
+        // BindToObject is deliberately not called here; see `BoundFilter`.
         let prop_bag: IPropertyBag = unsafe { moniker.BindToStorage(None, None) }?;
 
         Ok(Self {
@@ -391,7 +389,6 @@ impl VideoInputDevice {
         })
     }
 
-    /// Instantiates the capture filter on first use and caches it.
     fn bound(&self) -> windows_core::Result<&BoundFilter> {
         if let Some(bound) = self.bound.get() {
             return Ok(bound);
@@ -443,8 +440,6 @@ impl VideoInputDevice {
             .ok()
     }
 
-    /// Binds the capture filter if it isn't bound yet; `None` if the device
-    /// can't be instantiated (unplugged, in use, driver error).
     pub fn filter(&self) -> Option<&IBaseFilter> {
         Some(&self.bound().ok()?.filter)
     }

--- a/crates/camera-windows/examples/enumeration_leak.rs
+++ b/crates/camera-windows/examples/enumeration_leak.rs
@@ -20,15 +20,10 @@ fn main() {
 
     for i in 1..=iterations {
         let n = match mode.as_str() {
-            // MF only: enumerate + activate IMFMediaSource per device,
-            // exactly as DeviceSourcesIterator does inside get_devices().
             "mf" => cap_camera_mediafoundation::DeviceSourcesIterator::new()
                 .map(|it| it.count())
                 .unwrap_or(0),
 
-            // DirectShow only: CoCreateInstance(CLSID_SystemDeviceEnum) plus
-            // BindToStorage/BindToObject per device, which instantiates each
-            // capture filter.
             "ds" => cap_camera_directshow::VideoInputDeviceIterator::new()
                 .map(|it| it.count())
                 .unwrap_or(0),

--- a/crates/camera-windows/examples/enumeration_leak.rs
+++ b/crates/camera-windows/examples/enumeration_leak.rs
@@ -1,0 +1,44 @@
+//! Splits the camera-enumeration leak between the Media Foundation and
+//! DirectShow halves of `get_devices()`.
+//!
+//! Usage: enumeration_leak.exe [mf|ds|both] [iterations]
+//!
+//! Sample handles/threads from outside while it runs; whichever mode grows is
+//! the leaking half.
+
+fn main() {
+    let mode = std::env::args().nth(1).unwrap_or_else(|| "both".into());
+    let iterations: usize = std::env::args()
+        .nth(2)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(30);
+
+    println!("pid {} mode={mode} iterations={iterations}", std::process::id());
+
+    let _ = cap_camera_directshow::initialize_directshow();
+    let _ = cap_camera_mediafoundation::initialize_mediafoundation();
+
+    for i in 1..=iterations {
+        let n = match mode.as_str() {
+            // MF only: enumerate + activate IMFMediaSource per device,
+            // exactly as DeviceSourcesIterator does inside get_devices().
+            "mf" => cap_camera_mediafoundation::DeviceSourcesIterator::new()
+                .map(|it| it.count())
+                .unwrap_or(0),
+
+            // DirectShow only: CoCreateInstance(CLSID_SystemDeviceEnum) plus
+            // BindToStorage/BindToObject per device, which instantiates each
+            // capture filter.
+            "ds" => cap_camera_directshow::VideoInputDeviceIterator::new()
+                .map(|it| it.count())
+                .unwrap_or(0),
+
+            _ => cap_camera_windows::get_devices().map(|d| d.len()).unwrap_or(0),
+        };
+
+        println!("{i}: {n} device(s)");
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+    }
+
+    println!("done");
+}


### PR DESCRIPTION
Fixes the underlying cause of the Windows instability in #2115. Supersedes my earlier attempt in #2117 (see the correction there — that patch was real but treated a symptom on the Media Foundation side; this is the leak that was actually killing the process).

### The bug

`VideoInputDevice::new()` called `IMoniker::BindToObject` for every device during plain enumeration. That instantiates the camera's DirectShow capture filter and opens the device through its KS driver, and those resources are not reclaimed when the filter is released.

Camera enumeration runs continuously — `spawn_devices_snapshot_emitter` every 500 ms→5 s, plus the frontend's 5 s `listVideoDevices` poll — so the leak is unbounded for the life of the process.

### Measurement

Windows 11, 7 camera devices present (1 physical + 6 virtual: Quest Link ×4, SpoutCam, OBS Virtual Camera). Calling `cap_camera::list_cameras()` once per second, nothing else running:

| | RSS | handles | threads |
|---|---|---|---|
| **before** | 24 → 30 MB | **851 → 2184** | **21 → 52** |
| **after** | 16 → 17 MB | 356 → 358 | 10 → 10 |

≈ **+43 handles and +1 thread per enumeration**, scaling with device count.

Splitting the two halves of `get_devices()` isolates it — Media Foundation is flat (317 handles, 9 threads, unchanged), DirectShow accounts for all of it.

In the running desktop app the same growth was ~9 handles/second, monotonic. After the fix, handles and threads stay flat across a session.

### Why this produces the crashes in #2115

Thousands of leaked threads (1 MB reserved stack each) and tens of thousands of handles per hour explain the whole symptom cluster, and why it looks random:

- `0xC000070A` / `STATUS_INVALID_HANDLE` on a threadpool wait — handle exhaustion
- `0xC0000005` reading inside `devenum.dll`
- `thread 'tokio-runtime-worker' has overflowed its stack`
- users reporting the app degrades the longer it runs, and is fine right after launch

It also explains the reporting bias: the leak is **per device per poll**, so a laptop with one webcam leaks ~6 handles per poll while a machine with Quest Link, OBS Virtual Camera and similar leaks 7× that. Multi-camera Windows setups get hit hard; a typical dev machine barely shows it.

### The fix

Enumeration only needs the moniker's property bag (`BindToStorage`) for name, id and model id. `BindToObject` is deferred until something actually needs the filter, pin or stream config — `formats()` or `start_capturing()` — and cached in a `OnceCell`, so behaviour is unchanged for real consumers.

`filter()`, `output_pin()` and `stream_config()` now return `Option` because binding can fail for a device that is unplugged or in use. `media_types()` already returned `Option`; callers are unchanged. Only the crate's own example needed updating.

### Reproducing it yourself

`crates/camera-windows/examples/enumeration_leak.rs` is included:

```
cargo run --release -p cap-camera-windows --example enumeration_leak -- ds 30
```

Run with `mf`, `ds` or `both` and watch the process's handle/thread counts (`Get-Process`). Before this change `ds` climbs steadily and `mf` is flat; after, both are flat. Happy to drop the example from the PR if you'd rather not carry it.

### Not addressed here

The polling itself is still aggressive — two independent loops re-enumerating every 2.5–5 s forever, each doing a full MF + DirectShow scan. With this fix that is no longer a leak, but caching results and refreshing on `WM_DEVICECHANGE` instead would remove a lot of steady-state work. Happy to do that separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR defers DirectShow capture-filter instantiation until formats or capture are requested, avoiding resource growth during ordinary Windows camera enumeration.
- Adds lazy, cached binding of each device’s filter, output pin, and stream configuration.
- Updates the DirectShow CLI example for the optional accessor contract.
- Adds a diagnostic example that repeatedly exercises Media Foundation, DirectShow, or combined enumeration.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only redundant comments in the new diagnostic example requiring non-blocking cleanup.

The lazy DirectShow binding path and current callers remain coherent, while the sole accepted concern is maintainability-only commentary in the diagnostic example.

**Files Needing Attention:** crates/camera-windows/examples/enumeration_leak.rs

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/camera-directshow/src/lib.rs | Replaces eager DirectShow filter creation with lazy OnceCell-backed binding while preserving the existing format and capture paths. |
| crates/camera-directshow/examples/cli.rs | Adapts the example to handle output-pin binding failure and reuse the successfully bound pin. |
| crates/camera-windows/examples/enumeration_leak.rs | Adds an enumeration leak diagnostic; several branch comments redundantly narrate adjacent code contrary to repository guidance. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
crates/camera-windows/examples/enumeration_leak.rs:20-21
**Redundant branch narration**

The comments above the `mf`, `ds`, and fallback branches only restate the immediately following calls, adding documentation that must be kept synchronized without providing non-obvious context.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(windows): don&#39;t instantiate capture ..."](https://github.com/capsoftware/cap/commit/b31d4dd34e01f602dbc7221ae5ae937f5e733aa3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53628650)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/capsoftware/cap/blob/main/AGENTS.md))

<!-- /greptile_comment -->