### PR TITLE
perf(db): add hot-path indexes for recovery crons, Loom imports and storage listings

### DIFF
--- a/packages/database/migrations/0042_perf_indexes.sql
+++ b/packages/database/migrations/0042_perf_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX `id_idx` ON `imported_videos` (`id`);--> statement-breakpoint
+CREATE INDEX `integration_object_key_prefix_idx` ON `storage_objects` (`integrationId`,`objectKey`(191));--> statement-breakpoint
+CREATE INDEX `screenshot_transcription_created_idx` ON `videos` (`isScreenshot`,`transcriptionStatus`,`createdAt`);

--- a/packages/database/migrations/meta/0042_snapshot.json
+++ b/packages/database/migrations/meta/0042_snapshot.json
@@ -1,0 +1,4417 @@
+{
+	"version": "5",
+	"dialect": "mysql",
+	"id": "8b7635aa-9c42-41dc-993c-1f2ae7af6364",
+	"prevId": "4cabd769-52d3-4eb0-b6aa-e67a5a62591e",
+	"tables": {
+		"accounts": {
+			"name": "accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerAccountId": {
+					"name": "providerAccountId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_in": {
+					"name": "expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_in": {
+					"name": "refresh_token_expires_in",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"tempColumn": {
+					"name": "tempColumn",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				},
+				"provider_account_id_idx": {
+					"name": "provider_account_id_idx",
+					"columns": ["providerAccountId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"accounts_id": {
+					"name": "accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"agent_api_authorization_codes": {
+			"name": "agent_api_authorization_codes",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"codeHash": {
+					"name": "codeHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"codeChallenge": {
+					"name": "codeChallenge",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"redirectUri": {
+					"name": "redirectUri",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"consumedAt": {
+					"name": "consumedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"code_hash_idx": {
+					"name": "code_hash_idx",
+					"columns": ["codeHash"],
+					"isUnique": true
+				},
+				"expires_at_idx": {
+					"name": "expires_at_idx",
+					"columns": ["expiresAt"],
+					"isUnique": false
+				},
+				"user_created_at_idx": {
+					"name": "user_created_at_idx",
+					"columns": ["userId", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"agent_api_authorization_codes_id": {
+					"name": "agent_api_authorization_codes_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"agent_api_idempotency": {
+			"name": "agent_api_idempotency",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"operation": {
+					"name": "operation",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyHash": {
+					"name": "keyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"requestHash": {
+					"name": "requestHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"statusCode": {
+					"name": "statusCode",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"response": {
+					"name": "response",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_operation_key_idx": {
+					"name": "user_operation_key_idx",
+					"columns": ["userId", "operation", "keyHash"],
+					"isUnique": true
+				},
+				"expires_at_idx": {
+					"name": "expires_at_idx",
+					"columns": ["expiresAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"agent_api_idempotency_id": {
+					"name": "agent_api_idempotency_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"agent_api_keys": {
+			"name": "agent_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tokenHash": {
+					"name": "tokenHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Cap CLI'"
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"revokedAt": {
+					"name": "revokedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"lastUsedAt": {
+					"name": "lastUsedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"token_hash_idx": {
+					"name": "token_hash_idx",
+					"columns": ["tokenHash"],
+					"isUnique": true
+				},
+				"user_created_at_idx": {
+					"name": "user_created_at_idx",
+					"columns": ["userId", "createdAt"],
+					"isUnique": false
+				},
+				"expires_at_idx": {
+					"name": "expires_at_idx",
+					"columns": ["expiresAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"agent_api_keys_id": {
+					"name": "agent_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"agent_api_operations": {
+			"name": "agent_api_operations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"resourceId": {
+					"name": "resourceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"resultResourceId": {
+					"name": "resultResourceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'queued'"
+				},
+				"payload": {
+					"name": "payload",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"result": {
+					"name": "result",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"errorCode": {
+					"name": "errorCode",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"errorMessage": {
+					"name": "errorMessage",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"completedAt": {
+					"name": "completedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_created_at_idx": {
+					"name": "user_created_at_idx",
+					"columns": ["userId", "createdAt"],
+					"isUnique": false
+				},
+				"state_updated_at_idx": {
+					"name": "state_updated_at_idx",
+					"columns": ["state", "updatedAt"],
+					"isUnique": false
+				},
+				"resource_id_idx": {
+					"name": "resource_id_idx",
+					"columns": ["resourceId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"agent_api_operations_id": {
+					"name": "agent_api_operations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"auth_api_keys": {
+			"name": "auth_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(36)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'unknown'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_id_created_at_idx": {
+					"name": "user_id_created_at_idx",
+					"columns": ["userId", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"auth_api_keys_id": {
+					"name": "auth_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"comments": {
+			"name": "comments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(6)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"authorId": {
+					"name": "authorId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"parentCommentId": {
+					"name": "parentCommentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"mediaKey": {
+					"name": "mediaKey",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"mediaDuration": {
+					"name": "mediaDuration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"mediaMeta": {
+					"name": "mediaMeta",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"video_type_created_idx": {
+					"name": "video_type_created_idx",
+					"columns": ["videoId", "type", "createdAt", "id"],
+					"isUnique": false
+				},
+				"author_id_idx": {
+					"name": "author_id_idx",
+					"columns": ["authorId"],
+					"isUnique": false
+				},
+				"parent_comment_id_idx": {
+					"name": "parent_comment_id_idx",
+					"columns": ["parentCommentId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"comments_id": {
+					"name": "comments_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_api_keys": {
+			"name": "developer_api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyType": {
+					"name": "keyType",
+					"type": "varchar(8)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyPrefix": {
+					"name": "keyPrefix",
+					"type": "varchar(12)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"keyHash": {
+					"name": "keyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"encryptedKey": {
+					"name": "encryptedKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"lastUsedAt": {
+					"name": "lastUsedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"revokedAt": {
+					"name": "revokedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"key_hash_idx": {
+					"name": "key_hash_idx",
+					"columns": ["keyHash"],
+					"isUnique": true
+				},
+				"app_key_type_idx": {
+					"name": "app_key_type_idx",
+					"columns": ["appId", "keyType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_api_keys_appId_developer_apps_id_fk": {
+					"name": "developer_api_keys_appId_developer_apps_id_fk",
+					"tableFrom": "developer_api_keys",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_api_keys_id": {
+					"name": "developer_api_keys_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_app_domains": {
+			"name": "developer_app_domains",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"domain": {
+					"name": "domain",
+					"type": "varchar(253)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_app_domains_appId_developer_apps_id_fk": {
+					"name": "developer_app_domains_appId_developer_apps_id_fk",
+					"tableFrom": "developer_app_domains",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_app_domains_id": {
+					"name": "developer_app_domains_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_domain_unique": {
+					"name": "app_domain_unique",
+					"columns": ["appId", "domain"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_apps": {
+			"name": "developer_apps",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"environment": {
+					"name": "environment",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"logoUrl": {
+					"name": "logoUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_deleted_idx": {
+					"name": "owner_deleted_idx",
+					"columns": ["ownerId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"developer_apps_id": {
+					"name": "developer_apps_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_accounts": {
+			"name": "developer_credit_accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceMicroCredits": {
+					"name": "balanceMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripePaymentMethodId": {
+					"name": "stripePaymentMethodId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"autoTopUpEnabled": {
+					"name": "autoTopUpEnabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"autoTopUpThresholdMicroCredits": {
+					"name": "autoTopUpThresholdMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"autoTopUpAmountCents": {
+					"name": "autoTopUpAmountCents",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_id_unique": {
+					"name": "app_id_unique",
+					"columns": ["appId"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"developer_credit_accounts_appId_developer_apps_id_fk": {
+					"name": "developer_credit_accounts_appId_developer_apps_id_fk",
+					"tableFrom": "developer_credit_accounts",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_accounts_id": {
+					"name": "developer_credit_accounts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_credit_transactions": {
+			"name": "developer_credit_transactions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amountMicroCredits": {
+					"name": "amountMicroCredits",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balanceAfterMicroCredits": {
+					"name": "balanceAfterMicroCredits",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"referenceId": {
+					"name": "referenceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"referenceType": {
+					"name": "referenceType",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"account_type_created_idx": {
+					"name": "account_type_created_idx",
+					"columns": ["accountId", "type", "createdAt"],
+					"isUnique": false
+				},
+				"account_ref_dedup_idx": {
+					"name": "account_ref_dedup_idx",
+					"columns": ["accountId", "referenceId", "referenceType"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"dev_credit_txn_account_fk": {
+					"name": "dev_credit_txn_account_fk",
+					"tableFrom": "developer_credit_transactions",
+					"tableTo": "developer_credit_accounts",
+					"columnsFrom": ["accountId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_credit_transactions_id": {
+					"name": "developer_credit_transactions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"developer_daily_storage_snapshots": {
+			"name": "developer_daily_storage_snapshots",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"snapshotDate": {
+					"name": "snapshotDate",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"totalDurationMinutes": {
+					"name": "totalDurationMinutes",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"videoCount": {
+					"name": "videoCount",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"microCreditsCharged": {
+					"name": "microCreditsCharged",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processedAt": {
+					"name": "processedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"developer_daily_storage_snapshots_appId_developer_apps_id_fk": {
+					"name": "developer_daily_storage_snapshots_appId_developer_apps_id_fk",
+					"tableFrom": "developer_daily_storage_snapshots",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_daily_storage_snapshots_id": {
+					"name": "developer_daily_storage_snapshots_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"app_date_unique": {
+					"name": "app_date_unique",
+					"columns": ["appId", "snapshotDate"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"developer_videos": {
+			"name": "developer_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"appId": {
+					"name": "appId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"externalUserId": {
+					"name": "externalUserId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Untitled'"
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"s3Key": {
+					"name": "s3Key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"app_created_idx": {
+					"name": "app_created_idx",
+					"columns": ["appId", "createdAt"],
+					"isUnique": false
+				},
+				"app_user_idx": {
+					"name": "app_user_idx",
+					"columns": ["appId", "externalUserId"],
+					"isUnique": false
+				},
+				"app_deleted_idx": {
+					"name": "app_deleted_idx",
+					"columns": ["appId", "deletedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"developer_videos_appId_developer_apps_id_fk": {
+					"name": "developer_videos_appId_developer_apps_id_fk",
+					"tableFrom": "developer_videos",
+					"tableTo": "developer_apps",
+					"columnsFrom": ["appId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"developer_videos_id": {
+					"name": "developer_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"folders": {
+			"name": "folders",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"color": {
+					"name": "color",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'normal'"
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parentId": {
+					"name": "parentId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				},
+				"parent_id_idx": {
+					"name": "parent_id_idx",
+					"columns": ["parentId"],
+					"isUnique": false
+				},
+				"space_id_idx": {
+					"name": "space_id_idx",
+					"columns": ["spaceId"],
+					"isUnique": false
+				},
+				"public_parent_id_idx": {
+					"name": "public_parent_id_idx",
+					"columns": ["public", "parentId"],
+					"isUnique": false
+				},
+				"public_space_parent_id_idx": {
+					"name": "public_space_parent_id_idx",
+					"columns": ["public", "spaceId", "parentId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"folders_id": {
+					"name": "folders_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"imported_videos": {
+			"name": "imported_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"id_idx": {
+					"name": "id_idx",
+					"columns": ["id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"imported_videos_orgId_source_source_id_pk": {
+					"name": "imported_videos_orgId_source_source_id_pk",
+					"columns": ["orgId", "source", "source_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"integration_installations": {
+			"name": "integration_installations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"externalId": {
+					"name": "externalId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"displayName": {
+					"name": "displayName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"installedByUserId": {
+					"name": "installedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"encryptedCredentials": {
+					"name": "encryptedCredentials",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"provider_external_id_idx": {
+					"name": "provider_external_id_idx",
+					"columns": ["provider", "externalId"],
+					"isUnique": true
+				},
+				"organization_provider_display_name_idx": {
+					"name": "organization_provider_display_name_idx",
+					"columns": ["organizationId", "provider", "displayName"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"integration_installations_id": {
+					"name": "integration_installations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_conversations": {
+			"name": "messenger_conversations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent": {
+					"name": "agent",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'agent'"
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverByUserId": {
+					"name": "takeoverByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"takeoverAt": {
+					"name": "takeoverAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"lastMessageAt": {
+					"name": "lastMessageAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_last_message_idx": {
+					"name": "user_last_message_idx",
+					"columns": ["userId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"anonymous_last_message_idx": {
+					"name": "anonymous_last_message_idx",
+					"columns": ["anonymousId", "lastMessageAt"],
+					"isUnique": false
+				},
+				"mode_last_message_idx": {
+					"name": "mode_last_message_idx",
+					"columns": ["mode", "lastMessageAt"],
+					"isUnique": false
+				},
+				"updated_at_idx": {
+					"name": "updated_at_idx",
+					"columns": ["updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"messenger_conversations_id": {
+					"name": "messenger_conversations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_messages": {
+			"name": "messenger_messages",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"conversationId": {
+					"name": "conversationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"anonymousId": {
+					"name": "anonymousId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"conversation_created_at_idx": {
+					"name": "conversation_created_at_idx",
+					"columns": ["conversationId", "createdAt"],
+					"isUnique": false
+				},
+				"role_created_at_idx": {
+					"name": "role_created_at_idx",
+					"columns": ["role", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"messenger_messages_conversationId_messenger_conversations_id_fk": {
+					"name": "messenger_messages_conversationId_messenger_conversations_id_fk",
+					"tableFrom": "messenger_messages",
+					"tableTo": "messenger_conversations",
+					"columnsFrom": ["conversationId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"messenger_messages_id": {
+					"name": "messenger_messages_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"messenger_support_emails": {
+			"name": "messenger_support_emails",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"conversationId": {
+					"name": "conversationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userEmail": {
+					"name": "userEmail",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subject": {
+					"name": "subject",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"message": {
+					"name": "message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"support_email_user_created_at_idx": {
+					"name": "support_email_user_created_at_idx",
+					"columns": ["userId", "createdAt"],
+					"isUnique": false
+				},
+				"support_email_conversation_created_at_idx": {
+					"name": "support_email_conversation_created_at_idx",
+					"columns": ["conversationId", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"support_email_conversation_fk": {
+					"name": "support_email_conversation_fk",
+					"tableFrom": "messenger_support_emails",
+					"tableTo": "messenger_conversations",
+					"columnsFrom": ["conversationId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"messenger_support_emails_id": {
+					"name": "messenger_support_emails_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"notifications": {
+			"name": "notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recipientId": {
+					"name": "recipientId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(16)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"data": {
+					"name": "data",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dedupKey": {
+					"name": "dedupKey",
+					"type": "varchar(128)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"readAt": {
+					"name": "readAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"org_id_idx": {
+					"name": "org_id_idx",
+					"columns": ["orgId"],
+					"isUnique": false
+				},
+				"type_idx": {
+					"name": "type_idx",
+					"columns": ["type"],
+					"isUnique": false
+				},
+				"read_at_idx": {
+					"name": "read_at_idx",
+					"columns": ["readAt"],
+					"isUnique": false
+				},
+				"created_at_idx": {
+					"name": "created_at_idx",
+					"columns": ["createdAt"],
+					"isUnique": false
+				},
+				"recipient_read_idx": {
+					"name": "recipient_read_idx",
+					"columns": ["recipientId", "readAt"],
+					"isUnique": false
+				},
+				"recipient_created_idx": {
+					"name": "recipient_created_idx",
+					"columns": ["recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"dedup_key_idx": {
+					"name": "dedup_key_idx",
+					"columns": ["dedupKey"],
+					"isUnique": true
+				},
+				"type_recipient_created_idx": {
+					"name": "type_recipient_created_idx",
+					"columns": ["type", "recipientId", "createdAt"],
+					"isUnique": false
+				},
+				"type_recipient_video_created_idx": {
+					"name": "type_recipient_video_created_idx",
+					"columns": ["type", "recipientId", "videoId", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"notifications_id": {
+					"name": "notifications_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_invites": {
+			"name": "organization_invites",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedEmail": {
+					"name": "invitedEmail",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"invitedByUserId": {
+					"name": "invitedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"invited_email_idx": {
+					"name": "invited_email_idx",
+					"columns": ["invitedEmail"],
+					"isUnique": false
+				},
+				"invited_by_user_id_idx": {
+					"name": "invited_by_user_id_idx",
+					"columns": ["invitedByUserId"],
+					"isUnique": false
+				},
+				"status_idx": {
+					"name": "status_idx",
+					"columns": ["status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_invites_id": {
+					"name": "organization_invites_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_members": {
+			"name": "organization_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"hasProSeat": {
+					"name": "hasProSeat",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"user_id_organization_id_idx": {
+					"name": "user_id_organization_id_idx",
+					"columns": ["userId", "organizationId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_members_id": {
+					"name": "organization_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organization_sso": {
+			"name": "organization_sso",
+			"columns": {
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"purchasedByUserId": {
+					"name": "purchasedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionId": {
+					"name": "stripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripePriceId": {
+					"name": "stripePriceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'unpaid'"
+				},
+				"paidThrough": {
+					"name": "paidThrough",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"currentPeriodEnd": {
+					"name": "currentPeriodEnd",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"cancelAtPeriodEnd": {
+					"name": "cancelAtPeriodEnd",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"checkoutAttemptId": {
+					"name": "checkoutAttemptId",
+					"type": "varchar(36)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"checkoutCurrency": {
+					"name": "checkoutCurrency",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"checkoutPriceId": {
+					"name": "checkoutPriceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"checkoutSessionId": {
+					"name": "checkoutSessionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"checkoutStartedAt": {
+					"name": "checkoutStartedAt",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"sso_stripe_subscription_id_idx": {
+					"name": "sso_stripe_subscription_id_idx",
+					"columns": ["stripeSubscriptionId"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organization_sso_organizationId": {
+					"name": "organization_sso_organizationId",
+					"columns": ["organizationId"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"organizations": {
+			"name": "organizations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tombstoneAt": {
+					"name": "tombstoneAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"allowedEmailDomain": {
+					"name": "allowedEmailDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customDomain": {
+					"name": "customDomain",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"domainVerified": {
+					"name": "domainVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"shareableLinkIconUrl": {
+					"name": "shareableLinkIconUrl",
+					"type": "varchar(1024)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"workosOrganizationId": {
+					"name": "workosOrganizationId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"workosConnectionId": {
+					"name": "workosConnectionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"owner_id_tombstone_idx": {
+					"name": "owner_id_tombstone_idx",
+					"columns": ["ownerId", "tombstoneAt"],
+					"isUnique": false
+				},
+				"custom_domain_idx": {
+					"name": "custom_domain_idx",
+					"columns": ["customDomain"],
+					"isUnique": false
+				},
+				"workos_organization_id_idx": {
+					"name": "workos_organization_id_idx",
+					"columns": ["workosOrganizationId"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"organizations_id": {
+					"name": "organizations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"s3_buckets": {
+			"name": "s3_buckets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"region": {
+					"name": "region",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"endpoint": {
+					"name": "endpoint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"bucketName": {
+					"name": "bucketName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accessKeyId": {
+					"name": "accessKeyId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"secretAccessKey": {
+					"name": "secretAccessKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('aws')"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_organization_idx": {
+					"name": "owner_organization_idx",
+					"columns": ["ownerId", "organizationId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "updatedAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"s3_buckets_id": {
+					"name": "s3_buckets_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"sessions": {
+			"name": "sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sessionToken": {
+					"name": "sessionToken",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"session_token_idx": {
+					"name": "session_token_idx",
+					"columns": ["sessionToken"],
+					"isUnique": true
+				},
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"sessions_id": {
+					"name": "sessions_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"shared_videos": {
+			"name": "shared_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedByUserId": {
+					"name": "sharedByUserId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sharedAt": {
+					"name": "sharedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"shared_by_user_id_idx": {
+					"name": "shared_by_user_id_idx",
+					"columns": ["sharedByUserId"],
+					"isUnique": false
+				},
+				"video_id_organization_id_idx": {
+					"name": "video_id_organization_id_idx",
+					"columns": ["videoId", "organizationId"],
+					"isUnique": false
+				},
+				"video_id_folder_id_idx": {
+					"name": "video_id_folder_id_idx",
+					"columns": ["videoId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"shared_videos_id": {
+					"name": "shared_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"signed_baas": {
+			"name": "signed_baas",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"stripeSubscriptionId": {
+					"name": "stripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"entityName": {
+					"name": "entityName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"entityType": {
+					"name": "entityType",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"entityAddress": {
+					"name": "entityAddress",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"signerName": {
+					"name": "signerName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"signerTitle": {
+					"name": "signerTitle",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"noticesEmail": {
+					"name": "noticesEmail",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"signatureData": {
+					"name": "signatureData",
+					"type": "longtext",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"signedAt": {
+					"name": "signedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"emailSentAt": {
+					"name": "emailSentAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"signed_baa_organization_id_idx": {
+					"name": "signed_baa_organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": true
+				},
+				"signed_baa_stripe_subscription_idx": {
+					"name": "signed_baa_stripe_subscription_idx",
+					"columns": ["stripeSubscriptionId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"signed_baas_id": {
+					"name": "signed_baas_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"space_members": {
+			"name": "space_members",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'member'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"user_id_idx": {
+					"name": "user_id_idx",
+					"columns": ["userId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_members_id": {
+					"name": "space_members_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"space_id_user_id_unique": {
+					"name": "space_id_user_id_unique",
+					"columns": ["spaceId", "userId"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"space_videos": {
+			"name": "space_videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spaceId": {
+					"name": "spaceId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedById": {
+					"name": "addedById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"addedAt": {
+					"name": "addedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"added_by_id_idx": {
+					"name": "added_by_id_idx",
+					"columns": ["addedById"],
+					"isUnique": false
+				},
+				"space_id_video_id_idx": {
+					"name": "space_id_video_id_idx",
+					"columns": ["spaceId", "videoId"],
+					"isUnique": false
+				},
+				"space_id_folder_id_idx": {
+					"name": "space_id_folder_id_idx",
+					"columns": ["spaceId", "folderId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"space_videos_id": {
+					"name": "space_videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"spaces": {
+			"name": "spaces",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"primary": {
+					"name": "primary",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdById": {
+					"name": "createdById",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"iconUrl": {
+					"name": "iconUrl",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "varchar(1000)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"privacy": {
+					"name": "privacy",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Private'"
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"organization_id_idx": {
+					"name": "organization_id_idx",
+					"columns": ["organizationId"],
+					"isUnique": false
+				},
+				"created_by_id_idx": {
+					"name": "created_by_id_idx",
+					"columns": ["createdById"],
+					"isUnique": false
+				},
+				"public_organization_id_idx": {
+					"name": "public_organization_id_idx",
+					"columns": ["public", "organizationId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"spaces_id": {
+					"name": "spaces_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_integrations": {
+			"name": "storage_integrations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organizationId": {
+					"name": "organizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"displayName": {
+					"name": "displayName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"encryptedConfig": {
+					"name": "encryptedConfig",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"googleDriveAccessToken": {
+					"name": "googleDriveAccessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveAccessTokenExpiresAt": {
+					"name": "googleDriveAccessTokenExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseId": {
+					"name": "googleDriveTokenRefreshLeaseId",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveTokenRefreshLeaseExpiresAt": {
+					"name": "googleDriveTokenRefreshLeaseExpiresAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"googleDriveStorageQuotaCache": {
+					"name": "googleDriveStorageQuotaCache",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"owner_provider_idx": {
+					"name": "owner_provider_idx",
+					"columns": ["ownerId", "provider"],
+					"isUnique": false
+				},
+				"owner_active_idx": {
+					"name": "owner_active_idx",
+					"columns": ["ownerId", "active"],
+					"isUnique": false
+				},
+				"organization_provider_idx": {
+					"name": "organization_provider_idx",
+					"columns": ["organizationId", "provider"],
+					"isUnique": false
+				},
+				"organization_active_idx": {
+					"name": "organization_active_idx",
+					"columns": ["organizationId", "active", "status"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"storage_integrations_id": {
+					"name": "storage_integrations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"storage_objects": {
+			"name": "storage_objects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"integrationId": {
+					"name": "integrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"objectKey": {
+					"name": "objectKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"objectKeyHash": {
+					"name": "objectKeyHash",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerObjectId": {
+					"name": "providerObjectId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploadSessionUrl": {
+					"name": "uploadSessionUrl",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"uploadStatus": {
+					"name": "uploadStatus",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"contentType": {
+					"name": "contentType",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"contentLength": {
+					"name": "contentLength",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {
+				"integration_key_hash_idx": {
+					"name": "integration_key_hash_idx",
+					"columns": ["integrationId", "objectKeyHash"],
+					"isUnique": true
+				},
+				"integration_status_idx": {
+					"name": "integration_status_idx",
+					"columns": ["integrationId", "uploadStatus"],
+					"isUnique": false
+				},
+				"integration_object_key_prefix_idx": {
+					"name": "integration_object_key_prefix_idx",
+					"columns": ["integrationId", "`objectKey`(191)"],
+					"isUnique": false
+				},
+				"video_id_idx": {
+					"name": "video_id_idx",
+					"columns": ["videoId"],
+					"isUnique": false
+				},
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"storage_objects_integrationId_storage_integrations_id_fk": {
+					"name": "storage_objects_integrationId_storage_integrations_id_fk",
+					"tableFrom": "storage_objects",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["integrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"storage_objects_id": {
+					"name": "storage_objects_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"lastName": {
+					"name": "lastName",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeCustomerId": {
+					"name": "stripeCustomerId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionId": {
+					"name": "stripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"thirdPartyStripeSubscriptionId": {
+					"name": "thirdPartyStripeSubscriptionId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionStatus": {
+					"name": "stripeSubscriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"stripeSubscriptionPriceId": {
+					"name": "stripeSubscriptionPriceId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preferences": {
+					"name": "preferences",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "('null')"
+				},
+				"activeOrganizationId": {
+					"name": "activeOrganizationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"onboardingSteps": {
+					"name": "onboardingSteps",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"onboarding_completed_at": {
+					"name": "onboarding_completed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"customBucket": {
+					"name": "customBucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"inviteQuota": {
+					"name": "inviteQuota",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"defaultOrgId": {
+					"name": "defaultOrgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"authSessionVersion": {
+					"name": "authSessionVersion",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {
+				"email_idx": {
+					"name": "email_idx",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"users_id": {
+					"name": "users_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"verification_tokens": {
+			"name": "verification_tokens",
+			"columns": {
+				"identifier": {
+					"name": "identifier",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires": {
+					"name": "expires",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"verification_tokens_identifier": {
+					"name": "verification_tokens_identifier",
+					"columns": ["identifier"]
+				}
+			},
+			"uniqueConstraints": {
+				"verification_tokens_token_unique": {
+					"name": "verification_tokens_token_unique",
+					"columns": ["token"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"video_edits": {
+			"name": "video_edits",
+			"columns": {
+				"videoId": {
+					"name": "videoId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sourceKey": {
+					"name": "sourceKey",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"editSpec": {
+					"name": "editSpec",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"video_edits_videoId_videos_id_fk": {
+					"name": "video_edits_videoId_videos_id_fk",
+					"tableFrom": "video_edits",
+					"tableTo": "videos",
+					"columnsFrom": ["videoId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"video_edits_videoId": {
+					"name": "video_edits_videoId",
+					"columns": ["videoId"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"video_processing_jobs": {
+			"name": "video_processing_jobs",
+			"columns": {
+				"video_id": {
+					"name": "video_id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"owner_id": {
+					"name": "owner_id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"generation": {
+					"name": "generation",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"manifest_sha256": {
+					"name": "manifest_sha256",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'committing'"
+				},
+				"attempt_id": {
+					"name": "attempt_id",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"attempt_count": {
+					"name": "attempt_count",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"lease_expires_at": {
+					"name": "lease_expires_at",
+					"type": "datetime(3)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"next_retry_at": {
+					"name": "next_retry_at",
+					"type": "datetime(3)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"remote_job_id": {
+					"name": "remote_job_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"verification": {
+					"name": "verification",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"output": {
+					"name": "output",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"error_code": {
+					"name": "error_code",
+					"type": "varchar(64)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "datetime(3)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "datetime(3)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"processing_state_retry_video_idx": {
+					"name": "processing_state_retry_video_idx",
+					"columns": ["state", "next_retry_at", "video_id"],
+					"isUnique": false
+				},
+				"processing_state_lease_video_idx": {
+					"name": "processing_state_lease_video_idx",
+					"columns": ["state", "lease_expires_at", "video_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"video_processing_jobs_video_id": {
+					"name": "video_processing_jobs_video_id",
+					"columns": ["video_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"video_uploads": {
+			"name": "video_uploads",
+			"columns": {
+				"video_id": {
+					"name": "video_id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"uploaded": {
+					"name": "uploaded",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"total": {
+					"name": "total",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"mode": {
+					"name": "mode",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phase": {
+					"name": "phase",
+					"type": "varchar(32)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'uploading'"
+				},
+				"processing_progress": {
+					"name": "processing_progress",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"processing_message": {
+					"name": "processing_message",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"processing_error": {
+					"name": "processing_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"raw_file_key": {
+					"name": "raw_file_key",
+					"type": "varchar(512)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"phase_updated_at_video_id_idx": {
+					"name": "phase_updated_at_video_id_idx",
+					"columns": ["phase", "updated_at", "video_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"video_uploads_video_id": {
+					"name": "video_uploads_video_id",
+					"columns": ["video_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"videos": {
+			"name": "videos",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ownerId": {
+					"name": "ownerId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"orgId": {
+					"name": "orgId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'My Video'"
+				},
+				"bucket": {
+					"name": "bucket",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"storageIntegrationId": {
+					"name": "storageIntegrationId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration": {
+					"name": "duration",
+					"type": "float",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"width": {
+					"name": "width",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"height": {
+					"name": "height",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fps": {
+					"name": "fps",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"settings": {
+					"name": "settings",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcriptionStatus": {
+					"name": "transcriptionStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "('{\"type\":\"MediaConvert\"}')"
+				},
+				"folderId": {
+					"name": "folderId",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(now())"
+				},
+				"effectiveCreatedAt": {
+					"name": "effectiveCreatedAt",
+					"type": "datetime",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"generated": {
+						"as": "COALESCE(\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%s.%fZ'),\n          STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.customCreatedAt')), '%Y-%m-%dT%H:%i:%sZ'),\n          `createdAt`\n        )",
+						"type": "stored"
+					}
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"onUpdate": true,
+					"default": "(now())"
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"xStreamInfo": {
+					"name": "xStreamInfo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"firstViewEmailSentAt": {
+					"name": "firstViewEmailSentAt",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"isScreenshot": {
+					"name": "isScreenshot",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"awsRegion": {
+					"name": "awsRegion",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"awsBucket": {
+					"name": "awsBucket",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"videoStartTime": {
+					"name": "videoStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"audioStartTime": {
+					"name": "audioStartTime",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobId": {
+					"name": "jobId",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"jobStatus": {
+					"name": "jobStatus",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"skipProcessing": {
+					"name": "skipProcessing",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"owner_id_idx": {
+					"name": "owner_id_idx",
+					"columns": ["ownerId"],
+					"isUnique": false
+				},
+				"is_public_idx": {
+					"name": "is_public_idx",
+					"columns": ["public"],
+					"isUnique": false
+				},
+				"folder_id_idx": {
+					"name": "folder_id_idx",
+					"columns": ["folderId"],
+					"isUnique": false
+				},
+				"storage_integration_id_idx": {
+					"name": "storage_integration_id_idx",
+					"columns": ["storageIntegrationId"],
+					"isUnique": false
+				},
+				"org_owner_folder_idx": {
+					"name": "org_owner_folder_idx",
+					"columns": ["orgId", "ownerId", "folderId"],
+					"isUnique": false
+				},
+				"org_effective_created_idx": {
+					"name": "org_effective_created_idx",
+					"columns": ["orgId", "effectiveCreatedAt"],
+					"isUnique": false
+				},
+				"screenshot_transcription_created_idx": {
+					"name": "screenshot_transcription_created_idx",
+					"columns": ["isScreenshot", "transcriptionStatus", "createdAt"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"videos_storageIntegrationId_storage_integrations_id_fk": {
+					"name": "videos_storageIntegrationId_storage_integrations_id_fk",
+					"tableFrom": "videos",
+					"tableTo": "storage_integrations",
+					"columnsFrom": ["storageIntegrationId"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"videos_id": {
+					"name": "videos_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		}
+	},
+	"views": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"tables": {},
+		"indexes": {
+			"integration_object_key_prefix_idx": {
+				"columns": {
+					"`objectKey`(191)": {
+						"isExpression": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -295,6 +295,13 @@
 			"when": 1788384021541,
 			"tag": "0041_saml_sso",
 			"breakpoints": true
+		},
+		{
+			"idx": 42,
+			"version": "5",
+			"when": 1788437051131,
+			"tag": "0042_perf_indexes",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -473,6 +473,11 @@ export const videos = mysqlTable(
 			table.orgId,
 			table.effectiveCreatedAt,
 		),
+		index("screenshot_transcription_created_idx").on(
+			table.isScreenshot,
+			table.transcriptionStatus,
+			table.createdAt,
+		),
 	],
 );
 
@@ -860,6 +865,9 @@ export const storageObjects = mysqlTable(
 			table.integrationId,
 			table.uploadStatus,
 		),
+		integrationObjectKeyPrefixIndex: index(
+			"integration_object_key_prefix_idx",
+		).on(table.integrationId, sql`${table.objectKey}(191)`),
 		videoIdIndex: index("video_id_idx").on(table.videoId),
 		ownerIdIndex: index("owner_id_idx").on(table.ownerId),
 	}),
@@ -1488,6 +1496,7 @@ export const importedVideos = mysqlTable(
 	},
 	(table) => [
 		primaryKey({ columns: [table.orgId, table.source, table.sourceId] }),
+		index("id_idx").on(table.id),
 	],
 );
 

--- a/packages/web-backend/src/Storage/StorageRepo.ts
+++ b/packages/web-backend/src/Storage/StorageRepo.ts
@@ -533,14 +533,23 @@ export class StorageRepo extends Effect.Service<StorageRepo>()("StorageRepo", {
 			) =>
 				db.use(async (db) => {
 					const pageSize = Math.min(Math.max(maxKeys ?? 1_000, 1), 1_000);
+					const prefixPattern = prefix
+						? `${escapeLikePattern(prefix)}%`
+						: undefined;
 					const objects = await db
 						.select()
 						.from(Db.storageObjects)
 						.where(
 							Dz.and(
 								Dz.eq(Db.storageObjects.integrationId, integrationId),
-								prefix
-									? Dz.sql`BINARY ${Db.storageObjects.objectKey} LIKE ${`${escapeLikePattern(prefix)}%`}`
+								// The collation-aware LIKE is a superset of the BINARY match and is
+								// what lets MySQL range-scan integration_object_key_prefix_idx;
+								// the BINARY LIKE keeps the result case-sensitive.
+								prefixPattern
+									? Dz.like(Db.storageObjects.objectKey, prefixPattern)
+									: undefined,
+								prefixPattern
+									? Dz.sql`BINARY ${Db.storageObjects.objectKey} LIKE ${prefixPattern}`
 									: undefined,
 								continuationToken
 									? Dz.sql`BINARY ${Db.storageObjects.objectKey} > BINARY ${continuationToken}`


### PR DESCRIPTION
Three additive indexes plus a one-line predicate change, driven by PlanetScale Insights for `cap/cap-production/main` and verified with `EXPLAIN` on a branch restored from today's backup.

**What changed**
- `videos (isScreenshot, transcriptionStatus, createdAt)`: the two stalled-pipeline recovery crons in `apps/web/lib/video-pipeline-recovery.ts` full-scanned `videos` every run (Insights: 22.6M + 22.6M rows read over 96 runs each, p99 197ms / 240ms). After: index range scan estimated at 735 / 3,355 rows instead of 215k.
- `imported_videos (id)`: every `imported_videos.id = ?` lookup was a table scan (no index on `id`). Video deletion runs `DELETE ... WHERE id = ?` inside a transaction, which under REPEATABLE READ next-key-locks every scanned row, so a delete could block concurrent Loom imports. The Loom recovery join also did a 304-row PK range per candidate. After: single-row covering lookup.
- `storage_objects (integrationId, objectKey(191))` + `listObjectsByPrefix` now adds `objectKey LIKE prefix%` alongside the existing `BINARY objectKey LIKE prefix%`. The collation-aware predicate is a strict superset of the binary one, so results are unchanged, but it lets MySQL range-scan the new index. Before: every listing read all objects for the integration (Insights: 9.8M rows over 1,229 runs, p99 628ms; the largest integration has 278k objects). After: range scan on the prefix for typical `owner/video/` listings; large HLS-segment prefixes keep today's plan.

**Validation**
- `EXPLAIN` on the restored branch for the three target queries and for the hot dashboard/list queries on the same tables (caps list, user cap count, storage hash/status lookups, notifications list): target plans switched to the new indexes, every other plan unchanged.
- Migration generated with `pnpm db:generate`; `tsc --noEmit` clean for `@cap/database` and `@cap/web-backend`; Biome clean.
- Schema is applied via PlanetScale deploy request #90 (additive, online, revertible); code and schema are independent so deploy order does not matter.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds three database indexes for recovery, imported-video, and storage-listing access paths while preserving case-sensitive storage-prefix semantics.
- Adds indexes for stalled video-pipeline recovery queries, imported-video ID lookups, and integration-scoped object-key prefixes.
- Adds an optimizer-friendly collation-aware prefix predicate while retaining the existing binary predicate and pagination ordering.
- Appends the generated migration snapshot and journal entry.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The added indexes are compatible with the repository’s database targets and migration chain, while the storage query retains its original binary filtering and pagination semantics.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/web-backend/src/Storage/StorageRepo.ts | Adds an index-usable LIKE predicate without changing the effective case-sensitive result set or binary pagination order. |
| packages/database/schema.ts | Declares three additive indexes that align with the generated migration artifacts. |
| packages/database/migrations/0042_perf_indexes.sql | Creates valid MySQL 8 indexes for the three targeted query paths. |
| packages/database/migrations/meta/0042_snapshot.json | Records the new indexes consistently, including the raw SQL prefix-index expression. |
| packages/database/migrations/meta/_journal.json | Appends migration 0042 without modifying prior migration history. |

<sub>Reviews (1): Last reviewed commit: ["perf(storage): let prefix listings use t..."](https://github.com/capsoftware/cap/commit/9bdd587703e548fa14a4a05addc98b82e32cbc3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59935609)</sub>

**Context used:**

- Knowledge Base — [Data and identity platform](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/data-and-identity-platform.md)
- Knowledge Base — [Database schema and migrations](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/database-schema-and-migrations.md)

<!-- /greptile_comment -->