### PR TITLE
fix: explain missing SSO profile attributes

### DIFF
--- a/apps/web/__tests__/unit/sso-auth-route.test.ts
+++ b/apps/web/__tests__/unit/sso-auth-route.test.ts
@@ -43,6 +43,10 @@ vi.mock("next-auth", () => ({ default: mocks.nextAuth }));
 vi.mock("next-auth/jwt", () => ({ getToken: mocks.getToken }));
 
 const RETURN_TO = "/api/mobile/session/request?redirectUri=cap%3A%2F%2Fauth";
+const MISSING_PROFILE_QUERY = {
+	error: "server_error",
+	error_description: "The SAML Response did not contain expected attributes.",
+};
 const INTENT = {
 	organizationId: "caporganization",
 	workosOrganizationId: "org_verified",
@@ -368,6 +372,98 @@ describe("SSO auth request boundary", () => {
 			expect(redirect.searchParams.get("next")).toBe(RETURN_TO);
 		},
 	);
+
+	it("explains missing profile attributes without exposing the provider response", async () => {
+		mocks.nextAuth.mockResolvedValueOnce(
+			new Response(null, {
+				status: 302,
+				headers: { location: "/api/auth/error?error=OAuthCallback" },
+			}),
+		);
+		const { request, context } = makeRequest({
+			action: "callback",
+			query: { ...MISSING_PROFILE_QUERY, state: "private-oauth-state" },
+		});
+
+		const response = await GET(request, context);
+		const redirect = await errorUrl(response);
+
+		expect(mocks.nextAuth).toHaveBeenCalledOnce();
+		expect(redirect.origin).toBe(env.WEB_URL);
+		expect(redirect.pathname).toBe("/login");
+		expect(Object.fromEntries(redirect.searchParams)).toEqual({
+			error: "SsoMissingProfileAttributes",
+			next: RETURN_TO,
+		});
+		expect(response.headers.get("set-cookie")).toContain(
+			`${ssoIntentCookie(true).name}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Secure`,
+		);
+	});
+
+	it.each<Record<string, string> | URLSearchParams>([
+		{},
+		{ error: "server_error" },
+		{ error_description: MISSING_PROFILE_QUERY.error_description },
+		{ ...MISSING_PROFILE_QUERY, error: "access_denied" },
+		{ error: "server_error", error_description: "Something else failed" },
+		{
+			...MISSING_PROFILE_QUERY,
+			error_description: `${MISSING_PROFILE_QUERY.error_description} Visit https://attacker.example`,
+		},
+		new URLSearchParams([
+			...Object.entries(MISSING_PROFILE_QUERY),
+			["error", "access_denied"],
+		]),
+		new URLSearchParams([
+			...Object.entries(MISSING_PROFILE_QUERY),
+			["error_description", "Something else failed"],
+		]),
+	])(
+		"keeps unrecognized or ambiguous provider errors generic: %j",
+		async (query) => {
+			mocks.nextAuth.mockResolvedValueOnce(
+				new Response(null, {
+					status: 302,
+					headers: { location: "/api/auth/error?error=OAuthCallback" },
+				}),
+			);
+			const { request, context } = makeRequest({ action: "callback", query });
+
+			const redirect = await errorUrl(await GET(request, context));
+
+			expect(Object.fromEntries(redirect.searchParams)).toEqual({
+				error: "SsoSignInFailed",
+				next: RETURN_TO,
+			});
+		},
+	);
+
+	it("does not classify a missing-profile error before validating the login intent", async () => {
+		const { request, context } = makeRequest({
+			action: "callback",
+			intent: null,
+			query: MISSING_PROFILE_QUERY,
+		});
+
+		const redirect = await errorUrl(await GET(request, context));
+
+		expect(redirect.searchParams.get("error")).toBe("SsoSessionExpired");
+		expect(mocks.nextAuth).not.toHaveBeenCalled();
+	});
+
+	it("does not replace a successful callback with a query-supplied error", async () => {
+		const { request, context } = makeRequest({
+			action: "callback",
+			query: MISSING_PROFILE_QUERY,
+		});
+
+		const response = await GET(request, context);
+
+		expect(response.headers.get("location")).toBe("/dashboard");
+		expect(response.headers.get("set-cookie")).toContain(
+			"next-auth.session-token=verified-session",
+		);
+	});
 
 	it("does not append the signed continuation to an external redirect", async () => {
 		const location = "https://attacker.example/login?error=Callback";

--- a/apps/web/__tests__/unit/sso-login-pages.test.ts
+++ b/apps/web/__tests__/unit/sso-login-pages.test.ts
@@ -1,4 +1,4 @@
-import { createElement } from "react";
+import { type ButtonHTMLAttributes, createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import LoginPage from "@/app/(org)/login/page";
@@ -6,6 +6,7 @@ import SignupPage from "@/app/(org)/signup/page";
 
 const mocks = vi.hoisted(() => ({
 	getCurrentUser: vi.fn(),
+	searchParams: new URLSearchParams(),
 	redirect: vi.fn((url: string): never => {
 		throw new Error(`redirect:${url}`);
 	}),
@@ -17,7 +18,35 @@ vi.mock("@cap/database/auth/session", () => ({
 vi.mock("@cap/env", () => ({
 	serverEnv: () => ({ WEB_URL: "https://cap.test" }),
 }));
-vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+vi.mock("next/navigation", () => ({
+	redirect: mocks.redirect,
+	useSearchParams: () => mocks.searchParams,
+	useRouter: () => ({ push: vi.fn() }),
+}));
+vi.mock("@cap/ui", () => ({
+	Button: ({
+		spinner: _spinner,
+		...props
+	}: ButtonHTMLAttributes<HTMLButtonElement> & { spinner?: boolean }) =>
+		createElement("button", { type: "button", ...props }),
+	Input: "input",
+	LogoBadge: "div",
+}));
+vi.mock("@/actions/organization/get-organization-sso-data", () => ({
+	getOrganizationSSOData: vi.fn(),
+}));
+vi.mock("@/app/(org)/auth-email", () => ({
+	getEmailCodeCooldownSeconds: () => 0,
+	requestEmailCode: vi.fn(),
+}));
+vi.mock("@/app/utils/analytics", () => ({ trackEvent: vi.fn() }));
+vi.mock("@/utils/public-env", () => ({
+	usePublicEnv: () => ({
+		googleAuthAvailable: false,
+		workosAuthAvailable: true,
+	}),
+}));
+vi.mock("next-auth/react", () => ({ signIn: vi.fn() }));
 vi.mock("@/app/(org)/login/form", () => ({
 	LoginForm: () => createElement("form", { "aria-label": "Login form" }),
 }));
@@ -34,6 +63,7 @@ const ssoEntries: [string, Query][] = [
 	["work-domain entry", { sso: "1" }],
 	["expired intent retry", { error: "SsoSessionExpired" }],
 	["failed SSO retry", { error: "SsoSignInFailed" }],
+	["missing profile retry", { error: "SsoMissingProfileAttributes" }],
 	[
 		"unapproved domain retry",
 		{ error: "profile_not_allowed_outside_organization" },
@@ -43,6 +73,7 @@ const ssoEntries: [string, Query][] = [
 
 beforeEach(() => {
 	mocks.getCurrentUser.mockResolvedValue({ id: "existing-user" });
+	mocks.searchParams = new URLSearchParams();
 });
 
 describe.each([
@@ -137,3 +168,50 @@ describe("authenticated login continuation", () => {
 		).rejects.toThrow("redirect:/dashboard");
 	});
 });
+
+describe.each(["login", "signup"] as const)(
+	"%s missing-profile notice",
+	(surface) => {
+		async function renderForm() {
+			const Form =
+				surface === "login"
+					? (
+							await vi.importActual<typeof import("@/app/(org)/login/form")>(
+								"@/app/(org)/login/form",
+							)
+						).LoginForm
+					: (
+							await vi.importActual<typeof import("@/app/(org)/signup/form")>(
+								"@/app/(org)/signup/form",
+							)
+						).SignupForm;
+			return renderToStaticMarkup(createElement(Form));
+		}
+
+		it("renders actionable guidance and the SSO form before client effects run", async () => {
+			mocks.searchParams.set("error", "SsoMissingProfileAttributes");
+
+			const markup = await renderForm();
+
+			expect(markup).toContain('role="alert"');
+			expect(markup).toContain("SSO profile details are missing");
+			expect(markup).toContain("first name, and last name");
+			expect(markup).toContain("IT administrator");
+			expect(markup).toContain("SSO attribute mapping");
+			expect(markup).toContain('name="organization"');
+			expect(markup).toContain("Continue with SSO");
+		});
+
+		it.each(["", "SsoSignInFailed", "<script>untrusted error</script>"])(
+			"does not show a missing-profile notice for %j",
+			async (error) => {
+				mocks.searchParams.set("error", error);
+
+				const markup = await renderForm();
+
+				expect(markup).not.toContain("SSO profile details are missing");
+				expect(markup).not.toContain("untrusted error");
+			},
+		);
+	},
+);

--- a/apps/web/__tests__/unit/sso-state.test.ts
+++ b/apps/web/__tests__/unit/sso-state.test.ts
@@ -67,17 +67,21 @@ describe("SSO login intent", () => {
 		expect(verifySsoLoginIntent(value, secret, now - 31_000)).toBeNull();
 	});
 
-	it("preserves a same-origin app continuation through SSO error recovery", () => {
-		const returnTo = "/api/mobile/session/request?redirectUri=cap%3A%2F%2Fauth";
-		const value = createSsoLoginIntent({ ...context, returnTo }, secret, now);
-		expect(verifySsoLoginIntent(value, secret, now)?.returnTo).toBe(returnTo);
-		const errorUrl = new URL(
-			ssoLoginErrorPath("SsoSignInFailed", returnTo),
-			"https://cap.test",
-		);
-		expect(errorUrl.searchParams.get("next")).toBe(returnTo);
-		expect(errorUrl.searchParams.get("error")).toBe("SsoSignInFailed");
-	});
+	it.each(["SsoSignInFailed", "SsoMissingProfileAttributes"] as const)(
+		"preserves a same-origin app continuation through %s recovery",
+		(error) => {
+			const returnTo =
+				"/api/mobile/session/request?redirectUri=cap%3A%2F%2Fauth";
+			const value = createSsoLoginIntent({ ...context, returnTo }, secret, now);
+			expect(verifySsoLoginIntent(value, secret, now)?.returnTo).toBe(returnTo);
+			const errorUrl = new URL(
+				ssoLoginErrorPath(error, returnTo),
+				"https://cap.test",
+			);
+			expect(errorUrl.searchParams.get("next")).toBe(returnTo);
+			expect(errorUrl.searchParams.get("error")).toBe(error);
+		},
+	);
 
 	it.each([
 		"https://attacker.example/",

--- a/apps/web/app/(org)/login/form.tsx
+++ b/apps/web/app/(org)/login/form.tsx
@@ -29,6 +29,7 @@ import { trackEvent } from "@/app/utils/analytics";
 import { usePublicEnv } from "@/utils/public-env";
 import { getEmailCodeCooldownSeconds, requestEmailCode } from "../auth-email";
 import { getSafeNextPath } from "../safe-next";
+import { SsoErrorNotice } from "../sso-error-notice";
 
 const MotionInput = motion(Input);
 const MotionLogoBadge = motion(LogoBadge);
@@ -47,6 +48,7 @@ export function LoginForm() {
 		Boolean(
 			searchParams?.get("organizationId") ||
 				searchParams?.get("connection_id") ||
+				searchParams?.get("error") === "SsoMissingProfileAttributes" ||
 				searchParams?.get("sso") === "1" ||
 				searchParams?.get("mobileProvider") === "workos",
 		),
@@ -91,6 +93,9 @@ export function LoginForm() {
 				return toast.error(
 					"This email already has a Cap account. Sign in using your original sign-in method.",
 				);
+			} else if (error === "SsoMissingProfileAttributes") {
+				setShowOrgInput(true);
+				return;
 			} else if (error === "SsoSessionExpired") {
 				setShowOrgInput(true);
 				return toast.error(
@@ -308,6 +313,7 @@ export function LoginForm() {
 				</motion.p>
 			</motion.div>
 			<motion.div layout="position" className="flex flex-col space-y-3">
+				<SsoErrorNotice error={searchParams?.get("error")} />
 				<Suspense
 					fallback={
 						<>

--- a/apps/web/app/(org)/login/page.tsx
+++ b/apps/web/app/(org)/login/page.tsx
@@ -37,6 +37,7 @@ export default async function LoginPage(props: {
 			sso === "1" ||
 			error === "SsoSessionExpired" ||
 			error === "SsoSignInFailed" ||
+			error === "SsoMissingProfileAttributes" ||
 			error === "profile_not_allowed_outside_organization" ||
 			error === "signin_consent_denied",
 	);

--- a/apps/web/app/(org)/signup/form.tsx
+++ b/apps/web/app/(org)/signup/form.tsx
@@ -29,6 +29,7 @@ import { trackEvent } from "@/app/utils/analytics";
 import { usePublicEnv } from "@/utils/public-env";
 import { getEmailCodeCooldownSeconds, requestEmailCode } from "../auth-email";
 import { getSafeNextPath } from "../safe-next";
+import { SsoErrorNotice } from "../sso-error-notice";
 
 const MotionInput = motion(Input);
 const MotionLogoBadge = motion(LogoBadge);
@@ -47,6 +48,7 @@ export function SignupForm() {
 		Boolean(
 			searchParams?.get("organizationId") ||
 				searchParams?.get("connection_id") ||
+				searchParams?.get("error") === "SsoMissingProfileAttributes" ||
 				searchParams?.get("sso") === "1",
 		),
 	);
@@ -88,6 +90,9 @@ export function SignupForm() {
 				return toast.error(
 					"This email already has a Cap account. Sign in using your original sign-in method.",
 				);
+			} else if (error === "SsoMissingProfileAttributes") {
+				setShowOrgInput(true);
+				return;
 			} else if (error === "SsoSessionExpired") {
 				setShowOrgInput(true);
 				return toast.error(
@@ -271,6 +276,7 @@ export function SignupForm() {
 				</motion.p>
 			</motion.div>
 			<motion.div layout="position" className="flex flex-col space-y-3">
+				<SsoErrorNotice error={searchParams?.get("error")} />
 				<Suspense
 					fallback={
 						<>

--- a/apps/web/app/(org)/signup/page.tsx
+++ b/apps/web/app/(org)/signup/page.tsx
@@ -35,6 +35,7 @@ export default async function SignupPage(props: {
 			sso === "1" ||
 			error === "SsoSessionExpired" ||
 			error === "SsoSignInFailed" ||
+			error === "SsoMissingProfileAttributes" ||
 			error === "profile_not_allowed_outside_organization" ||
 			error === "signin_consent_denied",
 	);

--- a/apps/web/app/(org)/sso-error-notice.tsx
+++ b/apps/web/app/(org)/sso-error-notice.tsx
@@ -1,0 +1,26 @@
+export function SsoErrorNotice({
+	error,
+}: {
+	error: string | null | undefined;
+}) {
+	if (error !== "SsoMissingProfileAttributes") return null;
+
+	return (
+		<div
+			role="alert"
+			className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700"
+		>
+			<h2 className="mb-2 font-semibold">SSO profile details are missing</h2>
+			<p>
+				Your identity provider did not send all the profile details needed to
+				sign in. Check that your profile includes your email, first name, and
+				last name.
+			</p>
+			<p className="mt-2">
+				If those are filled in, ask your IT administrator to check the required
+				SSO attribute mapping. After correcting the profile or mapping, start
+				SSO again.
+			</p>
+		</div>
+	);
+}

--- a/apps/web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.ts
@@ -108,10 +108,23 @@ async function handler(
 					(redirectUrl.pathname === "/login" &&
 						redirectUrl.searchParams.has("error")))
 			) {
+				const isMissingProfileAttributes =
+					request.method === "GET" &&
+					request.nextUrl.searchParams.getAll("error").length === 1 &&
+					request.nextUrl.searchParams.getAll("error_description").length ===
+						1 &&
+					request.nextUrl.searchParams.get("error") === "server_error" &&
+					request.nextUrl.searchParams.get("error_description") ===
+						"The SAML Response did not contain expected attributes.";
 				response.headers.set(
 					"location",
 					new URL(
-						ssoLoginErrorPath("SsoSignInFailed", intent.returnTo),
+						ssoLoginErrorPath(
+							isMissingProfileAttributes
+								? "SsoMissingProfileAttributes"
+								: "SsoSignInFailed",
+							intent.returnTo,
+						),
 						env.WEB_URL,
 					).toString(),
 				);

--- a/packages/database/auth/sso-state.ts
+++ b/packages/database/auth/sso-state.ts
@@ -37,7 +37,10 @@ function isSafeReturnPath(value: unknown): value is string {
 }
 
 export function ssoLoginErrorPath(
-	error: "SsoSessionExpired" | "SsoSignInFailed",
+	error:
+		| "SsoSessionExpired"
+		| "SsoSignInFailed"
+		| "SsoMissingProfileAttributes",
 	returnTo?: string,
 ) {
 	const query = new URLSearchParams({ error });


### PR DESCRIPTION
## Summary

- Recognize WorkOS’s missing-profile-attributes response and show a persistent, accessible notice on login and signup with profile-field and administrator guidance.
- Match only the known error code and description on an unambiguous GET callback; keep other failures generic and never display raw provider text.
- Preserve login-intent and account checks, safe return paths, successful callbacks, and signed-in SSO retries.

## Validation

- 337 SSO/auth unit tests passed, including real-form server rendering, callback classification, duplicate/untrusted parameters, and continuation preservation.
- Scoped Biome checks and `git diff --check` passed.
- `next typegen` and `tsc -b apps/web` passed.
- Independent targeted review found no issues.
- Deployed preview verified in the browser: the accessible notice is visible on login and signup; login layout fits the viewport without horizontal overflow.

No environment-variable or database changes. WorkOS owns the Test IdP form; this change improves Cap’s error response rather than weakening required-attribute validation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR recognizes WorkOS’s known missing-profile-attributes callback failure and presents fixed, actionable guidance without exposing provider-supplied text.
- Adds exact, ambiguity-resistant callback classification while preserving signed SSO intent and safe continuations.
- Adds an accessible persistent notice and SSO retry state to login and signup surfaces.
- Extends unit coverage for classification, rendering, authenticated retries, and continuation handling.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The callback classification remains behind existing signed-intent and account checks, matches only one unambiguous provider response, preserves safe continuations, and exposes only fixed application-controlled guidance.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/api/auth/[...nextauth]/route.ts | Safely classifies the exact known WorkOS callback failure only after intent validation and rewrites recognized local failure redirects while preserving the signed continuation. |
| packages/database/auth/sso-state.ts | Extends the typed SSO error-path contract with the missing-profile code while retaining existing return-path validation. |
| apps/web/app/(org)/sso-error-notice.tsx | Adds a fixed, accessible alert containing profile-field and administrator remediation guidance without reflecting query text. |
| apps/web/app/(org)/login/form.tsx | Displays the persistent notice and opens the manual SSO retry surface for the new error state. |
| apps/web/app/(org)/signup/form.tsx | Mirrors login behavior for the new missing-profile retry state and notice. |
| apps/web/app/(org)/login/page.tsx | Keeps authenticated users on the login form when recovering from the recognized SSO profile failure. |
| apps/web/app/(org)/signup/page.tsx | Keeps authenticated users on the signup form when presented with the recognized SSO retry state. |
| apps/web/__tests__/unit/sso-auth-route.test.ts | Covers exact classification, ambiguous and untrusted parameters, intent validation, successful callbacks, cookie cleanup, and continuation preservation. |
| apps/web/__tests__/unit/sso-login-pages.test.ts | Covers authenticated retry rendering and server-rendered accessibility and guidance on both authentication surfaces. |
| apps/web/__tests__/unit/sso-state.test.ts | Confirms the new error code preserves safe signed continuations consistently with existing SSO failures. |

<sub>Reviews (1): Last reviewed commit: ["fix: show actionable SSO profile guidanc..."](https://github.com/capsoftware/cap/commit/73ae7dc8214f522bb992c6e0ae73a862506fbcd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59788702)</sub>

<!-- /greptile_comment -->
