### PR TITLE
fix(auth): invalidate email OTP on a failed guess, not just a match

### DIFF
--- a/apps/web/__tests__/integration/sso-database.test.ts
+++ b/apps/web/__tests__/integration/sso-database.test.ts
@@ -371,5 +371,36 @@ describe.runIf(Boolean(databaseUrl))(
 					.where(eq(verificationTokens.identifier, identifier)),
 			).toHaveLength(0);
 		});
+
+		it("never authenticates a wrong guess when it races the correct one", async () => {
+			const identifier = `${id()}@example.com`;
+			const token = "531942";
+			const adapter = DrizzleAdapter(database());
+			if (!adapter.useVerificationToken) {
+				throw new Error("Missing useVerificationToken adapter.");
+			}
+			await database()
+				.insert(verificationTokens)
+				.values({ identifier, token, expires: new Date(Date.now() + 600_000) });
+
+			const guesses = ["000000", "111111", token, "222222", "333333"];
+			const attempts = await Promise.all(
+				guesses.map((guess) =>
+					adapter.useVerificationToken({ identifier, token: guess }),
+				),
+			);
+
+			const successes = attempts.filter((result) => result !== null);
+			expect(successes.length).toBeLessThanOrEqual(1);
+			for (const success of successes) {
+				expect(success).toMatchObject({ identifier, token });
+			}
+			expect(
+				await database()
+					.select()
+					.from(verificationTokens)
+					.where(eq(verificationTokens.identifier, identifier)),
+			).toHaveLength(0);
+		});
 	},
 );

--- a/apps/web/__tests__/integration/sso-database.test.ts
+++ b/apps/web/__tests__/integration/sso-database.test.ts
@@ -6,6 +6,7 @@ import {
 	organizationSso,
 	organizations,
 	users,
+	verificationTokens,
 } from "@cap/database/schema";
 import { Organisation, User } from "@cap/web-domain";
 import { and, eq } from "drizzle-orm";
@@ -342,6 +343,32 @@ describe.runIf(Boolean(databaseUrl))(
 					.select()
 					.from(organizationMembers)
 					.where(eq(organizationMembers.userId, userId)),
+			).toHaveLength(0);
+		});
+
+		it("burns an email OTP exactly once under concurrent guesses", async () => {
+			const identifier = `${id()}@example.com`;
+			const token = "482913";
+			const adapter = DrizzleAdapter(database());
+			if (!adapter.useVerificationToken) {
+				throw new Error("Missing useVerificationToken adapter.");
+			}
+			await database()
+				.insert(verificationTokens)
+				.values({ identifier, token, expires: new Date(Date.now() + 600_000) });
+
+			const attempts = await Promise.all(
+				Array.from({ length: 8 }, () =>
+					adapter.useVerificationToken({ identifier, token }),
+				),
+			);
+
+			expect(attempts.filter((result) => result !== null)).toHaveLength(1);
+			expect(
+				await database()
+					.select()
+					.from(verificationTokens)
+					.where(eq(verificationTokens.identifier, identifier)),
 			).toHaveLength(0);
 		});
 	},

--- a/apps/web/__tests__/unit/verification-token.test.ts
+++ b/apps/web/__tests__/unit/verification-token.test.ts
@@ -1,0 +1,98 @@
+import { verificationTokens } from "@cap/database/schema";
+import type { SQL } from "drizzle-orm";
+import { MySqlDialect } from "drizzle-orm/mysql-core";
+import type { MySql2Database } from "drizzle-orm/mysql2";
+import { describe, expect, it } from "vitest";
+import { DrizzleAdapter } from "../../../../packages/database/auth/drizzle-adapter";
+
+type TokenRow = { identifier: string; token: string; expires: Date };
+
+function parsePredicate(condition: SQL) {
+	const query = new MySqlDialect().sqlToQuery(condition);
+	const match = /^`verification_tokens`\.`(identifier|token)` = \?$/.exec(
+		query.sql,
+	);
+	if (!match?.[1]) throw new Error(`Unexpected predicate: ${query.sql}`);
+	return {
+		column: match[1] as "identifier" | "token",
+		value: query.params[0] as string,
+	};
+}
+
+function fakeDatabase(initialRow: TokenRow) {
+	let row: TokenRow | undefined = initialRow;
+	const db = {
+		select: () => ({
+			from: () => ({
+				where: (condition: SQL) => ({
+					limit: async () => {
+						if (!row) return [];
+						const { column, value } = parsePredicate(condition);
+						return row[column] === value ? [row] : [];
+					},
+				}),
+			}),
+		}),
+		delete: () => ({
+			where: async (condition: SQL) => {
+				if (!row) return;
+				const { column, value } = parsePredicate(condition);
+				if (row[column] === value) row = undefined;
+			},
+		}),
+	};
+	return { db: db as unknown as MySql2Database, getRow: () => row };
+}
+
+describe("useVerificationToken", () => {
+	const identifier = "person@example.com";
+	const validRow: TokenRow = {
+		identifier,
+		token: "111111",
+		expires: new Date(Date.now() + 60_000),
+	};
+
+	it("burns the code on a wrong guess instead of leaving it guessable", async () => {
+		const { db, getRow } = fakeDatabase({ ...validRow });
+		const adapter = DrizzleAdapter(db);
+
+		const wrongGuess = await adapter.useVerificationToken?.({
+			identifier,
+			token: "000000",
+		});
+
+		expect(wrongGuess).toBeNull();
+		expect(getRow()).toBeUndefined();
+
+		const correctGuessAfterward = await adapter.useVerificationToken?.({
+			identifier,
+			token: "111111",
+		});
+		expect(correctGuessAfterward).toBeNull();
+	});
+
+	it("returns the row and deletes it on a correct guess", async () => {
+		const { db, getRow } = fakeDatabase({ ...validRow });
+		const adapter = DrizzleAdapter(db);
+
+		const result = await adapter.useVerificationToken?.({
+			identifier,
+			token: "111111",
+		});
+
+		expect(result).toMatchObject({ identifier, token: "111111" });
+		expect(getRow()).toBeUndefined();
+	});
+
+	it("returns null when no code was ever requested for the identifier", async () => {
+		const { db } = fakeDatabase({ ...validRow });
+		const adapter = DrizzleAdapter(db);
+
+		const result = await adapter.useVerificationToken?.({
+			identifier: "nobody@example.com",
+			token: "111111",
+		});
+
+		expect(result).toBeNull();
+	});
+});

--- a/apps/web/__tests__/unit/verification-token.test.ts
+++ b/apps/web/__tests__/unit/verification-token.test.ts
@@ -1,4 +1,3 @@
-import { verificationTokens } from "@cap/database/schema";
 import type { SQL } from "drizzle-orm";
 import { MySqlDialect } from "drizzle-orm/mysql-core";
 import type { MySql2Database } from "drizzle-orm/mysql2";
@@ -7,41 +6,53 @@ import { DrizzleAdapter } from "../../../../packages/database/auth/drizzle-adapt
 
 type TokenRow = { identifier: string; token: string; expires: Date };
 
-function parsePredicate(condition: SQL) {
+function matchesPredicate(condition: SQL, row: TokenRow) {
 	const query = new MySqlDialect().sqlToQuery(condition);
-	const match = /^`verification_tokens`\.`(identifier|token)` = \?$/.exec(
-		query.sql,
-	);
-	if (!match?.[1]) throw new Error(`Unexpected predicate: ${query.sql}`);
-	return {
-		column: match[1] as "identifier" | "token",
-		value: query.params[0] as string,
-	};
+	const columns = [
+		...query.sql.matchAll(
+			/`verification_tokens`\.`(identifier|token)`\s*=\s*\?/g,
+		),
+	].map((match) => match[1] as "identifier" | "token");
+	if (columns.length === 0) {
+		throw new Error(`Unexpected predicate: ${query.sql}`);
+	}
+	return columns.every((column, i) => row[column] === query.params[i]);
 }
 
-function fakeDatabase(initialRow: TokenRow) {
+function fakeDatabase(
+	initialRow: TokenRow,
+	options?: { afterSelect?: () => void },
+) {
 	let row: TokenRow | undefined = initialRow;
 	const db = {
 		select: () => ({
 			from: () => ({
 				where: (condition: SQL) => ({
 					limit: async () => {
-						if (!row) return [];
-						const { column, value } = parsePredicate(condition);
-						return row[column] === value ? [row] : [];
+						const result = row && matchesPredicate(condition, row) ? [row] : [];
+						options?.afterSelect?.();
+						return result;
 					},
 				}),
 			}),
 		}),
 		delete: () => ({
 			where: async (condition: SQL) => {
-				if (!row) return;
-				const { column, value } = parsePredicate(condition);
-				if (row[column] === value) row = undefined;
+				if (row && matchesPredicate(condition, row)) {
+					row = undefined;
+					return [{ affectedRows: 1 }];
+				}
+				return [{ affectedRows: 0 }];
 			},
 		}),
 	};
-	return { db: db as unknown as MySql2Database, getRow: () => row };
+	return {
+		db: db as unknown as MySql2Database,
+		getRow: () => row,
+		setRow: (next: TokenRow) => {
+			row = next;
+		},
+	};
 }
 
 describe("useVerificationToken", () => {
@@ -94,5 +105,42 @@ describe("useVerificationToken", () => {
 		});
 
 		expect(result).toBeNull();
+	});
+
+	it("lets only one of two concurrent correct guesses succeed", async () => {
+		const { db, getRow } = fakeDatabase({ ...validRow });
+		const adapter = DrizzleAdapter(db);
+
+		const [first, second] = await Promise.all([
+			adapter.useVerificationToken?.({ identifier, token: "111111" }),
+			adapter.useVerificationToken?.({ identifier, token: "111111" }),
+		]);
+
+		const successes = [first, second].filter((result) => result !== null);
+		expect(successes).toHaveLength(1);
+		expect(getRow()).toBeUndefined();
+	});
+
+	it("does not delete a resent code that replaced the row a guess read", async () => {
+		const resentRow: TokenRow = {
+			identifier,
+			token: "222222",
+			expires: new Date(Date.now() + 60_000),
+		};
+		const { db, getRow, setRow } = fakeDatabase(
+			{ ...validRow },
+			{
+				afterSelect: () => setRow({ ...resentRow }),
+			},
+		);
+		const adapter = DrizzleAdapter(db);
+
+		const wrongGuessAgainstStaleCode = await adapter.useVerificationToken?.({
+			identifier,
+			token: "000000",
+		});
+
+		expect(wrongGuessAgainstStaleCode).toBeNull();
+		expect(getRow()).toEqual(resentRow);
 	});
 });

--- a/packages/database/auth/drizzle-adapter.ts
+++ b/packages/database/auth/drizzle-adapter.ts
@@ -510,31 +510,28 @@ export function DrizzleAdapter(
 			return row;
 		},
 		async useVerificationToken({ identifier, token }) {
+			const normalizedIdentifier = identifier?.toLowerCase() ?? "";
 			const rows = await db
 				.select()
 				.from(verificationTokens)
-				.where(eq(verificationTokens.token, token))
+				.where(eq(verificationTokens.identifier, normalizedIdentifier))
 				.limit(1);
 			const row = rows[0];
 			if (!row) {
 				console.warn("[useVerificationToken] No token found");
 				return null;
 			}
-			const normalizedIdentifier = identifier?.toLowerCase() ?? "";
-			const storedIdentifier = row.identifier?.toLowerCase() ?? "";
-			if (normalizedIdentifier !== storedIdentifier) {
-				console.warn("[useVerificationToken] Identifier mismatch");
-				return null;
-			}
+			// Delete on every attempt (not just a match) so a wrong guess burns the
+			// code instead of leaving it guessable for the rest of its TTL.
 			await db
 				.delete(verificationTokens)
-				.where(
-					and(
-						eq(verificationTokens.token, token),
-						eq(verificationTokens.identifier, row.identifier),
-					),
-				);
-			return { ...row, identifier: storedIdentifier };
+				.where(eq(verificationTokens.identifier, row.identifier));
+
+			if (row.token !== token) {
+				console.warn("[useVerificationToken] Token mismatch");
+				return null;
+			}
+			return { ...row, identifier: normalizedIdentifier };
 		},
 	};
 }

--- a/packages/database/auth/drizzle-adapter.ts
+++ b/packages/database/auth/drizzle-adapter.ts
@@ -17,6 +17,15 @@ import {
 } from "../schema.ts";
 import type { ValidatedSsoIdentity } from "./sso.ts";
 
+const getAffectedRows = (result: unknown) => {
+	if (Array.isArray(result)) {
+		return (
+			(result[0] as { affectedRows?: number } | undefined)?.affectedRows ?? 0
+		);
+	}
+	return (result as { affectedRows?: number } | undefined)?.affectedRows ?? 0;
+};
+
 type CreateUserData = Parameters<NonNullable<Adapter["createUser"]>>[0];
 type LinkAccountData = Parameters<NonNullable<Adapter["linkAccount"]>>[0];
 type UnlinkAccountData = Parameters<NonNullable<Adapter["unlinkAccount"]>>[0];
@@ -521,12 +530,24 @@ export function DrizzleAdapter(
 				console.warn("[useVerificationToken] No token found");
 				return null;
 			}
-			// Delete on every attempt (not just a match) so a wrong guess burns the
-			// code instead of leaving it guessable for the rest of its TTL.
-			await db
+			// Claim the exact row we just read (identifier + token) with a single
+			// delete, and only proceed if we actually removed it. This makes
+			// consumption atomic: concurrent requests race on the same delete, so
+			// at most one of them can claim the row, whether the guess is right or
+			// wrong. Scoping by token too (not identifier alone) means the delete
+			// can't clobber a resend that replaced this row after we read it.
+			const result = await db
 				.delete(verificationTokens)
-				.where(eq(verificationTokens.identifier, row.identifier));
-
+				.where(
+					and(
+						eq(verificationTokens.identifier, row.identifier),
+						eq(verificationTokens.token, row.token),
+					),
+				);
+			if (getAffectedRows(result) !== 1) {
+				console.warn("[useVerificationToken] Token already consumed");
+				return null;
+			}
 			if (row.token !== token) {
 				console.warn("[useVerificationToken] Token mismatch");
 				return null;


### PR DESCRIPTION
## Summary
Fixes #2221. `useVerificationToken` in the NextAuth Drizzle adapter only invalidated the verification row on a successful code match. A wrong 6-digit guess found no matching row and simply returned `null`, leaving the real code untouched and guessable for the rest of its 10-minute TTL a brute-forceable account takeover.

## Root cause
`useVerificationToken` queried `verification_tokens` by the **guessed token value**. Since the row is keyed by `identifier`, a wrong guess never matched, so there was nothing to invalidate on failure. The mobile login path (`apps/web/app/api/mobile/[...route]/route.ts`) already avoided this by looking the row up by `identifier` first and deleting it on any outcome — the web path had no equivalent.

## Fix
In `packages/database/auth/drizzle-adapter.ts`:
- Look up the verification row by `identifier` (the key an attacker doesn't control) instead of by the guessed `token`.
- Delete the row on **every** attempt match or mismatch before returning, so a wrong guess burns the code immediately instead of leaving it valid for reuse.
- Return the row only when the stored token actually matches the guess.

This mirrors the correct mobile behavior and closes the gap without depending on rate limiting (`AUTH_OTP_VERIFY`/`AUTH_OTP_SEND` remain unwired and, even wired, are Vercel-Firewall-only and fail open on self-hosted deployments  so this fix is the durable, hosting-agnostic one, as noted in the issue).

## Testing
- Added `apps/web/__tests__/unit/verification-token.test.ts` (no prior test coverage existed for this adapter method), covering:
  - A wrong guess deletes the stored code; a subsequent *correct* guess against the same code also fails (proves it's burned, not just rejected).
  - A correct guess consumes and returns the row.
  - No code requested for an identifier returns `null`.
- Ran the full `apps/web` unit suite (`pnpm test`): 2542 passed. 3 pre-existing failures (Slack manifest brand-color drift, an `agent-api-handler` hook timeout, an `sso-login-pages` render timeout) are unrelated verified none of those files reference the changed code.
- `tsc --noEmit` on `packages/database` is clean.

## Related
- #2221 (this issue)
- #2039,  broader unwired-rate-limit-ids issue
- #1924,  Firewall-based rate limiting (open, stale)
- #2068,  fixed the 24h→10min TTL, left this attempt-counter fix as follow-up
- #240, deliberately punted on wiring these two rate-limit ids

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes email OTP consumption to locate a token by normalized email identifier, delete it on either a matching or incorrect guess, and return it only on a match. It also adds unit coverage for sequential mismatch, successful consumption, and missing-token behavior.

- Correctly closes the straightforward sequential brute-force window left by failed guesses.
- Leaves selection, invalidation, and validation as separate database operations, so concurrent attempts do not reliably enforce the intended single-attempt guarantee.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until OTP lookup, invalidation, and validation enforce the single-attempt guarantee atomically under concurrent requests.

The sequential fix works, but concurrent requests can select the same token before deletion and then authenticate using stale state, while a resend racing the consume path can also have its replacement token deleted.

**Files Needing Attention:** packages/database/auth/drizzle-adapter.ts, apps/web/__tests__/unit/verification-token.test.ts

<details open><summary><h3>Security Review</h3></summary>

The sequential failed-guess behavior is improved, but concurrent callback requests can read the same token before deletion and authenticate from stale state. This leaves a race in the single-attempt OTP security invariant and can also interfere with a concurrently issued replacement token.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/database/auth/drizzle-adapter.ts | Changes OTP consumption to burn tokens on mismatches, but the unlocked select-delete-compare sequence remains vulnerable to concurrent stale-row authentication. |
| apps/web/__tests__/unit/verification-token.test.ts | Adds useful sequential OTP-consumption tests, though its single-row fake cannot cover the adapter's concurrency-sensitive database behavior. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/database/auth/drizzle-adapter.ts:526-528
**Concurrent attempts reuse tokens**

Concurrent verification requests can select the same token before either deletion finishes. Because the deletion result is ignored, each request can then authenticate using its previously selected row. A correct request may succeed even after a racing wrong guess was supposed to burn the token, and concurrent correct requests may both succeed. A resend racing this sequence can also have its newly issued token deleted while the old token authenticates. The lookup, invalidation, and match decision must be atomic, with concurrency covered by the existing real-MySQL integration-test facility.

**How this was verified:** The callback accepts concurrent requests, while the adapter performs an unlocked SELECT followed by a separate DELETE and returns the previously selected row without checking the deletion result.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): invalidate email OTP on a fai..."](https://github.com/capsoftware/cap/commit/2562bc18c517043c68ed7cc764656324d62290b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60792482)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Data and identity platform](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/data-and-identity-platform.md)

<!-- /greptile_comment -->