### PR TITLE
fix(desktop): use DXC for Windows shaders

### DIFF
--- a/apps/desktop/scripts/prepare.js
+++ b/apps/desktop/scripts/prepare.js
@@ -87,6 +87,8 @@ export async function createTauriPlatformConfigs(
 				],
 				resources: {
 					"../../../target/ffmpeg/bin/*.dll": "./",
+					"../../../target/native-deps/dxc/*.dll": "./",
+					"../../../target/native-deps/dxc/LICENSE-*.txt": "licenses/dxc/",
 					"../../../target/native-deps/onnxruntime/lib/*.dll": "./",
 				},
 				windows: {

--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -200,10 +200,50 @@ pub fn create_wgpu_instance_sync() -> wgpu::Instance {
     #[cfg(target_os = "windows")]
     let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
         backends: wgpu::Backends::DX12,
+        backend_options: wgpu::BackendOptions {
+            dx12: wgpu::Dx12BackendOptions {
+                shader_compiler: bundled_dxc_compiler(),
+            },
+            ..Default::default()
+        },
         ..Default::default()
     });
 
     instance
+}
+
+#[cfg(target_os = "windows")]
+fn bundled_dxc_compiler() -> wgpu::Dx12Compiler {
+    let Some((dxc_path, dxil_path)) = bundled_dxc_paths() else {
+        tracing::debug!("Bundled DXC unavailable; using FXC for DX12 shader compilation");
+        return wgpu::Dx12Compiler::Fxc;
+    };
+
+    tracing::info!(
+        dxc_path = %dxc_path.display(),
+        dxil_path = %dxil_path.display(),
+        "Using bundled DXC for DX12 shader compilation"
+    );
+    wgpu::Dx12Compiler::DynamicDxc {
+        dxc_path: dxc_path.to_string_lossy().into_owned(),
+        dxil_path: dxil_path.to_string_lossy().into_owned(),
+        max_shader_model: wgpu::DxcShaderModel::V6_7,
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn bundled_dxc_paths() -> Option<(PathBuf, PathBuf)> {
+    let executable = std::env::current_exe().ok()?;
+    let executable_dir = executable.parent()?;
+    let profile_dir = (executable_dir.file_name()? == "deps")
+        .then(|| executable_dir.parent())
+        .flatten();
+
+    [Some(executable_dir), profile_dir]
+        .into_iter()
+        .flatten()
+        .map(|dir| (dir.join("dxcompiler.dll"), dir.join("dxil.dll")))
+        .find(|(dxc_path, dxil_path)| dxc_path.is_file() && dxil_path.is_file())
 }
 
 pub async fn create_wgpu_instance() -> wgpu::Instance {

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -503,18 +503,16 @@ async function setupWindowsOnnxRuntime() {
 async function setupWindowsDxc() {
 	const asset = {
 		version: "1.9.2607.13",
-		name: "microsoft.direct3d.dxc.1.9.2607.13.nupkg",
+		name: "microsoft.direct3d.dxc.1.9.2607.13.zip",
+		url: "https://api.nuget.org/v3-flatcontainer/microsoft.direct3d.dxc/1.9.2607.13/microsoft.direct3d.dxc.1.9.2607.13.nupkg",
 		sha256: "5d6acd23089b2979a3c1d39b7e31227da989a47b5d9f3db57111ad4717ea537e",
 	};
 	const assetArch = { x86_64: "x64", aarch64: "arm64" }[arch];
 	if (!assetArch)
 		throw new Error(`Unsupported Windows architecture for DXC: ${arch}`);
 
-	const archivePath = await downloadVerifiedAsset({
-		...asset,
-		url: `https://api.nuget.org/v3-flatcontainer/microsoft.direct3d.dxc/${asset.version}/${asset.name}`,
-	});
-	const extractDir = path.join(targetDir, asset.name.replace(/\.nupkg$/, ""));
+	const archivePath = await downloadVerifiedAsset(asset);
+	const extractDir = path.join(targetDir, asset.name.replace(/\.zip$/, ""));
 	const outputDir = path.join(targetDir, "native-deps", "dxc");
 	const markerPath = path.join(outputDir, "asset.txt");
 	const marker = `${asset.name}:${assetArch}:${asset.sha256}`;
@@ -594,10 +592,12 @@ async function downloadVerifiedAsset(asset) {
 	const actualHash = createHash("sha256")
 		.update(await fs.readFile(archivePath))
 		.digest("hex");
-	if (actualHash !== asset.sha256)
+	if (actualHash !== asset.sha256) {
+		await fs.rm(archivePath, { force: true });
 		throw new Error(
-			`${asset.name} SHA-256 mismatch: got ${actualHash}, expected ${asset.sha256}`,
+			`${asset.name} SHA-256 mismatch: got ${actualHash}, expected ${asset.sha256}; removed invalid cached archive`,
 		);
+	}
 
 	return archivePath;
 }

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { exec as execCb, execFile as execFileCb } from "node:child_process";
+import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { env } from "node:process";
@@ -203,6 +204,8 @@ async function main() {
 			},
 		);
 		console.log("Copied ffmpeg/lib and ffmpeg/include to target/native-deps");
+
+		await setupWindowsDxc();
 
 		const onnxRuntimePath = await setupWindowsOnnxRuntime();
 		cargoConfigContents += `ORT_DYLIB_PATH = { relative = true, force = true, value = "${cargoConfigPath(
@@ -495,6 +498,108 @@ async function setupWindowsOnnxRuntime() {
 	console.log("Copied ONNX Runtime DLLs to target/debug and target/release");
 
 	return outputPath;
+}
+
+async function setupWindowsDxc() {
+	const asset = {
+		version: "1.9.2607.13",
+		name: "microsoft.direct3d.dxc.1.9.2607.13.nupkg",
+		sha256: "5d6acd23089b2979a3c1d39b7e31227da989a47b5d9f3db57111ad4717ea537e",
+	};
+	const assetArch = { x86_64: "x64", aarch64: "arm64" }[arch];
+	if (!assetArch)
+		throw new Error(`Unsupported Windows architecture for DXC: ${arch}`);
+
+	const archivePath = await downloadVerifiedAsset({
+		...asset,
+		url: `https://api.nuget.org/v3-flatcontainer/microsoft.direct3d.dxc/${asset.version}/${asset.name}`,
+	});
+	const extractDir = path.join(targetDir, asset.name.replace(/\.nupkg$/, ""));
+	const outputDir = path.join(targetDir, "native-deps", "dxc");
+	const markerPath = path.join(outputDir, "asset.txt");
+	const marker = `${asset.name}:${assetArch}:${asset.sha256}`;
+	const currentMarker = await fs
+		.readFile(markerPath, "utf-8")
+		.then((value) => value.trim())
+		.catch(() => null);
+	const files = [
+		{
+			name: "dxcompiler.dll",
+			source: ["build", "native", "bin", assetArch, "dxcompiler.dll"],
+			runtime: true,
+		},
+		{
+			name: "dxil.dll",
+			source: ["build", "native", "bin", assetArch, "dxil.dll"],
+			runtime: true,
+		},
+		{ name: "LICENSE-LLVM.txt", source: ["LICENSE-LLVM.txt"] },
+		{ name: "LICENSE-MS.txt", source: ["LICENSE-MS.txt"] },
+	];
+	const missingAssets = await missingFiles(
+		outputDir,
+		files.map((file) => file.name),
+	);
+
+	if (currentMarker !== marker || missingAssets.length > 0) {
+		await fs.rm(extractDir, { recursive: true, force: true }).catch(() => {});
+		await exec(
+			`Expand-Archive -Path "${archivePath}" -DestinationPath "${extractDir}" -Force`,
+			{ shell: "powershell.exe" },
+		);
+		await fs.rm(outputDir, { recursive: true, force: true }).catch(() => {});
+		await fs.mkdir(outputDir, { recursive: true });
+		for (const file of files)
+			await fs.copyFile(
+				path.join(extractDir, ...file.source),
+				path.join(outputDir, file.name),
+			);
+		await fs.writeFile(markerPath, marker);
+		console.log(`Prepared DXC ${asset.version} for ${assetArch}`);
+	} else console.log(`Using cached DXC ${asset.version} for ${assetArch}`);
+
+	const profileDirs = [
+		path.join(targetDir, "debug"),
+		path.join(targetDir, "release"),
+	];
+	if (process.env.RUST_TARGET_TRIPLE)
+		for (const profile of ["debug", "release"])
+			profileDirs.push(
+				path.join(targetDir, process.env.RUST_TARGET_TRIPLE, profile),
+			);
+
+	for (const profileDir of profileDirs) {
+		await fs.mkdir(profileDir, { recursive: true });
+		for (const file of files.filter((file) => file.runtime))
+			await fs.copyFile(
+				path.join(outputDir, file.name),
+				path.join(profileDir, file.name),
+			);
+	}
+	console.log("Copied DXC DLLs to target profile directories");
+}
+
+async function downloadVerifiedAsset(asset) {
+	const archivePath = path.join(targetDir, asset.name);
+	if (!(await fileExists(archivePath))) {
+		const response = await fetch(asset.url);
+		if (!response.ok)
+			throw new Error(
+				`Failed to download ${asset.name}: HTTP ${response.status}`,
+			);
+		await fs.writeFile(archivePath, Buffer.from(await response.arrayBuffer()));
+		console.log(`Downloaded ${asset.name}`);
+	} else console.log(`Using cached ${asset.name}`);
+
+	const actualHash = createHash("sha256")
+		.update(await fs.readFile(archivePath))
+		.digest("hex");
+	if (actualHash !== asset.sha256)
+		throw new Error(
+			`${asset.name} SHA-256 mismatch: got ${actualHash}, expected ${asset.sha256}`,
+		);
+
+	return archivePath;
 }
 
 async function writeFileIfChanged(filePath, contents) {


### PR DESCRIPTION
Fixes #2134

## Summary

Use Microsoft's official DXC redistributable for Windows DX12 shader compilation.

Cap keeps the existing WGSL unchanged. Windows setup downloads and verifies the official `Microsoft.Direct3D.DXC` NuGet package, stages the matching architecture DLLs, and packages the runtime and license notices with the desktop app. The renderer selects the adjacent DXC pair and falls back to FXC when the bundle is unavailable.

## Why DXC

The current FXC path spends most of editor startup compiling `composite-video-frame.wgsl`. Five runs on the affected NVIDIA RTX 3080 Ti Laptop GPU measured:

| Compiler | Average | Range |
| --- | ---: | ---: |
| FXC | 26,207.059 ms | 22,171.644-28,926.749 ms |
| DXC, unchanged WGSL | 254.666 ms | 204.120-378.561 ms |

DXC reduces composite pipeline creation by 99.03%, or 102.9x, without introducing shader variants or changing the blur algorithm.

This option was selected because it:

- preserves the current WGSL and rendering behavior;
- uses WGPU's maintained Windows compiler path;
- avoids mode-specific shader permutations and dynamic-loop compatibility problems;
- uses Microsoft's official redistributable instead of WebView2-private DLLs;
- retains FXC behavior for builds that do not contain the verified DXC bundle.

## Rendering verification

A deterministic 360-frame stress sequence exercised directional blur, radial zoom blur, resampling, rounded corners, shadows, borders, color grading, and grain.

Metrics were calculated on raw RGBA frames before video compression:

| Comparison | PSNR | SSIM |
| --- | ---: | ---: |
| FXC vs unchanged WGSL compiled by DXC | 86.553432 dB | 0.999999 |

The compilers produce negligible floating-point differences, but no visible quality regression was found. The full methodology and root-cause analysis are in #2134.

## Implementation

- Download `Microsoft.Direct3D.DXC` 1.9.2607.13 from NuGet during Windows native setup.
- Verify the package against a pinned SHA-256 digest before extraction.
- Stage x64 or ARM64 `dxcompiler.dll` and `dxil.dll` for local and target builds.
- Include the official LLVM and Microsoft notices in the desktop bundle.
- Resolve DXC beside the executable, including Cargo's `target/*/deps` test layout.
- Use FXC when the verified runtime is not present.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p cap-rendering`
- `cargo test -p cap-rendering --lib -- --nocapture` (`151 passed`, `1 ignored`)
- `pnpm dlx @biomejs/biome@2.2.0 check --write scripts/setup.js apps/desktop/scripts/prepare.js`
- `node --check scripts/setup.js`
- `node --check apps/desktop/scripts/prepare.js`
- Generated `tauri.windows.conf.json` includes the DXC DLLs and notices.
- Verified NuGet SHA-256, x64 extraction, and valid Microsoft Authenticode signatures locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a verified Microsoft DXC download and staging flow for Windows, packages the runtime DLLs and notices with the desktop application, and configures the shared renderer to prefer adjacent DXC libraries with an FXC fallback.
- Downloads and verifies the pinned DXC NuGet package during Windows setup.
- Stages architecture-specific runtime DLLs into Cargo profile directories and desktop resources.
- Selects dynamic DXC for DX12 shader compilation when both required DLLs are available.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking cache-recovery issue in the Windows DXC setup flow.

The runtime compiler selection retains an FXC fallback, while the only accepted concern is that a corrupted cached DXC package must be deleted manually before Windows setup can succeed again.

**Files Needing Attention:** scripts/setup.js

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/setup.js | Adds verified DXC acquisition and staging, but an invalid cached archive causes persistent setup failures without automatic recovery. |
| crates/rendering/src/lib.rs | Configures Windows DX12 rendering to use adjacent DXC libraries while retaining FXC fallback behavior. |
| apps/desktop/scripts/prepare.js | Adds the DXC runtime DLLs and license notices to generated Windows Tauri resources. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/setup.js:597-600
**Invalid DXC cache persists**

When the cached DXC package is truncated or corrupted, checksum verification throws without deleting it, so every subsequent Windows setup reuses the same invalid archive and fails until it is manually removed.

```suggestion
	if (actualHash !== asset.sha256) {
		await fs.rm(archivePath, { force: true });
		throw new Error(
			`${asset.name} SHA-256 mismatch: got ${actualHash}, expected ${asset.sha256}; removed the invalid cached archive`,
		);
	}
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): use DXC for Windows shader..."](https://github.com/capsoftware/cap/commit/52c750766f5e6d8a02ba4cf776d470c8a55e5551) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54663990)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->