### PR TITLE
fix(desktop): honor rendered screenshot clipboard source

### DIFF
--- a/apps/desktop/src-tauri/src/automation.rs
+++ b/apps/desktop/src-tauri/src/automation.rs
@@ -22,6 +22,41 @@ use crate::general_settings::PostStudioRecordingBehaviour;
 const WEBHOOK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
+#[derive(Debug, PartialEq, Eq)]
+enum ClipboardImageSource {
+    File(PathBuf),
+    ScreenshotProject(PathBuf),
+}
+
+fn resolve_clipboard_image_source(
+    ctx: &TriggerContext,
+    source: ClipboardSource,
+) -> Result<ClipboardImageSource, String> {
+    match source {
+        ClipboardSource::Raw => ctx
+            .image_path
+            .as_ref()
+            .or(ctx.output_path.as_ref())
+            .cloned()
+            .map(ClipboardImageSource::File)
+            .ok_or_else(|| "No image or output path available for clipboard copy".to_string()),
+        ClipboardSource::Rendered => {
+            if let Some(path) = ctx.output_path.clone() {
+                return Ok(ClipboardImageSource::File(path));
+            }
+            if ctx.image_path.is_some()
+                && let Some(path) = ctx.project_path.clone()
+            {
+                return Ok(ClipboardImageSource::ScreenshotProject(path));
+            }
+            ctx.image_path
+                .clone()
+                .map(ClipboardImageSource::File)
+                .ok_or_else(|| "No rendered output available for clipboard copy".to_string())
+        }
+    }
+}
+
 pub struct DesktopAutomationHost {
     app: AppHandle,
     clipboard: Arc<RwLock<ClipboardContext>>,
@@ -58,24 +93,26 @@ impl AutomationHost for DesktopAutomationHost {
         ctx: &TriggerContext,
         source: &ClipboardSource,
     ) -> Result<(), String> {
-        let path = match source {
-            ClipboardSource::Raw => ctx
-                .image_path
-                .as_ref()
-                .or(ctx.output_path.as_ref())
-                .ok_or("No image or output path available for clipboard copy")?,
-            ClipboardSource::Rendered => ctx
-                .output_path
-                .as_ref()
-                .or(ctx.image_path.as_ref())
-                .ok_or("No output path available for clipboard copy")?,
+        let source = resolve_clipboard_image_source(ctx, *source)?;
+        let img_data = match source {
+            ClipboardImageSource::File(path) => {
+                let path = path.to_string_lossy().to_string();
+                info!(%path, "Automation: copying file to clipboard");
+                clipboard_rs::RustImageData::from_path(&path)
+                    .map_err(|e| format!("Failed to load image for clipboard: {e}"))?
+            }
+            ClipboardImageSource::ScreenshotProject(path) => {
+                info!(project = %path.display(), "Automation: rendering screenshot for clipboard");
+                let rendered = crate::screenshot_editor::render_screenshot_project_for_export(
+                    self.app.clone(),
+                    path,
+                )
+                .await?;
+                clipboard_rs::RustImageData::from_bytes(&rendered.image_bytes)
+                    .map_err(|e| format!("Failed to load rendered screenshot for clipboard: {e}"))?
+            }
         };
 
-        let path_str = path.to_string_lossy().to_string();
-        info!(path = %path_str, "Automation: copying to clipboard");
-
-        let img_data = clipboard_rs::RustImageData::from_path(&path_str)
-            .map_err(|e| format!("Failed to load image for clipboard: {e}"))?;
         self.clipboard
             .write()
             .await
@@ -934,4 +971,52 @@ pub async fn list_automation_capabilities() -> Vec<String> {
         "ApplyPreset".to_string(),
         "DeleteLocalFiles".to_string(),
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rendered_screenshot_uses_project_instead_of_raw_capture() {
+        let ctx = TriggerContext::new()
+            .with_project_path(PathBuf::from("capture.cap"))
+            .with_image_path(PathBuf::from("capture.cap/original.png"));
+
+        assert_eq!(
+            resolve_clipboard_image_source(&ctx, ClipboardSource::Rendered),
+            Ok(ClipboardImageSource::ScreenshotProject(PathBuf::from(
+                "capture.cap"
+            )))
+        );
+    }
+
+    #[test]
+    fn rendered_output_takes_priority_over_screenshot_project() {
+        let ctx = TriggerContext::new()
+            .with_project_path(PathBuf::from("capture.cap"))
+            .with_image_path(PathBuf::from("capture.cap/original.png"))
+            .with_output_path(PathBuf::from("capture-rendered.png"));
+
+        assert_eq!(
+            resolve_clipboard_image_source(&ctx, ClipboardSource::Rendered),
+            Ok(ClipboardImageSource::File(PathBuf::from(
+                "capture-rendered.png"
+            )))
+        );
+    }
+
+    #[test]
+    fn raw_screenshot_keeps_original_capture() {
+        let ctx = TriggerContext::new()
+            .with_project_path(PathBuf::from("capture.cap"))
+            .with_image_path(PathBuf::from("capture.cap/original.png"));
+
+        assert_eq!(
+            resolve_clipboard_image_source(&ctx, ClipboardSource::Raw),
+            Ok(ClipboardImageSource::File(PathBuf::from(
+                "capture.cap/original.png"
+            )))
+        );
+    }
 }

--- a/apps/desktop/src-tauri/src/screenshot_editor.rs
+++ b/apps/desktop/src-tauri/src/screenshot_editor.rs
@@ -105,14 +105,9 @@ impl ScreenshotEditorInstances {
     async fn create_standalone_instance(
         app_handle: &AppHandle,
         path: PathBuf,
+        start_preview: bool,
     ) -> Result<Arc<ScreenshotEditorInstance>, String> {
         let create_started = Instant::now();
-        let (frame_tx, frame_rx) = watch::channel(None);
-        let (ws_port, ws_shutdown_token) =
-            create_watch_frame_ws(frame_rx, Default::default()).await;
-        if ws_port == 0 {
-            return Err("Failed to start screenshot editor frame websocket".to_string());
-        }
 
         let (data, width, height) = {
             let key = path
@@ -221,6 +216,35 @@ impl ScreenshotEditorInstances {
         } else {
             (None, None)
         };
+
+        if !start_preview {
+            let pretty_name = recording_meta
+                .as_ref()
+                .map(|meta| meta.pretty_name.clone())
+                .unwrap_or_else(|| "Screenshot".to_string());
+            let (config_tx, _) = watch::channel(ScreenshotConfigUpdate {
+                revision: 0,
+                config: loaded_config.unwrap_or_default(),
+            });
+
+            return Ok(Arc::new(ScreenshotEditorInstance {
+                ws_port: 0,
+                ws_shutdown_token: CancellationToken::new(),
+                config_tx,
+                path,
+                pretty_name,
+                image_width: width,
+                image_height: height,
+                source_rgba: Arc::new(data),
+            }));
+        }
+
+        let (frame_tx, frame_rx) = watch::channel(None);
+        let (ws_port, ws_shutdown_token) =
+            create_watch_frame_ws(frame_rx, Default::default()).await;
+        if ws_port == 0 {
+            return Err("Failed to start screenshot editor frame websocket".to_string());
+        }
 
         let recording_meta = if let Some(meta) = recording_meta {
             meta
@@ -512,7 +536,8 @@ impl ScreenshotEditorInstances {
                     }
                 }
 
-                let instance = Self::create_standalone_instance(window.app_handle(), path).await?;
+                let instance =
+                    Self::create_standalone_instance(window.app_handle(), path, true).await?;
                 entry.insert(instance.clone());
                 Ok(instance)
             }
@@ -592,7 +617,8 @@ impl PendingScreenshotEditorInstances {
         }
 
         tokio::spawn(async move {
-            let result = ScreenshotEditorInstances::create_standalone_instance(&app, path).await;
+            let result =
+                ScreenshotEditorInstances::create_standalone_instance(&app, path, true).await;
             tx.send(Some(result)).ok();
         });
     }
@@ -1464,7 +1490,7 @@ pub async fn render_screenshot_project_for_export(
     app: AppHandle,
     path: PathBuf,
 ) -> Result<ScreenshotProjectExport, String> {
-    let instance = ScreenshotEditorInstances::create_standalone_instance(&app, path).await?;
+    let instance = ScreenshotEditorInstances::create_standalone_instance(&app, path, false).await?;
     let config = instance.config_tx.borrow().config.clone();
     let image_width = instance.image_width;
     let image_height = instance.image_height;


### PR DESCRIPTION
Rendered screenshot clipboard automations now use Cap's project renderer instead of silently copying the original capture.

When a screenshot trigger selects Edited / rendered, the desktop host renders its Cap project after earlier actions, so an Apply preset action is reflected in the clipboard result. Raw copies and explicit output files keep their existing behavior.

One-off project exports now load the source and configuration without starting an unused preview WebSocket and continuous preview renderer. Editor windows and editor prewarming keep the existing preview path.

Three focused source-selection tests cover raw copies, rendered projects and explicit output precedence. Rust formatting and diff checks pass. Local desktop test execution is blocked before reaching this crate because the shell cannot expose the installed Windows SDK headers to Clang while generating FFmpeg bindings. No native clipboard acceptance run was performed for this branch; CI remains the compile and test gate.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Rendered screenshot clipboard actions now render the associated Cap project, while raw copies and explicit output files preserve their existing source-selection behavior.
- Adds explicit clipboard image-source resolution with focused unit tests.
- Adds an export-only screenshot editor initialization path that avoids starting preview infrastructure.
- Routes rendered screenshot clipboard data through the existing project PNG renderer.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The rendered clipboard path receives PNG-encoded project output, and the export-only editor instance retains all state consumed by the renderer while omitting only unused preview infrastructure.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/automation.rs | Selects raw, explicit-output, or project-rendered clipboard sources and decodes rendered PNG bytes using the established clipboard path. |
| apps/desktop/src-tauri/src/screenshot_editor.rs | Adds a non-preview standalone instance mode while retaining every source, configuration, and dimension field consumed by one-off exports. |

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): honor rendered screenshot ..."](https://github.com/capsoftware/cap/commit/8353dc547a78f0b01ba23869775db7aa91070cd6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59327310)</sub>

<!-- /greptile_comment -->