### PR TITLE
fix: use BufferSize::Default for PipeWire ALSA devices on Linux

### DIFF
--- a/crates/recording/src/feeds/microphone.rs
+++ b/crates/recording/src/feeds/microphone.rs
@@ -987,10 +987,29 @@ fn stream_config_with_latency(
     let buffer_size_frames = desired_buffer_size_frames(config, device_name);
 
     if let Some(frames) = buffer_size_frames {
-        stream_config.buffer_size = BufferSize::Fixed(frames);
+        if uses_pulse_backend(device_name) {
+            stream_config.buffer_size = BufferSize::Default;
+        } else {
+            stream_config.buffer_size = BufferSize::Fixed(frames);
+        }
     }
 
     (stream_config, buffer_size_frames)
+}
+
+#[cfg(target_os = "linux")]
+fn uses_pulse_backend(device_name: Option<&str>) -> bool {
+    device_name
+        .map(|n| {
+            let lower = n.to_ascii_lowercase();
+            lower == "default" || lower == "pulse" || lower == "pipewire"
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn uses_pulse_backend(_device_name: Option<&str>) -> bool {
+    false
 }
 
 fn desired_buffer_size_frames(

--- a/crates/recording/src/sources/screen_capture/linux.rs
+++ b/crates/recording/src/sources/screen_capture/linux.rs
@@ -941,6 +941,14 @@ fn select_system_audio_monitor() -> anyhow::Result<SelectedSystemAudioInput> {
         return Ok(selected);
     }
 
+    if !pactl_available() {
+        return Err(anyhow!(
+            "Linux system audio capture needs `pactl` to discover monitor sources, but it was not found on PATH. \
+            Install it (e.g. `apt install pulseaudio-utils`, `dnf install pulseaudio-utils`, `pacman -S libpulse`) and try again. \
+            Available cpal input devices: {available:?}."
+        ));
+    }
+
     Err(anyhow!(
         "No PulseAudio/PipeWire monitor input was found for Linux system audio. \
         Available input devices: {available:?}. Select a monitor source with --mic, or enable a monitor source in your audio server."
@@ -1027,6 +1035,14 @@ fn pactl_monitor_rank(name: &str) -> Option<u8> {
     } else {
         None
     }
+}
+
+fn pactl_available() -> bool {
+    Command::new("pactl")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
 }
 
 fn pactl_default_source() -> Option<String> {


### PR DESCRIPTION
cpal's BufferSize::Fixed calls snd_pcm_hw_params_set_buffer_size (exact),
  which pipewire-alsa rejects unless the frame count matches its current
  quantum. Fall back to BufferSize::Default (uses _near) for default/pulse/
  pipewire device names on Linux.

  Also emit a targeted error when pactl is not installed instead of the
  generic 'no monitor input found' message — the previous message sent
  users chasing ALSA config when the real fix is installing pulseaudio-utils.

  Fixes #2131.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves Linux audio capture compatibility and diagnostics.
- Uses CPAL’s default buffer-size negotiation for Linux devices named `default`, `pulse`, or `pipewire`.
- Reports targeted installation guidance when system-audio discovery cannot find `pactl` on `PATH`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The buffer-selection change is Linux-scoped and narrowly targets the device aliases described by the fix, while the new diagnostic preserves successful monitor selection and only changes the terminal error path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/recording/src/feeds/microphone.rs | Selects `BufferSize::Default` for recognized Linux PulseAudio/PipeWire ALSA device names while preserving fixed latency buffers elsewhere. |
| crates/recording/src/sources/screen_capture/linux.rs | Adds a dedicated missing-`pactl` diagnostic after existing CPAL and pactl monitor-source discovery attempts fail. |

<sub>Reviews (1): Last reviewed commit: ["fix: use BufferSize::Default for PipeWir..."](https://github.com/capsoftware/cap/commit/1ce924af709ad3fe0f5cfc0d8f0d1ffc7be968ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55341758)</sub>

<!-- /greptile_comment -->