### PR TITLE
fix(billing): use live Stripe price for Signed BAA

### DIFF
--- a/packages/utils/src/constants/plans.ts
+++ b/packages/utils/src/constants/plans.ts
@@ -18,7 +18,7 @@ export const STRIPE_PLAN_IDS = {
 
 export const STRIPE_SIGNED_BAA_PRICE_IDS: Record<string, string> = {
 	development: "price_1U5xKIFJxA1XpeSsdg4Q8H3Z",
-	production: "price_REPLACE_BEFORE_PRODUCTION",
+	production: "price_1U6C99FJxA1XpeSsUg1rXHo2",
 };
 
 export const SIGNED_BAA_PRICE_PER_MONTH = 99;


### PR DESCRIPTION
## Problem

Clicking **Sign & pay $99/mo** on `/dashboard/settings/organization/billing` in production returned a 500 (`digest: '2637639230'`). Vercel production logs on `dpl_49f6z9nTsFhXeHmdq7feViMMZUnp` show:

```
Error: Signed BAA billing is not configured. Please contact support.
```

`STRIPE_SIGNED_BAA_PRICE_IDS.production` was still `price_REPLACE_BEFORE_PRODUCTION`, so the `.includes("REPLACE")` guard in `getBaaPriceId()` threw on every attempt. No live Stripe price for the add-on existed.

## Fix

Created the live Stripe product/price and wired its ID in:

- Product `prod_V6OxWdGuyj9HKp` ("Signed BAA", `metadata.type=signed_baa`)
- Price `price_1U6C99FJxA1XpeSsUg1rXHo2` — $99/mo recurring, with `currency_options` for **usd / gbp / eur at 9900 each**, mirroring how the live Cap Pro price is configured. Without the currency options, customers whose Stripe currency is locked to GBP or EUR would hit a currency mismatch on subscribe.

## Blast radius

The throw happened before any write, so nothing needs cleaning up: the `signed_baas` table has zero rows and no `signed_baa` subscription or charge exists in Stripe.

Webhook handling was already correct for this path — `isSignedBaaSubscription` guards the `customer.subscription.created/updated/deleted` handlers, so the add-on subscription cannot overwrite `users.stripeSubscriptionId`/`Status` or inflate the seat quota.

## Verification

- `vitest run __tests__/unit/signed-baa.test.ts __tests__/unit/signed-baa-webhook.test.ts` — 16/16 pass (tests mock `VERCEL_ENV: "development"`, so they exercise the dev price and are unaffected)
- `biome check packages/utils/src/constants/plans.ts` — clean
- Live price re-read with `expand[]=currency_options` to confirm all three currencies landed at 9900

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the Signed BAA production placeholder with the configured live Stripe price so production checkout can proceed.
- Sets the production Signed BAA price to `price_1U6C99FJxA1XpeSsUg1rXHo2`.
- Leaves development pricing and the advertised monthly amount unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no repository-visible blocking or non-blocking issues.

The production Signed BAA checkout now receives a concrete price identifier instead of the placeholder that caused the configuration guard to reject every request.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/utils/src/constants/plans.ts | Replaces the guarded production placeholder with a concrete Stripe price identifier; no actionable defect was found in the repository-visible change. |

<sub>Reviews (1): Last reviewed commit: ["fix(billing): use live Stripe price for ..."](https://github.com/capsoftware/cap/commit/ef3f8ad2067f571fcce07902036dbe77fa16d2b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54823387)</sub>

<!-- /greptile_comment -->