### PR TITLE
fix(desktop): retry transient clipboard image writes

### DIFF
--- a/apps/desktop/src-tauri/src/automation.rs
+++ b/apps/desktop/src-tauri/src/automation.rs
@@ -64,25 +64,6 @@ fn clipboard_write_retry_delay(attempt: usize) -> Option<std::time::Duration> {
         .then(|| std::time::Duration::from_millis(CLIPBOARD_WRITE_RETRY_BASE_MS << attempt))
 }
 
-enum ClipboardImage {
-    File(PathBuf),
-    Encoded(Vec<u8>),
-}
-
-impl ClipboardImage {
-    fn load(&self) -> Result<clipboard_rs::RustImageData, String> {
-        match self {
-            Self::File(path) => {
-                let path = path.to_string_lossy().to_string();
-                clipboard_rs::RustImageData::from_path(&path)
-                    .map_err(|e| format!("Failed to load image for clipboard: {e}"))
-            }
-            Self::Encoded(bytes) => clipboard_rs::RustImageData::from_bytes(bytes)
-                .map_err(|e| format!("Failed to load rendered screenshot for clipboard: {e}")),
-        }
-    }
-}
-
 pub struct DesktopAutomationHost {
     app: AppHandle,
     clipboard: Arc<RwLock<ClipboardContext>>,
@@ -93,12 +74,11 @@ impl DesktopAutomationHost {
         Self { app, clipboard }
     }
 
-    async fn set_clipboard_image(&self, image: &ClipboardImage) -> Result<(), String> {
+    async fn set_clipboard_image(&self, image: clipboard_rs::RustImageData) -> Result<(), String> {
         for attempt in 0..CLIPBOARD_WRITE_ATTEMPTS {
-            let image_data = image.load()?;
             let result = {
                 let clipboard = self.clipboard.write().await;
-                clipboard.set_image(image_data)
+                clipboard.set_image(image.clone())
             };
 
             match result {
@@ -151,7 +131,9 @@ impl AutomationHost for DesktopAutomationHost {
         let image = match source {
             ClipboardImageSource::File(path) => {
                 info!(path = %path.display(), "Automation: copying file to clipboard");
-                ClipboardImage::File(path)
+                let path = path.to_string_lossy().to_string();
+                clipboard_rs::RustImageData::from_path(&path)
+                    .map_err(|e| format!("Failed to load image for clipboard: {e}"))?
             }
             ClipboardImageSource::ScreenshotProject(path) => {
                 info!(project = %path.display(), "Automation: rendering screenshot for clipboard");
@@ -160,11 +142,12 @@ impl AutomationHost for DesktopAutomationHost {
                     path,
                 )
                 .await?;
-                ClipboardImage::Encoded(rendered.image_bytes)
+                clipboard_rs::RustImageData::from_bytes(&rendered.image_bytes)
+                    .map_err(|e| format!("Failed to load rendered screenshot for clipboard: {e}"))?
             }
         };
 
-        self.set_clipboard_image(&image).await
+        self.set_clipboard_image(image).await
     }
 
     async fn save_to_location(

--- a/apps/desktop/src-tauri/src/automation.rs
+++ b/apps/desktop/src-tauri/src/automation.rs
@@ -64,6 +64,25 @@ fn clipboard_write_retry_delay(attempt: usize) -> Option<std::time::Duration> {
         .then(|| std::time::Duration::from_millis(CLIPBOARD_WRITE_RETRY_BASE_MS << attempt))
 }
 
+enum ClipboardImage {
+    File(PathBuf),
+    Encoded(Vec<u8>),
+}
+
+impl ClipboardImage {
+    fn load(&self) -> Result<clipboard_rs::RustImageData, String> {
+        match self {
+            Self::File(path) => {
+                let path = path.to_string_lossy().to_string();
+                clipboard_rs::RustImageData::from_path(&path)
+                    .map_err(|e| format!("Failed to load image for clipboard: {e}"))
+            }
+            Self::Encoded(bytes) => clipboard_rs::RustImageData::from_bytes(bytes)
+                .map_err(|e| format!("Failed to load rendered screenshot for clipboard: {e}")),
+        }
+    }
+}
+
 pub struct DesktopAutomationHost {
     app: AppHandle,
     clipboard: Arc<RwLock<ClipboardContext>>,
@@ -74,11 +93,12 @@ impl DesktopAutomationHost {
         Self { app, clipboard }
     }
 
-    async fn set_clipboard_image(&self, image: clipboard_rs::RustImageData) -> Result<(), String> {
+    async fn set_clipboard_image(&self, image: &ClipboardImage) -> Result<(), String> {
         for attempt in 0..CLIPBOARD_WRITE_ATTEMPTS {
+            let image_data = image.load()?;
             let result = {
                 let clipboard = self.clipboard.write().await;
-                clipboard.set_image(image.clone())
+                clipboard.set_image(image_data)
             };
 
             match result {
@@ -131,9 +151,7 @@ impl AutomationHost for DesktopAutomationHost {
         let image = match source {
             ClipboardImageSource::File(path) => {
                 info!(path = %path.display(), "Automation: copying file to clipboard");
-                let path = path.to_string_lossy().to_string();
-                clipboard_rs::RustImageData::from_path(&path)
-                    .map_err(|e| format!("Failed to load image for clipboard: {e}"))?
+                ClipboardImage::File(path)
             }
             ClipboardImageSource::ScreenshotProject(path) => {
                 info!(project = %path.display(), "Automation: rendering screenshot for clipboard");
@@ -142,12 +160,11 @@ impl AutomationHost for DesktopAutomationHost {
                     path,
                 )
                 .await?;
-                clipboard_rs::RustImageData::from_bytes(&rendered.image_bytes)
-                    .map_err(|e| format!("Failed to load rendered screenshot for clipboard: {e}"))?
+                ClipboardImage::Encoded(rendered.image_bytes)
             }
         };
 
-        self.set_clipboard_image(image).await
+        self.set_clipboard_image(&image).await
     }
 
     async fn save_to_location(

--- a/apps/desktop/src-tauri/src/automation.rs
+++ b/apps/desktop/src-tauri/src/automation.rs
@@ -21,6 +21,8 @@ use crate::general_settings::PostStudioRecordingBehaviour;
 
 const WEBHOOK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+const CLIPBOARD_WRITE_ATTEMPTS: usize = 4;
+const CLIPBOARD_WRITE_RETRY_BASE_MS: u64 = 50;
 
 #[derive(Debug, PartialEq, Eq)]
 enum ClipboardImageSource {
@@ -57,6 +59,30 @@ fn resolve_clipboard_image_source(
     }
 }
 
+fn clipboard_write_retry_delay(attempt: usize) -> Option<std::time::Duration> {
+    (attempt + 1 < CLIPBOARD_WRITE_ATTEMPTS)
+        .then(|| std::time::Duration::from_millis(CLIPBOARD_WRITE_RETRY_BASE_MS << attempt))
+}
+
+enum ClipboardImage {
+    File(PathBuf),
+    Encoded(Vec<u8>),
+}
+
+impl ClipboardImage {
+    fn load(&self) -> Result<clipboard_rs::RustImageData, String> {
+        match self {
+            Self::File(path) => {
+                let path = path.to_string_lossy().to_string();
+                clipboard_rs::RustImageData::from_path(&path)
+                    .map_err(|e| format!("Failed to load image for clipboard: {e}"))
+            }
+            Self::Encoded(bytes) => clipboard_rs::RustImageData::from_bytes(bytes)
+                .map_err(|e| format!("Failed to load rendered screenshot for clipboard: {e}")),
+        }
+    }
+}
+
 pub struct DesktopAutomationHost {
     app: AppHandle,
     clipboard: Arc<RwLock<ClipboardContext>>,
@@ -65,6 +91,34 @@ pub struct DesktopAutomationHost {
 impl DesktopAutomationHost {
     pub fn new(app: AppHandle, clipboard: Arc<RwLock<ClipboardContext>>) -> Self {
         Self { app, clipboard }
+    }
+
+    async fn set_clipboard_image(&self, image: &ClipboardImage) -> Result<(), String> {
+        for attempt in 0..CLIPBOARD_WRITE_ATTEMPTS {
+            let image_data = image.load()?;
+            let result = {
+                let clipboard = self.clipboard.write().await;
+                clipboard.set_image(image_data)
+            };
+
+            match result {
+                Ok(()) => return Ok(()),
+                Err(error) => {
+                    let Some(retry_delay) = clipboard_write_retry_delay(attempt) else {
+                        return Err(format!("Failed to set clipboard image: {error}"));
+                    };
+                    warn!(
+                        attempt = attempt + 1,
+                        retry_delay_ms = retry_delay.as_millis(),
+                        %error,
+                        "Clipboard image write failed; retrying"
+                    );
+                    tokio::time::sleep(retry_delay).await;
+                }
+            }
+        }
+
+        unreachable!("clipboard retry loop always returns")
     }
 }
 
@@ -94,12 +148,10 @@ impl AutomationHost for DesktopAutomationHost {
         source: &ClipboardSource,
     ) -> Result<(), String> {
         let source = resolve_clipboard_image_source(ctx, *source)?;
-        let img_data = match source {
+        let image = match source {
             ClipboardImageSource::File(path) => {
-                let path = path.to_string_lossy().to_string();
-                info!(%path, "Automation: copying file to clipboard");
-                clipboard_rs::RustImageData::from_path(&path)
-                    .map_err(|e| format!("Failed to load image for clipboard: {e}"))?
+                info!(path = %path.display(), "Automation: copying file to clipboard");
+                ClipboardImage::File(path)
             }
             ClipboardImageSource::ScreenshotProject(path) => {
                 info!(project = %path.display(), "Automation: rendering screenshot for clipboard");
@@ -108,18 +160,11 @@ impl AutomationHost for DesktopAutomationHost {
                     path,
                 )
                 .await?;
-                clipboard_rs::RustImageData::from_bytes(&rendered.image_bytes)
-                    .map_err(|e| format!("Failed to load rendered screenshot for clipboard: {e}"))?
+                ClipboardImage::Encoded(rendered.image_bytes)
             }
         };
 
-        self.clipboard
-            .write()
-            .await
-            .set_image(img_data)
-            .map_err(|e| format!("Failed to set clipboard image: {e}"))?;
-
-        Ok(())
+        self.set_clipboard_image(&image).await
     }
 
     async fn save_to_location(
@@ -1018,5 +1063,22 @@ mod tests {
                 "capture.cap/original.png"
             )))
         );
+    }
+
+    #[test]
+    fn clipboard_write_retries_use_bounded_exponential_backoff() {
+        assert_eq!(
+            clipboard_write_retry_delay(0),
+            Some(std::time::Duration::from_millis(50))
+        );
+        assert_eq!(
+            clipboard_write_retry_delay(1),
+            Some(std::time::Duration::from_millis(100))
+        );
+        assert_eq!(
+            clipboard_write_retry_delay(2),
+            Some(std::time::Duration::from_millis(200))
+        );
+        assert_eq!(clipboard_write_retry_delay(3), None);
     }
 }


### PR DESCRIPTION
Transient clipboard contention no longer drops an otherwise successful screenshot automation.

The desktop host now retries failed image clipboard writes with a short, bounded exponential backoff. Raw files and rendered project outputs share the same path. Project rendering happens once; each attempt only rebuilds clipboard image data. The clipboard lock is released before waiting, so unrelated operations are not held behind the backoff.

This follows a transient Windows clipboard ownership failure observed in production, where an immediate retry succeeded. A focused test covers the retry bounds, and the existing source-selection tests remain unchanged.

Rust formatting and diff checks pass. Local Cargo tests did not start because Git Bash exited the Visual Studio environment wrapper before Cargo; upstream CI is the compile and test gate. No native clipboard acceptance run was performed for this branch.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds bounded retries for transient desktop clipboard image-write failures while releasing the clipboard lock during backoff.
- Retries image writes up to four times with 50, 100, and 200 ms delays.
- Uses the same retry path for file-backed and rendered screenshot images.
- Renders screenshot projects once, rebuilding only clipboard image data for each attempt.
- Adds a focused unit test covering retry count and delay bounds.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the bounded clipboard retry implementation.

The retry loop remains bounded, releases the clipboard lock before sleeping, preserves platform-specific clipboard method resolution, and renders project output only once.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/automation.rs | Adds a bounded clipboard image-write retry helper and test without introducing a concrete correctness, security, or platform-build defect. |

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): retry transient clipboard ..."](https://github.com/capsoftware/cap/commit/7fe7ee2e31f5b6d069c7b5dad2c7d9d4415f6c5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59437893)</sub>

<!-- /greptile_comment -->