### PR TITLE
Pricing parity: GBP and EUR for Cap Pro

### DIFF
--- a/apps/desktop/src/routes/(window-chrome)/upgrade.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/upgrade.tsx
@@ -1,8 +1,9 @@
 import { Button } from "@cap/ui-solid";
 import { createMutation, useQueryClient } from "@tanstack/solid-query";
 import { getCurrentWindow, Window } from "@tauri-apps/api/window";
-import { type Accessor, createSignal, Show } from "solid-js";
+import { type Accessor, createResource, createSignal, Show } from "solid-js";
 import { generalSettingsStore } from "~/store";
+import { getPresentmentCurrencySymbol } from "~/utils/currency";
 import { getProPlanId } from "~/utils/plans";
 import { createLicenseQuery } from "~/utils/queries";
 import { createRive } from "~/utils/rive";
@@ -38,6 +39,8 @@ export default function Page() {
 	const signIn = createSignInMutation();
 	const license = createLicenseQuery();
 	const [openLicenseDialog, setOpenLicenseDialog] = createSignal(false);
+	const [currencySymbol] = createResource(getPresentmentCurrencySymbol);
+	const proSymbol = () => currencySymbol() ?? "$";
 
 	const resetLicense = createMutation(() => ({
 		mutationFn: async () => {
@@ -471,7 +474,8 @@ export default function Page() {
 										</div>
 										<div class="flex flex-col justify-center items-center">
 											<h3 class="text-4xl leading-6 text-gray-1">
-												{isProAnnual() ? "$8.16" : "$12"}
+												{proSymbol()}
+												{isProAnnual() ? "8.16" : "12"}
 												<span class="text-gray-10 text-[16px]">.00 /</span>
 											</h3>
 											{isProAnnual() && (
@@ -493,8 +497,8 @@ export default function Page() {
 												Switch to {isProAnnual() ? "monthly" : "yearly"}:{" "}
 												<span class="font-medium">
 													{isProAnnual()
-														? "$12 per user, billed monthly"
-														: "$8.16 per user, billed annually"}
+														? `${proSymbol()}12 per user, billed monthly`
+														: `${proSymbol()}8.16 per user, billed annually`}
 												</span>
 											</p>
 										</div>

--- a/apps/desktop/src/utils/currency.ts
+++ b/apps/desktop/src/utils/currency.ts
@@ -1,0 +1,28 @@
+import { fetch } from "@tauri-apps/plugin-http";
+
+import { getConfiguredServerUrl } from "./web-api";
+
+const CURRENCY_SYMBOLS: Record<string, string> = {
+	usd: "$",
+	gbp: "£",
+	eur: "€",
+};
+
+export async function getPresentmentCurrencySymbol(): Promise<string> {
+	try {
+		const serverUrl = await getConfiguredServerUrl();
+		const headers: Record<string, string> = {};
+		const bypassSecret = import.meta.env.VITE_VERCEL_AUTOMATION_BYPASS_SECRET;
+		if (bypassSecret) headers["x-vercel-protection-bypass"] = bypassSecret;
+
+		const resp = await fetch(new URL("/api/currency", serverUrl).toString(), {
+			headers,
+		});
+		if (!resp.ok) return "$";
+
+		const body = (await resp.json()) as { currency?: string };
+		return CURRENCY_SYMBOLS[body.currency ?? ""] ?? "$";
+	} catch {
+		return "$";
+	}
+}

--- a/apps/web/__tests__/unit/currency.test.ts
+++ b/apps/web/__tests__/unit/currency.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+	currencyForCountry,
+	currencySymbol,
+	formatAmount,
+	SUPPORTED_CURRENCIES,
+} from "@/utils/currency";
+
+describe("currencyForCountry", () => {
+	it("maps the UK and crown dependencies to GBP", () => {
+		for (const country of ["GB", "IM", "JE", "GG"]) {
+			expect(currencyForCountry(country)).toBe("gbp");
+		}
+	});
+
+	it("maps eurozone countries and territories to EUR", () => {
+		for (const country of ["DE", "FR", "IE", "NL", "GF", "YT", "XK"]) {
+			expect(currencyForCountry(country)).toBe("eur");
+		}
+	});
+
+	it("falls back to USD for non-euro EU countries", () => {
+		for (const country of ["SE", "PL", "DK", "CZ", "HU", "NO", "CH"]) {
+			expect(currencyForCountry(country)).toBe("usd");
+		}
+	});
+
+	it("falls back to USD for the rest of the world", () => {
+		for (const country of ["US", "CA", "AU", "IN", "BR", "JP"]) {
+			expect(currencyForCountry(country)).toBe("usd");
+		}
+	});
+
+	it("falls back to USD when the country is missing or empty", () => {
+		expect(currencyForCountry(null)).toBe("usd");
+		expect(currencyForCountry(undefined)).toBe("usd");
+		expect(currencyForCountry("")).toBe("usd");
+	});
+
+	it("normalizes casing and surrounding whitespace", () => {
+		expect(currencyForCountry("gb")).toBe("gbp");
+		expect(currencyForCountry(" de ")).toBe("eur");
+	});
+
+	it("only ever returns a supported currency", () => {
+		for (const country of ["GB", "DE", "US", "ZZ", null]) {
+			expect(SUPPORTED_CURRENCIES).toContain(currencyForCountry(country));
+		}
+	});
+});
+
+describe("currencySymbol", () => {
+	it("returns the symbol for each supported currency", () => {
+		expect(currencySymbol("usd")).toBe("$");
+		expect(currencySymbol("gbp")).toBe("£");
+		expect(currencySymbol("eur")).toBe("€");
+	});
+
+	it("accepts uppercase codes", () => {
+		expect(currencySymbol("GBP")).toBe("£");
+	});
+
+	it("falls back to an uppercase code prefix for other currencies", () => {
+		expect(currencySymbol("aud")).toBe("AUD ");
+		expect(currencySymbol("jpy")).toBe("JPY ");
+	});
+});
+
+describe("formatAmount", () => {
+	it("formats supported currencies with their symbol", () => {
+		expect(formatAmount(12, "usd")).toBe("$12.00");
+		expect(formatAmount(12, "gbp")).toBe("£12.00");
+		expect(formatAmount(12, "eur")).toBe("€12.00");
+	});
+
+	it("keeps parity pricing identical apart from the symbol", () => {
+		const amounts = SUPPORTED_CURRENCIES.map((currency) =>
+			formatAmount(8.16, currency).replace(/^\D+/, ""),
+		);
+		expect(new Set(amounts)).toEqual(new Set(["8.16"]));
+	});
+
+	it("formats currencies outside the supported set", () => {
+		expect(formatAmount(12, "aud")).toContain("12.00");
+	});
+
+	it("falls back without throwing on an invalid currency code", () => {
+		expect(formatAmount(12, "notacurrency")).toBe("NOTACURRENCY 12.00");
+	});
+});

--- a/apps/web/app/(org)/dashboard/analytics/components/AnalyticsDashboard.tsx
+++ b/apps/web/app/(org)/dashboard/analytics/components/AnalyticsDashboard.tsx
@@ -8,6 +8,7 @@ import { useMutation } from "@tanstack/react-query";
 import clsx from "clsx";
 import { Effect } from "effect";
 import { AnimatePresence, motion } from "framer-motion";
+import { useCurrency } from "hooks/useCurrency";
 import { Minus, Plus } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { memo, useEffect, useState } from "react";
@@ -48,6 +49,7 @@ export function AnalyticsDashboard() {
 	const capId = searchParams.get("capId");
 	const user = useCurrentUser();
 	const stripeCtx = useStripeContext();
+	const { currency } = useCurrency();
 	const { push } = useRouter();
 	const { activeOrganization, organizationData, spacesData } =
 		useDashboardContext();
@@ -245,7 +247,7 @@ export function AnalyticsDashboard() {
 												className="text-3xl font-medium tabular-nums text-gray-12"
 												format={{
 													style: "currency",
-													currency: "USD",
+													currency: currency.toUpperCase(),
 												}}
 											/>
 											<span className="mb-2 ml-2 text-gray-11">

--- a/apps/web/app/(org)/dashboard/settings/organization/components/BillingSummaryCard.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/BillingSummaryCard.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/actions/organization/get-subscription-details";
 import { manageBilling } from "@/actions/organization/manage-billing";
 import { useDashboardContext } from "@/app/(org)/dashboard/Contexts";
+import { formatAmount } from "@/utils/currency";
 
 export function BillingSummaryCard() {
 	const { activeOrganization, setUpgradeModalOpen } = useDashboardContext();
@@ -97,6 +98,11 @@ export function BillingSummaryCard() {
 	const intervalLabel =
 		subscription.billingInterval === "year" ? "annually" : "monthly";
 	const totalAmount = subscription.pricePerSeat * subscription.currentQuantity;
+	const seatAmountLabel = formatAmount(
+		subscription.pricePerSeat,
+		subscription.currency,
+	);
+	const totalAmountLabel = formatAmount(totalAmount, subscription.currency);
 	const nextBillingDate = format(
 		new Date(subscription.currentPeriodEnd * 1000),
 		"MMM d, yyyy",
@@ -120,10 +126,9 @@ export function BillingSummaryCard() {
 					</div>
 					<div className="flex flex-col gap-1 text-sm text-gray-11">
 						<p>
-							${subscription.pricePerSeat.toFixed(2)}/seat/mo (
-							{subscription.currentQuantity}{" "}
-							{subscription.currentQuantity === 1 ? "seat" : "seats"} = $
-							{totalAmount.toFixed(2)}/mo, billed {intervalLabel})
+							{seatAmountLabel}/seat/mo ({subscription.currentQuantity}{" "}
+							{subscription.currentQuantity === 1 ? "seat" : "seats"} ={" "}
+							{totalAmountLabel}/mo, billed {intervalLabel})
 						</p>
 						{pastDue ? (
 							<p className="text-red-700">

--- a/apps/web/app/(org)/dashboard/settings/organization/components/SeatManagementCard.tsx
+++ b/apps/web/app/(org)/dashboard/settings/organization/components/SeatManagementCard.tsx
@@ -13,6 +13,7 @@ import {
 	updateSeatQuantity,
 } from "@/actions/organization/update-seat-quantity";
 import { useDashboardContext } from "@/app/(org)/dashboard/Contexts";
+import { formatAmount } from "@/utils/currency";
 import { calculateSeats } from "@/utils/organization";
 
 const DEBOUNCE_MS = 500;
@@ -169,7 +170,7 @@ export function SeatManagementCard() {
 								<span className="text-sm text-gray-11">
 									{preview.proratedAmount === 0
 										? "No prorated adjustment"
-										: `${preview.proratedAmount > 0 ? "Due now" : "Prorated credit"}: $${Math.abs(preview.proratedAmount / 100).toFixed(2)} ${preview.currency.toUpperCase()}`}
+										: `${preview.proratedAmount > 0 ? "Due now" : "Prorated credit"}: ${formatAmount(Math.abs(preview.proratedAmount / 100), preview.currency)}`}
 								</span>
 							) : null}
 							<Button

--- a/apps/web/app/(org)/onboarding/components/InviteTeamPage.tsx
+++ b/apps/web/app/(org)/onboarding/components/InviteTeamPage.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import NumberFlow from "@number-flow/react";
 import { useMutation } from "@tanstack/react-query";
 import clsx from "clsx";
+import { useCurrency } from "hooks/useCurrency";
 import { useRouter } from "next/navigation";
 import { type MouseEvent, startTransition, useId, useState } from "react";
 import { toast } from "sonner";
@@ -17,6 +18,7 @@ import { Base } from "./Base";
 export function InviteTeamPage() {
 	const billingCycleId = useId();
 	const stripeCtx = useStripeContext();
+	const { currency, symbol } = useCurrency();
 	const [users, setUsers] = useState(1);
 	const [isAnnually, setIsAnnually] = useState(true);
 	const router = useRouter();
@@ -116,7 +118,8 @@ export function InviteTeamPage() {
 		>
 			<div className="text-center">
 				<span className="mr-2 text-2xl tabular-nums lg:text-3xl text-gray-12">
-					$<NumberFlow suffix="/mo" value={currentTotalPrice} />
+					{symbol}
+					<NumberFlow suffix="/mo" value={currentTotalPrice} />
 				</span>
 				<span className="text-base tabular-nums text-gray-10">
 					{" "}
@@ -131,7 +134,7 @@ export function InviteTeamPage() {
 							format={{
 								notation: "compact",
 								style: "currency",
-								currency: "USD",
+								currency: currency.toUpperCase(),
 							}}
 							suffix="/mo"
 						/>{" "}
@@ -155,7 +158,7 @@ export function InviteTeamPage() {
 							format={{
 								notation: "compact",
 								style: "currency",
-								currency: "USD",
+								currency: currency.toUpperCase(),
 							}}
 							suffix="/mo"
 						/>{" "}

--- a/apps/web/app/api/currency/route.ts
+++ b/apps/web/app/api/currency/route.ts
@@ -1,21 +1,55 @@
-import type { NextRequest } from "next/server";
+import {
+	HttpApi,
+	HttpApiBuilder,
+	HttpApiEndpoint,
+	HttpApiGroup,
+	HttpServerRequest,
+	HttpServerResponse,
+} from "@effect/platform";
+import { Effect, Layer, Schema } from "effect";
+import { apiToHandler } from "@/lib/server";
 import { currencyForCountry } from "@/utils/currency";
 
 export const dynamic = "force-dynamic";
 
-export async function GET(request: NextRequest) {
-	const override =
-		process.env.VERCEL_ENV !== "production"
-			? request.nextUrl.searchParams.get("country")
-			: null;
-	const country = override || request.headers.get("x-vercel-ip-country");
+const GetCurrencyParams = Schema.Struct({
+	country: Schema.optional(Schema.String),
+});
 
-	return Response.json(
-		{ currency: currencyForCountry(country), country: country ?? null },
-		{
-			// The response varies per visitor IP, so it must never land in a shared
-			// CDN cache where one region's currency would be served to another.
-			headers: { "Cache-Control": "private, no-store" },
-		},
-	);
-}
+class Api extends HttpApi.make("CapCurrencyApi").add(
+	HttpApiGroup.make("root").add(
+		HttpApiEndpoint.get("getCurrency")`/api/currency`.setUrlParams(
+			GetCurrencyParams,
+		),
+	),
+) {}
+
+const ApiLive = HttpApiBuilder.api(Api).pipe(
+	Layer.provide(
+		HttpApiBuilder.group(Api, "root", (handlers) =>
+			handlers.handle("getCurrency", ({ urlParams }) =>
+				Effect.gen(function* () {
+					const request = yield* HttpServerRequest.HttpServerRequest;
+					const override =
+						process.env.VERCEL_ENV !== "production" ? urlParams.country : null;
+					const country =
+						override || request.headers["x-vercel-ip-country"] || null;
+
+					return HttpServerResponse.unsafeJson(
+						{ currency: currencyForCountry(country), country },
+						{
+							// The response varies per visitor IP, so it must never land in a
+							// shared CDN cache where one region's currency would be served to
+							// another.
+							headers: { "Cache-Control": "private, no-store" },
+						},
+					);
+				}),
+			),
+		),
+	),
+);
+
+const handler = apiToHandler(ApiLive);
+
+export const GET = handler;

--- a/apps/web/app/api/currency/route.ts
+++ b/apps/web/app/api/currency/route.ts
@@ -1,0 +1,21 @@
+import type { NextRequest } from "next/server";
+import { currencyForCountry } from "@/utils/currency";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+	const override =
+		process.env.VERCEL_ENV !== "production"
+			? request.nextUrl.searchParams.get("country")
+			: null;
+	const country = override || request.headers.get("x-vercel-ip-country");
+
+	return Response.json(
+		{ currency: currencyForCountry(country), country: country ?? null },
+		{
+			// The response varies per visitor IP, so it must never land in a shared
+			// CDN cache where one region's currency would be served to another.
+			headers: { "Cache-Control": "private, no-store" },
+		},
+	);
+}

--- a/apps/web/components/UpgradeModal.tsx
+++ b/apps/web/components/UpgradeModal.tsx
@@ -4,6 +4,7 @@ import { buildEnv } from "@cap/env";
 import { Button, Dialog, DialogContent, Switch } from "@cap/ui";
 import NumberFlow from "@number-flow/react";
 import { useMutation } from "@tanstack/react-query";
+import { useCurrency } from "hooks/useCurrency";
 import {
 	BarChart3,
 	Database,
@@ -69,6 +70,7 @@ const UpgradeModalImpl = ({
 	dismissible = true,
 }: UpgradeModalProps) => {
 	const stripeCtx = useStripeContext();
+	const { currency } = useCurrency();
 	const [isAnnual, setIsAnnual] = useState(true);
 	const [proQuantity, setProQuantity] = useState(1);
 	const { push } = useRouter();
@@ -238,7 +240,7 @@ const UpgradeModalImpl = ({
 												className="text-3xl font-medium tabular-nums text-gray-12"
 												format={{
 													style: "currency",
-													currency: "USD",
+													currency: currency.toUpperCase(),
 												}}
 											/>
 											<span className="mb-2 ml-2 text-gray-11">

--- a/apps/web/components/pages/HomePage/Pricing/ProCard.tsx
+++ b/apps/web/components/pages/HomePage/Pricing/ProCard.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@cap/ui";
 import NumberFlow from "@number-flow/react";
 import { useMutation } from "@tanstack/react-query";
+import { useCurrency } from "hooks/useCurrency";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { useStripeContext } from "@/app/Layout/StripeContext";
@@ -17,6 +18,7 @@ const copy = homepageCopy.pricing.pro;
 
 export const ProCard = () => {
 	const stripeCtx = useStripeContext();
+	const { symbol } = useCurrency();
 	const [users, setUsers] = useState(1);
 	const [isAnnually, setIsAnnually] = useState(false);
 	const artRef = useRef<ProArtRef>(null);
@@ -103,7 +105,8 @@ export const ProCard = () => {
 
 			<div className="flex gap-1.5 items-baseline mt-6">
 				<span className="text-4xl font-semibold tracking-tight tabular-nums text-gray-12">
-					$<NumberFlow value={perUser} />
+					{symbol}
+					<NumberFlow value={perUser} />
 				</span>
 				<span className="text-sm text-gray-10">/ user / month</span>
 			</div>
@@ -132,7 +135,8 @@ export const ProCard = () => {
 				<p className="text-sm text-gray-10">
 					Total:{" "}
 					<span className="font-medium text-gray-12">
-						$<NumberFlow value={isAnnually ? yearlyTotal : monthlyTotal} />
+						{symbol}
+						<NumberFlow value={isAnnually ? yearlyTotal : monthlyTotal} />
 					</span>{" "}
 					{isAnnually ? "/ year" : "/ month"}
 				</p>

--- a/apps/web/components/pages/_components/ComparePlans.tsx
+++ b/apps/web/components/pages/_components/ComparePlans.tsx
@@ -4,6 +4,7 @@ import { Button } from "@cap/ui";
 import { classNames } from "@cap/utils";
 import { faCheck } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useCurrency } from "hooks/useCurrency";
 import { Fragment, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useCurrentUser } from "@/app/Layout/AuthContext";
@@ -158,6 +159,7 @@ const getButtonText = (key: PlanKey): string => {
 
 export const ComparePlans = () => {
 	const user = useCurrentUser();
+	const { symbol } = useCurrency();
 	const [proLoading, setProLoading] = useState(false);
 	const [guestLoading, setGuestLoading] = useState(false);
 	const [commercialLoading, setCommercialLoading] = useState(false);
@@ -189,9 +191,14 @@ export const ComparePlans = () => {
 				short: "Desktop",
 				price: "$29/yr",
 			},
-			{ key: "pro", name: "Cap Pro", short: "Pro", price: "$8.16/user/mo" },
+			{
+				key: "pro",
+				name: "Cap Pro",
+				short: "Pro",
+				price: `${symbol}8.16/user/mo`,
+			},
 		],
-		[],
+		[symbol],
 	);
 
 	const handleCheckout = async (

--- a/apps/web/hooks/useCurrency.ts
+++ b/apps/web/hooks/useCurrency.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+	currencySymbol,
+	isSupportedCurrency,
+	type SupportedCurrency,
+} from "@/utils/currency";
+
+let currencyRequest: Promise<SupportedCurrency> | null = null;
+
+function loadCurrency(): Promise<SupportedCurrency> {
+	currencyRequest ??= fetch("/api/currency")
+		.then((res) => res.json())
+		.then((data: { currency?: string }) =>
+			isSupportedCurrency(data.currency) ? data.currency : "usd",
+		)
+		.catch((): SupportedCurrency => {
+			currencyRequest = null;
+			return "usd";
+		});
+
+	return currencyRequest;
+}
+
+export function useCurrency() {
+	// Starts at usd so SSR and the first client render agree; geo detection only
+	// ever runs in the effect below.
+	const [currency, setCurrency] = useState<SupportedCurrency>("usd");
+
+	useEffect(() => {
+		let active = true;
+		loadCurrency().then((next) => {
+			if (active) setCurrency(next);
+		});
+		return () => {
+			active = false;
+		};
+	}, []);
+
+	return { currency, symbol: currencySymbol(currency) };
+}

--- a/apps/web/lib/messenger/constants.ts
+++ b/apps/web/lib/messenger/constants.ts
@@ -86,8 +86,9 @@ PLATFORM SUPPORT:
 
 PRICING (early adopter beta pricing, locked in for lifetime of subscription):
 - Free plan: personal use, Studio Mode, unlimited local recordings, shareable links up to 5 minutes, export to MP4 or GIF, web recorder
-- Desktop License: $58 one-time (lifetime) or $29/year, commercial usage rights, Studio Mode with full editor, unlimited local recordings, shareable links up to 5 minutes, export to MP4 or GIF
-- Cap Pro: $8.16/mo per user (billed annually) or $12/mo per user (billed monthly), includes everything in Desktop License plus unlimited cloud storage and bandwidth, unlimited shareable links (no 5-minute limit), auto-generated AI titles/summaries/chapters/transcriptions, custom domain (cap.yourdomain.com), password-protected shares, viewer analytics, team workspaces, Loom video importer, custom S3 bucket and Google Drive support, priority support
+- Desktop License: $58 one-time (lifetime) or $29/year, commercial usage rights, Studio Mode with full editor, unlimited local recordings, shareable links up to 5 minutes, export to MP4 or GIF. USD only, no local currency option.
+- Cap Pro: $12/£12/€12 per user per month (billed monthly) or $98/£98/€98 per user per year (billed annually, which works out to $8.16/£8.16/€8.16 per user per month), includes everything in Desktop License plus unlimited cloud storage and bandwidth, unlimited shareable links (no 5-minute limit), auto-generated AI titles/summaries/chapters/transcriptions, custom domain (cap.yourdomain.com), password-protected shares, viewer analytics, team workspaces, Loom video importer, custom S3 bucket and Google Drive support, priority support
+- Cap Pro currency: the price is the same number in every currency, only the symbol changes. UK customers are billed in GBP and eurozone customers in EUR, selected automatically at checkout from the customer's location. Everyone else is billed in USD. There is nothing the customer needs to do to pick a currency.
 - Enterprise: custom pricing, contact via https://cal.com/cap.so/15min, includes SLAs, priority support, Loom video importer, bulk discounts, managed self-hosting, SAML SSO via WorkOS, advanced security controls
 - Early adopters keep their pricing forever, even after beta ends and regular prices change.
 - Student discount available at https://cap.so/student-discount

--- a/apps/web/utils/currency.ts
+++ b/apps/web/utils/currency.ts
@@ -1,0 +1,88 @@
+export const SUPPORTED_CURRENCIES = ["usd", "gbp", "eur"] as const;
+
+export type SupportedCurrency = (typeof SUPPORTED_CURRENCIES)[number];
+
+const GBP_COUNTRIES = new Set(["GB", "IM", "JE", "GG"]);
+
+// Mirrors the countries Stripe Checkout's IP localization presents in EUR, so
+// the displayed price matches what checkout charges. Non-euro EU countries
+// (SE, PL, DK, ...) are deliberately absent and fall through to USD.
+const EUR_COUNTRIES = new Set([
+	"AD",
+	"AT",
+	"AX",
+	"BE",
+	"BL",
+	"CY",
+	"DE",
+	"EE",
+	"ES",
+	"FI",
+	"FR",
+	"GF",
+	"GP",
+	"GR",
+	"HR",
+	"IE",
+	"IT",
+	"LT",
+	"LU",
+	"LV",
+	"MC",
+	"ME",
+	"MF",
+	"MT",
+	"NL",
+	"PM",
+	"PT",
+	"RE",
+	"SI",
+	"SK",
+	"SM",
+	"TF",
+	"VA",
+	"XK",
+	"YT",
+]);
+
+const CURRENCY_SYMBOLS: Record<SupportedCurrency, string> = {
+	usd: "$",
+	gbp: "£",
+	eur: "€",
+};
+
+export function isSupportedCurrency(
+	value: string | null | undefined,
+): value is SupportedCurrency {
+	return SUPPORTED_CURRENCIES.includes(value as SupportedCurrency);
+}
+
+export function currencyForCountry(
+	country: string | null | undefined,
+): SupportedCurrency {
+	if (!country) return "usd";
+
+	const code = country.trim().toUpperCase();
+	if (GBP_COUNTRIES.has(code)) return "gbp";
+	if (EUR_COUNTRIES.has(code)) return "eur";
+	return "usd";
+}
+
+// Billing surfaces render whatever currency Stripe returns, which may be a code
+// we have no symbol for, so unknown codes degrade to a readable prefix.
+export function currencySymbol(code: string): string {
+	const normalized = code.toLowerCase();
+	if (isSupportedCurrency(normalized)) return CURRENCY_SYMBOLS[normalized];
+	return `${code.toUpperCase()} `;
+}
+
+export function formatAmount(amount: number, currency: string): string {
+	try {
+		return new Intl.NumberFormat("en", {
+			style: "currency",
+			currency,
+		}).format(amount);
+	} catch {
+		return `${currencySymbol(currency)}${amount.toFixed(2)}`;
+	}
+}


### PR DESCRIPTION
## Summary

Cap Pro now has pricing parity across USD, GBP and EUR: 12/mo and 98/yr in all three currencies, same digits, different symbol.

The Stripe side is already live: the existing production monthly and yearly prices carry gbp and eur currency_options, so Stripe Checkout automatically presents the visitor's local currency by IP. No new price IDs, so existing subscriptions, seat updates and webhooks are unaffected. Verified against production with rendered checkout pages (GBP 12.00/mo and GBP 98.00/yr from a UK IP) and the eurozone path via Stripe's location simulation in test mode.

This PR is the display layer:

- New `apps/web/utils/currency.ts` with a country-to-currency map that mirrors Stripe Checkout's own IP localization (GBP for UK and crown dependencies, EUR for eurozone countries and territories, USD otherwise, including non-euro EU countries like Sweden and Poland which Checkout also bills in USD).
- New public `GET /api/currency` endpoint reading `x-vercel-ip-country`, force-dynamic with `private, no-store` caching, plus a `?country=XX` override outside production for testing.
- New `useCurrency()` hook (SSR-safe, USD first paint, module-level request cache).
- Pre-purchase surfaces show the visitor's presentment currency: homepage/pricing ProCard, ComparePlans Pro row, UpgradeModal, onboarding InviteTeamPage, analytics upsell.
- Post-purchase surfaces (BillingSummaryCard, SeatManagementCard) now format amounts in the subscription's actual Stripe currency instead of a hardcoded dollar sign; the seat proration line goes from "$12.00 GBP" style to a properly formatted amount.
- Desktop upgrade screen fetches the currency from the web server and swaps the symbol on the Cap Pro card only, falling back silently to USD offline.
- Support AI pricing context updated to explain parity pricing and automatic currency selection.

Deliberately unchanged: Commercial License ($29/$58, separate license server), developer credits, SEO marketing pages and schema.org JSON-LD (static content stays USD).

## Testing

- 14 new unit tests for the currency utilities, including a parity invariant (identical digits in all three currencies).
- Full web unit suite: 1520 passed, 1 pre-existing failure (slack-app-manifest, reproduces on clean main).
- `tsc -b apps/web apps/desktop` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Cap Pro pricing displays are localized to USD, GBP, or EUR while post-purchase billing surfaces use the subscription’s actual Stripe currency.

- Adds a public Effect-based currency endpoint, shared currency utilities, and an SSR-safe client hook.
- Updates web and desktop purchase surfaces to show localized symbols.
- Correctly replaces the previously ad-hoc route handler with the repository-standard `HttpApi` and `apiToHandler` pattern.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported API-route architecture violation has been fixed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/app/api/currency/route.ts | Implements geographic currency resolution using the required Effect HttpApi builder and apiToHandler route pattern, resolving the previous review finding. |
| apps/web/utils/currency.ts | Defines supported currencies, country mappings, symbols, and resilient amount formatting. |
| apps/web/hooks/useCurrency.ts | Provides an SSR-safe USD initial state and shared client-side request for geographic currency resolution. |
| apps/desktop/src/utils/currency.ts | Fetches the presentment currency for the desktop upgrade screen with a silent USD fallback. |
| apps/web/app/(org)/dashboard/settings/organization/components/BillingSummaryCard.tsx | Formats recurring billing amounts using the subscription currency rather than a hardcoded dollar sign. |

<sub>Reviews (2): Last reviewed commit: ["refactor(web): build /api/currency with ..."](https://github.com/capsoftware/cap/commit/7218d8e754b0d59425937c1e26734d3d9ce201a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53788833)</sub>

**Context used:**

- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-app.md)
- Knowledge Base — [Desktop Frontend (apps/desktop/src)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-frontend.md)

<!-- /greptile_comment -->