### PR TITLE
fix: recover download redirects and stop missing-video upload retries

### DIFF
--- a/apps/web/__tests__/unit/download-route.test.ts
+++ b/apps/web/__tests__/unit/download-route.test.ts
@@ -20,13 +20,11 @@ describe("desktop download route", () => {
 		const cancel = vi.fn();
 		vi.stubGlobal(
 			"fetch",
-			vi
-				.fn()
-				.mockResolvedValue({
-					status: 206,
-					url: "https://downloads.example/cap.dmg",
-					body: { cancel },
-				}),
+			vi.fn().mockResolvedValue({
+				status: 206,
+				url: "https://downloads.example/cap.dmg",
+				body: { cancel },
+			}),
 		);
 		const response = await GET(request, {
 			params: Promise.resolve({ platform: "Apple-Silicon" }),

--- a/apps/web/__tests__/unit/download-route.test.ts
+++ b/apps/web/__tests__/unit/download-route.test.ts
@@ -1,0 +1,52 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/releases", () => ({ getGitHubReleases: vi.fn() }));
+
+import { GET } from "@/app/(site)/download/[platform]/route";
+import { getGitHubReleases } from "@/utils/releases";
+
+const request = new NextRequest("https://cap.so/download/apple-silicon");
+
+describe("desktop download route", () => {
+	it("handles missing route parameters without throwing", async () => {
+		const response = await GET(request, {
+			params: Promise.resolve({} as { platform: string }),
+		});
+		expect(response.headers.get("location")).toBe("https://cap.so/download");
+	});
+
+	it("redirects to the resolved download and cancels its probe body", async () => {
+		const cancel = vi.fn();
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValue({
+					status: 206,
+					url: "https://downloads.example/cap.dmg",
+					body: { cancel },
+				}),
+		);
+		const response = await GET(request, {
+			params: Promise.resolve({ platform: "Apple-Silicon" }),
+		});
+		expect(response.headers.get("location")).toBe(
+			"https://downloads.example/cap.dmg",
+		);
+		expect(cancel).toHaveBeenCalledOnce();
+		vi.unstubAllGlobals();
+	});
+
+	it("uses the GitHub fallback when the download provider fails", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Unavailable")));
+		vi.mocked(getGitHubReleases).mockResolvedValue([
+			{ downloads: { "macos-arm64": "https://github.com/cap.dmg" } },
+		] as Awaited<ReturnType<typeof getGitHubReleases>>);
+		const response = await GET(request, {
+			params: Promise.resolve({ platform: "apple-silicon" }),
+		});
+		expect(response.headers.get("location")).toBe("https://github.com/cap.dmg");
+		vi.unstubAllGlobals();
+	});
+});

--- a/apps/web/__tests__/unit/download-route.test.ts
+++ b/apps/web/__tests__/unit/download-route.test.ts
@@ -17,7 +17,7 @@ describe("desktop download route", () => {
 	});
 
 	it("redirects to the resolved download and cancels its probe body", async () => {
-		const cancel = vi.fn();
+		const cancel = vi.fn().mockResolvedValue(undefined);
 		vi.stubGlobal(
 			"fetch",
 			vi.fn().mockResolvedValue({
@@ -45,6 +45,25 @@ describe("desktop download route", () => {
 			params: Promise.resolve({ platform: "apple-silicon" }),
 		});
 		expect(response.headers.get("location")).toBe("https://github.com/cap.dmg");
+		vi.unstubAllGlobals();
+	});
+	it("preserves a successful redirect when probe cancellation fails", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				status: 206,
+				url: "https://downloads.example/cap.dmg",
+				body: {
+					cancel: vi.fn().mockRejectedValue(new Error("Already closed")),
+				},
+			}),
+		);
+		const response = await GET(request, {
+			params: Promise.resolve({ platform: "apple-silicon" }),
+		});
+		expect(response.headers.get("location")).toBe(
+			"https://downloads.example/cap.dmg",
+		);
 		vi.unstubAllGlobals();
 	});
 });

--- a/apps/web/__tests__/unit/multipart-presign.test.ts
+++ b/apps/web/__tests__/unit/multipart-presign.test.ts
@@ -73,6 +73,13 @@ describe("multipart presign ownership failures", () => {
 		expect(mocks.storage).not.toHaveBeenCalled();
 	});
 
+	it("does not reveal or sign a recording owned by someone else", async () => {
+		mocks.getOwnedById.mockReturnValue(Effect.fail({ _tag: "PolicyDenied" }));
+		const response = await request();
+		expect(response.status).toBe(404);
+		expect(mocks.storage).not.toHaveBeenCalled();
+	});
+
 	it("still signs a part for its owner", async () => {
 		mocks.getOwnedById.mockReturnValue(
 			Effect.succeed(Option.some([{ id: "missing-video" }])),

--- a/apps/web/__tests__/unit/multipart-presign.test.ts
+++ b/apps/web/__tests__/unit/multipart-presign.test.ts
@@ -1,0 +1,96 @@
+import { Effect, Option } from "effect";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	getOwnedById: vi.fn(),
+	storage: vi.fn(),
+	sign: vi.fn(),
+}));
+vi.mock("@cap/web-backend", async () => {
+	const { Context, Layer } = await import("effect");
+	return {
+		Database: Context.GenericTag("test/Database"),
+		VideosPolicy: Context.GenericTag("test/VideosPolicy"),
+		Storage: { getAccessForVideo: mocks.storage },
+		makeCurrentUserLayer: () => Layer.empty,
+		provideOptionalAuth: (effect: unknown) => effect,
+	};
+});
+vi.mock("@/app/api/utils", () => ({
+	withAuth: async (
+		c: { set: (key: string, value: unknown) => void },
+		next: () => Promise<void>,
+	) => {
+		c.set("user", { id: "owner" });
+		await next();
+	},
+}));
+vi.mock("@/lib/server", async () => {
+	const { Effect, Context, Layer } = await import("effect");
+	return {
+		runPromise: (effect: Effect.Effect<unknown, unknown, unknown>) =>
+			Effect.runPromise(
+				effect.pipe(
+					Effect.provide(
+						Layer.succeed(Context.GenericTag("test/VideosPolicy"), {
+							getOwnedById: mocks.getOwnedById,
+						}),
+					),
+				) as Effect.Effect<unknown>,
+			),
+	};
+});
+vi.mock("@/lib/google-drive-storage-quota", () => ({
+	invalidateGoogleDriveStorageQuotaCache: vi.fn(),
+}));
+vi.mock("@/lib/queue-video-transcription", () => ({
+	queueVideoTranscription: vi.fn(),
+	shouldQueueTranscriptionAfterMultipartComplete: vi.fn(),
+}));
+vi.mock("@/lib/video-processing", () => ({
+	startVideoProcessingWorkflow: vi.fn(),
+}));
+
+import { app } from "@/app/api/upload/[...route]/multipart";
+
+const request = () =>
+	app.request("/presign-part", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			videoId: "missing-video",
+			uploadId: "upload",
+			partNumber: 1,
+		}),
+	});
+
+describe("multipart presign ownership failures", () => {
+	it("returns 404 without accessing storage for a missing or unowned video", async () => {
+		mocks.getOwnedById.mockReturnValue(Effect.succeed(Option.none()));
+		const response = await request();
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual({ error: "Video not found" });
+		expect(mocks.storage).not.toHaveBeenCalled();
+	});
+
+	it("still signs a part for its owner", async () => {
+		mocks.getOwnedById.mockReturnValue(
+			Effect.succeed(Option.some([{ id: "missing-video" }])),
+		);
+		mocks.sign.mockReturnValue(Effect.succeed("https://uploads.example/part"));
+		mocks.storage.mockReturnValue(
+			Effect.succeed([
+				{
+					provider: "s3",
+					multipart: { getPresignedUploadPartUrl: mocks.sign },
+				},
+			]),
+		);
+		const response = await request();
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			provider: "s3",
+			presignedUrl: "https://uploads.example/part",
+		});
+	});
+});

--- a/apps/web/__tests__/unit/multipart-presign.test.ts
+++ b/apps/web/__tests__/unit/multipart-presign.test.ts
@@ -69,7 +69,10 @@ describe("multipart presign ownership failures", () => {
 		mocks.getOwnedById.mockReturnValue(Effect.succeed(Option.none()));
 		const response = await request();
 		expect(response.status).toBe(404);
-		expect(await response.json()).toEqual({ error: "Video not found" });
+		expect(await response.json()).toEqual({
+			error: "Video not found",
+			code: "VIDEO_NOT_FOUND",
+		});
 		expect(mocks.storage).not.toHaveBeenCalled();
 	});
 

--- a/apps/web/app/(site)/download/[platform]/route.ts
+++ b/apps/web/app/(site)/download/[platform]/route.ts
@@ -16,7 +16,7 @@ async function checkCrabNebulaDownload(
 			},
 		});
 
-		await res.body?.cancel();
+		await res.body?.cancel().catch(() => {});
 		if (res.status >= 200 && res.status < 300) {
 			return { ok: true, finalUrl: res.url };
 		}

--- a/apps/web/app/(site)/download/[platform]/route.ts
+++ b/apps/web/app/(site)/download/[platform]/route.ts
@@ -1,13 +1,14 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getGitHubReleases, type ReleaseDownloadKey } from "@/utils/releases";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 
 async function checkCrabNebulaDownload(
 	url: string,
 ): Promise<{ ok: true; finalUrl: string } | { ok: false }> {
 	try {
 		const res = await fetch(url, {
+			signal: AbortSignal.timeout(10_000),
 			redirect: "follow",
 			cache: "no-store",
 			headers: {
@@ -15,6 +16,7 @@ async function checkCrabNebulaDownload(
 			},
 		});
 
+		await res.body?.cancel();
 		if (res.status >= 200 && res.status < 300) {
 			return { ok: true, finalUrl: res.url };
 		}
@@ -43,7 +45,10 @@ export async function GET(
 	props: { params: Promise<{ platform: string }> },
 ) {
 	const params = await props.params;
-	const platform = params.platform.toLowerCase();
+	const platform = params.platform?.toLowerCase();
+	if (!platform) {
+		return NextResponse.redirect(new URL("/download", request.url));
+	}
 
 	const downloadUrls: Record<
 		string,

--- a/apps/web/app/api/upload/[...route]/multipart.ts
+++ b/apps/web/app/api/upload/[...route]/multipart.ts
@@ -247,10 +247,20 @@ app.post(
 					return { presignedUrl, provider: bucket.provider };
 				}).pipe(
 					Effect.catchTag("VideoNotFoundError", () =>
-						Effect.succeed(c.json({ error: "Video not found" }, 404)),
+						Effect.succeed(
+							c.json(
+								{ error: "Video not found", code: "VIDEO_NOT_FOUND" },
+								404,
+							),
+						),
 					),
 					Effect.catchTag("PolicyDenied", () =>
-						Effect.succeed(c.json({ error: "Video not found" }, 404)),
+						Effect.succeed(
+							c.json(
+								{ error: "Video not found", code: "VIDEO_NOT_FOUND" },
+								404,
+							),
+						),
 					),
 					Effect.provide(makeCurrentUserLayer(user)),
 					provideOptionalAuth,

--- a/apps/web/app/api/upload/[...route]/multipart.ts
+++ b/apps/web/app/api/upload/[...route]/multipart.ts
@@ -249,6 +249,9 @@ app.post(
 					Effect.catchTag("VideoNotFoundError", () =>
 						Effect.succeed(c.json({ error: "Video not found" }, 404)),
 					),
+					Effect.catchTag("PolicyDenied", () =>
+						Effect.succeed(c.json({ error: "Video not found" }, 404)),
+					),
 					Effect.provide(makeCurrentUserLayer(user)),
 					provideOptionalAuth,
 					runPromiseAnyEnv,

--- a/apps/web/app/api/upload/[...route]/multipart.ts
+++ b/apps/web/app/api/upload/[...route]/multipart.ts
@@ -246,12 +246,17 @@ app.post(
 
 					return { presignedUrl, provider: bucket.provider };
 				}).pipe(
+					Effect.catchTag("VideoNotFoundError", () =>
+						Effect.succeed(c.json({ error: "Video not found" }, 404)),
+					),
 					Effect.provide(makeCurrentUserLayer(user)),
 					provideOptionalAuth,
 					runPromiseAnyEnv,
 				);
 
-				return c.json(presignedUrl);
+				return presignedUrl instanceof Response
+					? presignedUrl
+					: c.json(presignedUrl);
 			} catch (s3Error) {
 				console.error("S3 operation failed:", s3Error);
 				throw new Error(

--- a/packages/recorder-core/__tests__/instant-recording-uploader.test.ts
+++ b/packages/recorder-core/__tests__/instant-recording-uploader.test.ts
@@ -926,4 +926,33 @@ describe("InstantRecordingUploader", () => {
 			]),
 		).resolves.toBe("cancelled");
 	});
+	it("stops retrying a part when its recording no longer exists", async () => {
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ error: "Video not found" }), {
+					status: 404,
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const uploader = new InstantRecordingUploader({
+			videoId,
+			uploadId: "upload-123",
+			mimeType: "video/webm",
+			subpath: "raw-upload.webm",
+			setUploadStatus: vi.fn(),
+			sendProgressUpdate: vi.fn().mockResolvedValue(undefined),
+		});
+		const chunk = makeBlob(STREAMED_PART_BYTES, "video/webm");
+		uploader.handleChunk(chunk, chunk.size);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		await expect(
+			uploader.finalize({
+				durationSeconds: 1,
+				width: 320,
+				height: 180,
+				subpath: "raw-upload.webm",
+			}),
+		).rejects.toThrow("404");
+	});
 });

--- a/packages/recorder-core/__tests__/instant-recording-uploader.test.ts
+++ b/packages/recorder-core/__tests__/instant-recording-uploader.test.ts
@@ -929,9 +929,12 @@ describe("InstantRecordingUploader", () => {
 	it("stops retrying a part when its recording no longer exists", async () => {
 		const fetchMock = vi.fn(
 			async () =>
-				new Response(JSON.stringify({ error: "Video not found" }), {
-					status: 404,
-				}),
+				new Response(
+					JSON.stringify({ error: "Video not found", code: "VIDEO_NOT_FOUND" }),
+					{
+						status: 404,
+					},
+				),
 		);
 		vi.stubGlobal("fetch", fetchMock);
 		const uploader = new InstantRecordingUploader({
@@ -954,5 +957,24 @@ describe("InstantRecordingUploader", () => {
 				subpath: "raw-upload.webm",
 			}),
 		).rejects.toThrow("404");
+	});
+	it("retains retries for an unrelated presign 404", async () => {
+		const fetchMock = vi.fn(
+			async () => new Response("Not found", { status: 404 }),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const uploader = new InstantRecordingUploader({
+			videoId,
+			uploadId: "upload-123",
+			mimeType: "video/webm",
+			subpath: "raw-upload.webm",
+			setUploadStatus: vi.fn(),
+			sendProgressUpdate: vi.fn().mockResolvedValue(undefined),
+		});
+		const chunk = makeBlob(STREAMED_PART_BYTES, "video/webm");
+		uploader.handleChunk(chunk, chunk.size);
+		await new Promise((resolve) => setTimeout(resolve, 600));
+		expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+		await uploader.cancel();
 	});
 });

--- a/packages/recorder-core/src/instant-mp4-uploader.ts
+++ b/packages/recorder-core/src/instant-mp4-uploader.ts
@@ -666,7 +666,10 @@ export class InstantRecordingUploader {
 					throw new CancelledUploadError();
 				}
 
-				if (attempt >= MAX_PART_UPLOAD_ATTEMPTS) {
+				if (
+					attempt >= MAX_PART_UPLOAD_ATTEMPTS ||
+					(error instanceof HttpRequestError && error.status === 404)
+				) {
 					this.updateChunkState(partNumber, { status: "error" });
 					this.pendingUploadBytes = Math.max(
 						0,

--- a/packages/recorder-core/src/instant-mp4-uploader.ts
+++ b/packages/recorder-core/src/instant-mp4-uploader.ts
@@ -75,12 +75,23 @@ interface MultipartCompletePayload {
 class HttpRequestError extends Error {
 	readonly status: number;
 	readonly url: string;
+	readonly code?: string;
 
 	constructor(url: string, status: number, message: string) {
 		super(`Request to ${url} failed: ${status} ${message}`);
 		this.name = "HttpRequestError";
 		this.status = status;
 		this.url = url;
+		try {
+			const body: unknown = JSON.parse(message);
+			if (
+				body &&
+				typeof body === "object" &&
+				"code" in body &&
+				typeof body.code === "string"
+			)
+				this.code = body.code;
+		} catch {}
 	}
 }
 
@@ -668,7 +679,9 @@ export class InstantRecordingUploader {
 
 				if (
 					attempt >= MAX_PART_UPLOAD_ATTEMPTS ||
-					(error instanceof HttpRequestError && error.status === 404)
+					(error instanceof HttpRequestError &&
+						error.status === 404 &&
+						error.code === "VIDEO_NOT_FOUND")
 				) {
 					this.updateChunkState(partNumber, { status: "error" });
 					this.pendingUploadBytes = Math.max(


### PR DESCRIPTION
Fix production download failures when route parameters are missing by using the Node runtime and guarding the platform parameter. Cancel CDN probe bodies and bound the probe duration.

Return HTTP 404 when multipart part signing cannot find an owned recording, and stop browser part retries for that response. Existing storage authorization remains in place; transient failures retain their retry behavior.

Validation: download route tests (3), multipart route tests (2), recorder uploader tests (16), scoped Biome, and git diff checks passed. Production recording recovery is being audited separately without changing source media or weakening verification. No database migration.








<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes desktop downloads resilient to missing route parameters and bounded CDN probes, while adding an explicit server/client contract that stops multipart upload retries only when the owned recording is unavailable.
- Moves the download route to Node.js, guards missing platform values, bounds CDN probing, and safely cancels probe bodies.
- Returns a structured 404 when multipart part signing cannot find an owned video.
- Parses structured HTTP errors in recorder core and preserves retry behavior for unrelated failures.
- Adds focused route and uploader regression tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the two previous findings are resolved and no actionable new regression remains.

The cancellation failure is now isolated from successful download resolution, and uploader retry termination is restricted to the server’s explicit 404 `VIDEO_NOT_FOUND` contract. Both previous threads were manually resolved, and the current implementation also addresses their underlying concerns.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/(site)/download/[platform]/route.ts | Safely handles absent platform parameters and bounds download probes without allowing body-cancellation failures to override valid redirects. |
| apps/web/app/api/upload/[...route]/multipart.ts | Maps unavailable or unowned recordings to a structured 404 before storage signing occurs. |
| packages/recorder-core/src/instant-mp4-uploader.ts | Extracts structured error codes and terminates part retries only for the explicit missing-video response. |
| apps/web/__tests__/unit/download-route.test.ts | Covers missing parameters, successful probes, fallback behavior, and rejected body cancellation. |
| apps/web/__tests__/unit/multipart-presign.test.ts | Covers missing, unowned, and owner-authorized multipart signing behavior. |
| packages/recorder-core/__tests__/instant-recording-uploader.test.ts | Verifies fatal handling for the structured missing-video response while preserving unrelated 404 retries. |

<sub>Reviews (4): Last reviewed commit: ["fix: distinguish missing recordings from..."](https://github.com/capsoftware/cap/commit/65f2eeb706093a2633a58ee002f209a8a91b4f1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60964911)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Web application routes and components](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-application-routes.md)
- Knowledge Base — [Web API and domain services](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-api-and-domain-services.md)
- Knowledge Base — [Recorder SDK and shared core](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/recorder-sdk-and-shared-core.md)
</details>


<!-- /greptile_comment -->