### PR TITLE
perf(web): remove duplicate video reads and run dashboard queries concurrently

### DIFF
--- a/apps/web/__tests__/unit/videos-policy.test.ts
+++ b/apps/web/__tests__/unit/videos-policy.test.ts
@@ -1,4 +1,8 @@
-import { buildCanView, type VideosPolicyDeps } from "@cap/web-backend";
+import {
+	buildCanView,
+	buildCanViewLoaded,
+	type VideosPolicyDeps,
+} from "@cap/web-backend";
 import {
 	CurrentUser,
 	type Organisation,
@@ -571,5 +575,168 @@ describe("VideosPolicy.canView", () => {
 				"denied",
 			);
 		});
+	});
+});
+
+function runCanViewLoaded(
+	deps: VideosPolicyDeps,
+	video: Video.Video,
+	password: Option.Option<string>,
+	user: Option.Option<CurrentUser["Type"]>,
+	attachedPasswords: ReadonlyArray<string> = [],
+): Promise<"allowed" | "denied" | "password"> {
+	const policy = buildCanViewLoaded(deps, video, password);
+
+	const program = Effect.zipRight(
+		policy,
+		Effect.succeed("allowed" as const),
+	).pipe(
+		Effect.catchTag("PolicyDenied", () => Effect.succeed("denied" as const)),
+		Effect.catchTag("VerifyVideoPasswordError", () =>
+			Effect.succeed("password" as const),
+		),
+	);
+
+	const withPassword =
+		attachedPasswords.length === 0
+			? program
+			: Effect.provideService(program, Video.VideoPasswordAttachment, {
+					passwords: attachedPasswords,
+				});
+
+	const withUser = user.pipe(
+		Option.match({
+			onNone: () => withPassword,
+			onSome: (u) => Effect.provideService(withPassword, CurrentUser, u),
+		}),
+	);
+
+	return Effect.runPromise(withUser);
+}
+
+describe("VideosPolicy.canViewLoaded", () => {
+	const scenarios: Array<{
+		name: string;
+		config: Parameters<typeof makeDeps>[0] & { video: Video.Video };
+		user: Option.Option<CurrentUser["Type"]>;
+		attachedPasswords?: string[];
+	}> = [
+		{
+			name: "owner on a private restricted video",
+			config: {
+				video: makeVideo({ public: false }),
+				allowedEmailDomain: Option.some("restricted.com"),
+			},
+			user: makeUser("owner@anything.com", TEST_OWNER_ID),
+		},
+		{
+			name: "anonymous viewer on a public video",
+			config: { video: makeVideo() },
+			user: noUser,
+		},
+		{
+			name: "anonymous viewer on a private video",
+			config: { video: makeVideo({ public: false }) },
+			user: noUser,
+		},
+		{
+			name: "org member on a private video",
+			config: { video: makeVideo({ public: false }), orgMembership: true },
+			user: makeUser("member@company.com"),
+		},
+		{
+			name: "space member with an email restriction that does not match",
+			config: {
+				video: makeVideo({ public: false }),
+				spaceMembership: true,
+				allowedEmailDomain: Option.some("company.com"),
+			},
+			user: makeUser("bob@gmail.com"),
+		},
+		{
+			name: "anonymous viewer with a video password and no attachment",
+			config: { video: makeVideo(), password: Option.some("video-hash") },
+			user: noUser,
+		},
+		{
+			name: "anonymous viewer with a matching video password",
+			config: { video: makeVideo(), password: Option.some("video-hash") },
+			user: noUser,
+			attachedPasswords: ["video-hash"],
+		},
+		{
+			name: "anonymous viewer with a matching inherited space password",
+			config: {
+				video: makeVideo(),
+				spacePasswords: ["space-one-hash", "space-two-hash"],
+			},
+			user: noUser,
+			attachedPasswords: ["space-two-hash"],
+		},
+		{
+			name: "logged-in viewer outside the allowed email domain",
+			config: {
+				video: makeVideo(),
+				allowedEmailDomain: Option.some("company.com"),
+			},
+			user: makeUser("outsider@gmail.com"),
+		},
+		{
+			name: "anonymous viewer with an email restriction",
+			config: {
+				video: makeVideo(),
+				allowedEmailDomain: Option.some("company.com"),
+			},
+			user: noUser,
+		},
+		{
+			name: "logged-in viewer inside the allowed email domain",
+			config: {
+				video: makeVideo(),
+				allowedEmailDomain: Option.some("company.com"),
+			},
+			user: makeUser("employee@company.com"),
+		},
+	];
+
+	for (const scenario of scenarios) {
+		it(`matches canView for ${scenario.name}`, async () => {
+			const deps = makeDeps(scenario.config);
+			const password = scenario.config.password ?? Option.none<string>();
+
+			expect(
+				await runCanViewLoaded(
+					deps,
+					scenario.config.video,
+					password,
+					scenario.user,
+					scenario.attachedPasswords,
+				),
+			).toBe(await runCanView(deps, scenario.user, scenario.attachedPasswords));
+		});
+	}
+
+	it("never reads the video row again", async () => {
+		let getByIdCalls = 0;
+		const deps = makeDeps({ video: makeVideo({ public: false }) });
+		const countingDeps: VideosPolicyDeps = {
+			...deps,
+			repo: {
+				getById: (id) => {
+					getByIdCalls += 1;
+					return deps.repo.getById(id);
+				},
+			},
+		};
+
+		expect(
+			await runCanViewLoaded(
+				countingDeps,
+				makeVideo({ public: false }),
+				Option.none(),
+				makeUser("member@company.com"),
+			),
+		).toBe("denied");
+		expect(getByIdCalls).toBe(0);
 	});
 });

--- a/apps/web/app/(org)/dashboard/caps/page.tsx
+++ b/apps/web/app/(org)/dashboard/caps/page.tsx
@@ -37,40 +37,42 @@ const getSharedSpacesForVideos = Effect.fn(function* (
 
 	const db = yield* Database;
 
-	// Fetch space-level sharing
-	const spaceSharing = yield* db.use((db) =>
-		db
-			.select({
-				videoId: spaceVideos.videoId,
-				id: spaces.id,
-				name: spaces.name,
-				organizationId: spaces.organizationId,
-				iconUrl: spaces.iconUrl,
-				settings: spaces.settings,
-				hasPassword: sql`${spaces.password} IS NOT NULL`.mapWith(Boolean),
-			})
-			.from(spaceVideos)
-			.innerJoin(spaces, eq(spaceVideos.spaceId, spaces.id))
-			.innerJoin(organizations, eq(spaces.organizationId, organizations.id))
-			.where(inArray(spaceVideos.videoId, videoIds)),
-	);
-
-	// Fetch organization-level sharing
-	const orgSharing = yield* db.use((db) =>
-		db
-			.select({
-				videoId: sharedVideos.videoId,
-				id: organizations.id,
-				name: organizations.name,
-				organizationId: organizations.id,
-				iconUrl: organizations.iconUrl,
-			})
-			.from(sharedVideos)
-			.innerJoin(
-				organizations,
-				eq(sharedVideos.organizationId, organizations.id),
-			)
-			.where(inArray(sharedVideos.videoId, videoIds)),
+	const [spaceSharing, orgSharing] = yield* Effect.all(
+		[
+			db.use((db) =>
+				db
+					.select({
+						videoId: spaceVideos.videoId,
+						id: spaces.id,
+						name: spaces.name,
+						organizationId: spaces.organizationId,
+						iconUrl: spaces.iconUrl,
+						settings: spaces.settings,
+						hasPassword: sql`${spaces.password} IS NOT NULL`.mapWith(Boolean),
+					})
+					.from(spaceVideos)
+					.innerJoin(spaces, eq(spaceVideos.spaceId, spaces.id))
+					.innerJoin(organizations, eq(spaces.organizationId, organizations.id))
+					.where(inArray(spaceVideos.videoId, videoIds)),
+			),
+			db.use((db) =>
+				db
+					.select({
+						videoId: sharedVideos.videoId,
+						id: organizations.id,
+						name: organizations.name,
+						organizationId: organizations.id,
+						iconUrl: organizations.iconUrl,
+					})
+					.from(sharedVideos)
+					.innerJoin(
+						organizations,
+						eq(sharedVideos.organizationId, organizations.id),
+					)
+					.where(inArray(sharedVideos.videoId, videoIds)),
+			),
+		],
+		{ concurrency: "unbounded" },
 	);
 
 	// Combine and group by videoId
@@ -136,7 +138,7 @@ export default async function CapsPage(props: PageProps<"/dashboard/caps">) {
 	const userId = user.id;
 	const offset = (page - 1) * limit;
 
-	const totalCountResult = await db()
+	const totalCountPromise = db()
 		.select({ count: count() })
 		.from(videos)
 		.leftJoin(organizations, eq(videos.orgId, organizations.id))
@@ -148,9 +150,7 @@ export default async function CapsPage(props: PageProps<"/dashboard/caps">) {
 			),
 		);
 
-	const totalCount = totalCountResult[0]?.count || 0;
-
-	const videoData = await db()
+	const videoDataPromise = db()
 		.select({
 			id: videos.id,
 			ownerId: videos.ownerId,
@@ -222,7 +222,7 @@ export default async function CapsPage(props: PageProps<"/dashboard/caps">) {
 		.limit(limit)
 		.offset(offset);
 
-	const foldersData = await db()
+	const foldersDataPromise = db()
 		.select({
 			id: folders.id,
 			name: folders.name,
@@ -244,18 +244,27 @@ export default async function CapsPage(props: PageProps<"/dashboard/caps">) {
 			),
 		);
 
-	// Fetch shared spaces data for all videos
-	const videoIds = videoData.map((video) => video.id);
-	const sharedSpacesMap =
-		await getSharedSpacesForVideos(videoIds).pipe(runPromise);
-	const [organizationSettingsRow] = user.activeOrganizationId
-		? await db()
+	const organizationSettingsPromise = user.activeOrganizationId
+		? db()
 				.select({ settings: organizations.settings })
 				.from(organizations)
 				.where(eq(organizations.id, user.activeOrganizationId))
 				.limit(1)
-		: [];
+		: Promise.resolve([]);
+
+	const [totalCountResult, videoData, foldersData, [organizationSettingsRow]] =
+		await Promise.all([
+			totalCountPromise,
+			videoDataPromise,
+			foldersDataPromise,
+			organizationSettingsPromise,
+		]);
+	const totalCount = totalCountResult[0]?.count || 0;
 	const organizationSettings = organizationSettingsRow?.settings ?? null;
+
+	const videoIds = videoData.map((video) => video.id);
+	const sharedSpacesMap =
+		await getSharedSpacesForVideos(videoIds).pipe(runPromise);
 
 	const processedVideoData = await Effect.all(
 		videoData.map(

--- a/apps/web/app/(org)/dashboard/dashboard-data.ts
+++ b/apps/web/app/(org)/dashboard/dashboard-data.ts
@@ -87,197 +87,263 @@ function mergeUserOrganizations(
 	return Array.from(organizationsById.values());
 }
 
-export async function getDashboardData(user: typeof userSelectProps) {
-	try {
-		const [ownedOrganizations, memberOrganizations] = await Promise.all([
-			db()
-				.select()
-				.from(organizations)
-				.where(
-					and(
-						isNull(organizations.tombstoneAt),
-						eq(organizations.ownerId, user.id),
-					),
+type OrganizationRow = typeof organizations.$inferSelect;
+
+async function loadUserOrganizations(user: typeof userSelectProps) {
+	const [ownedOrganizations, memberOrganizations] = await Promise.all([
+		db()
+			.select()
+			.from(organizations)
+			.where(
+				and(
+					isNull(organizations.tombstoneAt),
+					eq(organizations.ownerId, user.id),
 				),
-			db()
-				.select({ organization: organizations })
-				.from(organizationMembers)
-				.innerJoin(
-					organizations,
-					eq(organizations.id, organizationMembers.organizationId),
-				)
-				.where(
-					and(
-						eq(organizationMembers.userId, user.id),
-						isNull(organizations.tombstoneAt),
-					),
+			),
+		db()
+			.select({ organization: organizations })
+			.from(organizationMembers)
+			.innerJoin(
+				organizations,
+				eq(organizations.id, organizationMembers.organizationId),
+			)
+			.where(
+				and(
+					eq(organizationMembers.userId, user.id),
+					isNull(organizations.tombstoneAt),
 				),
-		]);
+			),
+	]);
 
-		const userOrganizations = mergeUserOrganizations(
-			ownedOrganizations,
-			memberOrganizations,
-		);
+	return mergeUserOrganizations(ownedOrganizations, memberOrganizations);
+}
 
-		const organizationIds = userOrganizations.map((org) => org.id);
+function resolveActiveOrganization(
+	user: typeof userSelectProps,
+	userOrganizations: OrganizationRow[],
+) {
+	const organizationIds = userOrganizations.map((org) => org.id);
 
-		let organizationInvitesData: (typeof organizationInvites.$inferSelect)[] =
-			[];
-		if (organizationIds.length > 0) {
-			organizationInvitesData = await db()
-				.select()
-				.from(organizationInvites)
-				.where(inArray(organizationInvites.organizationId, organizationIds));
-		}
+	let activeOrganizationId = organizationIds.find(
+		(orgId) => orgId === user.activeOrganizationId,
+	);
 
-		let anyNewNotifications = false;
-		let spacesData: Spaces[] = [];
-		let organizationSettings: OrganizationSettings | null = null;
-		let userCapsCount = 0;
-		let currentOrganizationRole: OrganizationRole | null = null;
+	if (!activeOrganizationId && organizationIds.length > 0) {
+		activeOrganizationId = organizationIds[0];
+	}
 
-		let activeOrganizationId = organizationIds.find(
-			(orgId) => orgId === user.activeOrganizationId,
-		);
+	if (!activeOrganizationId) return null;
 
-		if (!activeOrganizationId && organizationIds.length > 0) {
-			activeOrganizationId = organizationIds[0];
-		}
+	return {
+		activeOrganizationId,
+		activeOrgInfo: userOrganizations.find(
+			(org) => org.id === activeOrganizationId,
+		),
+	};
+}
 
-		if (activeOrganizationId) {
-			const activeOrgInfo = userOrganizations.find(
-				(org) => org.id === activeOrganizationId,
-			);
-			const [activeOrgMembership] = await db()
-				.select({ role: organizationMembers.role })
-				.from(organizationMembers)
-				.where(
-					and(
-						eq(organizationMembers.organizationId, activeOrganizationId),
-						eq(organizationMembers.userId, user.id),
-					),
-				)
-				.limit(1);
-			currentOrganizationRole = getEffectiveOrganizationRole({
-				userId: user.id,
-				ownerId: activeOrgInfo?.ownerId,
-				memberRole: activeOrgMembership?.role,
-			});
+async function loadActiveOrganizationRole(
+	user: typeof userSelectProps,
+	activeOrganizationId: OrganizationRow["id"],
+	activeOrgInfo: OrganizationRow | undefined,
+) {
+	const [activeOrgMembership] = await db()
+		.select({ role: organizationMembers.role })
+		.from(organizationMembers)
+		.where(
+			and(
+				eq(organizationMembers.organizationId, activeOrganizationId),
+				eq(organizationMembers.userId, user.id),
+			),
+		)
+		.limit(1);
 
-			const [notification] = await db()
-				.select({ id: notifications.id })
-				.from(notifications)
-				.where(
-					and(
-						eq(notifications.recipientId, user.id),
-						eq(notifications.orgId, activeOrganizationId),
-						isNull(notifications.readAt),
-					),
-				)
-				.limit(1);
+	return getEffectiveOrganizationRole({
+		userId: user.id,
+		ownerId: activeOrgInfo?.ownerId,
+		memberRole: activeOrgMembership?.role,
+	});
+}
 
-			anyNewNotifications = !!notification;
+function loadSpaces(
+	user: typeof userSelectProps,
+	activeOrganizationId: OrganizationRow["id"],
+	currentOrganizationRole: OrganizationRole | null,
+): Promise<Spaces[]> {
+	return Effect.gen(function* () {
+		const db = yield* Database;
+		const imageUploads = yield* ImageUploads;
 
-			const [organizationSetting] = await db()
-				.select({ settings: organizations.settings })
-				.from(organizations)
-				.where(eq(organizations.id, activeOrganizationId));
-			organizationSettings = organizationSetting?.settings || null;
-
-			spacesData = await Effect.gen(function* () {
-				const db = yield* Database;
-				const imageUploads = yield* ImageUploads;
-
-				return yield* db
-					.use((db) =>
-						db
-							.select({
-								id: spaces.id,
-								primary: spaces.primary,
-								privacy: spaces.privacy,
-								public: spaces.public,
-								name: spaces.name,
-								description: spaces.description,
-								organizationId: spaces.organizationId,
-								createdById: spaces.createdById,
-								iconUrl: spaces.iconUrl,
-								settings: spaces.settings,
-								currentUserSpaceRole: sql<string | null>`(
+		return yield* db
+			.use((db) =>
+				db
+					.select({
+						id: spaces.id,
+						primary: spaces.primary,
+						privacy: spaces.privacy,
+						public: spaces.public,
+						name: spaces.name,
+						description: spaces.description,
+						organizationId: spaces.organizationId,
+						createdById: spaces.createdById,
+						iconUrl: spaces.iconUrl,
+						settings: spaces.settings,
+						currentUserSpaceRole: sql<string | null>`(
           SELECT space_members.role FROM space_members
           WHERE space_members.spaceId = spaces.id
           AND space_members.userId = ${user.id}
           LIMIT 1
         )`,
-								hasPassword: sql`${spaces.password} IS NOT NULL`.mapWith(
-									Boolean,
-								),
-								memberCount: sql<number>`(
+						hasPassword: sql`${spaces.password} IS NOT NULL`.mapWith(Boolean),
+						memberCount: sql<number>`(
           SELECT COUNT(*) FROM space_members WHERE space_members.spaceId = spaces.id
         )`,
-								videoCount: sql<number>`(
+						videoCount: sql<number>`(
           SELECT COUNT(*) FROM space_videos WHERE space_videos.spaceId = spaces.id
         )`,
-							})
-							.from(spaces)
-							.where(
-								and(
-									eq(spaces.organizationId, activeOrganizationId),
-									or(
-										eq(spaces.createdById, user.id),
-										eq(spaces.privacy, "Public"),
-										sql`EXISTS (
+					})
+					.from(spaces)
+					.where(
+						and(
+							eq(spaces.organizationId, activeOrganizationId),
+							or(
+								eq(spaces.createdById, user.id),
+								eq(spaces.privacy, "Public"),
+								sql`EXISTS (
           SELECT 1 FROM space_members 
           WHERE space_members.spaceId = spaces.id 
           AND space_members.userId = ${user.id}
         )`,
-									),
-								),
-							),
-					)
-					.pipe(
-						Effect.map((rows) =>
-							rows.map(
-								Effect.fn(function* (row) {
-									const { currentUserSpaceRole, ...spaceRow } = row;
-									const currentUserRole = getEffectiveSpaceRole({
-										userId: user.id,
-										createdById: row.createdById,
-										memberRole: currentUserSpaceRole,
-									});
-									return {
-										...spaceRow,
-										iconUrl: row.iconUrl
-											? yield* imageUploads.resolveImageUrl(row.iconUrl)
-											: null,
-										currentUserRole,
-										currentUserCanManage: canManageSpace({
-											organizationRole: currentOrganizationRole,
-											spaceRole: currentUserRole,
-										}),
-									};
-								}),
 							),
 						),
-						Effect.flatMap(Effect.all),
-					);
-			}).pipe(runPromise);
+					),
+			)
+			.pipe(
+				Effect.map((rows) =>
+					rows.map(
+						Effect.fn(function* (row) {
+							const { currentUserSpaceRole, ...spaceRow } = row;
+							const currentUserRole = getEffectiveSpaceRole({
+								userId: user.id,
+								createdById: row.createdById,
+								memberRole: currentUserSpaceRole,
+							});
+							return {
+								...spaceRow,
+								iconUrl: row.iconUrl
+									? yield* imageUploads.resolveImageUrl(row.iconUrl)
+									: null,
+								currentUserRole,
+								currentUserCanManage: canManageSpace({
+									organizationRole: currentOrganizationRole,
+									spaceRole: currentUserRole,
+								}),
+							};
+						}),
+					),
+				),
+				Effect.flatMap(Effect.all),
+			);
+	}).pipe(runPromise);
+}
 
-			if (activeOrgInfo) {
-				const orgMemberCountResult = await db()
-					.select({ value: sql<number>`COUNT(*)` })
-					.from(organizationMembers)
-					.where(eq(organizationMembers.organizationId, activeOrgInfo.id));
-				const orgMemberCount = orgMemberCountResult[0]?.value || 0;
+async function loadAllSpacesEntry(
+	activeOrgInfo: OrganizationRow,
+	currentOrganizationRole: OrganizationRole | null,
+): Promise<Spaces> {
+	const [orgMemberCountResult, orgVideoCountResult] = await Promise.all([
+		db()
+			.select({ value: sql<number>`COUNT(*)` })
+			.from(organizationMembers)
+			.where(eq(organizationMembers.organizationId, activeOrgInfo.id)),
+		db()
+			.select({
+				value: sql<number>`COUNT(DISTINCT ${sharedVideos.videoId})`,
+			})
+			.from(sharedVideos)
+			.where(eq(sharedVideos.organizationId, activeOrgInfo.id)),
+	]);
+	const orgMemberCount = orgMemberCountResult[0]?.value || 0;
+	const orgVideoCount = orgVideoCountResult[0]?.value || 0;
 
-				const orgVideoCountResult = await db()
-					.select({
-						value: sql<number>`COUNT(DISTINCT ${sharedVideos.videoId})`,
-					})
-					.from(sharedVideos)
-					.where(eq(sharedVideos.organizationId, activeOrgInfo.id));
-				const orgVideoCount = orgVideoCountResult[0]?.value || 0;
+	return Effect.gen(function* () {
+		const imageUploads = yield* ImageUploads;
 
-				const userCapsCountResult = await db()
+		const iconUrl = activeOrgInfo.iconUrl;
+
+		return {
+			id: activeOrgInfo.id,
+			primary: true,
+			privacy: "Public",
+			name: `All ${activeOrgInfo.name}`,
+			description: `View all content in ${activeOrgInfo.name}`,
+			organizationId: activeOrgInfo.id,
+			iconUrl: iconUrl ? yield* imageUploads.resolveImageUrl(iconUrl) : null,
+			memberCount: orgMemberCount,
+			createdById: activeOrgInfo.ownerId,
+			videoCount: orgVideoCount,
+			settings: null,
+			hasPassword: false,
+			public: false,
+			currentUserRole: currentOrganizationRole,
+			currentUserCanManage: canManageOrganizationMembers(
+				currentOrganizationRole,
+			),
+		} as const;
+	}).pipe(runPromise);
+}
+
+export async function getDashboardSpacesData(
+	user: typeof userSelectProps,
+): Promise<Spaces[]> {
+	const userOrganizations = await loadUserOrganizations(user);
+	const active = resolveActiveOrganization(user, userOrganizations);
+	if (!active) return [];
+
+	const currentOrganizationRole = await loadActiveOrganizationRole(
+		user,
+		active.activeOrganizationId,
+		active.activeOrgInfo,
+	);
+	const [spacesRows, allSpacesEntry] = await Promise.all([
+		loadSpaces(user, active.activeOrganizationId, currentOrganizationRole),
+		active.activeOrgInfo
+			? loadAllSpacesEntry(active.activeOrgInfo, currentOrganizationRole)
+			: Promise.resolve(null),
+	]);
+
+	return allSpacesEntry ? [allSpacesEntry, ...spacesRows] : spacesRows;
+}
+
+async function loadActiveOrganizationData(
+	user: typeof userSelectProps,
+	{
+		activeOrganizationId,
+		activeOrgInfo,
+	}: NonNullable<ReturnType<typeof resolveActiveOrganization>>,
+) {
+	const [currentOrganizationRole, [notification]] = await Promise.all([
+		loadActiveOrganizationRole(user, activeOrganizationId, activeOrgInfo),
+		db()
+			.select({ id: notifications.id })
+			.from(notifications)
+			.where(
+				and(
+					eq(notifications.recipientId, user.id),
+					eq(notifications.orgId, activeOrganizationId),
+					isNull(notifications.readAt),
+				),
+			)
+			.limit(1),
+	]);
+
+	const [spacesRows, allSpacesEntry, userCapsCountResult] = await Promise.all([
+		loadSpaces(user, activeOrganizationId, currentOrganizationRole),
+		activeOrgInfo
+			? loadAllSpacesEntry(activeOrgInfo, currentOrganizationRole)
+			: Promise.resolve(null),
+		activeOrgInfo
+			? db()
 					.select({
 						value: sql<number>`COUNT(DISTINCT ${videos.id})`,
 					})
@@ -287,49 +353,40 @@ export async function getDashboardData(user: typeof userSelectProps) {
 							eq(videos.orgId, activeOrgInfo.id),
 							eq(videos.ownerId, user.id),
 						),
-					);
+					)
+			: Promise.resolve<{ value: number }[]>([]),
+	]);
 
-				userCapsCount = userCapsCountResult[0]?.value || 0;
+	return {
+		anyNewNotifications: !!notification,
+		organizationSettings: activeOrgInfo?.settings || null,
+		spacesData: allSpacesEntry ? [allSpacesEntry, ...spacesRows] : spacesRows,
+		userCapsCount: userCapsCountResult[0]?.value || 0,
+	};
+}
 
-				const allSpacesEntry = await Effect.gen(function* () {
-					const imageUploads = yield* ImageUploads;
+export async function getDashboardData(user: typeof userSelectProps) {
+	try {
+		const userOrganizations = await loadUserOrganizations(user);
+		const organizationIds = userOrganizations.map((org) => org.id);
+		const active = resolveActiveOrganization(user, userOrganizations);
 
-					const iconUrl = activeOrgInfo.iconUrl;
+		const [organizationInvitesData, activeData] = await Promise.all([
+			organizationIds.length > 0
+				? db()
+						.select()
+						.from(organizationInvites)
+						.where(inArray(organizationInvites.organizationId, organizationIds))
+				: Promise.resolve<(typeof organizationInvites.$inferSelect)[]>([]),
+			active ? loadActiveOrganizationData(user, active) : Promise.resolve(null),
+		]);
 
-					return {
-						id: activeOrgInfo.id,
-						primary: true,
-						privacy: "Public",
-						name: `All ${activeOrgInfo.name}`,
-						description: `View all content in ${activeOrgInfo.name}`,
-						organizationId: activeOrgInfo.id,
-						iconUrl: iconUrl
-							? yield* imageUploads.resolveImageUrl(iconUrl)
-							: null,
-						memberCount: orgMemberCount,
-						createdById: activeOrgInfo.ownerId,
-						videoCount: orgVideoCount,
-						settings: null,
-						hasPassword: false,
-						public: false,
-						currentUserRole: currentOrganizationRole,
-						currentUserCanManage: canManageOrganizationMembers(
-							currentOrganizationRole,
-						),
-					} as const;
-				}).pipe(runPromise);
-
-				spacesData = [allSpacesEntry, ...spacesData];
-			}
-		}
-
-		const [userPreferences] = await db()
-			.select({
-				preferences: users.preferences,
-			})
-			.from(users)
-			.where(eq(users.id, user.id))
-			.limit(1);
+		const spacesData: Spaces[] = activeData?.spacesData ?? [];
+		const organizationSettings: OrganizationSettings | null =
+			activeData?.organizationSettings ?? null;
+		const anyNewNotifications = activeData?.anyNewNotifications ?? false;
+		const userCapsCount = activeData?.userCapsCount ?? 0;
+		const userPreferences = { preferences: user.preferences };
 
 		const organizationSelect: Organization[] = await Effect.all(
 			userOrganizations.map(
@@ -337,38 +394,56 @@ export async function getDashboardData(user: typeof userSelectProps) {
 					const db = yield* Database;
 					const iconImages = yield* ImageUploads;
 
-					const allMembers = yield* db.use((db) =>
-						db
-							.select({
-								member: organizationMembers,
-								user: {
-									id: users.id,
-									name: users.name,
-									lastName: users.lastName,
-									email: users.email,
-									image: users.image,
-								},
-							})
-							.from(organizationMembers)
-							.leftJoin(users, eq(organizationMembers.userId, users.id))
-							.where(eq(organizationMembers.organizationId, organization.id)),
-					);
-
 					const managerIds = Array.from(
 						new Set([organization.ownerId, user.id]),
 					);
-					const managers = yield* db.use((db) =>
-						db
-							.select({
-								id: users.id,
-								inviteQuota: users.inviteQuota,
-								stripeSubscriptionId: users.stripeSubscriptionId,
-								stripeSubscriptionStatus: users.stripeSubscriptionStatus,
-								thirdPartyStripeSubscriptionId:
-									users.thirdPartyStripeSubscriptionId,
-							})
-							.from(users)
-							.where(inArray(users.id, managerIds)),
+					const [allMembers, managers, ownedIds] = yield* Effect.all(
+						[
+							db.use((db) =>
+								db
+									.select({
+										member: organizationMembers,
+										user: {
+											id: users.id,
+											name: users.name,
+											lastName: users.lastName,
+											email: users.email,
+											image: users.image,
+										},
+									})
+									.from(organizationMembers)
+									.leftJoin(users, eq(organizationMembers.userId, users.id))
+									.where(
+										eq(organizationMembers.organizationId, organization.id),
+									),
+							),
+							db.use((db) =>
+								db
+									.select({
+										id: users.id,
+										inviteQuota: users.inviteQuota,
+										stripeSubscriptionId: users.stripeSubscriptionId,
+										stripeSubscriptionStatus: users.stripeSubscriptionStatus,
+										thirdPartyStripeSubscriptionId:
+											users.thirdPartyStripeSubscriptionId,
+									})
+									.from(users)
+									.where(inArray(users.id, managerIds)),
+							),
+							db.use((db) =>
+								db
+									.select({ id: organizations.id })
+									.from(organizations)
+									.where(
+										and(
+											eq(organizations.ownerId, organization.ownerId),
+											isNull(organizations.tombstoneAt),
+										),
+									)
+									.then((rows) => rows.map((r) => r.id)),
+							),
+						],
+						{ concurrency: "unbounded" },
 					);
 					const owner = managers.find(
 						(manager) => manager.id === organization.ownerId,
@@ -390,37 +465,30 @@ export async function getDashboardData(user: typeof userSelectProps) {
 						actorCanManageProSeats: canManageOrganizationProSeats(currentRole),
 					});
 
-					const ownedOrgIds = db.use((db) =>
-						db
-							.select({ id: organizations.id })
-							.from(organizations)
-							.where(
-								and(
-									eq(organizations.ownerId, organization.ownerId),
-									isNull(organizations.tombstoneAt),
-								),
-							)
-							.then((rows) => rows.map((r) => r.id)),
-					);
-
-					const ownedIds = yield* ownedOrgIds;
-
-					const memberCountResult = yield* db.use((db) =>
-						ownedIds.length > 0
-							? db
-									.select({ value: count() })
-									.from(organizationMembers)
-									.where(inArray(organizationMembers.organizationId, ownedIds))
-							: Promise.resolve([{ value: 0 }]),
-					);
-
-					const inviteCountResult = yield* db.use((db) =>
-						ownedIds.length > 0
-							? db
-									.select({ value: count() })
-									.from(organizationInvites)
-									.where(inArray(organizationInvites.organizationId, ownedIds))
-							: Promise.resolve([{ value: 0 }]),
+					const [memberCountResult, inviteCountResult] = yield* Effect.all(
+						[
+							db.use((db) =>
+								ownedIds.length > 0
+									? db
+											.select({ value: count() })
+											.from(organizationMembers)
+											.where(
+												inArray(organizationMembers.organizationId, ownedIds),
+											)
+									: Promise.resolve([{ value: 0 }]),
+							),
+							db.use((db) =>
+								ownedIds.length > 0
+									? db
+											.select({ value: count() })
+											.from(organizationInvites)
+											.where(
+												inArray(organizationInvites.organizationId, ownedIds),
+											)
+									: Promise.resolve([{ value: 0 }]),
+							),
+						],
+						{ concurrency: "unbounded" },
 					);
 
 					const totalInvites =

--- a/apps/web/app/api/upload/[...route]/multipart.ts
+++ b/apps/web/app/api/upload/[...route]/multipart.ts
@@ -8,9 +8,8 @@ import {
 	provideOptionalAuth,
 	Storage,
 	VideosPolicy,
-	VideosRepo,
 } from "@cap/web-backend";
-import { Policy, Video } from "@cap/web-domain";
+import { Video } from "@cap/web-domain";
 import { zValidator } from "@hono/zod-validator";
 import { and, eq } from "drizzle-orm";
 import { Effect, Option, Schedule } from "effect";
@@ -91,13 +90,10 @@ app.post(
 		const videoId = Video.VideoId.make(videoIdRaw);
 
 		const resp = await Effect.gen(function* () {
-			const repo = yield* VideosRepo;
 			const policy = yield* VideosPolicy;
 			const db = yield* Database;
 
-			const video = yield* repo
-				.getById(videoId)
-				.pipe(Policy.withPolicy(policy.isOwner(videoId)));
+			const video = yield* policy.getOwnedById(videoId);
 			if (Option.isNone(video)) return yield* new Video.NotFoundError();
 
 			yield* db.use((db) =>
@@ -133,11 +129,8 @@ app.post(
 		try {
 			try {
 				const uploadId = await Effect.gen(function* () {
-					const repo = yield* VideosRepo;
 					const policy = yield* VideosPolicy;
-					const maybeVideo = yield* repo
-						.getById(videoId)
-						.pipe(Policy.withPolicy(policy.isOwner(videoId)));
+					const maybeVideo = yield* policy.getOwnedById(videoId);
 					if (Option.isNone(maybeVideo)) {
 						return yield* new Video.NotFoundError();
 					}
@@ -231,11 +224,8 @@ app.post(
 						"videoId" in body ? body.videoId : videoIdFromFileKey;
 					if (!videoIdRaw) throw new Error("Video id not found");
 					const videoId = Video.VideoId.make(videoIdRaw);
-					const repo = yield* VideosRepo;
 					const policy = yield* VideosPolicy;
-					const maybeVideo = yield* repo
-						.getById(videoId)
-						.pipe(Policy.withPolicy(policy.isOwner(videoId)));
+					const maybeVideo = yield* policy.getOwnedById(videoId);
 					if (Option.isNone(maybeVideo)) {
 						return yield* new Video.NotFoundError();
 					}
@@ -315,7 +305,6 @@ app.post(
 		const user = c.get("user");
 
 		return Effect.gen(function* () {
-			const repo = yield* VideosRepo;
 			const policy = yield* VideosPolicy;
 			const db = yield* Database;
 
@@ -327,9 +316,7 @@ app.post(
 			if (!videoIdRaw) return c.text("Video id not found", 400);
 			const videoId = Video.VideoId.make(videoIdRaw);
 
-			const maybeVideo = yield* repo
-				.getById(videoId)
-				.pipe(Policy.withPolicy(policy.isOwner(videoId)));
+			const maybeVideo = yield* policy.getOwnedById(videoId);
 			if (Option.isNone(maybeVideo)) {
 				c.status(404);
 				return c.text(`Video '${encodeURIComponent(videoId)}' not found`);
@@ -766,13 +753,10 @@ app.post("/abort", abortRequestValidator, (c) => {
 	const videoId = Video.VideoId.make(videoIdRaw);
 
 	return Effect.gen(function* () {
-		const repo = yield* VideosRepo;
 		const policy = yield* VideosPolicy;
 		const db = yield* Database;
 
-		const maybeVideo = yield* repo
-			.getById(videoId)
-			.pipe(Policy.withPolicy(policy.isOwner(videoId)));
+		const maybeVideo = yield* policy.getOwnedById(videoId);
 		if (Option.isNone(maybeVideo)) {
 			c.status(404);
 			return c.text(`Video '${encodeURIComponent(videoId)}' not found`);

--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -29,7 +29,7 @@ import {
 	Comment,
 	type ImageUpload,
 	type Organisation,
-	Policy,
+	type Policy,
 	type Video,
 } from "@cap/web-domain";
 import { and, eq, type InferSelectModel, isNull, sql } from "drizzle-orm";
@@ -40,8 +40,9 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getVideoAnalytics } from "@/actions/videos/get-analytics";
 import {
-	getDashboardData,
+	getDashboardSpacesData,
 	type OrganizationSettings,
+	type Spaces,
 } from "@/app/(org)/dashboard/dashboard-data";
 import { isAiConfigured } from "@/lib/ai/provider";
 import { completeDesktopSegmentsManifestAndQueue } from "@/lib/desktop-segments-recovery";
@@ -97,6 +98,22 @@ const hasRecordingStoppedParam = (searchParams: ShareVideoSearchParams) => {
 
 	return recordingStoppedParam === "1" || recordingStoppedParam === "true";
 };
+
+function toShareVideo<
+	T extends {
+		password: unknown;
+		ownerId: unknown;
+		organizationTombstoneAt: Date | null;
+	},
+>(row: T) {
+	const {
+		password: _password,
+		ownerId: _ownerId,
+		organizationTombstoneAt: _organizationTombstoneAt,
+		...video
+	} = row;
+	return video;
+}
 
 // Helper function to fetch shared spaces data for a video
 async function getSharedSpacesForVideo(videoId: Video.VideoId) {
@@ -316,7 +333,7 @@ export default async function ShareVideoPage(props: PageProps<"/s/[videoId]">) {
 	return Effect.gen(function* () {
 		const videosPolicy = yield* VideosPolicy;
 
-		const [video] = yield* Effect.promise(() =>
+		const [row] = yield* Effect.promise(() =>
 			db()
 				.select({
 					id: videos.id,
@@ -360,16 +377,29 @@ export default async function ShareVideoPage(props: PageProps<"/s/[videoId]">) {
 						),
 					activeUploadRawFileKey: videoUploads.rawFileKey,
 					owner: users,
+					ownerId: videos.ownerId,
+					password: videos.password,
+					organizationTombstoneAt: organizations.tombstoneAt,
 				})
 				.from(videos)
 				.leftJoin(sharedVideos, eq(videos.id, sharedVideos.videoId))
 				.innerJoin(users, eq(videos.ownerId, users.id))
 				.leftJoin(videoUploads, eq(videos.id, videoUploads.videoId))
 				.leftJoin(organizations, eq(videos.orgId, organizations.id))
-				.where(and(eq(videos.id, videoId), isNull(organizations.tombstoneAt))),
-		).pipe(Policy.withPublicPolicy(videosPolicy.canView(videoId)));
+				.where(eq(videos.id, videoId)),
+		);
 
-		return Option.fromNullable(video);
+		// The access decision runs on the row already loaded above instead of
+		// re-reading it, and stays ahead of the tombstone check so a denied or
+		// password-gated video on a deleted org still resolves the way it did
+		// when the policy ran before the select.
+		if (row) {
+			yield* videosPolicy.canViewLoaded(row, Option.fromNullable(row.password));
+		}
+
+		return Option.fromNullable(
+			row && row.organizationTombstoneAt === null ? toShareVideo(row) : null,
+		);
 	}).pipe(
 		Effect.flatten,
 		Effect.map((video) => ({ needsPassword: false, video }) as const),
@@ -480,19 +510,11 @@ async function AuthorizedContent({
 	// Everything below is an independent round trip (DB or storage); each is
 	// started here and awaited together further down, so the page pays for the
 	// slowest one instead of the sum of all of them.
-	const spacesDataPromise: Promise<
-		Awaited<ReturnType<typeof getDashboardData>>["spacesData"] | null
-	> = user
-		? getDashboardData(user).then(
-				(dashboardData) => dashboardData.spacesData,
-				(error) => {
-					console.error(
-						"Failed to fetch spaces data for sharing dialog:",
-						error,
-					);
-					return [];
-				},
-			)
+	const spacesDataPromise: Promise<Spaces[] | null> = user
+		? getDashboardSpacesData(user).catch((error) => {
+				console.error("Failed to fetch spaces data for sharing dialog:", error);
+				return [];
+			})
 		: Promise.resolve(null);
 
 	const sharedSpacesPromise = getSharedSpacesForVideo(videoId);
@@ -515,18 +537,7 @@ async function AuthorizedContent({
 				return false;
 			});
 
-	const aiGenerationEnabledPromise = db()
-		.select({
-			email: users.email,
-			stripeSubscriptionStatus: users.stripeSubscriptionStatus,
-			thirdPartyStripeSubscriptionId: users.thirdPartyStripeSubscriptionId,
-		})
-		.from(users)
-		.where(eq(users.id, video.owner.id))
-		.limit(1)
-		.then((videoOwnerQuery) =>
-			videoOwnerQuery[0] ? isAiGenerationEnabled(videoOwnerQuery[0]) : false,
-		);
+	const aiGenerationEnabledPromise = isAiGenerationEnabled(video.owner);
 
 	const screenshotImageUrlPromise = video.isScreenshot
 		? Effect.flatMap(Videos, (videos) => videos.getThumbnailURL(videoId)).pipe(

--- a/packages/web-backend/src/Videos/VideosPolicy.ts
+++ b/packages/web-backend/src/Videos/VideosPolicy.ts
@@ -1,5 +1,6 @@
 import { isEmailAllowedByRestriction } from "@cap/utils";
 import {
+	type CurrentUser,
 	type DatabaseError,
 	type Organisation,
 	Policy,
@@ -14,14 +15,18 @@ import { SpacesRepo } from "../Spaces/SpacesRepo.ts";
 import { collectPasswordHashes } from "./EffectiveVideoRules.ts";
 import { VideosRepo } from "./VideosRepo.ts";
 
+export type LoadedVideo = readonly [Video.Video, Option.Option<string>];
+
+export type ViewableVideo = Pick<
+	Video.Video,
+	"id" | "ownerId" | "orgId" | "public"
+>;
+
 export type VideosPolicyDeps = {
 	repo: {
 		getById: (
 			id: Video.VideoId,
-		) => Effect.Effect<
-			Option.Option<readonly [Video.Video, Option.Option<string>]>,
-			DatabaseError
-		>;
+		) => Effect.Effect<Option.Option<LoadedVideo>, DatabaseError>;
 	};
 	orgsRepo: {
 		membershipForVideo: (
@@ -43,13 +48,99 @@ export type VideosPolicyDeps = {
 	};
 };
 
-export function buildCanView(
-	{ repo, orgsRepo, spacesRepo }: VideosPolicyDeps,
-	videoId: Video.VideoId,
-) {
+export type ViewDecisionDeps = Pick<
+	VideosPolicyDeps,
+	"orgsRepo" | "spacesRepo"
+>;
+
+const decideCanView = (
+	{ orgsRepo, spacesRepo }: ViewDecisionDeps,
+	user: Option.Option<CurrentUser["Type"]>,
+	video: ViewableVideo,
+	password: Option.Option<string>,
+) =>
+	Effect.gen(function* () {
+		if (Option.isSome(user)) {
+			const userId = user.value.id;
+			if (userId === video.ownerId) return true;
+		}
+
+		const spacePasswords = yield* spacesRepo.passwordsForVideo(video.id);
+		const passwordHashes = collectPasswordHashes({
+			videoPassword: Option.getOrNull(password),
+			spacePasswords: [...spacePasswords],
+		});
+
+		if (Option.isSome(user)) {
+			const userId = user.value.id;
+			const [videoOrgShareMembership, videoSpaceShareMembership] =
+				yield* Effect.all(
+					[
+						orgsRepo
+							.membershipForVideo(userId, video.id)
+							.pipe(Effect.map(Array.get(0))),
+						spacesRepo.membershipForVideo(userId, video.id),
+					],
+					{ concurrency: "unbounded" },
+				);
+
+			if (
+				Option.isSome(videoOrgShareMembership) ||
+				Option.isSome(videoSpaceShareMembership)
+			) {
+				yield* Effect.log(
+					"Explicit org/space membership found. Access granted.",
+				);
+				yield* Video.verifyPasswordCandidates(video, passwordHashes);
+				return true;
+			}
+		}
+
+		if (!video.public) {
+			yield* Effect.log(
+				"Video is private and user has no explicit access. Access denied.",
+			);
+			return false;
+		}
+
+		const allowedEmails = yield* orgsRepo.allowedEmailDomain(video.orgId);
+		const restriction = Option.isSome(allowedEmails)
+			? allowedEmails.value.trim()
+			: "";
+
+		if (restriction.length > 0) {
+			if (Option.isNone(user)) {
+				yield* Effect.log(
+					"Email access restriction active and user not logged in. Access denied.",
+				);
+				yield* Effect.fail(
+					new Policy.PolicyDeniedError({
+						reason: "email_restriction_login_required",
+					}),
+				);
+			}
+			if (
+				Option.isSome(user) &&
+				!isEmailAllowedByRestriction(user.value.email, restriction)
+			) {
+				yield* Effect.log("Email access restriction active. Access denied.");
+				yield* Effect.fail(
+					new Policy.PolicyDeniedError({
+						reason: "email_restriction_denied",
+					}),
+				);
+			}
+		}
+
+		yield* Video.verifyPasswordCandidates(video, passwordHashes);
+
+		return true;
+	});
+
+export function buildCanView(deps: VideosPolicyDeps, videoId: Video.VideoId) {
 	return Policy.publicPolicy(
 		Effect.fn(function* (user) {
-			const res = yield* repo.getById(videoId);
+			const res = yield* deps.repo.getById(videoId);
 
 			if (Option.isNone(res)) {
 				yield* Effect.log("Video not found. Access granted.");
@@ -57,80 +148,18 @@ export function buildCanView(
 			}
 
 			const [video, password] = res.value;
-
-			if (Option.isSome(user)) {
-				const userId = user.value.id;
-				if (userId === video.ownerId) return true;
-			}
-
-			const spacePasswords = yield* spacesRepo.passwordsForVideo(video.id);
-			const passwordHashes = collectPasswordHashes({
-				videoPassword: Option.getOrNull(password),
-				spacePasswords: [...spacePasswords],
-			});
-
-			if (Option.isSome(user)) {
-				const userId = user.value.id;
-				const [videoOrgShareMembership, videoSpaceShareMembership] =
-					yield* Effect.all([
-						orgsRepo
-							.membershipForVideo(userId, video.id)
-							.pipe(Effect.map(Array.get(0))),
-						spacesRepo.membershipForVideo(userId, video.id),
-					]);
-
-				if (
-					Option.isSome(videoOrgShareMembership) ||
-					Option.isSome(videoSpaceShareMembership)
-				) {
-					yield* Effect.log(
-						"Explicit org/space membership found. Access granted.",
-					);
-					yield* Video.verifyPasswordCandidates(video, passwordHashes);
-					return true;
-				}
-			}
-
-			if (!video.public) {
-				yield* Effect.log(
-					"Video is private and user has no explicit access. Access denied.",
-				);
-				return false;
-			}
-
-			const allowedEmails = yield* orgsRepo.allowedEmailDomain(video.orgId);
-			const restriction = Option.isSome(allowedEmails)
-				? allowedEmails.value.trim()
-				: "";
-
-			if (restriction.length > 0) {
-				if (Option.isNone(user)) {
-					yield* Effect.log(
-						"Email access restriction active and user not logged in. Access denied.",
-					);
-					yield* Effect.fail(
-						new Policy.PolicyDeniedError({
-							reason: "email_restriction_login_required",
-						}),
-					);
-				}
-				if (
-					Option.isSome(user) &&
-					!isEmailAllowedByRestriction(user.value.email, restriction)
-				) {
-					yield* Effect.log("Email access restriction active. Access denied.");
-					yield* Effect.fail(
-						new Policy.PolicyDeniedError({
-							reason: "email_restriction_denied",
-						}),
-					);
-				}
-			}
-
-			yield* Video.verifyPasswordCandidates(video, passwordHashes);
-
-			return true;
+			return yield* decideCanView(deps, user, video, password);
 		}),
+	);
+}
+
+export function buildCanViewLoaded(
+	deps: ViewDecisionDeps,
+	video: ViewableVideo,
+	password: Option.Option<string>,
+) {
+	return Policy.publicPolicy((user) =>
+		decideCanView(deps, user, video, password),
 	);
 }
 
@@ -146,6 +175,11 @@ export class VideosPolicy extends Effect.Service<VideosPolicy>()(
 
 			const canView = (videoId: Video.VideoId) => buildCanView(deps, videoId);
 
+			const canViewLoaded = (
+				video: ViewableVideo,
+				password: Option.Option<string>,
+			) => buildCanViewLoaded(deps, video, password);
+
 			const isOwner = (videoId: Video.VideoId) =>
 				Policy.policy((user) =>
 					repo.getById(videoId).pipe(
@@ -158,7 +192,41 @@ export class VideosPolicy extends Effect.Service<VideosPolicy>()(
 					),
 				);
 
-			return { canView, isOwner };
+			const isOwnerLoaded = (video: Pick<Video.Video, "ownerId">) =>
+				Policy.policy((user) => Effect.succeed(video.ownerId === user.id));
+
+			const getViewableById = (videoId: Video.VideoId) =>
+				repo.getById(videoId).pipe(
+					Effect.flatMap(
+						Option.match({
+							onNone: () => Effect.succeed(Option.none<LoadedVideo>()),
+							onSome: (loaded) =>
+								canViewLoaded(loaded[0], loaded[1]).pipe(
+									Effect.as(Option.some(loaded)),
+								),
+						}),
+					),
+				);
+
+			const getOwnedById = (videoId: Video.VideoId) =>
+				repo.getById(videoId).pipe(
+					Effect.flatMap(
+						Option.match({
+							onNone: () => Effect.succeed(Option.none<LoadedVideo>()),
+							onSome: (loaded) =>
+								isOwnerLoaded(loaded[0]).pipe(Effect.as(Option.some(loaded))),
+						}),
+					),
+				);
+
+			return {
+				canView,
+				canViewLoaded,
+				isOwner,
+				isOwnerLoaded,
+				getViewableById,
+				getOwnedById,
+			};
 		}),
 		dependencies: [
 			VideosRepo.Default,

--- a/packages/web-backend/src/Videos/index.ts
+++ b/packages/web-backend/src/Videos/index.ts
@@ -130,12 +130,7 @@ export class Videos extends Effect.Service<Videos>()("Videos", {
 		const tinybird = yield* Tinybird;
 
 		const getByIdForViewing = (id: Video.VideoId) =>
-			repo
-				.getById(id)
-				.pipe(
-					Policy.withPublicPolicy(policy.canView(id)),
-					Effect.withSpan("Videos.getById"),
-				);
+			policy.getViewableById(id).pipe(Effect.withSpan("Videos.getById"));
 
 		const getAnalyticsCounts = Effect.fn("Videos.getAnalyticsCounts")(
 			function* (
@@ -302,9 +297,7 @@ export class Videos extends Effect.Service<Videos>()("Videos", {
 			 * Delete a video. Will fail if the user does not have access.
 			 */
 			delete: Effect.fn("Videos.delete")(function* (videoId: Video.VideoId) {
-				const maybeVideo = yield* repo
-					.getById(videoId)
-					.pipe(Policy.withPolicy(policy.isOwner(videoId)));
+				const maybeVideo = yield* policy.getOwnedById(videoId);
 				if (Option.isNone(maybeVideo))
 					return yield* Effect.fail(new Video.NotFoundError());
 				const [video] = maybeVideo.value;
@@ -353,9 +346,7 @@ export class Videos extends Effect.Service<Videos>()("Videos", {
 			duplicate: Effect.fn("Videos.duplicate")(function* (
 				videoId: Video.VideoId,
 			) {
-				const maybeVideo = yield* repo
-					.getById(videoId)
-					.pipe(Policy.withPolicy(policy.isOwner(videoId)));
+				const maybeVideo = yield* policy.getOwnedById(videoId);
 				if (Option.isNone(maybeVideo))
 					return yield* Effect.fail(new Video.NotFoundError());
 				const [video] = maybeVideo.value;
@@ -528,23 +519,22 @@ export class Videos extends Effect.Service<Videos>()("Videos", {
 				const updatedAt = input.updatedAt;
 				const videoId = input.videoId;
 
-				const [record] = yield* db
-					.use((db) =>
-						db
-							.select({
-								video: Db.videos,
-								upload: Db.videoUploads,
-							})
-							.from(Db.videos)
-							.leftJoin(
-								Db.videoUploads,
-								Dz.eq(Db.videos.id, Db.videoUploads.videoId),
-							)
-							.where(Dz.eq(Db.videos.id, videoId)),
-					)
-					.pipe(Policy.withPolicy(policy.isOwner(videoId)));
+				const [record] = yield* db.use((db) =>
+					db
+						.select({
+							video: Db.videos,
+							upload: Db.videoUploads,
+						})
+						.from(Db.videos)
+						.leftJoin(
+							Db.videoUploads,
+							Dz.eq(Db.videos.id, Db.videoUploads.videoId),
+						)
+						.where(Dz.eq(Db.videos.id, videoId)),
+				);
 
 				if (!record) return yield* Effect.fail(new Video.NotFoundError());
+				yield* policy.isOwnerLoaded(record.video);
 
 				yield* db.use((db) =>
 					db.transaction(async (tx) => {
@@ -705,9 +695,7 @@ export class Videos extends Effect.Service<Videos>()("Videos", {
 			getDownloadInfo: Effect.fn("Videos.getDownloadInfo")(function* (
 				videoId: Video.VideoId,
 			) {
-				const maybeVideo = yield* repo
-					.getById(videoId)
-					.pipe(Policy.withPublicPolicy(policy.canView(videoId)));
+				const maybeVideo = yield* policy.getViewableById(videoId);
 				if (Option.isNone(maybeVideo))
 					return yield* Effect.fail(new Video.NotFoundError());
 				const [video] = maybeVideo.value;
@@ -788,9 +776,7 @@ export class Videos extends Effect.Service<Videos>()("Videos", {
 			getThumbnailURL: Effect.fn("Videos.getThumbnailURL")(function* (
 				videoId: Video.VideoId,
 			) {
-				const maybeVideo = yield* repo
-					.getById(videoId)
-					.pipe(Policy.withPublicPolicy(policy.canView(videoId)));
+				const maybeVideo = yield* policy.getViewableById(videoId);
 				if (Option.isNone(maybeVideo)) return Option.none();
 				const [video] = maybeVideo.value;
 

--- a/packages/web-backend/src/index.ts
+++ b/packages/web-backend/src/index.ts
@@ -41,8 +41,11 @@ export {
 export { findScreenshotObjectKey, Videos } from "./Videos/index.ts";
 export {
 	buildCanView,
+	buildCanViewLoaded,
 	VideosPolicy,
 	type VideosPolicyDeps,
+	type ViewableVideo,
+	type ViewDecisionDeps,
 } from "./Videos/VideosPolicy.ts";
 export { VideosRepo } from "./Videos/VideosRepo.ts";
 export * as Workflows from "./Workflows.ts";

--- a/packages/web-domain/src/Video.ts
+++ b/packages/web-domain/src/Video.ts
@@ -269,7 +269,7 @@ export const verifyPassword = (video: Video, password: Option.Option<string>) =>
 	);
 
 export const verifyPasswordCandidates = (
-	video: Video,
+	video: Pick<Video, "id">,
 	passwords: ReadonlyArray<string>,
 ) =>
 	Effect.gen(function* () {


### PR DESCRIPTION
Follow-up to #2213. Insights showed that after the index pass the remaining load is request shape, not the schema: `select * from videos where id = ?` runs ~770k times a day, and the two most-visited authenticated pages issue their queries one after another. This PR removes the duplicate reads and serialises less, with results and error ordering kept identical.

**1. Policy checks reuse the row that was already loaded**
- `Policy.withPolicy` / `withPublicPolicy` run the policy before the wrapped effect, and both `VideosPolicy.canView` and `isOwner` load the video row that the effect then loads again. `VideosPolicy` now exposes `canViewLoaded`, `isOwnerLoaded`, `getViewableById` and `getOwnedById`, which fetch once and decide on the loaded row. `buildCanView` keeps its behaviour; the shared decision logic is factored into one place.
- Switched: `Videos.getByIdForViewing` (share page metadata, preview, playlist), `delete`, `duplicate`, `getDownloadInfo`, `getThumbnailURL`, `updateUploadProgress`, and the five multipart upload handlers (presign-part is 44k requests/day). Outcomes are unchanged in every case: missing video still yields not-found, non-owner still yields 403, view rules and password prompts are evaluated on the same inputs as before.
- The org/space membership pair inside `canView` was an `Effect.all` with no concurrency option, which runs sequentially; it now runs both queries concurrently.
- `verifyPasswordCandidates` only reads `video.id`, so its parameter is now `Pick<Video, "id">`.

**2. Share page**
- The page ran the full `canView` policy (with its own video read and sub-queries) and then a joined select of the same video. The joined select now runs first and `canViewLoaded` decides on that row. The tombstone filter moved from the `WHERE` to a check after the policy so a denied or password-gated video on a deleted org still resolves exactly as before. `password` and `ownerId` are read for the check and stripped before the row leaves the loader.
- `getDashboardData(user)` was called only to read `.spacesData` for the share dialog, which pulled the whole dashboard dataset including a 5-queries-per-organization loop. It now calls `getDashboardSpacesData`, built from the same helpers, which needs the org lookup, the role lookup, the spaces query and the two org counts.
- The owner's `users` row was re-fetched for the AI entitlement check even though the joined select already returns it in full.

**3. Dashboard**
- `getDashboardData` is split into helpers shared with the share page. Independent queries now run concurrently: invites alongside the active-org work; role and notification lookup together; spaces, the "All org" entry counts and the user cap count together; and inside the per-organization loop the members, managers and owned-org reads run together, then the two count queries. The org settings row is taken from the organization row already in memory instead of a third query, and `userPreferences` comes from the `user` row that was passed in.
- Caps page: total count, video list, folder list and org settings run together; the two shared-spaces lookups run together.

**Deliberately not included**
- Memoising the Effect-side `getCurrentUser` per request: 17 files update the user row and read it again inside the same request, so that needs its own audit before it is safe.

**Validation**
- `pnpm typecheck` (next typegen + `tsc -b`) clean.
- Biome clean on all touched files.
- `videos-policy.test.ts` extended with a parity table asserting `canViewLoaded` returns the same decision as `canView` across owner, anonymous, private, org and space membership, video and inherited passwords, and email-restriction scenarios, plus a test that the loaded variant never calls `repo.getById`. 52/52 pass.
- Full web unit suite: 2,538 pass. The single failure, `slack-app-manifest.test.ts`, compares the checked-in `slack-app-manifest.json` against fixed expectations and touches nothing in this change; it is pre-existing.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces redundant video and dashboard database reads while preserving existing authorization and response behavior.
- Adds loaded-row video policy helpers and migrates viewing, ownership, download, thumbnail, deletion, duplication, progress, and multipart-upload paths to them.
- Splits dashboard loading into reusable helpers and executes independent queries concurrently.
- Reuses share-page video and owner rows for authorization and entitlement checks.
- Adds parity tests for loaded-row viewing policies.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code regression identified.

The loaded-row policy paths preserve authorization and error outcomes, while the dashboard and caps concurrency changes retain required query dependencies and response shapes.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/web-backend/src/Videos/VideosPolicy.ts | Extracts the existing view decision into a loaded-row policy and adds single-read ownership/view helpers without changing established outcomes. |
| packages/web-backend/src/Videos/index.ts | Migrates video operations to the single-read policy helpers and preserves not-found and authorization handling. |
| apps/web/app/api/upload/[...route]/multipart.ts | Replaces duplicated ownership-policy reads across multipart handlers with the loaded-row ownership helper. |
| apps/web/app/(org)/dashboard/dashboard-data.ts | Extracts dashboard query helpers, reuses already-loaded rows, and parallelizes independent reads while retaining dependency ordering. |
| apps/web/app/(org)/dashboard/caps/page.tsx | Starts independent caps-page queries together and waits for their results before dependent shared-space processing. |
| apps/web/app/s/[videoId]/page.tsx | Authorizes the joined video row directly, preserves tombstone and password ordering, narrows dashboard loading, and reuses the complete owner row for AI entitlement. |
| apps/web/__tests__/unit/videos-policy.test.ts | Adds policy-parity coverage across ownership, visibility, membership, password, and email-restriction scenarios and verifies no duplicate repository read. |
| packages/web-domain/src/Video.ts | Narrows the password-candidate verifier input type to the only video field it consumes. |

<sub>Reviews (1): Last reviewed commit: ["perf(share): load the share page with on..."](https://github.com/capsoftware/cap/commit/e11583962392b01aa7cf7c6c338d5fb211e1828a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60031897)</sub>

<!-- /greptile_comment -->