### PR TITLE
fix(web): return restricted share viewers to the video after sign-in

### DIFF
--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -166,12 +166,19 @@ async function getSharedSpacesForVideo(videoId: Video.VideoId) {
 	return sharedSpaces;
 }
 
-function PolicyDeniedView({ reason }: { reason?: string }) {
+function PolicyDeniedView({
+	reason,
+	videoId,
+}: {
+	reason?: string;
+	videoId: string;
+}) {
+	const loginHref = `/login?next=/s/${videoId}`;
 	let title = "This video is private";
 	let description: React.ReactNode = (
 		<>
-			If you own this video, please <Link href="/login">sign in</Link> to manage
-			sharing.
+			If you own this video, please <Link href={loginHref}>sign in</Link> to
+			manage sharing.
 		</>
 	);
 
@@ -180,7 +187,7 @@ function PolicyDeniedView({ reason }: { reason?: string }) {
 		description = (
 			<>
 				The owner of this video has restricted access. Please{" "}
-				<Link href="/login">sign in</Link> with an authorized email address to
+				<Link href={loginHref}>sign in</Link> with an authorized email address to
 				view.
 			</>
 		);
@@ -195,12 +202,22 @@ function PolicyDeniedView({ reason }: { reason?: string }) {
 			<Logo className="size-32" />
 			<h1 className="mb-2 text-2xl font-semibold">{title}</h1>
 			<p className="text-gray-400">{description}</p>
+			{reason !== "email_restriction_denied" ? (
+				<Link
+					href={loginHref}
+					className="mt-4 inline-flex items-center rounded-full bg-gray-12 px-4 py-2 text-sm font-semibold text-gray-1"
+				>
+					Sign in
+				</Link>
+			) : null}
 		</div>
 	);
 }
 
 const renderPolicyDenied = (videoId: Video.VideoId, reason?: string) =>
-	Effect.succeed(<PolicyDeniedView key={videoId} reason={reason} />);
+	Effect.succeed(
+		<PolicyDeniedView key={videoId} videoId={videoId} reason={reason} />,
+	);
 
 const renderNoSuchElement = (awaitRecording: boolean) =>
 	awaitRecording


### PR DESCRIPTION
## Summary
Restricted `/s/{videoId}` pages tell the viewer to sign in, then send them to `/login` with no `next`. Google OAuth dumps them on `/dashboard`; they have to refresh the original tab.

Login already honors `?next=` (`getSafeNextPath` + `LoginForm`). This wires `PolicyDeniedView` to `/login?next=/s/{videoId}` and adds a visible Sign in button so the CTA is not a gray word in the body copy.

`email_restriction_denied` stays copy-only — those viewers are already signed in.

Fixes https://github.com/CapSoftware/Cap/issues/2192

## Test plan
- [ ] Open a video with email restriction while signed out. Denied page shows Sign in.
- [ ] Sign in with Google. Land back on `/s/{videoId}`, not `/dashboard`.
- [ ] Same for a private video (`This video is private`).
- [ ] Signed-in user whose email fails the restriction still sees copy-only denial.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a safe return path and visible sign-in CTA to restricted share-page denial states so anonymous viewers return to the requested video after authentication.
- Passes the current video ID into `PolicyDeniedView`.
- Uses `/login?next=/s/{videoId}` for inline and button sign-in links.
- Keeps the button hidden for signed-in viewers denied by email restrictions.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking misleading Sign in CTA for authenticated users who cannot access a private video.

The intended anonymous sign-in return flow is preserved, but reasonless private-video denials do not distinguish signed-in viewers, causing the new CTA to redirect those users back to the same denial.

**Files Needing Attention:** apps/web/app/s/[videoId]/page.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/s/[videoId]/page.tsx | Adds login return-path links to policy-denied views, but the new button is also shown to already-authenticated users denied access to private videos. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/app/s/[videoId]/page.tsx:205-212
**Misleading Sign In CTA**

A signed-in user who lacks access to a private video receives a reasonless policy denial, so this condition still displays the Sign in button. Clicking it redirects the authenticated user back to the same denied video, creating a dead-end CTA.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): return restricted share viewer..."](https://github.com/capsoftware/cap/commit/2dccacd9fb365b28d388307e5d00e3d0b4c036ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59687375)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Web application routes and components](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-application-routes.md)

<!-- /greptile_comment -->