### PR TITLE
feat: add freehand draw tool to screenshot editor

### DIFF
--- a/apps/desktop/src/routes/screenshot-editor/AnnotationLayer.tsx
+++ b/apps/desktop/src/routes/screenshot-editor/AnnotationLayer.tsx
@@ -750,7 +750,13 @@ export function AnnotationLayer(props: {
 							/>
 						</Show>
 
-						<Show when={selectedAnnotationId() === ann.id && !textEditingId()}>
+						<Show
+							when={
+								selectedAnnotationId() === ann.id &&
+								!textEditingId() &&
+								activeTool() === "select"
+							}
+						>
 							<SelectionHandles
 								annotation={ann}
 								handleSize={handleSize()}

--- a/apps/desktop/src/routes/screenshot-editor/AnnotationLayer.tsx
+++ b/apps/desktop/src/routes/screenshot-editor/AnnotationLayer.tsx
@@ -520,12 +520,24 @@ export function AnnotationLayer(props: {
 		}
 
 		if (dragState()) {
-			// Commit history if changed
-			// We can check if current annotations differ from snapshot, but that's expensive.
-			// Instead, we assume if we dragged, we changed.
-			// We need to know if we actually moved.
-			// But we don't have "current" vs "original" easily without checking.
-			// Simpler: always push if dragSnapshot exists.
+			const state = dragState();
+			if (state?.action === "resize") {
+				const ann = annotations.find((a) => a.id === state.id);
+				if (ann && ann.type === "draw" && ann.points && (ann.width < 0 || ann.height < 0)) {
+					const flipX = ann.width < 0;
+					const flipY = ann.height < 0;
+					setAnnotations((a) => a.id === state.id, {
+						x: flipX ? ann.x + ann.width : ann.x,
+						y: flipY ? ann.y + ann.height : ann.y,
+						width: Math.abs(ann.width),
+						height: Math.abs(ann.height),
+						points: ann.points!.map((p) => [
+							flipX ? 1 - p[0] : p[0],
+							flipY ? 1 - p[1] : p[1],
+						] as [number, number]),
+					});
+				}
+			}
 			if (dragSnapshot) {
 				projectHistory.push(dragSnapshot);
 			}

--- a/apps/desktop/src/routes/screenshot-editor/AnnotationLayer.tsx
+++ b/apps/desktop/src/routes/screenshot-editor/AnnotationLayer.tsx
@@ -244,7 +244,10 @@ export function AnnotationLayer(props: {
 				const dx2 = point.x - last[0];
 				const dy2 = point.y - last[1];
 				if (dx2 * dx2 + dy2 * dy2 < 4) return;
-				const newPoints: [number, number][] = [...temp.points, [point.x, point.y]];
+				const newPoints: [number, number][] = [
+					...temp.points,
+					[point.x, point.y],
+				];
 				const xs = newPoints.map((p) => p[0]);
 				const ys = newPoints.map((p) => p[1]);
 				const minX = Math.min(...xs);
@@ -437,10 +440,9 @@ export function AnnotationLayer(props: {
 				}
 				const w = ann.width || 1;
 				const h = ann.height || 1;
-				ann.points = ann.points.map((p) => [
-					(p[0] - ann.x) / w,
-					(p[1] - ann.y) / h,
-				] as [number, number]);
+				ann.points = ann.points.map(
+					(p) => [(p[0] - ann.x) / w, (p[1] - ann.y) / h] as [number, number],
+				);
 				if (drawSnapshot) projectHistory.push(drawSnapshot);
 				drawSnapshot = null;
 				setAnnotations((prev) => [...prev, ann]);
@@ -523,18 +525,27 @@ export function AnnotationLayer(props: {
 			const state = dragState();
 			if (state?.action === "resize") {
 				const ann = annotations.find((a) => a.id === state.id);
-				if (ann && ann.type === "draw" && ann.points && (ann.width < 0 || ann.height < 0)) {
+				if (
+					ann &&
+					ann.type === "draw" &&
+					ann.points &&
+					(ann.width < 0 || ann.height < 0)
+				) {
 					const flipX = ann.width < 0;
 					const flipY = ann.height < 0;
+					const points = ann.points;
 					setAnnotations((a) => a.id === state.id, {
 						x: flipX ? ann.x + ann.width : ann.x,
 						y: flipY ? ann.y + ann.height : ann.y,
 						width: Math.abs(ann.width),
 						height: Math.abs(ann.height),
-						points: ann.points!.map((p) => [
-							flipX ? 1 - p[0] : p[0],
-							flipY ? 1 - p[1] : p[1],
-						] as [number, number]),
+						points: points.map(
+							(p) =>
+								[flipX ? 1 - p[0] : p[0], flipY ? 1 - p[1] : p[1]] as [
+									number,
+									number,
+								],
+						),
 					});
 				}
 			}
@@ -743,22 +754,26 @@ export function AnnotationLayer(props: {
 				)}
 			</For>
 			<Show when={tempAnnotation()}>
-				{(ann) => (
-					<Show
-						when={ann().type === "draw" && ann().points && ann().points!.length >= 2}
-						fallback={<RenderAnnotation annotation={ann()} />}
-					>
-						<path
-							d={smoothPathFromPoints(ann().points!)}
-							fill="none"
-							stroke={ann().strokeColor}
-							stroke-width={ann().strokeWidth}
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							opacity={ann().opacity}
-						/>
-					</Show>
-				)}
+				{(ann) => {
+					const livePoints = () =>
+						ann().type === "draw" ? (ann().points ?? []) : [];
+					return (
+						<Show
+							when={livePoints().length >= 2}
+							fallback={<RenderAnnotation annotation={ann()} />}
+						>
+							<path
+								d={smoothPathFromPoints(livePoints())}
+								fill="none"
+								stroke={ann().strokeColor}
+								stroke-width={ann().strokeWidth}
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								opacity={ann().opacity}
+							/>
+						</Show>
+					);
+				}}
 			</Show>
 		</svg>
 	);
@@ -879,20 +894,27 @@ function RenderAnnotation(props: { annotation: Annotation }) {
 					style={{ "pointer-events": "all" }}
 				/>
 			)}
-			{props.annotation.type === "draw" && props.annotation.points && props.annotation.points.length >= 2 && (
-				<path
-					d={smoothPathFromPoints(props.annotation.points.map((p) => [
-						props.annotation.x + p[0] * (props.annotation.width || 1),
-						props.annotation.y + p[1] * (props.annotation.height || 1),
-					] as [number, number]))}
-					fill="none"
-					stroke={props.annotation.strokeColor}
-					stroke-width={props.annotation.strokeWidth}
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					opacity={props.annotation.opacity}
-				/>
-			)}
+			{props.annotation.type === "draw" &&
+				props.annotation.points &&
+				props.annotation.points.length >= 2 && (
+					<path
+						d={smoothPathFromPoints(
+							props.annotation.points.map(
+								(p) =>
+									[
+										props.annotation.x + p[0] * (props.annotation.width || 1),
+										props.annotation.y + p[1] * (props.annotation.height || 1),
+									] as [number, number],
+							),
+						)}
+						fill="none"
+						stroke={props.annotation.strokeColor}
+						stroke-width={props.annotation.strokeWidth}
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						opacity={props.annotation.opacity}
+					/>
+				)}
 		</>
 	);
 }

--- a/apps/desktop/src/routes/screenshot-editor/AnnotationLayer.tsx
+++ b/apps/desktop/src/routes/screenshot-editor/AnnotationLayer.tsx
@@ -200,6 +200,11 @@ export function AnnotationLayer(props: {
 
 		setIsDrawing(true);
 		const id = crypto.randomUUID();
+		const styleSource =
+			tool === "draw"
+				? (annotations.find((a) => a.id === selectedAnnotationId()) ??
+					[...annotations].reverse().find((a) => a.type === "draw"))
+				: undefined;
 		const newAnn: Annotation = {
 			id,
 			type: tool as AnnotationType,
@@ -207,10 +212,13 @@ export function AnnotationLayer(props: {
 			y: startY,
 			width: 0,
 			height: 0,
-			strokeColor: tool === "mask" ? "transparent" : "#F05656",
-			strokeWidth: tool === "mask" ? 0 : 4,
+			strokeColor:
+				tool === "mask"
+					? "transparent"
+					: (styleSource?.strokeColor ?? "#F05656"),
+			strokeWidth: tool === "mask" ? 0 : (styleSource?.strokeWidth ?? 4),
 			fillColor: "transparent",
-			opacity: 1,
+			opacity: styleSource?.opacity ?? 1,
 			rotation: 0,
 			text: tool === "text" ? "Text" : null,
 			maskType: tool === "mask" ? "pixelate" : null,
@@ -448,7 +456,6 @@ export function AnnotationLayer(props: {
 				setAnnotations((prev) => [...prev, ann]);
 				setTempAnnotation(null);
 				setIsDrawing(false);
-				setActiveTool("select");
 				setSelectedAnnotationId(ann.id);
 				return;
 			}
@@ -559,9 +566,9 @@ export function AnnotationLayer(props: {
 	};
 
 	const startDrag = (e: MouseEvent, id: string, handle?: string) => {
+		if (activeTool() !== "select") return;
 		e.preventDefault();
 		e.stopPropagation();
-		if (activeTool() !== "select") return;
 		window.getSelection()?.removeAllRanges();
 
 		const svg = (e.currentTarget as Element).closest("svg");

--- a/apps/desktop/src/routes/screenshot-editor/AnnotationLayer.tsx
+++ b/apps/desktop/src/routes/screenshot-editor/AnnotationLayer.tsx
@@ -215,6 +215,7 @@ export function AnnotationLayer(props: {
 			text: tool === "text" ? "Text" : null,
 			maskType: tool === "mask" ? "pixelate" : null,
 			maskLevel: tool === "mask" ? 7 : null,
+			points: tool === "draw" ? [[startX, startY]] : null,
 		};
 
 		if (tool === "text") {
@@ -237,6 +238,29 @@ export function AnnotationLayer(props: {
 			const temp = tempAnnotation();
 			if (!temp) return;
 			if (temp.type === "text") return;
+
+			if (temp.type === "draw" && temp.points) {
+				const last = temp.points[temp.points.length - 1];
+				const dx2 = point.x - last[0];
+				const dy2 = point.y - last[1];
+				if (dx2 * dx2 + dy2 * dy2 < 4) return;
+				const newPoints: [number, number][] = [...temp.points, [point.x, point.y]];
+				const xs = newPoints.map((p) => p[0]);
+				const ys = newPoints.map((p) => p[1]);
+				const minX = Math.min(...xs);
+				const minY = Math.min(...ys);
+				const maxX = Math.max(...xs);
+				const maxY = Math.max(...ys);
+				setTempAnnotation({
+					...temp,
+					points: newPoints,
+					x: minX,
+					y: minY,
+					width: maxX - minX,
+					height: maxY - minY,
+				});
+				return;
+			}
 
 			const currentX =
 				temp.type === "mask"
@@ -403,6 +427,30 @@ export function AnnotationLayer(props: {
 		const tempAnn = tempAnnotation();
 		if (isDrawing() && tempAnn) {
 			const ann = { ...tempAnn };
+
+			if (ann.type === "draw") {
+				if (!ann.points || ann.points.length < 2) {
+					setTempAnnotation(null);
+					setIsDrawing(false);
+					drawSnapshot = null;
+					return;
+				}
+				const w = ann.width || 1;
+				const h = ann.height || 1;
+				ann.points = ann.points.map((p) => [
+					(p[0] - ann.x) / w,
+					(p[1] - ann.y) / h,
+				] as [number, number]);
+				if (drawSnapshot) projectHistory.push(drawSnapshot);
+				drawSnapshot = null;
+				setAnnotations((prev) => [...prev, ann]);
+				setTempAnnotation(null);
+				setIsDrawing(false);
+				setActiveTool("select");
+				setSelectedAnnotationId(ann.id);
+				return;
+			}
+
 			if (
 				ann.type === "rectangle" ||
 				ann.type === "circle" ||
@@ -683,10 +731,43 @@ export function AnnotationLayer(props: {
 				)}
 			</For>
 			<Show when={tempAnnotation()}>
-				{(ann) => <RenderAnnotation annotation={ann()} />}
+				{(ann) => (
+					<Show
+						when={ann().type === "draw" && ann().points && ann().points!.length >= 2}
+						fallback={<RenderAnnotation annotation={ann()} />}
+					>
+						<path
+							d={smoothPathFromPoints(ann().points!)}
+							fill="none"
+							stroke={ann().strokeColor}
+							stroke-width={ann().strokeWidth}
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							opacity={ann().opacity}
+						/>
+					</Show>
+				)}
 			</Show>
 		</svg>
 	);
+}
+
+function smoothPathFromPoints(points: [number, number][]): string {
+	if (points.length < 2) return "";
+	if (points.length === 2) {
+		return `M ${points[0][0]},${points[0][1]} L ${points[1][0]},${points[1][1]}`;
+	}
+	let d = `M ${points[0][0]},${points[0][1]}`;
+	for (let i = 0; i < points.length - 1; i++) {
+		const p0 = points[i];
+		const p1 = points[i + 1];
+		const mx = (p0[0] + p1[0]) / 2;
+		const my = (p0[1] + p1[1]) / 2;
+		d += ` Q ${p0[0]},${p0[1]} ${mx},${my}`;
+	}
+	const last = points[points.length - 1];
+	d += ` L ${last[0]},${last[1]}`;
+	return d;
 }
 
 function RenderAnnotation(props: { annotation: Annotation }) {
@@ -784,6 +865,20 @@ function RenderAnnotation(props: { annotation: Annotation }) {
 					stroke="none"
 					opacity={props.annotation.opacity}
 					style={{ "pointer-events": "all" }}
+				/>
+			)}
+			{props.annotation.type === "draw" && props.annotation.points && props.annotation.points.length >= 2 && (
+				<path
+					d={smoothPathFromPoints(props.annotation.points.map((p) => [
+						props.annotation.x + p[0] * (props.annotation.width || 1),
+						props.annotation.y + p[1] * (props.annotation.height || 1),
+					] as [number, number]))}
+					fill="none"
+					stroke={props.annotation.strokeColor}
+					stroke-width={props.annotation.strokeWidth}
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					opacity={props.annotation.opacity}
 				/>
 			)}
 		</>

--- a/apps/desktop/src/routes/screenshot-editor/AnnotationTools.tsx
+++ b/apps/desktop/src/routes/screenshot-editor/AnnotationTools.tsx
@@ -6,6 +6,7 @@ import IconLucideCircle from "~icons/lucide/circle";
 import IconLucideEyeOff from "~icons/lucide/eye-off";
 import IconLucideLayers from "~icons/lucide/layers";
 import IconLucideMousePointer2 from "~icons/lucide/mouse-pointer-2";
+import IconLucidePencil from "~icons/lucide/pencil";
 import IconLucideSquare from "~icons/lucide/square";
 import IconLucideType from "~icons/lucide/type";
 import {
@@ -38,6 +39,12 @@ export function AnnotationTools() {
 				icon={IconLucideMousePointer2}
 				label="Select"
 				shortcut="V"
+			/>
+			<ToolButton
+				tool="draw"
+				icon={IconLucidePencil}
+				label="Draw"
+				shortcut="D"
 			/>
 			<ToolButton
 				tool="arrow"

--- a/apps/desktop/src/routes/screenshot-editor/Editor.tsx
+++ b/apps/desktop/src/routes/screenshot-editor/Editor.tsx
@@ -136,6 +136,10 @@ export function Editor() {
 						setActiveTool("circle");
 						setSelectedAnnotationId(null);
 						break;
+					case "d":
+						setActiveTool("draw");
+						setSelectedAnnotationId(null);
+						break;
 					case "t":
 						setActiveTool("text");
 						setSelectedAnnotationId(null);

--- a/apps/desktop/src/routes/screenshot-editor/LayersPanel.tsx
+++ b/apps/desktop/src/routes/screenshot-editor/LayersPanel.tsx
@@ -5,6 +5,7 @@ import IconLucideCircle from "~icons/lucide/circle";
 import IconLucideEyeOff from "~icons/lucide/eye-off";
 import IconLucideGripVertical from "~icons/lucide/grip-vertical";
 import IconLucideLayers from "~icons/lucide/layers";
+import IconLucidePencil from "~icons/lucide/pencil";
 import IconLucideSquare from "~icons/lucide/square";
 import IconLucideType from "~icons/lucide/type";
 import IconLucideX from "~icons/lucide/x";
@@ -16,6 +17,7 @@ const ANNOTATION_TYPE_ICONS = {
 	circle: IconLucideCircle,
 	mask: IconLucideEyeOff,
 	text: IconLucideType,
+	draw: IconLucidePencil,
 };
 
 const ANNOTATION_TYPE_LABELS = {
@@ -24,6 +26,7 @@ const ANNOTATION_TYPE_LABELS = {
 	circle: "Circle",
 	mask: "Mask",
 	text: "Text",
+	draw: "Draw",
 };
 
 export function LayersPanel() {

--- a/apps/desktop/src/routes/screenshot-editor/screenshotExport.ts
+++ b/apps/desktop/src/routes/screenshot-editor/screenshotExport.ts
@@ -88,6 +88,26 @@ const drawAnnotations = (
 			ctx.closePath();
 			ctx.fillStyle = ann.strokeColor;
 			ctx.fill();
+		} else if (ann.type === "draw" && ann.points && ann.points.length >= 2) {
+			ctx.beginPath();
+			ctx.lineCap = "round";
+			ctx.lineJoin = "round";
+			const w = ann.width || 1;
+			const h = ann.height || 1;
+			const pts = ann.points.map((p) => [ann.x + p[0] * w, ann.y + p[1] * h] as [number, number]);
+			ctx.moveTo(pts[0][0], pts[0][1]);
+			if (pts.length === 2) {
+				ctx.lineTo(pts[1][0], pts[1][1]);
+			} else {
+				for (let i = 0; i < pts.length - 1; i++) {
+					const mx = (pts[i][0] + pts[i + 1][0]) / 2;
+					const my = (pts[i][1] + pts[i + 1][1]) / 2;
+					ctx.quadraticCurveTo(pts[i][0], pts[i][1], mx, my);
+				}
+				const last = pts[pts.length - 1];
+				ctx.lineTo(last[0], last[1]);
+			}
+			ctx.stroke();
 		} else if (ann.type === "text" && ann.text) {
 			ctx.fillStyle = ann.strokeColor;
 			ctx.font = `${ann.height}px sans-serif`;

--- a/apps/desktop/src/routes/screenshot-editor/screenshotExport.ts
+++ b/apps/desktop/src/routes/screenshot-editor/screenshotExport.ts
@@ -94,7 +94,9 @@ const drawAnnotations = (
 			ctx.lineJoin = "round";
 			const w = ann.width || 1;
 			const h = ann.height || 1;
-			const pts = ann.points.map((p) => [ann.x + p[0] * w, ann.y + p[1] * h] as [number, number]);
+			const pts = ann.points.map(
+				(p) => [ann.x + p[0] * w, ann.y + p[1] * h] as [number, number],
+			);
 			ctx.moveTo(pts[0][0], pts[0][1]);
 			if (pts.length === 2) {
 				ctx.lineTo(pts[1][0], pts[1][1]);

--- a/apps/desktop/src/utils/tauri.ts
+++ b/apps/desktop/src/utils/tauri.ts
@@ -569,8 +569,8 @@ videoImportProgress: "video-import-progress"
 /** user-defined types **/
 
 export type Action = { type: "copyToClipboard"; source?: ClipboardSource } | { type: "saveToLocation"; dir: string; filenameTemplate?: string | null } | { type: "export"; profile: ExportProfile; destination?: ExportDestination } | { type: "upload"; organizationId?: string | null; copyLink?: boolean; openInBrowser?: boolean } | { type: "revealInFileManager" } | { type: "openFile" } | { type: "runCommand"; program: string; args?: string[]; cwd?: string | null; env?: { [key in string]: string }; useShell?: boolean } | { type: "webhook"; url: string; method?: string; headers?: { [key in string]: string }; bodyTemplate?: string | null } | { type: "recognizeTextToClipboard" } | { type: "notify"; titleTemplate?: string; bodyTemplate?: string } | { type: "openEditor" } | { type: "skipEditor" } | { type: "applyPreset"; name: string } | { type: "deleteLocalFiles" }
-export type Annotation = { id: string; type: AnnotationType; x: number; y: number; width: number; height: number; strokeColor: string; strokeWidth: number; fillColor: string; opacity: number; rotation: number; text: string | null; maskType?: MaskType | null; maskLevel?: number | null }
-export type AnnotationType = "arrow" | "circle" | "rectangle" | "text" | "mask"
+export type Annotation = { id: string; type: AnnotationType; x: number; y: number; width: number; height: number; strokeColor: string; strokeWidth: number; fillColor: string; opacity: number; rotation: number; text: string | null; maskType?: MaskType | null; maskLevel?: number | null; points?: ([number, number])[] | null }
+export type AnnotationType = "arrow" | "circle" | "rectangle" | "text" | "mask" | "draw"
 export type AppTheme = "system" | "light" | "dark"
 export type AspectRatio = "wide" | "vertical" | "square" | "classic" | "tall"
 export type Audio = { duration: number; sample_rate: number; channels: number; start_time: number }

--- a/crates/project/src/configuration.rs
+++ b/crates/project/src/configuration.rs
@@ -2106,6 +2106,7 @@ pub enum AnnotationType {
     Rectangle,
     Text,
     Mask,
+    Draw,
 }
 
 #[derive(Type, Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
@@ -2178,6 +2179,8 @@ pub struct Annotation {
     pub mask_type: Option<MaskType>,
     #[serde(default)]
     pub mask_level: Option<f64>,
+    #[serde(default)]
+    pub points: Option<Vec<[f64; 2]>>,
 }
 
 impl Annotation {


### PR DESCRIPTION
## Summary

I needed the ability to quickly annotate and mark up screenshots with freehand strokes — circling things, underlining, scribbling notes — without reaching for an external tool. The existing shape tools (arrow, rectangle, circle) are great for precise callouts but too rigid for quick markup.

This adds a **Draw** tool (pencil icon, keyboard shortcut `D`) to the screenshot editor toolbar between Select and Arrow. It records freehand strokes as normalized point data so the drawing scales correctly with resize and preserves its shape across edits.

### Changes

- New `draw` variant in `AnnotationType` (Rust + TS)
- `points` field on `Annotation` struct for storing path data
- Smooth quadratic bezier rendering in both SVG (editor) and canvas (export)
- Minimum distance filter to keep point arrays reasonable
- Works with existing stroke color, width, and opacity controls
- Keyboard shortcut `D` to activate

### Notes

- The `points` field uses `#[serde(default)]` so existing projects without it deserialize fine
- Points are stored normalized (0–1 relative to bounding box) so resize/move work identically to rectangles and circles
- The TS type in `tauri.ts` was updated manually to match the Rust change — will need regeneration on next specta run

## Example video

https://github.com/user-attachments/assets/bfc2469a-90d1-4bf6-971e-964f769b4a64



## Test plan

- [ ] Take a screenshot, select the Draw tool, draw a freehand stroke
- [ ] Verify stroke renders live while drawing
- [ ] Select the stroke, move it — confirm it moves correctly
- [ ] Resize the stroke via handles — confirm shape scales proportionally
- [ ] Press Done and verify the stroke appears in the exported image
- [ ] Change stroke color/width/opacity before drawing — confirm it applies

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds persistent freehand screenshot annotations with editor controls and matching SVG/canvas rendering.
- Adds the Draw toolbar action and keyboard shortcut.
- Records normalized stroke points and supports selection, movement, resizing, styling, and history.
- Extends the persisted Rust annotation schema and screenshot export renderer.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/screenshot-editor/AnnotationLayer.tsx | Implements freehand point capture, live SVG rendering, normalized persistence, resizing, and flipped-bound canonicalization without a new eligible blocking finding. |
| apps/desktop/src/routes/screenshot-editor/screenshotExport.ts | Adds canvas rendering for normalized draw paths using the same quadratic smoothing approach as the editor. |
| crates/project/src/configuration.rs | Extends the persisted annotation schema with the draw variant and a backward-compatible optional points field. |
| apps/desktop/src/utils/tauri.ts | Mirrors the Rust annotation additions in the TypeScript binding. |

<sub>Reviews (2): Last reviewed commit: ["fix: hide draw transform handles until s..."](https://github.com/capsoftware/cap/commit/2e2994871c4e94d1ae0d030b2ce29678bb5ef3a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54683711)</sub>

**Context used:**

- Knowledge Base — [Desktop Frontend (apps/desktop/src)](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/desktop-frontend.md)

<!-- /greptile_comment -->