### PR TITLE
fix: install clippy for main branch cache checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.88.0
         with:
           targets: ${{ matrix.settings.target }}
+          components: clippy
 
       - uses: ./.github/actions/setup-rust-cache
         with:


### PR DESCRIPTION
The main-only Rust cache jobs call `cargo clippy` without installing Clippy for Rust 1.88.0. The Windows cache job failed with `cargo-clippy.exe is not installed`, after its debug build and release-profile check had passed.

Install the component explicitly, matching the dedicated Clippy job. This changes one workflow line and does not change desktop code. It follows the validation of #2215, which is already merged.

Validation: YAML parsing passed; the parsed workflow differs only by the added component. Actionlint reports the same eight pre-existing diagnostics before and after, with no new diagnostics. The dedicated Windows Clippy job passed on the same source and toolchain with this component installed. The repaired main-only cache job needs confirmation in its next main run.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR installs Clippy explicitly for the main-branch Rust cache matrix so its existing `cargo clippy` step can run with Rust 1.88.0.
- Adds `components: clippy` to the cache job’s Rust toolchain setup.
- Leaves desktop source and runtime behavior unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds the missing Clippy component to the Rust cache matrix using the same toolchain configuration pattern already used by the dedicated Clippy job. |

<sub>Reviews (2): Last reviewed commit: ["fix: install clippy for main branch cach..."](https://github.com/capsoftware/cap/commit/c9b51b2fb3ed96d9c7442efa89712f4814574ff4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60075310)</sub>

<!-- /greptile_comment -->