### PR TITLE
Folder sorting, list view, collapse toggle and whole-card links

### DIFF
--- a/apps/web/__tests__/unit/folder-sort.test.ts
+++ b/apps/web/__tests__/unit/folder-sort.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { isFolderSort, sortFolders } from "@/lib/folder-sort";
+
+const folder = (id: string, name: string, createdAt: string) => ({
+	id,
+	name,
+	createdAt: new Date(createdAt),
+});
+
+// The exact shape from the customer report: numbered folders that came back
+// in primary-key order because nothing sorted them.
+const numbered = [
+	folder("k", "14_Account & Permissions", "2026-08-01T00:00:14Z"),
+	folder("a", "23_Support & Contact", "2026-08-01T00:00:23Z"),
+	folder("q", "7_Hot/Warm Leads", "2026-08-01T00:00:07Z"),
+	folder("m", "1_Getting Started", "2026-08-01T00:00:01Z"),
+	folder("c", "2_Command Center", "2026-08-01T00:00:02Z"),
+	folder("z", "10_Team Conversations", "2026-08-01T00:00:10Z"),
+];
+
+describe("sortFolders", () => {
+	it("orders numbered names numerically, not lexically", () => {
+		expect(sortFolders(numbered, "name-asc").map((f) => f.name)).toEqual([
+			"1_Getting Started",
+			"2_Command Center",
+			"7_Hot/Warm Leads",
+			"10_Team Conversations",
+			"14_Account & Permissions",
+			"23_Support & Contact",
+		]);
+	});
+
+	it("reverses the natural order for name-desc", () => {
+		expect(sortFolders(numbered, "name-desc").map((f) => f.name)).toEqual([
+			"23_Support & Contact",
+			"14_Account & Permissions",
+			"10_Team Conversations",
+			"7_Hot/Warm Leads",
+			"2_Command Center",
+			"1_Getting Started",
+		]);
+	});
+
+	it("sorts by creation time for newest/oldest", () => {
+		const oldest = sortFolders(numbered, "oldest").map((f) => f.id);
+		expect(oldest).toEqual(["m", "c", "q", "z", "k", "a"]);
+		expect(sortFolders(numbered, "newest").map((f) => f.id)).toEqual(
+			[...oldest].reverse(),
+		);
+	});
+
+	it("ignores case and surrounding whitespace when comparing names", () => {
+		const names = sortFolders(
+			[
+				folder("1", "beta", "2026-01-01"),
+				folder("2", "  Alpha", "2026-01-01"),
+				folder("3", "Gamma", "2026-01-01"),
+			],
+			"name-asc",
+		).map((f) => f.name);
+		expect(names).toEqual(["  Alpha", "beta", "Gamma"]);
+	});
+
+	it("breaks name ties by creation time, then id, so order is stable", () => {
+		const ids = sortFolders(
+			[
+				folder("b", "Same", "2026-01-02"),
+				folder("a", "Same", "2026-01-02"),
+				folder("c", "Same", "2026-01-01"),
+			],
+			"name-asc",
+		).map((f) => f.id);
+		expect(ids).toEqual(["c", "a", "b"]);
+	});
+
+	it("tolerates missing or malformed createdAt values", () => {
+		const ids = sortFolders(
+			[
+				{ id: "x", name: "B", createdAt: "not a date" },
+				{ id: "y", name: "A", createdAt: null },
+				{ id: "z", name: "C" },
+			],
+			"newest",
+		).map((f) => f.id);
+		// All collapse to time 0, so the name tiebreak decides (reversed for newest).
+		expect(ids).toEqual(["z", "x", "y"]);
+	});
+
+	it("does not mutate the input array", () => {
+		const input = [...numbered];
+		sortFolders(input, "name-asc");
+		expect(input.map((f) => f.id)).toEqual(numbered.map((f) => f.id));
+	});
+});
+
+describe("isFolderSort", () => {
+	it("accepts known values and rejects anything else", () => {
+		expect(isFolderSort("name-asc")).toBe(true);
+		expect(isFolderSort("newest")).toBe(true);
+		expect(isFolderSort("created")).toBe(false);
+		expect(isFolderSort(null)).toBe(false);
+	});
+});

--- a/apps/web/app/(org)/dashboard/caps/Caps.tsx
+++ b/apps/web/app/(org)/dashboard/caps/Caps.tsx
@@ -27,7 +27,7 @@ import { CapCard } from "./components/CapCard/CapCard";
 import { CapPagination } from "./components/CapPagination";
 import { EmptyCapState } from "./components/EmptyCapState";
 import type { FolderDataType } from "./components/Folder";
-import Folder from "./components/Folder";
+import { FoldersSection } from "./components/FoldersSection";
 import { useUploadingStatus } from "./UploadingContext";
 
 export type VideoData = {
@@ -271,23 +271,13 @@ export const Caps = ({
 					className={`${CHROME_EXTENSION_BUTTON_CLASS} font-medium`}
 				/>
 			</div>
-			{folders.length > 0 && (
-				<>
-					<div className="flex gap-3 items-center mb-6 w-full">
-						<h1 className="text-2xl font-medium text-gray-12">Folders</h1>
-					</div>
-					<div className="grid grid-cols-[repeat(auto-fill,minmax(250px,1fr))] gap-4 mb-10">
-						{folders.map((folder) => (
-							<Folder
-								key={folder.id}
-								{...folder}
-								canMove
-								moveRootLabel="My Caps"
-							/>
-						))}
-					</div>
-				</>
-			)}
+			<FoldersSection
+				title="Folders"
+				scope="personal"
+				folders={folders}
+				canMove
+				moveRootLabel="My Caps"
+			/>
 			{visibleVideos.length > 0 && (
 				<>
 					<div className="flex justify-between items-center mb-6 w-full">

--- a/apps/web/app/(org)/dashboard/caps/components/Folder.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/Folder.tsx
@@ -349,9 +349,6 @@ const FolderCard = ({
 				isMovingVideo && "opacity-70",
 			)}
 		>
-			{/* Stretched link: the whole card opens the folder, including the icon,
-			    the name, and the "x videos" line. Controls that must not navigate
-			    (menu button, rename field) sit above it with z-10. */}
 			{!isRenaming && (
 				<Link
 					href={folderHref}
@@ -432,10 +429,7 @@ const FolderCard = ({
 									"text-gray-12 m-0 p-0 font-normal tracking-normal",
 									isList
 										? "block text-[14px] truncate h-[22px] leading-[22px]"
-										: // Two lines before truncating: numbered names like
-											// "14_Account & Permissions" usually fit without an ellipsis.
-											// line-clamp sets its own display, so no `block` here.
-											"text-[15px] leading-[22px] line-clamp-2 break-words",
+										: "text-[15px] leading-[22px] line-clamp-2 break-words",
 								)}
 							>
 								{updateName}

--- a/apps/web/app/(org)/dashboard/caps/components/Folder.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/Folder.tsx
@@ -18,16 +18,22 @@ import { registerDropTarget } from "../../folder/[id]/components/ClientCapCard";
 import { FoldersDropdown } from "./FoldersDropdown";
 import { MoveItemsDialog } from "./MoveItemsDialog";
 
+export type FolderLayout = "grid" | "list";
+
 export type FolderDataType = {
 	name: string;
 	id: Folder.FolderId;
 	color: "normal" | "blue" | "red" | "yellow";
 	public: boolean;
 	videoCount: number;
+	// Drives "Newest/Oldest first" sorting. Optional so older callers that only
+	// need the card for a move menu keep working; missing dates sort as oldest.
+	createdAt?: Date | string | null;
 	spaceId?: Space.SpaceIdOrOrganisationId | null;
 	parentId: Folder.FolderId | null;
 	canMove?: boolean;
 	moveRootLabel?: string;
+	layout?: FolderLayout;
 };
 
 const FolderCard = ({
@@ -40,7 +46,9 @@ const FolderCard = ({
 	spaceId,
 	canMove,
 	moveRootLabel,
+	layout = "grid",
 }: FolderDataType) => {
+	const isList = layout === "list";
 	const router = useRouter();
 	const { theme } = useTheme();
 	const [confirmDeleteFolderOpen, setConfirmDeleteFolderOpen] = useState(false);
@@ -335,11 +343,23 @@ const FolderCard = ({
 			onDragLeave={handleDragLeave}
 			onDrop={handleDrop}
 			className={clsx(
-				"flex justify-between items-center px-4 py-4 w-full h-auto min-w-0 rounded-lg border transition-all duration-200 bg-gray-3 hover:bg-gray-4 hover:border-gray-6",
+				"flex relative justify-between items-center w-full h-auto min-w-0 rounded-lg border transition-all duration-200 bg-gray-3 hover:bg-gray-4 hover:border-gray-6",
+				isList ? "gap-3 px-3 py-2" : "px-4 py-4",
 				isDragOver ? "border-blue-10 bg-gray-4" : "border-gray-5",
 				isMovingVideo && "opacity-70",
 			)}
 		>
+			{/* Stretched link: the whole card opens the folder, including the icon,
+			    the name, and the "x videos" line. Controls that must not navigate
+			    (menu button, rename field) sit above it with z-10. */}
+			{!isRenaming && (
+				<Link
+					href={folderHref}
+					prefetch={false}
+					aria-label={`Open folder ${updateName}`}
+					className="absolute inset-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-9 focus-visible:ring-offset-1"
+				/>
+			)}
 			{moveEnabled && (
 				<MoveItemsDialog
 					open={isMoveDialogOpen}
@@ -353,14 +373,19 @@ const FolderCard = ({
 					}}
 				/>
 			)}
-			<div className="flex flex-1 gap-3 items-center">
-				<Link href={folderHref} prefetch={false} className="shrink-0">
+			<div className="flex flex-1 gap-3 items-center min-w-0">
+				<div className="shrink-0 pointer-events-none">
 					<FolderRive
 						key={`${theme}folder${id}`}
-						className="w-[50px] h-[50px]"
+						className={isList ? "size-9" : "w-[50px] h-[50px]"}
 					/>
-				</Link>
-				<div className="flex flex-col justify-center h-10">
+				</div>
+				<div
+					className={clsx(
+						"flex flex-1 min-w-0",
+						isList ? "gap-3 items-center" : "flex-col justify-center",
+					)}
+				>
 					{isRenaming ? (
 						<textarea
 							ref={nameRef}
@@ -389,25 +414,53 @@ const FolderCard = ({
 										});
 								}
 							}}
-							className="w-full resize-none bg-transparent border-none focus:outline-none
-                 focus:ring-0 focus:border-none text-gray-12 text-[15px] max-w-[116px] truncate p-0 m-0 h-[22px] leading-[22px] overflow-hidden font-normal tracking-normal"
+							className={clsx(
+								"relative z-10 flex-1 w-full min-w-0 resize-none bg-transparent border-none focus:outline-none focus:ring-0 focus:border-none text-gray-12 truncate p-0 m-0 h-[22px] leading-[22px] overflow-hidden font-normal tracking-normal",
+								isList ? "text-[14px]" : "text-[15px]",
+							)}
 						/>
 					) : (
-						<Link
-							href={folderHref}
-							prefetch={false}
-							className="block text-left"
+						<div
+							title={updateName}
+							className={clsx(
+								"block min-w-0 text-left",
+								isList ? "flex-1" : "w-full",
+							)}
 						>
-							<span className="block text-[15px] truncate text-gray-12 w-full max-w-[116px] m-0 p-0 h-[22px] leading-[22px] font-normal tracking-normal">
+							<span
+								className={clsx(
+									"text-gray-12 m-0 p-0 font-normal tracking-normal",
+									isList
+										? "block text-[14px] truncate h-[22px] leading-[22px]"
+										: // Two lines before truncating: numbered names like
+											// "14_Account & Permissions" usually fit without an ellipsis.
+											// line-clamp sets its own display, so no `block` here.
+											"text-[15px] leading-[22px] line-clamp-2 break-words",
+								)}
+							>
 								{updateName}
 							</span>
-						</Link>
+						</div>
 					)}
-					<div className="flex gap-2 items-center">
-						<p className="text-sm truncate text-gray-10 w-fit">{`${videoCount} ${
-							videoCount === 1 ? "video" : "videos"
-						}`}</p>
-						{publicEnabled && (
+					<div
+						className={clsx(
+							"flex gap-2 items-center",
+							isList && "shrink-0 justify-end w-32",
+						)}
+					>
+						{publicEnabled && isList && (
+							<span className="inline-flex gap-1 items-center text-[11px] font-medium text-blue-9">
+								<FontAwesomeIcon icon={faGlobe} className="size-2.5" />
+								Public
+							</span>
+						)}
+						<p
+							className={clsx(
+								"text-sm truncate text-gray-10 w-fit",
+								isList && "tabular-nums",
+							)}
+						>{`${videoCount} ${videoCount === 1 ? "video" : "videos"}`}</p>
+						{publicEnabled && !isList && (
 							<span className="inline-flex gap-1 items-center text-[11px] font-medium text-blue-9">
 								<FontAwesomeIcon icon={faGlobe} className="size-2.5" />
 								Public
@@ -426,31 +479,33 @@ const FolderCard = ({
 				title="Delete Folder"
 				description={`Are you sure you want to delete the folder "${name}"? This action cannot be undone.`}
 			/>
-			<FoldersDropdown
-				id={id}
-				parentId={parentId}
-				public={publicEnabled}
-				setIsRenaming={setIsRenaming}
-				setConfirmDeleteFolderOpen={setConfirmDeleteFolderOpen}
-				nameRef={nameRef}
-				onPublicToggle={() => {
-					const nextPublic = !publicEnabled;
-					if (nextPublic && !ownerIsPro) {
-						setUpgradeModalOpen(true);
-						return;
-					}
-					setPublicEnabled(nextPublic);
-					updateFolder.mutate({
-						id,
-						public: nextPublic,
-					});
-				}}
-				onCopyPublicLink={async () => {
-					await copyPublicLink();
-				}}
-				canMove={moveEnabled}
-				onMove={() => setIsMoveDialogOpen(true)}
-			/>
+			<div className="relative z-10 shrink-0">
+				<FoldersDropdown
+					id={id}
+					parentId={parentId}
+					public={publicEnabled}
+					setIsRenaming={setIsRenaming}
+					setConfirmDeleteFolderOpen={setConfirmDeleteFolderOpen}
+					nameRef={nameRef}
+					onPublicToggle={() => {
+						const nextPublic = !publicEnabled;
+						if (nextPublic && !ownerIsPro) {
+							setUpgradeModalOpen(true);
+							return;
+						}
+						setPublicEnabled(nextPublic);
+						updateFolder.mutate({
+							id,
+							public: nextPublic,
+						});
+					}}
+					onCopyPublicLink={async () => {
+						await copyPublicLink();
+					}}
+					canMove={moveEnabled}
+					onMove={() => setIsMoveDialogOpen(true)}
+				/>
+			</div>
 		</fieldset>
 	);
 };

--- a/apps/web/app/(org)/dashboard/caps/components/FoldersSection.tsx
+++ b/apps/web/app/(org)/dashboard/caps/components/FoldersSection.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@cap/ui";
+import {
+	faArrowDownAZ,
+	faArrowDownWideShort,
+	faArrowUpWideShort,
+	faArrowUpZA,
+	faCheck,
+	faChevronDown,
+	faGrip,
+	faList,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import clsx from "clsx";
+import { useEffect, useMemo, useState } from "react";
+import {
+	DEFAULT_FOLDER_SORT,
+	FOLDER_SORT_OPTIONS,
+	type FolderSort,
+	isFolderSort,
+	sortFolders,
+} from "@/lib/folder-sort";
+import FolderCard, { type FolderDataType, type FolderLayout } from "./Folder";
+
+const SORT_STORAGE_KEY = "cap-dashboard-folder-sort";
+const LAYOUT_STORAGE_KEY = "cap-dashboard-folder-layout";
+const COLLAPSED_STORAGE_KEY = "cap-dashboard-folders-collapsed";
+
+const SORT_ICONS: Record<FolderSort, typeof faArrowDownAZ> = {
+	"name-asc": faArrowDownAZ,
+	"name-desc": faArrowUpZA,
+	newest: faArrowDownWideShort,
+	oldest: faArrowUpWideShort,
+};
+
+const isFolderLayout = (value: unknown): value is FolderLayout =>
+	value === "grid" || value === "list";
+
+const isBooleanString = (value: unknown): value is "true" | "false" =>
+	value === "true" || value === "false";
+
+const readStored = <T,>(key: string, guard: (v: unknown) => v is T) => {
+	try {
+		const raw = window.localStorage.getItem(key);
+		return guard(raw) ? raw : null;
+	} catch {
+		return null;
+	}
+};
+
+const writeStored = (key: string, value: string) => {
+	try {
+		window.localStorage.setItem(key, value);
+	} catch {
+		// Storage may be unavailable (private mode, quota); the choice still
+		// applies for this page view.
+	}
+};
+
+// Preferences are remembered per location ("personal", or one space), so a
+// numbered-folder scheme in My Caps doesn't force its sort onto every space.
+// Subfolder pages share their container's setting.
+const useFolderViewPreferences = (scope: string) => {
+	const sortKey = `${SORT_STORAGE_KEY}:${scope}`;
+	const layoutKey = `${LAYOUT_STORAGE_KEY}:${scope}`;
+	const collapsedKey = `${COLLAPSED_STORAGE_KEY}:${scope}`;
+	const [sort, setSort] = useState<FolderSort>(DEFAULT_FOLDER_SORT);
+	const [layout, setLayout] = useState<FolderLayout>("grid");
+	const [collapsed, setCollapsed] = useState(false);
+
+	useEffect(() => {
+		setSort(readStored(sortKey, isFolderSort) ?? DEFAULT_FOLDER_SORT);
+		setLayout(readStored(layoutKey, isFolderLayout) ?? "grid");
+		setCollapsed(readStored(collapsedKey, isBooleanString) === "true");
+	}, [sortKey, layoutKey, collapsedKey]);
+
+	return {
+		sort,
+		layout,
+		collapsed,
+		toggleCollapsed: () => {
+			setCollapsed((current) => {
+				writeStored(collapsedKey, String(!current));
+				return !current;
+			});
+		},
+		updateSort: (next: FolderSort) => {
+			setSort(next);
+			writeStored(sortKey, next);
+		},
+		updateLayout: (next: FolderLayout) => {
+			setLayout(next);
+			writeStored(layoutKey, next);
+		},
+	};
+};
+
+const controlClass =
+	"flex items-center justify-center h-8 text-[13px] font-medium rounded-lg border transition-colors duration-200 text-gray-11 bg-gray-3 border-gray-5 hover:bg-gray-4 hover:border-gray-6 hover:text-gray-12";
+
+type FolderItem = Omit<FolderDataType, "layout" | "canMove" | "moveRootLabel">;
+
+interface FoldersSectionProps {
+	title: string;
+	/** Preference scope: "personal" for My Caps and its subfolders, or a space id. */
+	scope: string;
+	folders: FolderItem[];
+	canMove?: boolean;
+	moveRootLabel?: string;
+	headingSize?: "lg" | "md";
+}
+
+export const FoldersSection = ({
+	title,
+	scope,
+	folders,
+	canMove,
+	moveRootLabel,
+	headingSize = "lg",
+}: FoldersSectionProps) => {
+	const { sort, layout, collapsed, toggleCollapsed, updateSort, updateLayout } =
+		useFolderViewPreferences(scope);
+
+	const sorted = useMemo(() => sortFolders(folders, sort), [folders, sort]);
+	const activeSort =
+		FOLDER_SORT_OPTIONS.find((option) => option.value === sort) ??
+		FOLDER_SORT_OPTIONS[0];
+
+	if (folders.length === 0) return null;
+
+	return (
+		<section className={collapsed ? "mb-6" : "mb-10"}>
+			<div
+				className={clsx(
+					"flex flex-wrap gap-3 justify-between items-center w-full",
+					!collapsed && "mb-6",
+				)}
+			>
+				<button
+					type="button"
+					onClick={toggleCollapsed}
+					aria-expanded={!collapsed}
+					className="flex gap-2.5 items-center min-w-0 text-left rounded-lg group -ml-1 pl-1 pr-2 py-0.5 transition-colors hover:bg-gray-3"
+				>
+					<h1
+						className={clsx(
+							"font-medium truncate text-gray-12",
+							headingSize === "lg" ? "text-2xl" : "text-xl",
+						)}
+					>
+						{title}
+					</h1>
+					<span className="text-sm tabular-nums text-gray-10">
+						{folders.length}
+					</span>
+					<FontAwesomeIcon
+						icon={faChevronDown}
+						className={clsx(
+							"size-3 text-gray-9 transition-transform duration-200 group-hover:text-gray-11",
+							collapsed && "-rotate-90",
+						)}
+					/>
+				</button>
+				{!collapsed && (
+					<div className="flex gap-2 items-center">
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<button
+									type="button"
+									aria-label={`Sort folders: ${activeSort?.label}`}
+									className={clsx(controlClass, "gap-2 px-3")}
+								>
+									<FontAwesomeIcon
+										icon={SORT_ICONS[sort]}
+										className="size-3.5 text-gray-10"
+									/>
+									<span>{activeSort?.label}</span>
+									<FontAwesomeIcon
+										icon={faChevronDown}
+										className="size-2.5 text-gray-9"
+									/>
+								</button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end" className="min-w-44">
+								{FOLDER_SORT_OPTIONS.map((option) => (
+									<DropdownMenuItem
+										key={option.value}
+										onClick={() => updateSort(option.value)}
+										className={clsx(
+											"gap-2 rounded-lg",
+											option.value === sort && "text-gray-12",
+										)}
+									>
+										<FontAwesomeIcon
+											icon={SORT_ICONS[option.value]}
+											className="size-3 text-gray-10"
+										/>
+										<span className="flex-1">{option.label}</span>
+										{option.value === sort && (
+											<FontAwesomeIcon
+												icon={faCheck}
+												className="size-3 text-gray-12"
+											/>
+										)}
+									</DropdownMenuItem>
+								))}
+							</DropdownMenuContent>
+						</DropdownMenu>
+						<fieldset className="flex overflow-hidden rounded-lg border border-gray-5 bg-gray-3">
+							<legend className="sr-only">Folder layout</legend>
+							{(
+								[
+									{ value: "grid", icon: faGrip, label: "Grid" },
+									{ value: "list", icon: faList, label: "List" },
+								] as const
+							).map((option) => (
+								<button
+									key={option.value}
+									type="button"
+									aria-label={`${option.label} layout`}
+									aria-pressed={layout === option.value}
+									onClick={() => updateLayout(option.value)}
+									className={clsx(
+										"flex justify-center items-center w-8 h-8 transition-colors duration-200",
+										layout === option.value
+											? "bg-gray-5 text-gray-12"
+											: "text-gray-10 hover:bg-gray-4 hover:text-gray-12",
+									)}
+								>
+									<FontAwesomeIcon icon={option.icon} className="size-3.5" />
+								</button>
+							))}
+						</fieldset>
+					</div>
+				)}
+			</div>
+			{!collapsed && (
+				<div
+					className={clsx(
+						layout === "grid"
+							? "grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4"
+							: "flex flex-col gap-2",
+					)}
+				>
+					{sorted.map((folder) => (
+						<FolderCard
+							key={folder.id}
+							{...folder}
+							layout={layout}
+							canMove={canMove}
+							moveRootLabel={moveRootLabel}
+						/>
+					))}
+				</div>
+			)}
+		</section>
+	);
+};
+
+export default FoldersSection;

--- a/apps/web/app/(org)/dashboard/caps/page.tsx
+++ b/apps/web/app/(org)/dashboard/caps/page.tsx
@@ -229,6 +229,7 @@ export default async function CapsPage(props: PageProps<"/dashboard/caps">) {
 			color: folders.color,
 			public: folders.public,
 			parentId: folders.parentId,
+			createdAt: folders.createdAt,
 			videoCount: sql<number>`(
         SELECT COUNT(*) FROM videos WHERE videos.folderId = folders.id
       )`,

--- a/apps/web/app/(org)/dashboard/folder/[id]/page.tsx
+++ b/apps/web/app/(org)/dashboard/folder/[id]/page.tsx
@@ -15,7 +15,7 @@ import { runPromise } from "@/lib/server";
 
 import { CollectionShareControl } from "../../_components/CollectionShareControl";
 import { UploadCapButton } from "../../caps/components";
-import FolderCard from "../../caps/components/Folder";
+import { FoldersSection } from "../../caps/components/FoldersSection";
 import { WebRecorderDialog } from "../../caps/components/web-recorder-dialog/web-recorder-dialog";
 import {
 	BreadcrumbItem,
@@ -94,29 +94,22 @@ const FolderPage = async (props: PageProps<"/dashboard/folder/[id]">) => {
 					</div>
 				</div>
 
-				{/* Display Child Folders */}
-				{childFolders.length > 0 && (
-					<>
-						<h1 className="mb-6 text-xl font-medium text-gray-12">
-							Subfolders
-						</h1>
-						<div className="grid grid-cols-[repeat(auto-fill,minmax(250px,1fr))] gap-4 mb-10">
-							{childFolders.map((folder) => (
-								<FolderCard
-									key={folder.id}
-									name={folder.name}
-									color={folder.color}
-									public={folder.public}
-									id={folder.id}
-									parentId={folder.parentId}
-									videoCount={folder.videoCount}
-									canMove={share.canManage}
-									moveRootLabel="My Caps"
-								/>
-							))}
-						</div>
-					</>
-				)}
+				<FoldersSection
+					title="Subfolders"
+					scope="personal"
+					headingSize="md"
+					folders={childFolders.map((folder) => ({
+						id: folder.id,
+						name: folder.name,
+						color: folder.color,
+						public: folder.public,
+						parentId: folder.parentId,
+						videoCount: folder.videoCount,
+						createdAt: folder.createdAt,
+					}))}
+					canMove={share.canManage}
+					moveRootLabel="My Caps"
+				/>
 
 				{/* Display Videos */}
 				<FolderVideosSection

--- a/apps/web/app/(org)/dashboard/spaces/[spaceId]/SharedCaps.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/[spaceId]/SharedCaps.tsx
@@ -30,7 +30,8 @@ import { CollectionShareControl } from "../../_components/CollectionShareControl
 import SpaceDialog from "../../_components/Navbar/SpaceDialog";
 import { useDashboardContext } from "../../Contexts";
 import { CapPagination } from "../../caps/components/CapPagination";
-import Folder, { type FolderDataType } from "../../caps/components/Folder";
+import type { FolderDataType } from "../../caps/components/Folder";
+import { FoldersSection } from "../../caps/components/FoldersSection";
 import { NewFolderDialog } from "../../caps/components/NewFolderDialog";
 import { SelectedCapsBar } from "../../caps/components/SelectedCapsBar";
 import { AddVideosDialog } from "./components/AddVideosDialog";
@@ -418,20 +419,14 @@ export const SharedCaps = ({
 					</Button>
 				)}
 			</div>
-			{folders && folders.length > 0 && (
-				<>
-					<h1 className="mb-6 text-2xl font-medium text-gray-12">Folders</h1>
-					<div className="grid grid-cols-[repeat(auto-fill,minmax(250px,1fr))] gap-4 mb-10">
-						{folders.map((folder) => (
-							<Folder
-								key={folder.id}
-								{...folder}
-								canMove={canManageCurrentSharedCollection}
-								moveRootLabel={moveRootLabel}
-							/>
-						))}
-					</div>
-				</>
+			{folders && (
+				<FoldersSection
+					title="Folders"
+					scope={`space:${spaceId}`}
+					folders={folders}
+					canMove={canManageCurrentSharedCollection}
+					moveRootLabel={moveRootLabel}
+				/>
 			)}
 
 			{data.length > 0 && (

--- a/apps/web/app/(org)/dashboard/spaces/[spaceId]/folder/[folderId]/page.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/[spaceId]/folder/[folderId]/page.tsx
@@ -7,7 +7,7 @@ import { notFound } from "next/navigation";
 import { getOrganizationAccess } from "@/actions/organization/authorization";
 import { getSpaceAccess } from "@/actions/organization/space-authorization";
 import { CollectionShareControl } from "@/app/(org)/dashboard/_components/CollectionShareControl";
-import FolderCard from "@/app/(org)/dashboard/caps/components/Folder";
+import { FoldersSection } from "@/app/(org)/dashboard/caps/components/FoldersSection";
 import {
 	getChildFolders,
 	getFolderBreadcrumb,
@@ -150,29 +150,23 @@ const FolderPage = async (props: {
 						))}
 					</div>
 				</div>
-				{childFolders.length > 0 && (
-					<>
-						<h1 className="mb-6 text-xl font-medium text-gray-12">
-							Subfolders
-						</h1>
-						<div className="grid grid-cols-[repeat(auto-fill,minmax(250px,1fr))] gap-4 mb-10">
-							{childFolders.map((folder) => (
-								<FolderCard
-									key={folder.id}
-									name={folder.name}
-									color={folder.color}
-									public={folder.public}
-									spaceId={params.spaceId}
-									id={folder.id}
-									parentId={folder.parentId}
-									videoCount={folder.videoCount}
-									canMove={canManageCollection}
-									moveRootLabel={moveRootLabel}
-								/>
-							))}
-						</div>
-					</>
-				)}
+				<FoldersSection
+					title="Subfolders"
+					scope={`space:${params.spaceId}`}
+					headingSize="md"
+					folders={childFolders.map((folder) => ({
+						id: folder.id,
+						name: folder.name,
+						color: folder.color,
+						public: folder.public,
+						spaceId: params.spaceId,
+						parentId: folder.parentId,
+						videoCount: folder.videoCount,
+						createdAt: folder.createdAt,
+					}))}
+					canMove={canManageCollection}
+					moveRootLabel={moveRootLabel}
+				/>
 				<FolderVideosSection
 					initialVideos={videosData}
 					location={moveLocation}

--- a/apps/web/app/(org)/dashboard/spaces/[spaceId]/page.tsx
+++ b/apps/web/app/(org)/dashboard/spaces/[spaceId]/page.tsx
@@ -62,6 +62,7 @@ async function fetchFolders(
 			public: folders.public,
 			parentId: folders.parentId,
 			spaceId: folders.spaceId,
+			createdAt: folders.createdAt,
 			videoCount: sql<number>`(
           SELECT COUNT(*) FROM ${table} WHERE ${table}.folderId = folders.id
         )`,

--- a/apps/web/lib/folder-sort.ts
+++ b/apps/web/lib/folder-sort.ts
@@ -1,0 +1,68 @@
+export type FolderSort = "name-asc" | "name-desc" | "newest" | "oldest";
+
+export const FOLDER_SORT_OPTIONS: ReadonlyArray<{
+	value: FolderSort;
+	label: string;
+}> = [
+	{ value: "name-asc", label: "Name (A to Z)" },
+	{ value: "name-desc", label: "Name (Z to A)" },
+	{ value: "newest", label: "Newest first" },
+	{ value: "oldest", label: "Oldest first" },
+];
+
+export const DEFAULT_FOLDER_SORT: FolderSort = "name-asc";
+
+export const isFolderSort = (value: unknown): value is FolderSort =>
+	FOLDER_SORT_OPTIONS.some((option) => option.value === value);
+
+type SortableFolder = {
+	id: string;
+	name: string;
+	createdAt?: Date | string | null;
+};
+
+// Natural ordering: "2_Foo" sorts before "10_Bar", and case/accents don't
+// split otherwise-equal names apart. Users number their folders, so plain
+// lexical order ("1, 10, 11, 2") is the exact complaint this exists to fix.
+const collator = new Intl.Collator(undefined, {
+	numeric: true,
+	sensitivity: "base",
+});
+
+const compareName = (a: SortableFolder, b: SortableFolder) =>
+	collator.compare(a.name.trim(), b.name.trim()) ||
+	// Identical names: keep the earlier-created one first so the order is stable
+	// across renders and matches what a "created order" reader expects.
+	compareCreated(a, b) ||
+	a.id.localeCompare(b.id);
+
+const toTime = (value: SortableFolder["createdAt"]) => {
+	if (!value) return 0;
+	const time = value instanceof Date ? value.getTime() : Date.parse(value);
+	return Number.isNaN(time) ? 0 : time;
+};
+
+const compareCreated = (a: SortableFolder, b: SortableFolder) =>
+	toTime(a.createdAt) - toTime(b.createdAt);
+
+const compareCreatedThenName = (a: SortableFolder, b: SortableFolder) =>
+	compareCreated(a, b) ||
+	collator.compare(a.name.trim(), b.name.trim()) ||
+	a.id.localeCompare(b.id);
+
+export function sortFolders<T extends SortableFolder>(
+	folders: readonly T[],
+	sort: FolderSort = DEFAULT_FOLDER_SORT,
+): T[] {
+	const sorted = [...folders];
+	switch (sort) {
+		case "name-asc":
+			return sorted.sort(compareName);
+		case "name-desc":
+			return sorted.sort((a, b) => compareName(b, a));
+		case "oldest":
+			return sorted.sort(compareCreatedThenName);
+		case "newest":
+			return sorted.sort((a, b) => compareCreatedThenName(b, a));
+	}
+}

--- a/apps/web/lib/folder.ts
+++ b/apps/web/lib/folder.ts
@@ -392,6 +392,7 @@ export const getChildFolders = Effect.fn(function* (
 				public: folders.public,
 				parentId: folders.parentId,
 				organizationId: folders.organizationId,
+				createdAt: folders.createdAt,
 				videoCount,
 			})
 			.from(folders)

--- a/apps/web/lib/public-collections.ts
+++ b/apps/web/lib/public-collections.ts
@@ -27,6 +27,7 @@ import {
 import { and, desc, eq, inArray, isNull, type SQL, sql } from "drizzle-orm";
 import { Effect } from "effect";
 import { cache } from "react";
+import { sortFolders } from "@/lib/folder-sort";
 import { getVerifiedPasswordHashes } from "@/lib/password-cookie";
 import {
 	PUBLIC_COLLECTION_PAGE_SIZE,
@@ -664,17 +665,21 @@ async function getPublicChildFolders(
 					isNull(organizations.tombstoneAt),
 				);
 
-	const childFolders = await db()
-		.select({
-			id: folders.id,
-			name: folders.name,
-			color: folders.color,
-			parentId: folders.parentId,
-		})
-		.from(folders)
-		.innerJoin(organizations, eq(folders.organizationId, organizations.id))
-		.where(where)
-		.orderBy(folders.name);
+	// Sorted in JS rather than ORDER BY so numbered names ("2_", "10_") come
+	// out in numeric order, matching the dashboard's default folder sort.
+	const childFolders = sortFolders(
+		await db()
+			.select({
+				id: folders.id,
+				name: folders.name,
+				color: folders.color,
+				parentId: folders.parentId,
+				createdAt: folders.createdAt,
+			})
+			.from(folders)
+			.innerJoin(organizations, eq(folders.organizationId, organizations.id))
+			.where(where),
+	);
 
 	if (childFolders.length === 0) return [];
 


### PR DESCRIPTION
## Summary

A customer with numbered folders (`1_Getting Started` … `26_Glossary`) reported they show in a random order. Root cause: none of the folder queries had an `ORDER BY`, so rows came back in nanoid primary-key order. Folder names were also capped at a fixed 116px regardless of card width, so most names truncated even on wide screens.

This PR fixes the ordering and reworks the folder section UX on every surface that lists folders (My Caps, space root, personal subfolder page, space subfolder page).

## Changes

- **Natural numeric sort by default.** New `lib/folder-sort.ts` uses an `Intl.Collator` with `numeric: true`, so `2_`, `7_`, `10_`, `23_` order correctly. Case, accents and surrounding whitespace are ignored; ties fall back to creation time then id so the order is stable. Public collection pages (`/c/[id]`) use the same sort.
- **Sort control.** Name (A to Z), Name (Z to A), Newest first, Oldest first. `createdAt` is now selected in every folder query so the date modes work.
- **Grid / list toggle.** List rows give the name the full width, which is what makes 26+ folders scannable.
- **Collapsible section.** The "Folders" / "Subfolders" heading is a toggle with a chevron; collapsed state hides the cards and controls.
- **Per-location preferences.** Sort, layout and collapsed state persist in localStorage, scoped to My Caps or to each space (subfolder pages share their container's setting), so a numbering scheme in My Caps doesn't force its sort onto every space.
- **Whole-card hitbox.** Each card is a stretched link, so the icon, name, "x videos" line and padding all open the folder. The menu button and rename field sit above the link and stay interactive. Keyboard users get one focus stop per card with a visible ring.
- **Readable names in the grid.** The 116px cap is gone, names wrap to two lines before truncating, hover shows the full name, and the grid minimum column width went from 250px to 280px.
- **One shared component.** `FoldersSection.tsx` replaces the four hand-rolled grids.

## Verification

- `pnpm exec tsc --noEmit` clean, biome clean on changed files.
- 8 new unit tests for `sortFolders` / `isFolderSort` (`__tests__/unit/folder-sort.test.ts`).
- Drove the local dashboard headless with 155 seeded folders (the customer's exact numbered set, dotted versions like `1.9` / `1.10`, accented names, long names, nested and space folders) and confirmed: natural order on first load, Newest/Oldest reorder, list layout, collapse, all three prefs surviving a reload, prefs not leaking between My Caps and a space, clicking the "0 videos" text navigates, the ⋯ menu opens without navigating, and the rename field takes focus.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds naturally sorted folder views with persistent sorting, layout, and collapse preferences across dashboard surfaces.
- Introduces shared folder sorting and section components.
- Adds grid/list layouts, collapsible sections, and whole-card navigation.
- Includes folder creation timestamps in queries and applies matching sorting to public collections.
- Adds unit coverage for folder sorting and preference-value validation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/(org)/dashboard/caps/components/Folder.tsx | Adds responsive grid/list folder cards and accessible whole-card links; the previously flagged narrative comments have been removed. |
| apps/web/app/(org)/dashboard/caps/components/FoldersSection.tsx | Centralizes sorted, collapsible folder rendering and per-location persisted view preferences. |
| apps/web/lib/folder-sort.ts | Implements stable natural-name and creation-time folder sorting. |
| apps/web/lib/folder.ts | Extends folder query results with creation timestamps required by date sorting. |
| apps/web/lib/public-collections.ts | Applies shared natural sorting to folders displayed in public collections. |
| apps/web/__tests__/unit/folder-sort.test.ts | Covers numeric names, direction changes, date ordering, stable tie-breaking, malformed dates, immutability, and sort validation. |

<sub>Reviews (2): Last reviewed commit: ["web: drop narrative comments from folder..."](https://github.com/capsoftware/cap/commit/1c79d3df38065937711499dd5c8e578e6b89b2a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59922560)</sub>

<!-- /greptile_comment -->