### PR TITLE
fix(windows): stop camera enumeration leaking device resources and pause idle polling in the tray

### DIFF
--- a/apps/desktop/src-tauri/src/general_settings.rs
+++ b/apps/desktop/src-tauri/src/general_settings.rs
@@ -92,7 +92,10 @@ impl MainWindowRecordingStartBehaviour {
                 #[cfg(windows)]
                 return window.minimize();
                 #[cfg(not(windows))]
-                window.hide()
+                {
+                    crate::hide_main_window(window.app_handle());
+                    Ok(())
+                }
             }
             Self::Minimise => window.minimize(),
         }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -6812,10 +6812,12 @@ fn show_import_error_dialog(app: &AppHandle, message: String) {
 
 // Hidden webviews on Windows never see document.visibilityState change
 // (tauri-apps/tauri#9524), so the frontend cannot detect hide-to-tray on its
-// own; this event lets it pause polling (#2132).
-fn hide_main_window(app: &AppHandle) {
-    if let Some(main_window) = CapWindowId::Main.get(app) {
-        let _ = main_window.hide();
+// own; this event lets it pause polling, and only fires when the hide
+// actually happened so a failed hide never pauses a visible window (#2132).
+pub(crate) fn hide_main_window(app: &AppHandle) {
+    if let Some(main_window) = CapWindowId::Main.get(app)
+        && main_window.hide().is_ok()
+    {
         let _ = main_window.emit_to(CapWindowId::Main.label(), "main-window-hidden", ());
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1772,10 +1772,9 @@ fn spawn_devices_snapshot_emitter(app_handle: AppHandle) {
                 continue;
             }
 
-            // Device snapshots only feed UI pickers via DevicesUpdated, and on
-            // Windows every enumeration instantiates each capture device, so
-            // polling while all windows sit hidden in the tray burns CPU for
-            // nobody (#2132).
+            // Device snapshots only feed UI pickers via DevicesUpdated, so
+            // polling while every window sits hidden in the tray probes the
+            // OS device stack and burns CPU for nobody (#2132).
             if !any_webview_window_visible(&app_handle) {
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 continue;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1750,6 +1750,12 @@ async fn get_devices_snapshot() -> DevicesUpdated {
     }
 }
 
+fn any_webview_window_visible(app: &AppHandle) -> bool {
+    app.webview_windows()
+        .values()
+        .any(|window| window.is_visible().unwrap_or(false))
+}
+
 fn spawn_devices_snapshot_emitter(app_handle: AppHandle) {
     tokio::spawn(async move {
         let mut last_perm_tuple: (u8, u8, u8, u8) = (255, 255, 255, 255);
@@ -1763,6 +1769,15 @@ fn spawn_devices_snapshot_emitter(app_handle: AppHandle) {
 
             if power_observer::is_system_asleep() {
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                continue;
+            }
+
+            // Device snapshots only feed UI pickers via DevicesUpdated, and on
+            // Windows every enumeration instantiates each capture device, so
+            // polling while all windows sit hidden in the tray burns CPU for
+            // nobody (#2132).
+            if !any_webview_window_visible(&app_handle) {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 continue;
             }
 
@@ -4739,9 +4754,7 @@ pub async fn open_target_picker(
 ) {
     use tauri::Manager;
 
-    if let Some(window) = CapWindowId::Main.get(app) {
-        window.hide().ok();
-    }
+    hide_main_window(app);
 
     let state = app.state::<target_select_overlay::WindowFocusManager>();
     let display_id = None;
@@ -5644,7 +5657,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
                                 }
                                 CapWindowId::Main => {
                                 api.prevent_close();
-                                let _ = window.hide();
+                                hide_main_window(app);
 
                                 #[cfg(target_os = "macos")]
                                 crate::permissions::schedule_macos_dock_visibility_sync(app);
@@ -6798,9 +6811,13 @@ fn show_import_error_dialog(app: &AppHandle, message: String) {
         .show(|_| {});
 }
 
+// Hidden webviews on Windows never see document.visibilityState change
+// (tauri-apps/tauri#9524), so the frontend cannot detect hide-to-tray on its
+// own; this event lets it pause polling (#2132).
 fn hide_main_window(app: &AppHandle) {
     if let Some(main_window) = CapWindowId::Main.get(app) {
         let _ = main_window.hide();
+        let _ = main_window.emit_to(CapWindowId::Main.label(), "main-window-hidden", ());
     }
 }
 
@@ -6880,9 +6897,7 @@ fn open_project_from_path(path: &Path, app: AppHandle) -> Result<(), String> {
                 let _ = app
                     .opener()
                     .open_path(mp4_path.to_str().unwrap_or_default(), None::<String>);
-                if let Some(main_window) = CapWindowId::Main.get(&app) {
-                    main_window.hide().ok();
-                }
+                hide_main_window(&app);
             }
         }
     }

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -163,6 +163,8 @@ fn hide_recording_windows(app: &AppHandle, restore_target_select_overlays: bool)
                     focus_manager.remember_overlay_for_restore(label);
                 }
                 hide_overlay(&window);
+            } else if matches!(id, CapWindowId::Main) {
+                crate::hide_main_window(app);
             } else {
                 let _ = window.hide();
             }

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -1515,7 +1515,7 @@ impl ShowCapWindow {
                 init_target_mode: Some(target_mode),
             } = self
             {
-                window.hide().ok();
+                crate::hide_main_window(app);
                 emit_app_event(
                     app,
                     RequestSetTargetMode {
@@ -2044,9 +2044,7 @@ impl ShowCapWindow {
                 window
             }
             Self::Upgrade => {
-                if let Some(main) = CapWindowId::Main.get(app) {
-                    let _ = main.hide();
-                }
+                crate::hide_main_window(app);
 
                 let window = self
                     .window_builder(app, "/upgrade")
@@ -2080,9 +2078,7 @@ impl ShowCapWindow {
                 window
             }
             Self::ModeSelect => {
-                if let Some(main) = CapWindowId::Main.get(app) {
-                    let _ = main.hide();
-                }
+                crate::hide_main_window(app);
 
                 let window = self
                     .window_builder(app, "/mode-select")
@@ -2116,9 +2112,7 @@ impl ShowCapWindow {
                 window
             }
             Self::Onboarding => {
-                if let Some(main) = CapWindowId::Main.get(app) {
-                    let _ = main.hide();
-                }
+                crate::hide_main_window(app);
 
                 let width = (cursor_monitor.width * 0.58).clamp(860.0, 1080.0);
                 let height = (width * 0.72).clamp(690.0, 780.0);

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -1,5 +1,9 @@
 import { Route, Router, useCurrentMatches } from "@solidjs/router";
-import { QueryClient, QueryClientProvider } from "@tanstack/solid-query";
+import {
+	focusManager,
+	QueryClient,
+	QueryClientProvider,
+} from "@tanstack/solid-query";
 import {
 	getCurrentWebviewWindow,
 	type WebviewWindow,
@@ -124,6 +128,7 @@ export default function App() {
 function Inner() {
 	const currentWindow = getCurrentWebviewWindow();
 	createThemeListener(currentWindow);
+	createHiddenWindowQueryPause(currentWindow);
 
 	onMount(() => {
 		initAnonymousUser();
@@ -286,6 +291,27 @@ function prewarmFontCaches() {
 
 	if ("requestIdleCallback" in window) requestIdleCallback(warm);
 	else setTimeout(warm, 250);
+}
+
+// Hidden Tauri windows never flip document.visibilityState on Windows
+// (tauri-apps/tauri#9524), so TanStack keeps every refetchInterval firing
+// while the app idles in the tray (#2132). Pause queries from the window's
+// real hide/focus signals instead.
+function createHiddenWindowQueryPause(currentWindow: WebviewWindow) {
+	if (currentWindow.label !== "main") return;
+
+	const unlisteners = [
+		currentWindow.listen("main-window-hidden", () => {
+			focusManager.setFocused(false);
+		}),
+		currentWindow.onFocusChanged((event) => {
+			if (event.payload) focusManager.setFocused(true);
+		}),
+	];
+
+	onCleanup(() => {
+		for (const unlisten of unlisteners) void unlisten.then((fn) => fn());
+	});
 }
 
 function createThemeListener(currentWindow: WebviewWindow) {

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -311,9 +311,10 @@ function createHiddenWindowQueryPause(currentWindow: WebviewWindow) {
 				focusManager.setFocused(undefined);
 				return;
 			}
-			// Frontend-initiated hides don't go through the Rust helper, but a
-			// window that hides itself always loses focus first, so a blur with
-			// the window no longer visible means hidden, not just unfocused.
+			// Safety net for hide paths that bypass hide_main_window and
+			// hideCurrentWindow: a blur with the window no longer visible
+			// means hidden, not just unfocused. Not sufficient alone — an
+			// earlier benign blur (e.g. shell.open) masks a later hide.
 			void currentWindow.isVisible().then((visible) => {
 				if (!visible) focusManager.setFocused(false);
 			});

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -295,8 +295,10 @@ function prewarmFontCaches() {
 
 // Hidden Tauri windows never flip document.visibilityState on Windows
 // (tauri-apps/tauri#9524), so TanStack keeps every refetchInterval firing
-// while the app idles in the tray (#2132). Pause queries from the window's
-// real hide/focus signals instead.
+// while the app idles in the tray (#2132). Pause queries when the backend
+// hides the window; on focus, hand control back to TanStack's own
+// visibilitychange detection (setFocused(undefined)) so platforms where it
+// works, like macOS minimize, keep pausing natively.
 function createHiddenWindowQueryPause(currentWindow: WebviewWindow) {
 	if (currentWindow.label !== "main") return;
 
@@ -305,7 +307,7 @@ function createHiddenWindowQueryPause(currentWindow: WebviewWindow) {
 			focusManager.setFocused(false);
 		}),
 		currentWindow.onFocusChanged((event) => {
-			if (event.payload) focusManager.setFocused(true);
+			if (event.payload) focusManager.setFocused(undefined);
 		}),
 	];
 

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -302,11 +302,14 @@ function prewarmFontCaches() {
 function createHiddenWindowQueryPause(currentWindow: WebviewWindow) {
 	if (currentWindow.label !== "main") return;
 
+	let focusGeneration = 0;
+
 	const unlisteners = [
 		currentWindow.listen("main-window-hidden", () => {
 			focusManager.setFocused(false);
 		}),
 		currentWindow.onFocusChanged((event) => {
+			focusGeneration += 1;
 			if (event.payload) {
 				focusManager.setFocused(undefined);
 				return;
@@ -314,9 +317,13 @@ function createHiddenWindowQueryPause(currentWindow: WebviewWindow) {
 			// Safety net for hide paths that bypass hide_main_window and
 			// hideCurrentWindow: a blur with the window no longer visible
 			// means hidden, not just unfocused. Not sufficient alone — an
-			// earlier benign blur (e.g. shell.open) masks a later hide.
+			// earlier benign blur (e.g. shell.open) masks a later hide. The
+			// generation guard stops a stale visibility result from pausing a
+			// window that regained focus while the check was in flight.
+			const generation = focusGeneration;
 			void currentWindow.isVisible().then((visible) => {
-				if (!visible) focusManager.setFocused(false);
+				if (visible || generation !== focusGeneration) return;
+				focusManager.setFocused(false);
 			});
 		}),
 	];

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -307,7 +307,16 @@ function createHiddenWindowQueryPause(currentWindow: WebviewWindow) {
 			focusManager.setFocused(false);
 		}),
 		currentWindow.onFocusChanged((event) => {
-			if (event.payload) focusManager.setFocused(undefined);
+			if (event.payload) {
+				focusManager.setFocused(undefined);
+				return;
+			}
+			// Frontend-initiated hides don't go through the Rust helper, but a
+			// window that hides itself always loses focus first, so a blur with
+			// the window no longer visible means hidden, not just unfocused.
+			void currentWindow.isVisible().then((visible) => {
+				if (!visible) focusManager.setFocused(false);
+			});
 		}),
 	];
 

--- a/apps/desktop/src/routes/(window-chrome)/new-main/ChangeLogButton.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/ChangeLogButton.tsx
@@ -1,9 +1,9 @@
 import { makePersisted } from "@solid-primitives/storage";
 import { getVersion } from "@tauri-apps/api/app";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { createEffect, createResource } from "solid-js";
 import { createStore } from "solid-js/store";
 import Tooltip from "~/components/Tooltip";
+import { hideCurrentWindow } from "~/utils/hide-window";
 import { commands } from "~/utils/tauri";
 import { apiClient } from "~/utils/web-api";
 import IconLucideBell from "~icons/lucide/bell";
@@ -36,7 +36,7 @@ const ChangelogButton = () => {
 
 	const handleChangelogClick = () => {
 		commands.showWindow({ Settings: { page: "changelog" } });
-		getCurrentWindow().hide();
+		hideCurrentWindow();
 		const version = currentVersion();
 		if (version) {
 			setChangelogState({

--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -55,6 +55,7 @@ import {
 	type MicrophoneWithDetails,
 } from "~/utils/devices";
 import { clientEnv } from "~/utils/env";
+import { hideCurrentWindow } from "~/utils/hide-window";
 import {
 	importImageFromPicker,
 	importVideoFromPicker,
@@ -2024,7 +2025,7 @@ function Page() {
 		if (pickerActive && !hasHidden && !recording) {
 			setHasHiddenMainWindowForPicker(true);
 			setShouldRevealMainWindowAfterPicker(!editorPicker);
-			void getCurrentWindow().hide();
+			void hideCurrentWindow();
 		} else if (pickerActive && hasHidden) {
 			setShouldRevealMainWindowAfterPicker(!editorPicker);
 		} else if (recording) {
@@ -2922,7 +2923,7 @@ function Page() {
 			await shell.open(link);
 		}
 
-		await getCurrentWindow().hide();
+		await hideCurrentWindow();
 	};
 
 	const openScreenshot = async (screenshot: ScreenshotWithPath) => {
@@ -3224,7 +3225,7 @@ function Page() {
 								type="button"
 								onClick={async () => {
 									await commands.showWindow({ Settings: { page: "general" } });
-									getCurrentWindow().hide();
+									hideCurrentWindow();
 								}}
 								class="flex items-center justify-center size-5 focus:outline-hidden"
 							>
@@ -3412,7 +3413,7 @@ function Page() {
 										await commands.showWindow({
 											Settings: { page: "recordings" },
 										});
-										getCurrentWindow().hide();
+										hideCurrentWindow();
 									}}
 									uploadProgress={uploadProgress}
 									reuploadingPaths={reuploadingPaths()}
@@ -3436,7 +3437,7 @@ function Page() {
 										await commands.showWindow({
 											Settings: { page: "screenshots" },
 										});
-										getCurrentWindow().hide();
+										hideCurrentWindow();
 									}}
 								/>
 							) : variant === "camera" ? (

--- a/apps/desktop/src/utils/hide-window.ts
+++ b/apps/desktop/src/utils/hide-window.ts
@@ -5,9 +5,10 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 // window's own frontend. An earlier blur (e.g. shell.open stealing focus)
 // leaves a later hide invisible to the focus bridge, and
 // document.visibilityState never flips on Windows (tauri-apps/tauri#9524),
-// so the polling pause must be explicit.
-export function hideCurrentWindow() {
+// so the polling pause must be explicit — after the hide succeeds, so a
+// failed hide never pauses a still-visible window.
+export async function hideCurrentWindow() {
 	const currentWindow = getCurrentWindow();
+	await currentWindow.hide();
 	if (currentWindow.label === "main") focusManager.setFocused(false);
-	return currentWindow.hide();
 }

--- a/apps/desktop/src/utils/hide-window.ts
+++ b/apps/desktop/src/utils/hide-window.ts
@@ -1,0 +1,13 @@
+import { focusManager } from "@tanstack/solid-query";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+// Counterpart of the Rust-side hide_main_window for hides initiated by the
+// window's own frontend. An earlier blur (e.g. shell.open stealing focus)
+// leaves a later hide invisible to the focus bridge, and
+// document.visibilityState never flips on Windows (tauri-apps/tauri#9524),
+// so the polling pause must be explicit.
+export function hideCurrentWindow() {
+	const currentWindow = getCurrentWindow();
+	if (currentWindow.label === "main") focusManager.setFocused(false);
+	return currentWindow.hide();
+}

--- a/apps/desktop/src/utils/importMedia.ts
+++ b/apps/desktop/src/utils/importMedia.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import * as dialog from "@tauri-apps/plugin-dialog";
+import { hideCurrentWindow } from "~/utils/hide-window";
 import { commands } from "~/utils/tauri";
 
 const videoExtensions = [
@@ -32,7 +32,7 @@ const selectedPath = (result: string | string[] | null) =>
 	typeof result === "string" ? result : null;
 
 const maybeHideCurrentWindow = async (options?: ImportOptions) => {
-	if (options?.hideCurrentWindow) await getCurrentWindow().hide();
+	if (options?.hideCurrentWindow) await hideCurrentWindow();
 };
 
 export const importVideoPath = async (

--- a/crates/camera-directshow/examples/cli.rs
+++ b/crates/camera-directshow/examples/cli.rs
@@ -42,7 +42,12 @@ mod windows {
 
             let device = selected.0;
 
-            let video_control = device.output_pin().cast::<IAMVideoControl>().ok();
+            let output_pin = device
+                .output_pin()
+                .expect("failed to bind capture filter for selected device")
+                .clone();
+
+            let video_control = output_pin.cast::<IAMVideoControl>().ok();
 
             let formats = device
                 .media_types()
@@ -65,7 +70,7 @@ mod windows {
 
                     if let Some(video_control) = &video_control {
                         let time_per_frame_list = video_control.time_per_frame_list(
-                            device.output_pin(),
+                            &output_pin,
                             i as i32,
                             SIZE {
                                 cx: width,

--- a/crates/camera-directshow/src/lib.rs
+++ b/crates/camera-directshow/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
     ops::Deref,
     os::windows::ffi::OsStringExt,
     ptr::{self, null, null_mut},
+    sync::OnceLock,
     time::Duration,
 };
 use tracing::*;
@@ -359,10 +360,20 @@ impl Iterator for VideoInputDeviceIterator {
     }
 }
 
+/// Binding the capture filter opens the device through its KS driver, which
+/// costs a thread and dozens of kernel handles that are not reclaimed on
+/// release. Plain enumeration (name/id/model) must never pay that price, so
+/// binding is deferred until formats or capture genuinely need it
+/// (CapSoftware/Cap#2132).
 #[derive(Clone)]
 pub struct VideoInputDevice {
     moniker: IMoniker,
     prop_bag: IPropertyBag,
+    bound: OnceLock<BoundFilter>,
+}
+
+#[derive(Clone)]
+struct BoundFilter {
     filter: IBaseFilter,
     output_pin: IPin,
     stream_config: IAMStreamConfig,
@@ -371,20 +382,31 @@ pub struct VideoInputDevice {
 impl VideoInputDevice {
     fn new(moniker: IMoniker) -> windows_core::Result<Self> {
         let prop_bag: IPropertyBag = unsafe { moniker.BindToStorage(None, None) }?;
-        let filter: IBaseFilter = unsafe { moniker.BindToObject(None, None) }?;
-
-        let output_pin = filter
-            .get_pin(PINDIR_OUTPUT, PIN_CATEGORY_CAPTURE, GUID::zeroed())
-            .ok_or(E_FAIL)?;
-        let stream_config = output_pin.cast::<IAMStreamConfig>().ok().ok_or(E_FAIL)?;
 
         Ok(Self {
             moniker,
             prop_bag,
+            bound: OnceLock::new(),
+        })
+    }
+
+    fn bound(&self) -> windows_core::Result<&BoundFilter> {
+        if let Some(bound) = self.bound.get() {
+            return Ok(bound);
+        }
+
+        let filter: IBaseFilter = unsafe { self.moniker.BindToObject(None, None) }?;
+        let output_pin = filter
+            .get_pin(PINDIR_OUTPUT, PIN_CATEGORY_CAPTURE, GUID::zeroed())
+            .ok_or(E_FAIL)?;
+        let stream_config = output_pin.cast::<IAMStreamConfig>()?;
+
+        let _ = self.bound.set(BoundFilter {
             filter,
             output_pin,
             stream_config,
-        })
+        });
+        self.bound.get().ok_or_else(|| E_FAIL.into())
     }
 
     pub fn name(&self) -> Option<OsString> {
@@ -410,22 +432,16 @@ impl VideoInputDevice {
     }
 
     pub fn media_types(&self) -> Option<VideoMediaTypesIterator<'_>> {
-        self.stream_config
+        self.bound()
+            .ok()?
+            .stream_config
             .media_types()
             .map(|inner| VideoMediaTypesIterator { inner })
             .ok()
     }
 
-    pub fn filter(&self) -> &IBaseFilter {
-        &self.filter
-    }
-
-    pub fn stream_config(&self) -> &IAMStreamConfig {
-        &self.stream_config
-    }
-
-    pub fn output_pin(&self) -> &IPin {
-        &self.output_pin
+    pub fn output_pin(&self) -> windows_core::Result<&IPin> {
+        Ok(&self.bound()?.output_pin)
     }
 
     pub fn start_capturing(
@@ -433,8 +449,14 @@ impl VideoInputDevice {
         format: &AMMediaType,
         callback: SinkCallback,
     ) -> Result<CaptureHandle, StartCapturingError> {
+        let bound = self
+            .bound()
+            .map_err(StartCapturingError::BindDevice)?
+            .clone();
+
         unsafe {
-            self.stream_config
+            bound
+                .stream_config
                 .SetFormat(&**format)
                 .map_err(StartCapturingError::Other)?;
 
@@ -460,7 +482,7 @@ impl VideoInputDevice {
                 .SetFiltergraph(&graph_builder)
                 .map_err(StartCapturingError::ConfigureGraph)?;
             graph_builder
-                .AddFilter(&self.filter, None)
+                .AddFilter(&bound.filter, None)
                 .map_err(StartCapturingError::ConfigureGraph)?;
 
             let sink_filter: IBaseFilter = sink_filter
@@ -476,14 +498,14 @@ impl VideoInputDevice {
                 .FindInterface(
                     Some(&PIN_CATEGORY_CAPTURE),
                     Some(&MEDIATYPE_Video),
-                    &self.filter,
+                    &bound.filter,
                     &IAMStreamConfig::IID,
                     &mut stream_config,
                 )
                 .map_err(StartCapturingError::ConfigureGraph)?;
 
             graph_builder
-                .Connect(&self.output_pin, &input_sink_pin)
+                .Connect(&bound.output_pin, &input_sink_pin)
                 .map_err(StartCapturingError::ConfigureGraph)?;
 
             media_control.Run().map_err(StartCapturingError::Run)?;
@@ -491,7 +513,7 @@ impl VideoInputDevice {
             Ok(CaptureHandle {
                 media_control,
                 graph_builder,
-                output_capture_pin: self.output_pin,
+                output_capture_pin: bound.output_pin,
                 input_sink_pin,
             })
         }
@@ -521,6 +543,8 @@ impl CaptureHandle {
 
 #[derive(thiserror::Error, Debug)]
 pub enum StartCapturingError {
+    #[error("BindDevice: {0}")]
+    BindDevice(windows_core::Error),
     #[error("No input pin")]
     NoInputPin,
     #[error("CreateGraph: {0}")]

--- a/crates/camera-mediafoundation/src/lib.rs
+++ b/crates/camera-mediafoundation/src/lib.rs
@@ -157,6 +157,17 @@ impl Device {
         self.media_source.get().ok_or_else(|| E_FAIL.into())
     }
 
+    /// Retires this instance's Media Foundation path for good, releasing the
+    /// device at the driver so another backend can open it. Any cached source
+    /// stays shut down afterwards; only call this when abandoning MF for this
+    /// device.
+    pub fn shutdown(&self) {
+        if let Some(media_source) = self.media_source.get() {
+            let _ = unsafe { media_source.Shutdown() };
+        }
+        let _ = unsafe { self.activate.ShutdownObject() };
+    }
+
     pub fn name(&self) -> windows_core::Result<OsString> {
         unsafe { self.read_allocated_string(&MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME) }
     }

--- a/crates/camera-mediafoundation/src/lib.rs
+++ b/crates/camera-mediafoundation/src/lib.rs
@@ -10,15 +10,17 @@ use std::{
     ops::{Deref, DerefMut},
     os::windows::ffi::OsStringExt,
     slice::from_raw_parts,
-    sync::mpsc::{Receiver, Sender, channel},
+    sync::{
+        OnceLock,
+        mpsc::{Receiver, Sender, channel},
+    },
     time::Duration,
 };
-use tracing::error;
 use windows::Win32::{
     Foundation::{S_FALSE, *},
     Media::MediaFoundation::*,
     System::{
-        Com::{CLSCTX_INPROC_SERVER, CoCreateInstance, CoInitialize},
+        Com::{CLSCTX_INPROC_SERVER, CoCreateInstance, CoInitialize, CoTaskMemFree},
         Performance::QueryPerformanceCounter,
     },
 };
@@ -73,6 +75,20 @@ impl DeviceSourcesIterator {
     }
 }
 
+// MFEnumDeviceSources hands over one IMFActivate reference per device plus the
+// CoTaskMemAlloc'd array itself; without this Drop every enumeration leaked
+// both for the life of the process (CapSoftware/Cap#2132).
+impl Drop for DeviceSourcesIterator {
+    fn drop(&mut self) {
+        unsafe {
+            for index in 0..self.count {
+                (*self.devices.add(index as usize)).take();
+            }
+            CoTaskMemFree(Some(self.devices as *const _));
+        }
+    }
+}
+
 impl Iterator for DeviceSourcesIterator {
     type Item = Device;
 
@@ -93,30 +109,29 @@ impl Iterator for DeviceSourcesIterator {
                 continue;
             };
 
-            let media_source = match unsafe { device.ActivateObject::<IMFMediaSource>() } {
-                Ok(v) => v,
-                Err(e) => {
-                    error!("Failed to activate IMFMediaSource: {}", e);
-                    return None;
-                }
-            };
-
             return Some(Device {
-                media_source,
                 activate: device.clone(),
+                media_source: OnceLock::new(),
             });
         }
     }
 }
 
+/// Activating the media source opens the physical device through its driver,
+/// which costs real OS resources that are only reclaimed by `Shutdown`. Plain
+/// enumeration (name/id/model) must never pay that price, so activation is
+/// deferred until formats or capture genuinely need it
+/// (CapSoftware/Cap#2132).
 #[derive(Clone)]
 pub struct Device {
     activate: IMFActivate,
-    pub media_source: IMFMediaSource,
+    media_source: OnceLock<IMFMediaSource>,
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum StartCapturingError {
+    #[error("ActivateDevice: {0}")]
+    ActivateDevice(windows_core::Error),
     #[error("CreateEngine: {0}")]
     CreateEngine(windows_core::Error),
     #[error("ConfigureEngine: {0}")]
@@ -132,27 +147,38 @@ pub enum StartCapturingError {
 }
 
 impl Device {
-    pub fn name(&self) -> windows_core::Result<OsString> {
-        let mut raw = PWSTR(&mut 0);
-        let mut length = 0;
-        unsafe {
-            self.activate
-                .GetAllocatedString(&MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME, &mut raw, &mut length)
-                .map(|_| OsString::from_wide(from_raw_parts(raw.0, length as usize)))
+    fn media_source(&self) -> windows_core::Result<&IMFMediaSource> {
+        if let Some(media_source) = self.media_source.get() {
+            return Ok(media_source);
         }
+
+        let media_source = unsafe { self.activate.ActivateObject::<IMFMediaSource>() }?;
+        let _ = self.media_source.set(media_source);
+        self.media_source.get().ok_or_else(|| E_FAIL.into())
+    }
+
+    pub fn name(&self) -> windows_core::Result<OsString> {
+        unsafe { self.read_allocated_string(&MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME) }
     }
 
     pub fn id(&self) -> windows_core::Result<OsString> {
-        let mut raw = PWSTR(&mut 0);
+        unsafe {
+            self.read_allocated_string(&MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK)
+        }
+    }
+
+    unsafe fn read_allocated_string(
+        &self,
+        key: &windows_core::GUID,
+    ) -> windows_core::Result<OsString> {
+        let mut raw = PWSTR::null();
         let mut length = 0;
         unsafe {
             self.activate
-                .GetAllocatedString(
-                    &MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK,
-                    &mut raw,
-                    &mut length,
-                )
-                .map(|_| OsString::from_wide(from_raw_parts(raw.0, length as usize)))
+                .GetAllocatedString(key, &mut raw, &mut length)?;
+            let value = OsString::from_wide(from_raw_parts(raw.0, length as usize));
+            CoTaskMemFree(Some(raw.0 as *const _));
+            Ok(value)
         }
     }
 
@@ -166,6 +192,7 @@ impl Device {
     // Creates and disposes an IMFSourceReader internally,
     // so this device must be shut down manually after calling this function.
     pub fn formats(&self) -> windows_core::Result<impl Iterator<Item = IMFMediaType>> {
+        let media_source = self.media_source()?;
         let mut stream_index = 0;
 
         let reader = unsafe {
@@ -175,7 +202,7 @@ impl Device {
                 attributes.ok_or_else(|| windows_core::Error::from_hresult(S_FALSE))?;
             // Media source shuts down on drop if this isn't specified
             attributes.SetUINT32(&MF_SOURCE_READER_DISCONNECT_MEDIASOURCE_ON_SHUTDOWN, 1)?;
-            MFCreateSourceReaderFromMediaSource(&self.media_source, &attributes)
+            MFCreateSourceReaderFromMediaSource(media_source, &attributes)
                 .map(|inner| SourceReader { inner })
         }?;
 
@@ -197,6 +224,10 @@ impl Device {
         requested_format: &IMFMediaType,
         callback: Box<dyn FnMut(CallbackData) + 'static>,
     ) -> Result<CaptureHandle, StartCapturingError> {
+        let media_source = self
+            .media_source()
+            .map_err(StartCapturingError::ActivateDevice)?;
+
         unsafe {
             let capture_engine_factory: IMFCaptureEngineClassFactory = CoCreateInstance(
                 &CLSID_MFCaptureEngineClassFactory,
@@ -232,7 +263,7 @@ impl Device {
                     &video_callback.to_interface::<IMFCaptureEngineOnEventCallback>(),
                     &attributes,
                     None,
-                    &self.media_source,
+                    media_source,
                 )
                 .map_err(StartCapturingError::InitializeEngine)?;
 
@@ -377,20 +408,6 @@ impl CaptureHandle {
 
     pub fn stop_capturing(self) -> windows_core::Result<()> {
         unsafe { self.engine.StopPreview() }
-    }
-}
-
-impl Deref for Device {
-    type Target = IMFMediaSource;
-
-    fn deref(&self) -> &Self::Target {
-        &self.media_source
-    }
-}
-
-impl DerefMut for Device {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.media_source
     }
 }
 

--- a/crates/camera-windows/examples/enumeration_leak.rs
+++ b/crates/camera-windows/examples/enumeration_leak.rs
@@ -1,0 +1,54 @@
+//! Repro for CapSoftware/Cap#2132: repeatedly enumerate cameras while
+//! watching threads, handles and private bytes of this process from outside
+//! (Process Explorer, or `Get-Process -Id <pid>` in a loop).
+//!
+//! Usage: enumeration_leak.exe [mf|ds|both] [iterations] [sleep_ms]
+//!
+//! `mf` and `ds` isolate the Media Foundation and DirectShow halves of
+//! `get_devices()`; whichever mode grows is the leaking half. The printed
+//! per-enumeration wall time also rises as leaked threads and handles
+//! accumulate.
+
+fn main() {
+    let mode = std::env::args().nth(1).unwrap_or_else(|| "both".into());
+    let iterations: usize = std::env::args()
+        .nth(2)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(60);
+    let sleep_ms: u64 = std::env::args()
+        .nth(3)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1000);
+
+    println!(
+        "pid {} mode={mode} iterations={iterations} sleep_ms={sleep_ms}",
+        std::process::id()
+    );
+
+    let _ = cap_camera_directshow::initialize_directshow();
+    let _ = cap_camera_mediafoundation::initialize_mediafoundation();
+
+    for i in 1..=iterations {
+        let start = std::time::Instant::now();
+
+        let devices = match mode.as_str() {
+            "mf" => cap_camera_mediafoundation::DeviceSourcesIterator::new()
+                .map(|devices| devices.count())
+                .unwrap_or(0),
+            "ds" => cap_camera_directshow::VideoInputDeviceIterator::new()
+                .map(|devices| devices.count())
+                .unwrap_or(0),
+            _ => cap_camera_windows::get_devices()
+                .map(|devices| devices.len())
+                .unwrap_or(0),
+        };
+
+        println!(
+            "{i}: {devices} device(s) in {}ms",
+            start.elapsed().as_millis()
+        );
+        std::thread::sleep(std::time::Duration::from_millis(sleep_ms));
+    }
+
+    println!("done");
+}

--- a/crates/camera-windows/src/lib.rs
+++ b/crates/camera-windows/src/lib.rs
@@ -189,6 +189,8 @@ pub enum StartCapturingError {
     DirectShow(#[from] cap_camera_directshow::StartCapturingError),
     #[error("Format/{0}")]
     Format(#[from] VideoFormatError),
+    #[error("format doesn't match any backend available for this device")]
+    FormatMismatch,
 }
 
 impl VideoDeviceInfo {
@@ -391,7 +393,7 @@ impl VideoDeviceInfo {
 
                 CaptureHandle::DirectShow(handle)
             }
-            _ => todo!(),
+            _ => return Err(StartCapturingError::FormatMismatch),
         };
 
         Ok(res)
@@ -416,7 +418,14 @@ impl VideoDeviceInfo {
                     return formats;
                 }
 
-                dshow_fallback.as_ref().map(ds_formats).unwrap_or_default()
+                let Some(dshow) = dshow_fallback else {
+                    return Vec::new();
+                };
+
+                // Exclusive drivers reject DirectShow's bind while the failed
+                // MF source still holds the device open.
+                device.shutdown();
+                ds_formats(dshow)
             }
             VideoDeviceInfoInner::DirectShow(device) => ds_formats(device),
         }
@@ -622,9 +631,18 @@ pub fn get_devices() -> Result<Vec<VideoDeviceInfo>, GetDevicesError> {
     for dshow_device in dshow_devices {
         let name_and_model = dshow_device.name_and_model();
 
-        let mf_twin = devices
-            .iter()
-            .position(|device| device.is_mf() && device.name_and_model() == name_and_model);
+        // Identical devices produce identical names; pair each DS device with
+        // the first MF entry that doesn't have a fallback yet so twins map
+        // one-to-one instead of piling onto the first match.
+        let mf_twin = devices.iter().position(|device| {
+            matches!(
+                &device.inner,
+                VideoDeviceInfoInner::MediaFoundation {
+                    dshow_fallback: None,
+                    ..
+                }
+            ) && device.name_and_model() == name_and_model
+        });
 
         match mf_twin {
             Some(index) => {

--- a/crates/camera-windows/src/lib.rs
+++ b/crates/camera-windows/src/lib.rs
@@ -587,22 +587,18 @@ pub fn get_devices() -> Result<Vec<VideoDeviceInfo>, GetDevicesError> {
 
     let mut devices = mf_devices;
 
+    // The previous MF-formats probe here was a no-op (it re-inserted the same
+    // MF entry in both branches) that opened every paired device on every
+    // enumeration; deduplication only needs names (CapSoftware/Cap#2132).
     for dshow_device in dshow_devices {
         let name_and_model = dshow_device.name_and_model();
 
-        let mf_device = devices
+        let already_listed = devices
             .iter()
-            .enumerate()
-            .find(|(_, device)| device.is_mf() && device.name_and_model() == name_and_model);
+            .any(|device| device.is_mf() && device.name_and_model() == name_and_model);
 
-        match mf_device {
-            Some((i, mf_device)) => {
-                if mf_device.formats().is_empty() {
-                    devices.push(mf_device.clone());
-                    devices.swap_remove(i);
-                }
-            }
-            None => devices.push(dshow_device),
+        if !already_listed {
+            devices.push(dshow_device);
         }
     }
 

--- a/crates/camera-windows/src/lib.rs
+++ b/crates/camera-windows/src/lib.rs
@@ -418,14 +418,13 @@ impl VideoDeviceInfo {
                     return formats;
                 }
 
-                let Some(dshow) = dshow_fallback else {
-                    return Vec::new();
-                };
-
-                // Exclusive drivers reject DirectShow's bind while the failed
-                // MF source still holds the device open.
+                // MF yielded nothing for this device, so release it at the
+                // driver: repeated format requests must not accumulate
+                // half-open sources, and exclusive drivers reject
+                // DirectShow's bind while the failed source holds the device.
                 device.shutdown();
-                ds_formats(dshow)
+
+                dshow_fallback.as_ref().map(ds_formats).unwrap_or_default()
             }
             VideoDeviceInfoInner::DirectShow(device) => ds_formats(device),
         }

--- a/crates/camera-windows/src/lib.rs
+++ b/crates/camera-windows/src/lib.rs
@@ -321,7 +321,7 @@ impl VideoDeviceInfo {
     ) -> Result<CaptureHandle, StartCapturingError> {
         let res = match (self.inner, &format) {
             (
-                VideoDeviceInfoInner::MediaFoundation { device },
+                VideoDeviceInfoInner::MediaFoundation { device, .. },
                 VideoFormatInner::MediaFoundation(mf_format),
             ) => {
                 let format = VideoFormat::new_mf(mf_format.clone())?;
@@ -351,7 +351,14 @@ impl VideoDeviceInfo {
 
                 CaptureHandle::MediaFoundation(handle)
             }
-            (VideoDeviceInfoInner::DirectShow(device), VideoFormatInner::DirectShow(format)) => {
+            (
+                VideoDeviceInfoInner::DirectShow(device)
+                | VideoDeviceInfoInner::MediaFoundation {
+                    dshow_fallback: Some(device),
+                    ..
+                },
+                VideoFormatInner::DirectShow(format),
+            ) => {
                 let handle = device.start_capturing(
                     format,
                     Box::new(move |data| {
@@ -392,20 +399,26 @@ impl VideoDeviceInfo {
 
     pub fn formats(&self) -> Vec<VideoFormat> {
         match &self.inner {
-            VideoDeviceInfoInner::MediaFoundation { device } => device
-                .formats()
-                .map(|formats| {
-                    formats
-                        .filter_map(|t| VideoFormat::new_mf(t).ok())
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default(),
-            VideoDeviceInfoInner::DirectShow(device) => device
-                .media_types()
-                .into_iter()
-                .flatten()
-                .filter_map(|media_type| VideoFormat::new_ds(media_type).ok())
-                .collect::<Vec<_>>(),
+            VideoDeviceInfoInner::MediaFoundation {
+                device,
+                dshow_fallback,
+            } => {
+                let formats = device
+                    .formats()
+                    .map(|formats| {
+                        formats
+                            .filter_map(|t| VideoFormat::new_mf(t).ok())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+
+                if !formats.is_empty() {
+                    return formats;
+                }
+
+                dshow_fallback.as_ref().map(ds_formats).unwrap_or_default()
+            }
+            VideoDeviceInfoInner::DirectShow(device) => ds_formats(device),
         }
     }
 }
@@ -507,10 +520,26 @@ fn directshow_frame_is_bottom_up(pixel_format: PixelFormat, bi_height: i32) -> b
     bi_height > 0 && pixel_format.is_traditionally_bottom_up()
 }
 
+fn ds_formats(device: &cap_camera_directshow::VideoInputDevice) -> Vec<VideoFormat> {
+    device
+        .media_types()
+        .into_iter()
+        .flatten()
+        .filter_map(|media_type| VideoFormat::new_ds(media_type).ok())
+        .collect()
+}
+
 #[derive(Clone)]
 enum VideoDeviceInfoInner {
     MediaFoundation {
         device: cap_camera_mediafoundation::Device,
+        // Some devices register with Media Foundation but only actually work
+        // through DirectShow (capture cards, some virtual cameras). The DS
+        // twin is kept so formats/capture can fall back to it when the MF
+        // device fails to activate or reports no formats — probing MF during
+        // enumeration would open every device on every poll
+        // (CapSoftware/Cap#2132).
+        dshow_fallback: Option<cap_camera_directshow::VideoInputDevice>,
     },
     DirectShow(cap_camera_directshow::VideoInputDevice),
 }
@@ -549,7 +578,10 @@ pub fn get_devices() -> Result<Vec<VideoDeviceInfo>, GetDevicesError> {
                 id,
                 model_id,
                 category,
-                inner: VideoDeviceInfoInner::MediaFoundation { device },
+                inner: VideoDeviceInfoInner::MediaFoundation {
+                    device,
+                    dshow_fallback: None,
+                },
             })
         })
         .filter_map(|result| match result {
@@ -587,18 +619,24 @@ pub fn get_devices() -> Result<Vec<VideoDeviceInfo>, GetDevicesError> {
 
     let mut devices = mf_devices;
 
-    // The previous MF-formats probe here was a no-op (it re-inserted the same
-    // MF entry in both branches) that opened every paired device on every
-    // enumeration; deduplication only needs names (CapSoftware/Cap#2132).
     for dshow_device in dshow_devices {
         let name_and_model = dshow_device.name_and_model();
 
-        let already_listed = devices
+        let mf_twin = devices
             .iter()
-            .any(|device| device.is_mf() && device.name_and_model() == name_and_model);
+            .position(|device| device.is_mf() && device.name_and_model() == name_and_model);
 
-        if !already_listed {
-            devices.push(dshow_device);
+        match mf_twin {
+            Some(index) => {
+                if let (
+                    VideoDeviceInfoInner::MediaFoundation { dshow_fallback, .. },
+                    VideoDeviceInfoInner::DirectShow(dshow),
+                ) = (&mut devices[index].inner, dshow_device.inner)
+                {
+                    *dshow_fallback = Some(dshow);
+                }
+            }
+            None => devices.push(dshow_device),
         }
     }
 


### PR DESCRIPTION
Fixes #2132. Supersedes #2129 — full credit to @aacarcrash for first isolating the DirectShow `BindToObject` leak and its measurement methodology; this PR applies the same deferred-binding idea as one consistent design across both camera backends, fixes the Media Foundation half (which #2129 did not cover and which leaks memory and handles on its own), and stops the polling that drives the leak while Cap idles in the tray. With all three commits, repeated camera enumeration is completely flat and a hidden Cap does no device work at all.

### What #2132 measured

Cap 0.5.9 idle in the tray on Windows: 0.52–1.21 CPU cores, and after 4h16m: 3,345 threads, 223,563 handles, 3.43 GB private memory (~11 MB/min) — roughly one leaked thread per 4.64 s, matching the device-poll cadence.

Re-verified on the shipped 0.5.9 binary for this PR: the leak rate is identical whether the window is visible or hidden in the tray (0.38 vs 0.37 threads/s, ~29 handles/s both) — hiding to tray changes nothing about polling today.

### Root causes (four, stacked)

1. **DirectShow** (`cap-camera-directshow`): `VideoInputDevice::new()` called `IMoniker::BindToObject` for every device during plain enumeration, instantiating each capture filter through its KS driver. ~1 thread + ~33 handles leaked per enumeration on this machine (3 DS devices) — the half #2129 diagnosed.
2. **Media Foundation** (`cap-camera-mediafoundation`): `DeviceSourcesIterator::next()` called `ActivateObject::<IMFMediaSource>()` per device per enumeration, opening the physical device; sources were never `Shutdown`. The `IMFActivate` array from `MFEnumDeviceSources` was never released nor `CoTaskMemFree`'d (the crate had no `Drop` impls at all), and `GetAllocatedString` buffers in `name()`/`id()` were never freed. ~31 handles + ~0.69 MB leaked per enumeration (2 MF devices).
3. **A no-op probe re-opened paired devices** (`cap-camera-windows`): the MF/DS dedup in `get_devices()` called `mf_device.formats()` per pair per enumeration to guard a branch that pushes a clone of the same MF entry and `swap_remove`s the original — the list is provably identical whether the branch runs or not, and the DS twin is dropped either way. The probe cost a full device activation per pair per poll and decided nothing.
4. **The polling never stops when Cap is hidden**: `spawn_devices_snapshot_emitter` enumerates every 5 s forever (its only consumer is the `DevicesUpdated` UI-picker event), and the frontend's 5 s `refetchInterval`s cannot pause because Tauri on Windows never flips `document.visibilityState` for hidden windows (`window.hide()` doesn't call `CoreWebView2Controller.SetIsVisible(false)` since the #9415 revert — see tauri-apps/tauri#9524, tauri-apps/tauri#10592), so TanStack Query's built-in pause-while-hidden never engages.

### The fix

One shape for both camera backends — enumeration constructs devices from cheap identity data only, and the expensive OS object is deferred behind a `OnceLock` until formats or capture genuinely need it, then cached:

- **`cap-camera-directshow`**: `VideoInputDevice` holds `moniker` + `prop_bag` + `OnceLock<BoundFilter>` (filter, capture pin, stream config). `new()` only does `BindToStorage`. `media_types()` and `start_capturing()` bind lazily; `output_pin()` returns `windows_core::Result<&IPin>`; the unused `filter()`/`stream_config()` accessors are gone.
- **`cap-camera-mediafoundation`**: `Device` holds `activate` + `OnceLock<IMFMediaSource>`. `Drop for DeviceSourcesIterator` releases each `IMFActivate` and frees the array; `name()`/`id()` free their `GetAllocatedString` buffers; the `Deref/DerefMut → IMFMediaSource` impls are gone (nothing used them, and a deref that lazily opens a camera would be a hidden side effect).
- **`cap-camera-windows`**: the dedup keeps the DirectShow twin as a stored fallback on the merged Media Foundation entry instead of probing MF formats per poll. Twins pair one-to-one (each DS device attaches to the first MF entry that has no fallback yet, so identical devices don't pile onto one entry). The MF-vs-DS decision moves to use time: `formats()` tries MF first, and whenever MF fails to activate or reports nothing it shuts the failed source down — with or without a DS twin, so repeated format requests never accumulate half-open sources and exclusive drivers accept the DS bind that follows — then returns the DS twin's formats; `start_capturing` accepts DS formats on a merged device. A format that matches no backend available on the device now returns `StartCapturingError::FormatMismatch` instead of hitting the old `todo!()` panic. This restores the original intent of the old probe (prefer DS when MF is unusable — the shipped branch was a no-op) without opening any device during enumeration, so capture cards and virtual cameras that enumerate under MF but only work through DS keep working.
- **`apps/desktop` (Rust)**: the snapshot emitter skips enumeration while no webview window is visible — same guard style as the existing sleep check. Recording is unaffected: the in-progress window is visible during recording, and disconnect detection is owned by the dedicated camera/mic watchers either way. `hide_main_window` also emits `main-window-hidden` (only after the hide actually succeeded), and every main-window hide path routes through it: close-to-tray, target picker (both entry points), Upgrade/ModeSelect/Onboarding window swaps, instant-recording open, recording-window teardown when Settings or an editor takes over, and the non-Windows recording-start `Close` behaviour. The Windows recording-start path minimizes rather than hides (pre-existing DirectComposition workaround) and keeps native minimize semantics.
- **`apps/desktop` (TS)**: the main window bridges its real hide/focus signals into TanStack's `focusManager` — pause on `main-window-hidden`; on focus it hands control back to TanStack's own visibilitychange detection (`setFocused(undefined)`) so platforms where that signal works, like macOS minimize, keep pausing natively. Frontend-initiated hides (e.g. starting an Instant recording hides the main window from its own JS) don't go through the Rust helper and can happen after an unrelated blur already fired (`shell.open` steals focus while the window is still visible), so they pause explicitly through a `hideCurrentWindow()` util that all main-window self-hide sites use. The bridge additionally re-checks `isVisible()` on blur as a safety net for any future hide path that bypasses both helpers, with a focus-generation guard so a stale visibility result can't pause a window that regained focus mid-check. Pauses engage only after a hide succeeds. Fail-open in every direction: a missed hide site just means today's behavior, and push-driven `DevicesUpdated` refetches still land while paused.

Side fix: a device that fails to bind/activate no longer disappears (DS) or truncates the rest of the device list (MF) during enumeration — it stays listed and the error surfaces at `formats()`/`start_capturing()`, where selection already shows an error dialog.

### Measurements

i7-12800H, 20 logical cores, 3 DirectShow / 2 Media Foundation devices, 60 enumerations at 1/s, sampled externally:

| run | threads | handles | private MB |
|---|---|---|---|
| `mf` before | +1 | +1,842 | +41.5 |
| `ds` before | +44 | +1,982 | +9.2 |
| `both` before | +53 | +3,858 | +49.0 |
| `mf` after | **0** | **0** | **0** |
| `ds` after | **0** | **0** | **0** |
| `both` after | **0** | **0** | **0** |

Per-enumeration wall time stays flat at 3–9 ms across the run after the fix.

Why idle CPU reached a full core: hammering the old `get_devices()` for 4 minutes reached 1,259 threads / 92,884 handles / 1.16 GB, and CPU for the identical workload doubled from 0.20 to 0.42 cores as the leaked threads and handles accumulated. The 0.52–1.21 cores reported in #2132 after 4h16m (3,345 threads) sits on the same curve.

### Repro

Included example (`crates/camera-windows/examples/enumeration_leak.rs`):

```
cargo run --release -p cap-camera-windows --example enumeration_leak -- both 60
```

`mf` / `ds` isolate the two halves. Watch threads/handles/private bytes externally (Process Explorer, or `Get-Process -Id <pid>` in a loop); the printed per-enumeration wall time also degrades as the leak accumulates on unfixed builds.

### Behavior notes

- A device that appears in both backends now transparently falls back to DirectShow when its Media Foundation registration is unusable, instead of showing a broken picker entry. DS-only ghost registrations (dead virtual cameras with no working bind at all) still appear and fail at selection — inherent to not instantiating filters during enumeration; the old MF path had the worse bug of truncating the list.
- An MF source that turns out to be unusable is now fully `Shutdown` when the DS fallback takes over. Sources that are genuinely used (successful formats read or capture) are still released without `Shutdown` on drop; doing that safely needs ownership through the capture handle, and `stop_capturing()` doesn't await the engine's stopped event, so a drop-time `ShutdownObject` would race live teardown. Bounded (a few per session, only on real use — zero when idle); left as a follow-up.
- If Windows denies foreground activation on a restore path that shows the main window without focus, its intervals stay paused until first click; device data still refreshes via the `DevicesUpdated` push.
- Minimize (as opposed to hide) keeps pre-existing polling behavior on Windows, where a minimized window still reports `visibilityState === 'visible'`; on macOS the restored native detection pauses minimized windows as before.

### Verification

- `cargo check --all-targets` clean for `cap-camera-directshow`, `cap-camera-mediafoundation`, `cap-camera-windows`, `cap-camera`; `cargo check -p cap-desktop` clean; `cargo fmt --all`; Biome clean on the touched TS.
- Leak evals above measured on this branch on Windows 11, plus an independent line-by-line regression review of COM refcount balance, clone semantics, event plumbing, and TanStack pause/resume behavior against the pinned query-core 5.101.2 source.
