### PR TITLE
fix: recover Drive recordings with safe retry backoff

### DIFF
--- a/apps/web/__tests__/unit/finalize-desktop-recording.test.ts
+++ b/apps/web/__tests__/unit/finalize-desktop-recording.test.ts
@@ -172,14 +172,16 @@ beforeEach(() => {
 		withCurrent({ leaseExpiresAt: new Date(Date.now() + 5 * 60_000) });
 		return true;
 	});
-	mocks.retry.mockImplementation(async () => {
-		withCurrent({
-			state: "retry",
-			leaseExpiresAt: null,
-			nextRetryAt: new Date(Date.now() + 15_000),
-		});
-		return true;
-	});
+	mocks.retry.mockImplementation(
+		async ({ nextRetryAt }: { nextRetryAt?: Date }) => {
+			withCurrent({
+				state: "retry",
+				leaseExpiresAt: null,
+				nextRetryAt: nextRetryAt ?? new Date(Date.now() + 15_000),
+			});
+			return true;
+		},
+	);
 	mocks.blocked.mockImplementation(async () => {
 		withCurrent({ state: "source-blocked", leaseExpiresAt: null });
 		return true;
@@ -332,6 +334,32 @@ function pollingInput() {
 }
 
 describe("short durable processing polls", () => {
+	it.each(["processing-timeout", "worker-lease-expired"])(
+		"does not reuse a rich attempt's stale retry date after %s",
+		async (errorCode) => {
+			withCurrent({ leaseExpiresAt: new Date(now.getTime() - 1) });
+			mocks.observe.mockResolvedValue({
+				status: "unavailable",
+				delivered: false,
+			});
+			const input = {
+				...fixture,
+				...pollingInput(),
+				nextRetryAt: new Date(now.getTime() - 60_000),
+				...(errorCode === "processing-timeout" ? { deadline: now } : {}),
+			};
+			expect(await pollDesktopRecordingAttempt(input)).toBe("retry");
+			expect(current?.nextRetryAt).toEqual(new Date(now.getTime() + 15_000));
+			expect(mocks.retry.mock.calls[0]?.[0]).not.toHaveProperty("nextRetryAt");
+			expect(mocks.retry.mock.calls[0]?.[0]).toMatchObject({
+				videoId,
+				generation: fixture.generation,
+				attemptId: fixture.attemptId,
+				errorCode,
+			});
+		},
+	);
+
 	it("does not treat a delivered terminal webhook as durable success until publication is committed", async () => {
 		mocks.observe.mockResolvedValue({ status: "terminal", delivered: true });
 		expect(await pollDesktopRecordingAttempt(pollingInput())).toBe("waiting");
@@ -535,6 +563,39 @@ describe("source commitment and media request compatibility", () => {
 });
 
 describe("workflow retry lifetime", () => {
+	it("waits for fresh backoff after a source commit failure with a rich stale attempt", async () => {
+		withCurrent({
+			state: "committing",
+			source: null,
+			leaseExpiresAt: null,
+			nextRetryAt: new Date(now.getTime() - 60_000),
+		});
+		mocks.commitSource.mockRejectedValueOnce(
+			new Error("provider copy unavailable"),
+		);
+		expect(
+			await finalizeDesktopRecordingWorkflow({
+				videoId,
+				userId,
+				generation: fixture.generation,
+			}),
+		).toEqual({ success: true, jobId: "remote-job" });
+		expect(mocks.retry).toHaveBeenCalledWith({
+			videoId,
+			generation: fixture.generation,
+			attemptId: "attempt-2",
+			errorCode: "processing-interrupted",
+			errorMessage: "provider copy unavailable",
+		});
+		expect(mocks.sleep.mock.calls[0]).toEqual([
+			new Date(now.getTime() + 15_000),
+		]);
+		expect(mocks.claim.mock.calls[1]?.[0].now).toEqual(
+			new Date(now.getTime() + 15_000),
+		);
+		expect(mocks.fetch).toHaveBeenCalledOnce();
+	});
+
 	it("waits durably between failed attempts and continues past the old eight-attempt cutoff", async () => {
 		withCurrent({
 			state: "committing",

--- a/apps/web/__tests__/unit/google-drive-storage.test.ts
+++ b/apps/web/__tests__/unit/google-drive-storage.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { Organisation, Storage, User, Video } from "@cap/web-domain";
 import { Cause, Effect, Exit, Layer, Option } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -15,6 +16,7 @@ import { Storage as StorageService } from "../../../../packages/web-backend/src/
 import {
 	copyGoogleDriveFile,
 	createGoogleDriveResumableUpload,
+	findGoogleDriveFileByObjectKey,
 	GOOGLE_DRIVE_FOLDER_MIME_TYPE,
 	type GoogleDriveTokenStore,
 	syncGoogleDriveVideoNames,
@@ -1024,7 +1026,7 @@ describe("Google Drive upload updates and copies", () => {
 		expect(requestBody(init)).toEqual({
 			name: "Copied: launch/demo.mp4",
 			parents: ["folder-id"],
-			appProperties: { capObjectKey: resultKey },
+			appProperties: { capObjectKey: resultKey, capObjectKeySha256: null },
 		});
 		expect(harness.upserts.at(-1)).toMatchObject({
 			providerObjectId: "copied-file-id",
@@ -1035,6 +1037,364 @@ describe("Google Drive upload updates and copies", () => {
 				contentType: "video/mp4",
 			},
 		});
+	});
+});
+
+describe("Google Drive bounded object identity", () => {
+	const prefix = `${videoOwnerId}/${videoId}/`;
+	const generation = "11111111-1111-4111-8111-111111111111";
+	const snapshot = "22222222-2222-4222-8222-222222222222";
+	const plan = "33333333-3333-4333-8333-333333333333";
+	const manifestKey = `${prefix}.recording/sources/${generation}/${snapshot}/plans/${plan}/manifest.json`;
+	const outputKey = `${prefix}.recording/outputs/${generation}/${snapshot}.mp4`;
+	const digest = (key: string) =>
+		createHash("sha256").update(key, "utf8").digest("hex");
+	const makeHarness = () => {
+		const harness = makeRepoHarness();
+		harness.putObject(
+			storedObjectInput(".cap-folders/video-1", "folder-id", {
+				contentType: GOOGLE_DRIVE_FOLDER_MIME_TYPE,
+			}),
+		);
+		harness.putObject(
+			storedObjectInput(
+				".cap-warnings/video-1/DO_NOT_EDIT_OR_DELETE.txt",
+				"warning-id",
+				{ contentType: "text/plain" },
+			),
+		);
+		return harness;
+	};
+	const upload = (harness: RepoHarness, key: string) =>
+		Effect.runPromise(
+			createGoogleDriveResumableUpload(
+				harness.repo,
+				makeConfig(),
+				{
+					integrationId,
+					ownerId: integrationOwnerId,
+					videoId,
+					key,
+					contentType: "application/json",
+					contentLength: 2,
+				},
+				makeTokenStore(),
+			),
+		);
+
+	it.each([
+		["ASCII boundary", `${prefix}${"x".repeat(112 - prefix.length)}`, false],
+		["ASCII overflow", `${prefix}${"x".repeat(113 - prefix.length)}`, true],
+		[
+			"UTF-8 boundary",
+			`${prefix}${"é".repeat((112 - prefix.length) / 2)}`,
+			false,
+		],
+		[
+			"UTF-8 overflow",
+			`${prefix}${"é".repeat((112 - prefix.length) / 2 + 1)}`,
+			true,
+		],
+		["source plan manifest", manifestKey, true],
+		["immutable output", outputKey, true],
+	] as const)(
+		"starts an upload within the provider property limit: %s",
+		async (_, key, hashed) => {
+			const harness = makeHarness();
+			const fetchMock = vi.fn(
+				async (input: string | URL | Request, init?: RequestInit) => {
+					const url = String(input);
+					if (url.includes("/files/generateIds"))
+						return jsonResponse({ ids: ["new-object-id"] });
+					if (url.includes("uploadType=resumable") && init?.method === "POST") {
+						const properties = requestBody(init)?.appProperties;
+						if (!properties || typeof properties !== "object")
+							throw new Error("Missing object identity");
+						for (const [name, value] of Object.entries(properties)) {
+							if (
+								typeof value !== "string" ||
+								Buffer.byteLength(name + value, "utf8") > 124
+							)
+								return response(400);
+						}
+						return response(200, { Location: "https://upload.test/bounded" });
+					}
+					throw new Error("Unexpected provider request");
+				},
+			);
+			vi.stubGlobal("fetch", fetchMock);
+
+			await expect(upload(harness, key)).resolves.toBe(
+				"https://upload.test/bounded",
+			);
+			const post = fetchMock.mock.calls.find(
+				([, init]) => init?.method === "POST",
+			);
+			expect(requestBody(post?.[1])?.appProperties).toEqual(
+				hashed ? { capObjectKeySha256: digest(key) } : { capObjectKey: key },
+			);
+			expect(
+				harness.objects.get(objectMapKey(integrationId, key)),
+			).toMatchObject({
+				objectKey: key,
+				providerObjectId: "new-object-id",
+			});
+		},
+	);
+
+	it("preserves an existing long-key object's id and display metadata", async () => {
+		const harness = makeHarness();
+		const original = harness.putObject(
+			storedObjectInput(manifestKey, "existing-long-id", {
+				fileName: "Original visible name.json",
+				contentType: "application/json",
+			}),
+		);
+		const fetchMock = vi.fn(
+			async (_input: string | URL | Request, _init?: RequestInit) =>
+				response(200, { Location: "https://upload.test/existing-long" }),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(upload(harness, manifestKey)).resolves.toBe(
+			"https://upload.test/existing-long",
+		);
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const [input, init] = fetchMock.mock.calls[0] ?? [];
+		expect(String(input)).toContain("/files/existing-long-id?");
+		expect(requestBody(init)).toEqual({ mimeType: "application/json" });
+		expect(
+			harness.objects.get(objectMapKey(integrationId, manifestKey)),
+		).toMatchObject({
+			objectKey: manifestKey,
+			providerObjectId: original.providerObjectId,
+			metadata: original.metadata,
+		});
+	});
+
+	it.each([
+		["legacy long key", { capObjectKey: manifestKey }, true],
+		["hashed long key", { capObjectKeySha256: digest(manifestKey) }, true],
+		[
+			"matching dual identities",
+			{ capObjectKey: manifestKey, capObjectKeySha256: digest(manifestKey) },
+			true,
+		],
+		[
+			"contradictory legacy identity",
+			{ capObjectKey: resultKey, capObjectKeySha256: digest(manifestKey) },
+			false,
+		],
+		[
+			"contradictory hashed identity",
+			{ capObjectKey: manifestKey, capObjectKeySha256: digest(resultKey) },
+			false,
+		],
+		[
+			"different recording",
+			{ capObjectKeySha256: digest(`${manifestKey}-different`) },
+			false,
+		],
+		["missing identity", {}, false],
+	] as const)(
+		"searches both representations without accepting %s aliases",
+		async (_, appProperties, accepted) => {
+			const fetchMock = vi.fn(async (_input: string | URL | Request) =>
+				jsonResponse({
+					files: [{ id: "candidate-id", size: "2", appProperties }],
+				}),
+			);
+			vi.stubGlobal("fetch", fetchMock);
+			const result = await Effect.runPromise(
+				findGoogleDriveFileByObjectKey(
+					makeConfig(),
+					manifestKey,
+					makeTokenStore(),
+				),
+			);
+			expect(Option.isSome(result)).toBe(accepted);
+			const [input] = fetchMock.mock.calls[0] ?? [];
+			const query = new URL(String(input)).searchParams.get("q");
+			expect(query).toContain(`key='capObjectKey' and value='${manifestKey}'`);
+			expect(query).toContain(
+				`key='capObjectKeySha256' and value='${digest(manifestKey)}'`,
+			);
+		},
+	);
+
+	it("does not let a larger conflicting candidate displace an exact match", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				jsonResponse({
+					files: [
+						{
+							id: "wrong-id",
+							size: "1000",
+							appProperties: {
+								capObjectKey: resultKey,
+								capObjectKeySha256: digest(manifestKey),
+							},
+						},
+						{
+							id: "right-id",
+							size: "2",
+							appProperties: { capObjectKeySha256: digest(manifestKey) },
+						},
+					],
+				}),
+			),
+		);
+		const result = await Effect.runPromise(
+			findGoogleDriveFileByObjectKey(
+				makeConfig(),
+				manifestKey,
+				makeTokenStore(),
+			),
+		);
+		expect(Option.getOrThrow(result).id).toBe("right-id");
+	});
+
+	it("recovers a missing long-key object through its hashed provider identity", async () => {
+		const harness = makeHarness();
+		harness.putObject(storedObjectInput(manifestKey, "missing-manifest-id"));
+		const access = await getStorageAccess(harness);
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = new URL(String(input));
+			if (url.pathname.endsWith("/missing-manifest-id")) return response(404);
+			if (url.pathname.endsWith("/files")) {
+				return jsonResponse({
+					files: [
+						{
+							id: "recovered-manifest-id",
+							name: "manifest.json",
+							mimeType: "application/json",
+							size: "2",
+							appProperties: { capObjectKeySha256: digest(manifestKey) },
+						},
+					],
+				});
+			}
+			if (
+				url.pathname.endsWith("/recovered-manifest-id") &&
+				url.searchParams.get("alt") === "media"
+			)
+				return new Response("{}", {
+					headers: { "Content-Type": "application/json" },
+				});
+			throw new Error("Unexpected provider request");
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await Effect.runPromise(access.getObject(manifestKey));
+		expect(Option.getOrThrow(result)).toBe("{}");
+		expect(
+			harness.objects.get(objectMapKey(integrationId, manifestKey)),
+		).toMatchObject({
+			objectKey: manifestKey,
+			providerObjectId: "recovered-manifest-id",
+			uploadStatus: "complete",
+		});
+		expect(harness.updates).toHaveLength(1);
+	});
+
+	it.each([
+		["short to long", resultKey, manifestKey],
+		["long to short", manifestKey, resultKey],
+		["long to long", manifestKey, outputKey],
+	] as const)(
+		"clears inherited identity aliases when copying %s",
+		async (_, sourceKey, targetKey) => {
+			const harness = makeHarness();
+			harness.putObject(storedObjectInput(sourceKey, "source-id"));
+			const sourceProperties: Record<string, string> = {
+				customerTag: "preserve",
+				...(sourceKey === resultKey
+					? { capObjectKey: sourceKey }
+					: { capObjectKeySha256: digest(sourceKey) }),
+			};
+			const copiedProperties = { ...sourceProperties };
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+					const properties = requestBody(init)?.appProperties;
+					if (!properties || typeof properties !== "object")
+						throw new Error("Missing copy identity");
+					for (const [name, value] of Object.entries(properties)) {
+						if (value === null) delete copiedProperties[name];
+						else if (
+							typeof value === "string" &&
+							Buffer.byteLength(name + value, "utf8") <= 124
+						)
+							copiedProperties[name] = value;
+						else return response(400);
+					}
+					return jsonResponse({
+						id: "copied-id",
+						name: requestBody(init)?.name,
+						mimeType: "video/mp4",
+						size: "1234",
+					});
+				}),
+			);
+
+			await Effect.runPromise(
+				copyGoogleDriveFile({
+					repo: harness.repo,
+					config: makeConfig(),
+					sourceFileId: "source-id",
+					input: {
+						integrationId,
+						ownerId: integrationOwnerId,
+						videoId,
+						key: targetKey,
+						contentType: "video/mp4",
+					},
+					tokenStore: makeTokenStore(),
+				}),
+			);
+			expect(copiedProperties).toEqual({
+				customerTag: "preserve",
+				...(targetKey === resultKey
+					? { capObjectKey: targetKey }
+					: { capObjectKeySha256: digest(targetKey) }),
+			});
+			expect(
+				harness.objects.get(objectMapKey(integrationId, sourceKey))
+					?.providerObjectId,
+			).toBe("source-id");
+			expect(
+				harness.objects.get(objectMapKey(integrationId, targetKey)),
+			).toMatchObject({
+				objectKey: targetKey,
+				providerObjectId: "copied-id",
+				metadata: { fileName: targetKey.split("/").slice(2).join("__") },
+			});
+		},
+	);
+
+	it("keeps a newer long-key provider mapping when deletion finishes after remapping", async () => {
+		const harness = makeHarness();
+		harness.putObject(storedObjectInput(outputKey, "old-output-id"));
+		const access = await getStorageAccess(harness);
+		const fetchMock = vi.fn(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				if (init?.method !== "DELETE")
+					throw new Error("Unexpected provider request");
+				harness.putObject(storedObjectInput(outputKey, "new-output-id"));
+				return response(204);
+			},
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		await Effect.runPromise(access.deleteObject(outputKey));
+		expect(fetchMock).toHaveBeenCalledOnce();
+		expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+			"/files/old-output-id?",
+		);
+		expect(
+			harness.objects.get(objectMapKey(integrationId, outputKey))
+				?.providerObjectId,
+		).toBe("new-output-id");
 	});
 });
 
@@ -1221,6 +1581,7 @@ describe("Google Drive title synchronization", () => {
 						files: [
 							{
 								id: "recovered-stale-id",
+								appProperties: { capObjectKey: resultKey },
 								name: "Recovered.mp4",
 								mimeType: "video/mp4",
 								size: "123",
@@ -1268,6 +1629,7 @@ describe("Google Drive title synchronization", () => {
 						files: [
 							{
 								id: "different-file-id",
+								appProperties: { capObjectKey: resultKey },
 								name: "Different.mp4",
 								mimeType: "video/mp4",
 								size: "123",
@@ -1379,6 +1741,39 @@ describe("Google Drive title synchronization", () => {
 			},
 		});
 		expect(harness.fileNameUpdates).toHaveLength(2);
+	});
+
+	it("rejects contradictory object identities before any name change", async () => {
+		const { harness, files } = makeSyncHarness();
+		const file = files.get("file-id");
+		if (!file) throw new Error("Missing Drive file fixture");
+		file.appProperties = {
+			...file.appProperties,
+			capObjectKeySha256: createHash("sha256")
+				.update(`${resultKey}-different`, "utf8")
+				.digest("hex"),
+		};
+		const fetchMock = makeDriveFileFetch(files);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			Effect.runPromise(
+				syncGoogleDriveVideoNames(
+					harness.repo,
+					makeConfig(),
+					syncVideo,
+					makeTokenStore(),
+				),
+			),
+		).rejects.toBeDefined();
+		expect(
+			fetchMock.mock.calls.filter(([, init]) => init?.method === "PATCH"),
+		).toHaveLength(0);
+		expect(harness.fileNameUpdates).toHaveLength(0);
+		expect(file).toMatchObject({
+			name: "Old title.mp4",
+			md5Checksum: "original-md5",
+		});
 	});
 
 	it("refreshes verification ETags after a name-only rename without changing media bytes", async () => {

--- a/apps/web/workflows/finalize-desktop-recording.ts
+++ b/apps/web/workflows/finalize-desktop-recording.ts
@@ -510,9 +510,11 @@ export async function startDesktopRecordingJob(
 }
 
 export async function pollDesktopRecordingAttempt({
+	videoId,
+	generation,
+	attemptId,
 	jobId,
 	deadline,
-	...fence
 }: DesktopRecordingAttemptFence & {
 	jobId: string;
 	deadline: Date;
@@ -521,6 +523,7 @@ export async function pollDesktopRecordingAttempt({
 > {
 	"use step";
 
+	const fence = { videoId, generation, attemptId };
 	let current = await getProcessingState(fence);
 	if (!current) return "superseded";
 	if (current.state === "verified") return "verified";
@@ -574,18 +577,19 @@ export async function pollDesktopRecordingAttempt({
 }
 
 async function retryDesktopRecordingAttempt(
-	attempt: DesktopRecordingAttemptFence,
+	{ videoId, generation, attemptId }: DesktopRecordingAttemptFence,
 	errorMessage: string,
 	sourceErrorCode: ReturnType<typeof getSourceErrorCode>,
 ): Promise<"retry" | "source-blocked" | "superseded"> {
 	"use step";
 
-	const current = await getProcessingState(attempt);
-	if (!current || current.attemptId !== attempt.attemptId) return "superseded";
+	const fence = { videoId, generation, attemptId };
+	const current = await getProcessingState(fence);
+	if (!current || current.attemptId !== attemptId) return "superseded";
 	if (current.state === "source-blocked") return "source-blocked";
 	if (sourceErrorCode) {
 		return (await markSourceBlocked({
-			...attempt,
+			...fence,
 			errorCode: sourceErrorCode,
 			errorMessage,
 		}))
@@ -593,7 +597,7 @@ async function retryDesktopRecordingAttempt(
 			: "superseded";
 	}
 	return (await scheduleRetry({
-		...attempt,
+		...fence,
 		errorCode: "processing-interrupted",
 		errorMessage,
 	}))

--- a/packages/web-backend/src/Storage/GoogleDrive.ts
+++ b/packages/web-backend/src/Storage/GoogleDrive.ts
@@ -155,6 +155,43 @@ const isDriveRequestStatus = (
 const escapeDriveQueryValue = (value: string) =>
 	value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 
+const getGoogleDriveObjectKeyHash = (key: string) =>
+	createHash("sha256").update(key, "utf8").digest("hex");
+
+const getGoogleDriveObjectKeyProperty = (key: string) =>
+	Buffer.byteLength(`capObjectKey${key}`, "utf8") <= 124
+		? { name: "capObjectKey", value: key }
+		: { name: "capObjectKeySha256", value: getGoogleDriveObjectKeyHash(key) };
+
+const getGoogleDriveObjectKeyProperties = (
+	key: string,
+	clearInherited = false,
+): Record<string, string | null> => {
+	const property = getGoogleDriveObjectKeyProperty(key);
+	const properties: Record<string, string | null> = clearInherited
+		? { capObjectKey: null, capObjectKeySha256: null }
+		: {};
+	properties[property.name] = property.value;
+	return properties;
+};
+
+const googleDriveFileMatchesObjectKey = (
+	file: GoogleDriveFile,
+	key: string,
+) => {
+	const properties = file.appProperties;
+	if (!properties) return false;
+	const keyHash = getGoogleDriveObjectKeyHash(key);
+	return (
+		(properties.capObjectKey === key ||
+			properties.capObjectKeySha256 === keyHash) &&
+		(properties.capObjectKey === undefined ||
+			properties.capObjectKey === key) &&
+		(properties.capObjectKeySha256 === undefined ||
+			properties.capObjectKeySha256 === keyHash)
+	);
+};
+
 const GOOGLE_DRIVE_ACCESS_TOKEN_EXPIRY_MARGIN_MS = 60_000;
 const GOOGLE_DRIVE_TOKEN_REFRESH_LEASE_MS = 15_000;
 const googleDriveAccessTokenCache = new Map<
@@ -1097,7 +1134,7 @@ export const createGoogleDriveResumableUpload = (
 							name: fileName,
 							mimeType: contentType,
 							parents: [parentId],
-							appProperties: { capObjectKey: input.key },
+							appProperties: getGoogleDriveObjectKeyProperties(input.key),
 						}),
 					},
 					tokenStore,
@@ -1260,13 +1297,17 @@ export const findGoogleDriveFileByObjectKey = (
 	key: string,
 	tokenStore?: GoogleDriveTokenStore,
 ) => {
+	const property = getGoogleDriveObjectKeyProperty(key);
+	const legacyQuery = `appProperties has { key='capObjectKey' and value='${escapeDriveQueryValue(key)}' }`;
 	const query = [
-		`appProperties has { key='capObjectKey' and value='${escapeDriveQueryValue(key)}' }`,
+		property.name === "capObjectKey"
+			? legacyQuery
+			: `(${legacyQuery} or appProperties has { key='capObjectKeySha256' and value='${property.value}' })`,
 		"trashed=false",
 	].join(" and ");
 	const params = new URLSearchParams({
 		q: query,
-		fields: "files(id,name,mimeType,size,modifiedTime)",
+		fields: "files(id,name,mimeType,size,modifiedTime,appProperties)",
 		orderBy: "modifiedTime desc",
 		pageSize: "10",
 		spaces: "drive",
@@ -1288,7 +1329,9 @@ export const findGoogleDriveFileByObjectKey = (
 			}),
 		),
 		Effect.map((body) => {
-			const files = body.files ?? [];
+			const files = (body.files ?? []).filter((file) =>
+				googleDriveFileMatchesObjectKey(file, key),
+			);
 			return Option.fromNullable(
 				files.find((file) => Number(file.size ?? 0) > 0) ?? files[0],
 			);
@@ -1368,7 +1411,7 @@ const googleDriveFileMatchesTarget = (
 	file.parents?.length === 1 &&
 	file.parents[0] === input.parentId &&
 	(input.mimeType === GOOGLE_DRIVE_FOLDER_MIME_TYPE ||
-		file.appProperties?.capObjectKey === input.key);
+		googleDriveFileMatchesObjectKey(file, input.key));
 
 export const deleteGoogleDriveFile = (
 	config: GoogleDriveIntegrationConfig,
@@ -1418,9 +1461,7 @@ export const copyGoogleDriveFile = ({
 				body: JSON.stringify({
 					name: fileName,
 					parents: [parentId],
-					appProperties: {
-						capObjectKey: input.key,
-					},
+					appProperties: getGoogleDriveObjectKeyProperties(input.key, true),
 				}),
 			},
 			tokenStore,


### PR DESCRIPTION
## Summary

- Keep short Google Drive object keys unchanged and encode longer keys as a SHA-256 app property, respecting Drive's UTF-8 property size limit.
- Use the same identity rules for upload, copy, lookup and deletion, retain legacy lookup compatibility, and reject conflicting identities.
- Pass only the recording generation fence into retry scheduling so an earlier attempt's stale retry timestamp cannot bypass backoff.

## Verification

- 187 scoped Google Drive, storage lifecycle, workflow, durable job and publication tests passed.
- Scoped Biome and git diff checks passed.
- Regression coverage includes long and multibyte keys, inherited copy metadata, legacy lookups, conflicting identities, stale retry timestamps, processing timeouts and expired leases.

No database migration or client update is required. Existing provider IDs, logical keys, recordings and source files are retained. This changes only web/backend files; media processing code is unchanged.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes Google Drive object identity safe for long UTF-8 keys and prevents stale retry timestamps from bypassing recording-finalization backoff.

- Stores short object keys directly and long keys by SHA-256 identity while retaining compatible legacy lookup.
- Applies consistent identity validation across upload, copy, lookup, deletion recovery, and name synchronization.
- Restricts retry scheduling to the recording generation fence so retries receive a fresh backoff timestamp.
- Adds regression coverage for key boundaries, conflicting metadata, recovery, copy metadata, expired leases, and stale retry dates.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The production changes consistently apply the new Drive identity representation and remove stale retry scheduling data, while focused tests cover the principal compatibility, recovery, conflict, and lifecycle paths.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/workflows/finalize-desktop-recording.ts | Narrows retry inputs to the generation fence so stale attempt scheduling data cannot suppress fresh backoff. |
| packages/web-backend/src/Storage/GoogleDrive.ts | Introduces bounded object-key identities and consistently validates or clears legacy and hashed Drive metadata. |
| apps/web/__tests__/unit/finalize-desktop-recording.test.ts | Adds regression coverage proving timeout, lease-expiry, and source-commit retries use newly scheduled backoff. |
| apps/web/__tests__/unit/google-drive-storage.test.ts | Adds comprehensive boundary, compatibility, conflict, recovery, copy, deletion-race, and synchronization coverage. |

<sub>Reviews (1): Last reviewed commit: ["fix: preserve durable recording retry ba..."](https://github.com/capsoftware/cap/commit/ab849a4508f2d036f7e4db40b69e6c8eea67a67c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59740763)</sub>

**Context used:**

- Knowledge Base — [Web product and collaborative workspace](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-product.md)

<!-- /greptile_comment -->