### PR TITLE
fix: make chrome extension button respect dashboard theme

### DIFF
--- a/apps/web/lib/chrome-extension.ts
+++ b/apps/web/lib/chrome-extension.ts
@@ -2,7 +2,7 @@ export const CAP_CHROME_EXTENSION_URL =
 	"https://chromewebstore.google.com/detail/cap-screen-recorder-scree/fefjaffcodfiogbbngmjkcjpbpclbdcp";
 
 export const CHROME_EXTENSION_BUTTON_CLASS =
-	"border-gray-6 bg-white text-gray-12 shadow-[0_1px_2px_rgba(0,0,0,0.08)] hover:border-gray-7 hover:bg-gray-2";
+	"border-gray-6 bg-gray-1 text-gray-12 shadow-[0_1px_2px_rgba(0,0,0,0.08)] hover:border-gray-7 hover:bg-gray-2";
 
 export const CAP_CHROME_EXTENSION_INSTALLED_ATTRIBUTE =
 	"data-cap-chrome-extension-installed";


### PR DESCRIPTION
The "Add Chrome Extension" button was always rendering with bg-white - so in dark mode it stayed white while the rest of the dashboard went dark, and any dark: overrides weren't doing anything anyway.

Turns out we don't actually use Tailwind's dark: variant here. Theme is toggled via document.body.className = "dark" / "light" and Radix's gray-dark.css just flips the --gray-* CSS variables. bg-white doesn't flip, but bg-gray-1 / text-gray-12 do automatically.

Change:
- apps/web/lib/chrome-extension.ts - bg-white -> bg-gray-1 so the button background/text/border all invert with the theme like the rest of the UI. No dark: prefix needed, and no per-component overrides.
Tested by toggling light/dark in the dashboard - button now goes from light gray/near-black text to dark gray/off-white text as expected, hover state works in both.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the shared Chrome extension button background from fixed white to the theme-aware `gray-1` color token.
- Allows the button background to follow the dashboard’s light and dark themes.
- Preserves the existing themed text, border, and hover styles.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The changed utility is supported by the web Tailwind configuration and follows an existing theme-aware styling pattern, with no behavioral, security, or repository-rule violations found.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/lib/chrome-extension.ts | Replaces the fixed white button background with the supported, theme-aware `bg-gray-1` utility. |

<sub>Reviews (1): Last reviewed commit: ["fix: make chrome extension button respec..."](https://github.com/capsoftware/cap/commit/b590ab1d8e9b4de0e54c1b526686bba34c7e2e09) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60571214)</sub>

<!-- /greptile_comment -->