### PR TITLE
fix(scap-targets): enumerate top-level windows instead of desktop children

### DIFF
--- a/crates/scap-targets/src/platform/win.rs
+++ b/crates/scap-targets/src/platform/win.rs
@@ -36,14 +36,13 @@ use windows::{
                 SHGetFileInfoW,
             },
             WindowsAndMessaging::{
-                DI_FLAGS, DestroyIcon, DrawIconEx, EnumChildWindows, EnumWindows, GCLP_HICON,
-                GW_HWNDNEXT, GWL_EXSTYLE, GWL_STYLE, GetClassLongPtrW, GetClassNameW,
-                GetClientRect, GetCursorPos, GetDesktopWindow, GetIconInfo,
-                GetLayeredWindowAttributes, GetWindow, GetWindowLongPtrW, GetWindowLongW,
-                GetWindowRect, GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId,
-                HICON, ICONINFO, IsIconic, IsWindowVisible, PrivateExtractIconsW, SendMessageW,
-                WM_GETICON, WS_CHILD, WS_EX_LAYERED, WS_EX_TOOLWINDOW, WS_EX_TOPMOST,
-                WS_EX_TRANSPARENT, WindowFromPoint,
+                DI_FLAGS, DestroyIcon, DrawIconEx, EnumWindows, GCLP_HICON, GW_HWNDNEXT,
+                GWL_EXSTYLE, GWL_STYLE, GetClassLongPtrW, GetClassNameW, GetClientRect,
+                GetCursorPos, GetIconInfo, GetLayeredWindowAttributes, GetWindow,
+                GetWindowLongPtrW, GetWindowLongW, GetWindowRect, GetWindowTextLengthW,
+                GetWindowTextW, GetWindowThreadProcessId, HICON, ICONINFO, IsIconic,
+                IsWindowVisible, PrivateExtractIconsW, SendMessageW, WM_GETICON, WS_CHILD,
+                WS_EX_LAYERED, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_EX_TRANSPARENT, WindowFromPoint,
             },
         },
     },
@@ -329,8 +328,7 @@ impl WindowImpl {
         };
 
         unsafe {
-            let _ = EnumChildWindows(
-                Some(GetDesktopWindow()),
+            let _ = EnumWindows(
                 Some(enum_windows_proc),
                 LPARAM(std::ptr::addr_of_mut!(context) as isize),
             );


### PR DESCRIPTION
## Summary

- Fixes `cap targets windows --json` returning `[]` on Windows even when a visible eligible top-level application window is open.
- `WindowImpl::list()` in `crates/scap-targets/src/platform/win.rs` was calling `EnumChildWindows(Some(GetDesktopWindow()), ...)`, which enumerates child windows beneath the desktop rather than top-level application windows. Top-level application windows are not discovered this way, so the list came back empty.
- Switches the call to `EnumWindows`, matching the pattern already used by `get_topmost_at_cursor_fallback()` in the same file. The callback signature (`enum_windows_proc`), validity filters (visibility, child/tool-window exclusion, ignored executables, Cap-owned window exclusion), and `LPARAM` context-passing are unchanged.
- Removes the now-unused `EnumChildWindows` and `GetDesktopWindow` imports.

Fixes #2164

## Research

A subagent investigation of the Rust coding conventions in this codebase confirmed the fix follows project style:

- **Import grouping**: std → external crates → local crate, with `windows::` modules grouped by hierarchy. Unused imports should be removed (no `use windows::Win32::*` glob imports).
- **No doc comments**: the project uses a zero-code-comments-by-default policy; only `//` line comments are used. This change adds none.
- **Unsafe pattern**: per-operation `unsafe { ... }` blocks with `let _ = ApiCall(...)` for discarded `BOOL` results — the existing call site already follows this and is preserved.
- **Workspace lints**: `cargo fmt --all` and `cargo check -p scap-targets` both pass clean after the change.

## Diff

```diff
             WindowsAndMessaging::{
-                DI_FLAGS, DestroyIcon, DrawIconEx, EnumChildWindows, EnumWindows, GCLP_HICON,
-                GW_HWNDNEXT, GWL_EXSTYLE, GWL_STYLE, GetClassLongPtrW, GetClassNameW,
-                GetClientRect, GetCursorPos, GetDesktopWindow, GetIconInfo,
+                DI_FLAGS, DestroyIcon, DrawIconEx, EnumWindows, GCLP_HICON, GW_HWNDNEXT,
+                GWL_EXSTYLE, GWL_STYLE, GetClassLongPtrW, GetClassNameW, GetClientRect,
+                GetCursorPos, GetIconInfo, GetLayeredWindowAttributes, GetWindow,
 ...
         unsafe {
-            let _ = EnumChildWindows(
-                Some(GetDesktopWindow()),
+            let _ = EnumWindows(
                 Some(enum_windows_proc),
                 LPARAM(std::ptr::addr_of_mut!(context) as isize),
             );
```

## Test plan

- [ ] On Windows 11, with a visible eligible application window open, `cap targets windows --json` returns at least one target instead of `[]`.
- [ ] The returned target contains a numeric ID corresponding to the native `HWND` representation used by `crates/scap-targets/src/platform/win.rs`.
- [ ] The ID can be supplied to `cap record start --window <id>` without requiring `pywin32` in the consuming application.
- [ ] Invalid, hidden, child, tool, ignored, and Cap-owned windows remain filtered.
- [ ] `cargo fmt --all -- --check` passes.
- [ ] `cargo check -p scap-targets` passes with no warnings.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Windows capture-target discovery by replacing desktop-child enumeration with top-level window enumeration while preserving the existing eligibility callback and filters.
- Uses `EnumWindows` to discover top-level application windows.
- Removes the obsolete `EnumChildWindows` and `GetDesktopWindow` imports.
- Keeps the existing callback and `LPARAM` context-passing behavior unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable regressions identified in the changed Windows enumeration path.

The new API enumerates the top-level windows required by target listing, while existing downstream validation preserves the intended eligibility constraints.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/scap-targets/src/platform/win.rs | Correctly switches `WindowImpl::list()` to top-level window enumeration; downstream validation continues to exclude invalid, child, tool, cloaked, system, and Cap-owned targets. |

<sub>Reviews (1): Last reviewed commit: ["fix(scap-targets): enumerate top-level w..."](https://github.com/capsoftware/cap/commit/01149abcb74b8901c017cbed59bd4f9974769ddd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58406437)</sub>

<!-- /greptile_comment -->