### PR TITLE
test(chrome-extension): verify WebRTC session description formatting

### DIFF
--- a/apps/chrome-extension/src/shared/webrtc.test.ts
+++ b/apps/chrome-extension/src/shared/webrtc.test.ts
@@ -50,3 +50,26 @@ describe("waitForIceGatheringComplete", () => {
 		);
 	});
 });
+
+describe("toSessionDescriptionInit", () => {
+	it("formats valid RTCSessionDescription to RTCSessionDescriptionInit", async () => {
+		const { toSessionDescriptionInit } = await import("./webrtc");
+		const desc = {
+			type: "offer" as RTCSdpType,
+			sdp: "v=0\r\no=- 123456 2 IN IP4 127.0.0.1\r\n",
+			toJSON: () => ({}),
+		};
+		expect(toSessionDescriptionInit(desc as RTCSessionDescription)).toEqual({
+			type: "offer",
+			sdp: "v=0\r\no=- 123456 2 IN IP4 127.0.0.1\r\n",
+		});
+	});
+
+	it("throws error when session description is null or undefined", async () => {
+		const { toSessionDescriptionInit } = await import("./webrtc");
+		expect(() => toSessionDescriptionInit(null)).toThrow(
+			"Missing session description",
+		);
+	});
+});
+

--- a/apps/chrome-extension/src/shared/webrtc.test.ts
+++ b/apps/chrome-extension/src/shared/webrtc.test.ts
@@ -65,6 +65,19 @@ describe("toSessionDescriptionInit", () => {
 		});
 	});
 
+	it("formats answer RTCSessionDescription to RTCSessionDescriptionInit", async () => {
+		const { toSessionDescriptionInit } = await import("./webrtc");
+		const desc = {
+			type: "answer" as RTCSdpType,
+			sdp: "v=0\r\no=- 654321 2 IN IP4 127.0.0.1\r\n",
+			toJSON: () => ({}),
+		};
+		expect(toSessionDescriptionInit(desc as RTCSessionDescription)).toEqual({
+			type: "answer",
+			sdp: "v=0\r\no=- 654321 2 IN IP4 127.0.0.1\r\n",
+		});
+	});
+
 	it("throws error when session description is null or undefined", async () => {
 		const { toSessionDescriptionInit } = await import("./webrtc");
 		expect(() => toSessionDescriptionInit(null)).toThrow(
@@ -72,4 +85,3 @@ describe("toSessionDescriptionInit", () => {
 		);
 	});
 });
-

--- a/packages/recorder-core/__tests__/recorder-utils.test.ts
+++ b/packages/recorder-core/__tests__/recorder-utils.test.ts
@@ -198,3 +198,35 @@ describe("openShareUrlInNewTab", () => {
 		expect(openShareUrlInNewTab("")).toBe(false);
 	});
 });
+
+describe("detectRecordingModeFromTrack", () => {
+	it("returns null when track is null", async () => {
+		const { detectRecordingModeFromTrack } = await import(
+			"@cap/recorder-core/recorder-utils"
+		);
+		expect(detectRecordingModeFromTrack(null)).toBeNull();
+	});
+
+	it("detects fullscreen, window, and tab from track label heuristics", async () => {
+		const { detectRecordingModeFromTrack } = await import(
+			"@cap/recorder-core/recorder-utils"
+		);
+		const screenTrack = {
+			label: "Entire Screen 1",
+			getSettings: () => ({}),
+		} as unknown as MediaStreamTrack;
+		const windowTrack = {
+			label: "Application Window (Cap)",
+			getSettings: () => ({}),
+		} as unknown as MediaStreamTrack;
+		const tabTrack = {
+			label: "Browser Tab - YouTube",
+			getSettings: () => ({}),
+		} as unknown as MediaStreamTrack;
+
+		expect(detectRecordingModeFromTrack(screenTrack)).toBe("fullscreen");
+		expect(detectRecordingModeFromTrack(windowTrack)).toBe("window");
+		expect(detectRecordingModeFromTrack(tabTrack)).toBe("tab");
+	});
+});
+

--- a/packages/recorder-core/__tests__/recorder-utils.test.ts
+++ b/packages/recorder-core/__tests__/recorder-utils.test.ts
@@ -229,4 +229,3 @@ describe("detectRecordingModeFromTrack", () => {
 		expect(detectRecordingModeFromTrack(tabTrack)).toBe("tab");
 	});
 });
-

--- a/packages/recorder-core/__tests__/recorder-utils.test.ts
+++ b/packages/recorder-core/__tests__/recorder-utils.test.ts
@@ -229,3 +229,47 @@ describe("detectRecordingModeFromTrack", () => {
 		expect(detectRecordingModeFromTrack(tabTrack)).toBe("tab");
 	});
 });
+
+describe("error retry utilities", () => {
+	it("identifies user cancellation errors correctly", async () => {
+		const { isUserCancellationError } = await import(
+			"@cap/recorder-core/recorder-utils"
+		);
+		const notAllowed = new DOMException("Permission denied", "NotAllowedError");
+		const abort = new DOMException("Aborted by user", "AbortError");
+		const other = new DOMException("Format unsupported", "NotSupportedError");
+
+		expect(isUserCancellationError(notAllowed)).toBe(true);
+		expect(isUserCancellationError(abort)).toBe(true);
+		expect(isUserCancellationError(other)).toBe(false);
+		expect(isUserCancellationError(new Error("generic error"))).toBe(false);
+	});
+
+	it("identifies retryable display media preference errors", async () => {
+		const { shouldRetryDisplayMediaWithoutPreferences } = await import(
+			"@cap/recorder-core/recorder-utils"
+		);
+		const notSupported = new DOMException(
+			"Preferences not supported",
+			"NotSupportedError",
+		);
+		const overconstrained = new DOMException(
+			"Constraint unfulfilled",
+			"OverconstrainedError",
+		);
+		const invalidAccess = new DOMException(
+			"Invalid access",
+			"InvalidAccessError",
+		);
+		const typeError = new TypeError("Invalid parameter");
+		const notAllowed = new DOMException("Permission denied", "NotAllowedError");
+
+		expect(shouldRetryDisplayMediaWithoutPreferences(notSupported)).toBe(true);
+		expect(shouldRetryDisplayMediaWithoutPreferences(overconstrained)).toBe(
+			true,
+		);
+		expect(shouldRetryDisplayMediaWithoutPreferences(invalidAccess)).toBe(true);
+		expect(shouldRetryDisplayMediaWithoutPreferences(typeError)).toBe(true);
+		expect(shouldRetryDisplayMediaWithoutPreferences(notAllowed)).toBe(false);
+	});
+});


### PR DESCRIPTION
### Summary of Changes
- Adds unit test coverage for WebRTC session description exchange in Chrome extension recording pipeline.
- Test suite passed 100% green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands browser-recording unit coverage for WebRTC session-description conversion, capture-mode detection, cancellation classification, and display-media retry decisions.
- Adds offer, answer, and missing-description tests for the Chrome extension’s WebRTC helper.
- Adds recorder-core tests for track-label heuristics and browser error classification.
- One WebRTC test overstates its nullish-input coverage because it does not exercise undefined.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking gap in the stated undefined-input coverage.

The added tests are compatible with the configured runtime and package exports; the only accepted issue is that one test claims null-and-undefined coverage while exercising only null.

**Files Needing Attention:** apps/chrome-extension/src/shared/webrtc.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/chrome-extension/src/shared/webrtc.test.ts | Adds session-description formatting tests, with a minor coverage mismatch because the null-or-undefined test checks only null. |
| packages/recorder-core/__tests__/recorder-utils.test.ts | Adds valid coverage for recording-mode detection and browser error classification without introducing an identified defect. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/chrome-extension/src/shared/webrtc.test.ts:81-86
**Undefined case is untested**

The test claims coverage for both null and undefined descriptions but passes only `null`, so a regression in undefined handling would remain green.

```suggestion
	it("throws error when session description is null or undefined", async () => {
		const { toSessionDescriptionInit } = await import("./webrtc");
		expect(() => toSessionDescriptionInit(null)).toThrow(
			"Missing session description",
		);
		expect(() => toSessionDescriptionInit(undefined)).toThrow(
			"Missing session description",
		);
	});
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(chrome-extension): verify WebRTC se..."](https://github.com/capsoftware/cap/commit/d1aae99fe4ff85f5a23696233940dee45207fa64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58779377)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Mobile and browser capture clients](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/mobile-and-browser-capture-clients.md)
- Knowledge Base — [Recorder SDK and shared core](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/recorder-sdk-and-shared-core.md)

<!-- /greptile_comment -->