### PR TITLE
fix: verify Drive upload receipts with content checksums

### DIFF
--- a/apps/media-server/src/__tests__/lib/storage-upload.test.ts
+++ b/apps/media-server/src/__tests__/lib/storage-upload.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { uploadFileToStorage } from "../../lib/media-video";
+import { verifyRemoteRecordingBytes } from "../../lib/recording-verification";
 
 const originalFetch = globalThis.fetch;
 const partSize = 5 * 1024 * 1024;
@@ -26,6 +28,72 @@ describe("uploadFileToStorage", () => {
 	afterEach(() => {
 		globalThis.fetch = originalFetch;
 	});
+
+	test.each([false, true])(
+		"checks full remote bytes after Drive metadata version drift (corrupt=%s)",
+		async (corrupt) => {
+			const uploadFile = await createTempUploadFile(11);
+			const bytes = new Uint8Array(
+				await Bun.file(uploadFile.path).arrayBuffer(),
+			);
+			const sha256 = createHash("sha256").update(bytes).digest("hex");
+			const identity = `"cap-drive-content-v1:${createHash("sha256")
+				.update(JSON.stringify(["drive-file-1", bytes.length, sha256]))
+				.digest("hex")}"`;
+			globalThis.fetch = (async (_input, init) => {
+				if (init?.method === "PUT")
+					return Response.json({
+						id: "drive-file-1",
+						version: "1",
+						size: "11",
+						sha256Checksum: sha256,
+						headRevisionId: "revision-1",
+					});
+				const headers = new Headers(init?.headers);
+				expect(headers.get("if-match")).toBe(identity);
+				if (headers.has("range"))
+					return new Response(bytes.slice(0, 1), {
+						status: 206,
+						headers: {
+							ETag: identity,
+							"Content-Length": "1",
+							"Content-Range": "bytes 0-0/11",
+						},
+					});
+				const returned = bytes.slice();
+				if (corrupt) returned[5] = 99;
+				return new Response(returned, {
+					headers: { ETag: identity, "Content-Length": "11" },
+				});
+			}) as typeof fetch;
+			try {
+				const receipt = await uploadFileToStorage(
+					uploadFile.path,
+					{
+						type: "put",
+						url: "https://www.googleapis.com/upload/drive/v3/files?upload_id=session",
+					},
+					"video/mp4",
+				);
+				expect(receipt.objectIdentity).toBe(identity);
+				const verified = verifyRemoteRecordingBytes(
+					"https://storage.example.com/recording.mp4",
+					{
+						expectedSha256: sha256,
+						expectedFileSize: 11,
+						expectedObjectIdentity: identity,
+					},
+				);
+				if (corrupt)
+					await expect(verified).rejects.toThrow(
+						"Uploaded recording bytes do not match",
+					);
+				else expect((await verified).remoteSha256).toBe(sha256);
+			} finally {
+				await uploadFile.cleanup();
+			}
+		},
+	);
 
 	test("returns the successful PUT identity without a later HEAD lookup", async () => {
 		const uploadFile = await createTempUploadFile(11);
@@ -76,38 +144,59 @@ describe("uploadFileToStorage", () => {
 		},
 	);
 
-	test("binds a Drive upload to its completed response version without rounding", async () => {
-		const uploadFile = await createTempUploadFile(11);
-		const methods: string[] = [];
-		globalThis.fetch = (async (_input, init) => {
-			methods.push(init?.method ?? "GET");
-			expect(new Headers(init?.headers).get("content-range")).toBe(
-				"bytes 0-10/11",
-			);
-			return Response.json({
-				id: "drive-file-1",
-				version: "9007199254740993",
-				size: "11",
-			});
-		}) as typeof fetch;
-		try {
-			const receipt = await uploadFileToStorage(
-				uploadFile.path,
-				{
-					type: "put",
-					url: "https://www.googleapis.com/upload/drive/v3/files?upload_id=session",
-				},
-				"video/mp4",
-			);
-			expect(receipt.objectIdentity).toBe('"drive-file-1:9007199254740993"');
-			expect(methods).toEqual(["PUT"]);
-		} finally {
-			await uploadFile.cleanup();
-		}
-	});
+	test.each(["1", "6", "9007199254740993"])(
+		"binds a Drive upload to content independently of metadata version %s",
+		async (version) => {
+			const uploadFile = await createTempUploadFile(11);
+			const methods: string[] = [];
+			globalThis.fetch = (async (_input, init) => {
+				methods.push(init?.method ?? "GET");
+				expect(new Headers(init?.headers).get("content-range")).toBe(
+					"bytes 0-10/11",
+				);
+				return Response.json({
+					id: "drive-file-1",
+					version,
+					size: "11",
+					sha256Checksum: "a".repeat(64),
+					headRevisionId: "revision-1",
+				});
+			}) as typeof fetch;
+			try {
+				const receipt = await uploadFileToStorage(
+					uploadFile.path,
+					{
+						type: "put",
+						url: "https://www.googleapis.com/upload/drive/v3/files?upload_id=session",
+					},
+					"video/mp4",
+				);
+				expect(receipt.objectIdentity).toBe(
+					'"cap-drive-content-v1:9c353d47a7cf9c0f30c3008eb3576c4629a878019572a4d68404cbe0f222b88c"',
+				);
+				expect(methods).toEqual(["PUT"]);
+			} finally {
+				await uploadFile.cleanup();
+			}
+		},
+	);
 
 	test.each([
 		{ id: "drive-file-1", size: "11" },
+		{ id: "drive-file-1", version: "1", size: "11" },
+		{ id: "drive-file-1", size: "11", sha256Checksum: "a".repeat(64) },
+		{
+			id: "drive-file-1",
+			size: "11",
+			sha256Checksum: "invalid",
+			headRevisionId: "revision-1",
+		},
+		{
+			id: "drive-file-1",
+			size: "12",
+			sha256Checksum: "a".repeat(64),
+			headRevisionId: "revision-1",
+		},
 		{ id: 'invalid"id', version: "1", size: "11" },
 		{ id: "drive-file-1", version: "0", size: "11" },
 		{ id: "drive-file-1", version: "1", size: "12" },

--- a/apps/media-server/src/lib/media-video.ts
+++ b/apps/media-server/src/lib/media-video.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { type BunFile, file, spawn } from "bun";
@@ -2002,12 +2002,17 @@ async function readUploadReceipt(
 		return {};
 	}
 	if (!metadata || typeof metadata !== "object") return {};
-	const { id, version, size } = metadata as Record<string, unknown>;
+	const { id, size, sha256Checksum, headRevisionId } = metadata as Record<
+		string,
+		unknown
+	>;
 	if (
 		typeof id !== "string" ||
 		!/^[a-zA-Z0-9_-]{1,200}$/.test(id) ||
-		typeof version !== "string" ||
-		!/^[1-9]\d{0,19}$/.test(version) ||
+		typeof sha256Checksum !== "string" ||
+		!/^[a-fA-F0-9]{64}$/.test(sha256Checksum) ||
+		typeof headRevisionId !== "string" ||
+		!headRevisionId ||
 		typeof size !== "string" ||
 		!/^\d+$/.test(size) ||
 		!Number.isSafeInteger(Number(size)) ||
@@ -2016,7 +2021,10 @@ async function readUploadReceipt(
 	) {
 		return {};
 	}
-	return { objectIdentity: `"${id}:${version}"` };
+	const digest = createHash("sha256")
+		.update(JSON.stringify([id, Number(size), sha256Checksum.toLowerCase()]))
+		.digest("hex");
+	return { objectIdentity: `"cap-drive-content-v1:${digest}"` };
 }
 
 async function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary

Follow-up to #2204. This is the media-worker half and must not deploy before the web-side reader is live.

- Bind Drive upload acknowledgements to provider file ID, exact size, and SHA-256 instead of metadata-sensitive file versions.
- Require checksum and head-revision fields from the resumable upload response; missing proof withholds the receipt and leaves the durable pipeline to retry.
- Keep the full remote-file SHA-256 verification and S3 upload behavior unchanged.

## Verification

- 18 upload and remote-byte verification tests passed in implementation, independent review, and the isolated PR checkout.
- Scoped Biome, TypeScript with the installed Bun types, and `git diff --check` passed.
- Tests include metadata-version changes, incomplete/legacy acknowledgements, same-size corrupt remote bytes, and S3 multipart behavior.

## Deployment gate

Merge/deploy #2204 first and confirm the production web runtime requests checksum-bearing upload responses. Drain active media work before replacing workers, then verify all replicas and run a small controlled Drive recovery on the new web runtime. Old pinned web workflows create legacy upload sessions and will fail closed under this producer; do not reuse them for Drive recovery.

No database migration or desktop release is required. This change does not reinterpret old receipts or remove retained source recordings.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces metadata-version-based Drive upload receipts with content identities derived from the provider file ID, exact size, and SHA-256 checksum.
- Requires checksum and head-revision metadata before issuing a Drive receipt.
- Normalizes the checksum and hashes the identity tuple into the shared `cap-drive-content-v1` format.
- Adds coverage for metadata-version drift, incomplete receipts, corrupt remote bytes, and unchanged multipart behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge when deployed according to its stated web-reader and active-workflow rollout gate.

The producer and reader use matching content-identity algorithms, malformed or legacy acknowledgements fail closed as intended, and independent full-byte hashing continues to reject corrupt remote content.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/media-server/src/lib/media-video.ts | Validates checksum-bearing Drive completion metadata and constructs an identity compatible with the web-side reader; no actionable defect found. |
| apps/media-server/src/__tests__/lib/storage-upload.test.ts | Expands receipt and remote-byte verification coverage across metadata drift, invalid acknowledgements, corruption, and multipart uploads. |

<sub>Reviews (1): Last reviewed commit: ["fix: verify Drive upload receipts with c..."](https://github.com/capsoftware/cap/commit/d015442b7212eff09ad33eab9e3a2194f2a7b609) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59790143)</sub>

<!-- /greptile_comment -->