### PR TITLE
fix: keep main window position after resize

### DIFF
--- a/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/index.tsx
@@ -120,6 +120,7 @@ import TargetDropdownButton from "./TargetDropdownButton";
 import TargetMenuGrid from "./TargetMenuGrid";
 import TargetTypeButton from "./TargetTypeButton";
 import useRequestPermission from "./useRequestPermission";
+import { getPostResizeWindowPosition } from "./window-geometry";
 
 const MAIN_WINDOW_SIZE = {
 	compact: { width: 330, height: 395 },
@@ -205,9 +206,6 @@ const listScreenshotsQuery = queryOptions<ScreenshotWithPath[]>({
 const nextAnimationFrame = () =>
 	new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
-const clamp = (value: number, minimum: number, maximum: number) =>
-	Math.min(Math.max(value, minimum), maximum);
-
 async function resizeMainWindow(expanded: boolean, animate: boolean) {
 	const currentWindow = getCurrentWindow();
 	const [physicalSize, outerSize, scaleFactor, physicalPosition, monitor] =
@@ -254,36 +252,6 @@ async function resizeMainWindow(expanded: boolean, animate: boolean) {
 	const reduceMotion = window.matchMedia(
 		"(prefers-reduced-motion: reduce)",
 	).matches;
-
-	if (monitor && physicalPosition) {
-		const padding = MAIN_WINDOW_SCREEN_PADDING * scaleFactor;
-		const workArea = monitor.workArea;
-		const targetPhysicalWidth = (targetWidth + frameWidth) * scaleFactor;
-		const targetPhysicalHeight = (targetHeight + frameHeight) * scaleFactor;
-		const minimumX = workArea.position.x + padding;
-		const minimumY = workArea.position.y + padding;
-		const maximumX = Math.max(
-			minimumX,
-			workArea.position.x + workArea.size.width - targetPhysicalWidth - padding,
-		);
-		const maximumY = Math.max(
-			minimumY,
-			workArea.position.y +
-				workArea.size.height -
-				targetPhysicalHeight -
-				padding,
-		);
-		const targetX = clamp(physicalPosition.x, minimumX, maximumX);
-		const targetY = clamp(physicalPosition.y, minimumY, maximumY);
-
-		if (targetX !== physicalPosition.x || targetY !== physicalPosition.y) {
-			await currentWindow
-				.setPosition(
-					new PhysicalPosition(Math.round(targetX), Math.round(targetY)),
-				)
-				.catch(() => undefined);
-		}
-	}
 
 	if (Math.abs(widthDelta) > 0.5 || Math.abs(heightDelta) > 0.5) {
 		if (!animate || reduceMotion) {
@@ -332,6 +300,36 @@ async function resizeMainWindow(expanded: boolean, animate: boolean) {
 			await resizeWorker;
 			if (resizeFailed) throw resizeError;
 		}
+	}
+
+	if (monitor && physicalPosition) {
+		// AppKit keeps the bottom edge fixed while growing an NSWindow, so restore
+		// the intended top-left position only after the resize finishes.
+		const positionAfterResize = await currentWindow
+			.outerPosition()
+			.catch(() => null);
+		if (!positionAfterResize) return;
+
+		const targetPosition = getPostResizeWindowPosition(
+			physicalPosition,
+			positionAfterResize,
+			{
+				width: (targetWidth + frameWidth) * scaleFactor,
+				height: (targetHeight + frameHeight) * scaleFactor,
+			},
+			monitor.workArea,
+			MAIN_WINDOW_SCREEN_PADDING * scaleFactor,
+		);
+		if (!targetPosition) return;
+
+		await currentWindow
+			.setPosition(
+				new PhysicalPosition(
+					Math.round(targetPosition.x),
+					Math.round(targetPosition.y),
+				),
+			)
+			.catch(() => undefined);
 	}
 }
 

--- a/apps/desktop/src/routes/(window-chrome)/new-main/window-geometry.test.ts
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/window-geometry.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { getPostResizeWindowPosition } from "./window-geometry";
+
+const builtInDisplayWorkArea = {
+	position: { x: 0, y: 0 },
+	size: { width: 1352, height: 848 },
+};
+
+describe("main window geometry", () => {
+	it("restores the top edge after a macOS resize moves it above the display", () => {
+		expect(
+			getPostResizeWindowPosition(
+				{ x: 376, y: 100 },
+				{ x: 376, y: -165 },
+				{ width: 600, height: 660 },
+				builtInDisplayWorkArea,
+				12,
+			),
+		).toEqual({ x: 376, y: 100 });
+	});
+
+	it("keeps the resized window inside a display with a negative origin", () => {
+		expect(
+			getPostResizeWindowPosition(
+				{ x: 1700, y: -400 },
+				{ x: 1700, y: -400 },
+				{ width: 600, height: 660 },
+				{
+					position: { x: 1352, y: -274 },
+					size: { width: 2048, height: 1152 },
+				},
+				12,
+			),
+		).toEqual({ x: 1700, y: -262 });
+	});
+
+	it("does not move a window that stayed at its intended position", () => {
+		expect(
+			getPostResizeWindowPosition(
+				{ x: 376, y: 100 },
+				{ x: 376, y: 100 },
+				{ width: 600, height: 660 },
+				builtInDisplayWorkArea,
+				12,
+			),
+		).toBeNull();
+	});
+});

--- a/apps/desktop/src/routes/(window-chrome)/new-main/window-geometry.ts
+++ b/apps/desktop/src/routes/(window-chrome)/new-main/window-geometry.ts
@@ -1,0 +1,49 @@
+type Point = {
+	x: number;
+	y: number;
+};
+
+type Size = {
+	width: number;
+	height: number;
+};
+
+type Rectangle = {
+	position: Point;
+	size: Size;
+};
+
+const clamp = (value: number, minimum: number, maximum: number) =>
+	Math.min(Math.max(value, minimum), maximum);
+
+export function getPostResizeWindowPosition(
+	positionBeforeResize: Point,
+	positionAfterResize: Point,
+	windowSize: Size,
+	workArea: Rectangle,
+	padding: number,
+) {
+	const minimumX = workArea.position.x + padding;
+	const minimumY = workArea.position.y + padding;
+	const maximumX = Math.max(
+		minimumX,
+		workArea.position.x + workArea.size.width - windowSize.width - padding,
+	);
+	const maximumY = Math.max(
+		minimumY,
+		workArea.position.y + workArea.size.height - windowSize.height - padding,
+	);
+	const targetPosition = {
+		x: clamp(positionBeforeResize.x, minimumX, maximumX),
+		y: clamp(positionBeforeResize.y, minimumY, maximumY),
+	};
+
+	if (
+		targetPosition.x === positionAfterResize.x &&
+		targetPosition.y === positionAfterResize.y
+	) {
+		return null;
+	}
+
+	return targetPosition;
+}


### PR DESCRIPTION
## Summary

- preserve the main window top-left position when switching between compact and expanded modes
- clamp the final position against the original monitor work area after the resize finishes
- add regression coverage for the macOS bottom-edge-anchored resize behavior and negative-origin displays

## Reproduction

On a MacBook with a notch, place the compact 330x395 main window at y=100 and reopen Cap in expanded mode. AppKit keeps the bottom edge fixed while changing the height to 660, which moves the top edge to y=-165. The window then sits behind the menu bar/notch and becomes difficult to drag.

The existing bounds check runs before `setSize`, so it validates the old position rather than the final one. This change restores and clamps the intended top-left position after resizing.

## Validation

- `pnpm exec vitest run apps/desktop/src/routes/\(window-chrome\)/new-main/window-geometry.test.ts`
- `pnpm --filter @cap/desktop exec tsc --noEmit`
- `pnpm exec biome check apps/desktop/src/routes/\(window-chrome\)/new-main/index.tsx apps/desktop/src/routes/\(window-chrome\)/new-main/window-geometry.ts apps/desktop/src/routes/\(window-chrome\)/new-main/window-geometry.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves the main window’s intended top-left position after compact/expanded resizing and clamps it to the original monitor’s work area.

- Moves position correction until after the resize completes.
- Extracts the post-resize clamping calculation into a geometry helper.
- Adds regression tests for macOS vertical displacement, negative-origin displays, and unchanged positions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking issues identified.

The post-resize correction consistently uses physical coordinates, restores the captured top-left position, clamps it within the selected monitor’s work area, and has targeted regression coverage for the reported edge cases.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/routes/(window-chrome)/new-main/index.tsx | Applies post-resize position restoration using the captured physical position, target outer size, and monitor work area; no actionable defect was established. |
| apps/desktop/src/routes/(window-chrome)/new-main/window-geometry.ts | Adds a unit-consistent helper that clamps the intended top-left position and avoids redundant position updates. |
| apps/desktop/src/routes/(window-chrome)/new-main/window-geometry.test.ts | Covers the reported macOS resize displacement, negative monitor origins, and the no-op case. |

<sub>Reviews (1): Last reviewed commit: ["fix: keep main window position after res..."](https://github.com/capsoftware/cap/commit/c27bf6bff1d65a02c5f755b8572b22f7ee2b2d46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58352328)</sub>

<!-- /greptile_comment -->