### PR TITLE
fix(desktop): attribute graceful exit requests

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -459,6 +459,20 @@ const APP_MENU_QUIT_ID: &str = "app_quit";
 #[cfg(target_os = "macos")]
 static MACOS_NATIVE_TERMINATE_APP: std::sync::OnceLock<AppHandle> = std::sync::OnceLock::new();
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum AppExitSource {
+    #[cfg(target_os = "macos")]
+    AppMenu,
+    #[cfg(target_os = "macos")]
+    MacOsNativeTermination,
+    Runtime,
+    #[cfg(unix)]
+    SigHup,
+    #[cfg(unix)]
+    SigTerm,
+    TrayMenu,
+}
+
 async fn await_exit_step<T, E, F>(name: &'static str, timeout: Duration, fut: F) -> Option<T>
 where
     E: std::fmt::Display,
@@ -671,7 +685,7 @@ unsafe extern "C" fn macos_application_should_terminate(
     if let Some(app) = MACOS_NATIVE_TERMINATE_APP.get() {
         let app = app.clone();
         tokio::spawn(async move {
-            request_app_exit(app).await;
+            request_app_exit(app, AppExitSource::MacOsNativeTermination).await;
         });
     } else {
         warn!("macOS native termination requested before app exit handler was installed");
@@ -3002,7 +3016,8 @@ fn restart_app(app: AppHandle) -> Result<(), String> {
     }
 }
 
-pub async fn request_app_exit(app: AppHandle) {
+pub(crate) async fn request_app_exit(app: AppHandle, source: AppExitSource) {
+    info!(?source, "Starting app exit request");
     let Some(exit_state) = app.try_state::<AppExitState>() else {
         show_exit_blocked(&app, ExitBlocked::StateUnavailable);
         return;
@@ -6182,7 +6197,7 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
             if event.id() == APP_MENU_QUIT_ID {
                 let app = app.clone();
                 tokio::spawn(async move {
-                    request_app_exit(app).await;
+                    request_app_exit(app, AppExitSource::AppMenu).await;
                 });
             }
         })
@@ -6323,21 +6338,23 @@ pub async fn run(recording_logging_handle: LoggingHandle, logs_dir: PathBuf) {
                         return;
                     };
                     loop {
-                        tokio::select! {
+                        let source = tokio::select! {
                             signal = term.recv() => {
                                 if signal.is_none() {
                                     return;
                                 }
                                 tracing::info!("Received SIGTERM; requesting graceful shutdown");
+                                AppExitSource::SigTerm
                             }
                             signal = hup.recv() => {
                                 if signal.is_none() {
                                     return;
                                 }
                                 tracing::info!("Received SIGHUP; requesting graceful shutdown");
+                                AppExitSource::SigHup
                             }
-                        }
-                        request_app_exit(app_for_signal.clone()).await;
+                        };
+                        request_app_exit(app_for_signal.clone(), source).await;
                         if app_is_exiting(&app_for_signal) {
                             return;
                         }
@@ -7294,7 +7311,7 @@ fn handle_run_event(_handle: &AppHandle, event: tauri::RunEvent) {
                 ExitRequestDecision::StartCleanup => {
                     let handle = _handle.clone();
                     spawn_on_runtime(async move {
-                        request_app_exit(handle).await;
+                        request_app_exit(handle, AppExitSource::Runtime).await;
                     });
                 }
                 ExitRequestDecision::AlreadyExiting => {}

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -943,7 +943,7 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                 Ok(TrayItem::Quit) => {
                     let app = app.clone();
                     tokio::spawn(async move {
-                        crate::request_app_exit(app).await;
+                        crate::request_app_exit(app, crate::AppExitSource::TrayMenu).await;
                     });
                 }
                 Ok(TrayItem::PreviousItem(path)) => {


### PR DESCRIPTION
## Summary

- add a typed `AppExitSource` to the shared graceful-shutdown entry point
- attribute requests from the macOS app menu, native/Dock termination, tray menu, Tauri runtime, `SIGTERM`, and `SIGHUP`
- log the source before shutdown admission so blocked and admitted attempts share the same diagnostic sequence

Closes #2201.

## Why

While investigating a report that Cap regularly disappeared after recording or editor work, the signed 0.5.9 app produced no Apple crash report. A controlled Quit during an active Studio recording reached cleanup with both microphone and camera returning `FeedLocked`, then exited voluntarily with status 0. Cap's own log did not identify the request origin; only the short-lived macOS unified log showed a native Quit AppleEvent/menu action.

The lifecycle guards already merged in #2172 prevent current `main` from admitting Quit while recording or finalization owns those resources. This patch closes the remaining observability gap so the next report can be classified from Cap's log without guessing whether the process crashed, the OS requested termination, or the user invoked one of several Quit paths.

The source is captured at the common `request_app_exit` boundary, before state availability, recording/finalization, export, update, or duplicate-exit checks can return. No behavior, timeout, or cleanup ordering changes.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p cap-desktop`
- `cargo test -p cap-desktop --test exit_shutdown` — 21 passed
- desktop frontend production build completed through Tauri's `beforeBuildCommand`
- local macOS 0.6.0 app bundle built, ad-hoc signed, installed, launched, and remained running

The local machine has Command Line Tools rather than full Xcode, so the small `cidre` Objective-C shim libraries were compiled with the installed Apple SDK/clang through a temporary local wrapper. That wrapper is not part of this change. Tauri created the `.app`; the packaging command then reported the expected missing private updater key, so release signing/notarization was not claimed.

## Investigation context

- affected stable build: 0.5.9
- comparison head: `82519d2a42a2336545a9f30133330f4d5e10ad0a` (0.6.0 source)
- macOS 26.6.2, Apple silicon M4, 24 GB RAM
- Focusrite Scarlett Solo USB negotiated at 192 kHz stereo; Cap resampled to 48 kHz mono
- Logitech BRIO at 1280x720, 30 fps
- no `.ips`, `.crash`, `.hang`, or `.spin` report for Cap

No recording names, local media paths, account data, or service URLs are included.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds typed source attribution to the desktop application's shared graceful-shutdown entry point.
- Labels exit requests originating from macOS app and native termination, Tauri runtime events, Unix signals, and the tray menu.
- Logs the source before shutdown admission so both accepted and blocked requests retain diagnostic provenance.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The source parameter is supplied by every existing graceful-exit caller, its platform-gated variants align with their callers, and the change leaves shutdown admission and cleanup behavior intact.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src-tauri/src/lib.rs | Introduces the cfg-safe AppExitSource enum, logs it at the common shutdown boundary, and supplies appropriate labels from platform, signal, and runtime callers. |
| apps/desktop/src-tauri/src/tray.rs | Attributes tray Quit actions to TrayMenu when invoking the shared graceful-exit path. |

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): attribute graceful exit re..."](https://github.com/capsoftware/cap/commit/deed684bcba60a9db0e0fe5737199a2a1b32c086) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59783274)</sub>

<!-- /greptile_comment -->