### PR TITLE
fix: unblock verified recording sources across S3 and Drive

### DIFF
--- a/.github/workflows/docker-build-media-server.yml
+++ b/.github/workflows/docker-build-media-server.yml
@@ -81,6 +81,9 @@ jobs:
             src/__tests__/lib/recording-verification.integration.test.ts \
             src/__tests__/lib/job-manager.test.ts
           docker run --rm --network none --entrypoint bun "$MEDIA_IMAGE" test \
+            src/__tests__/lib/media-size.test.ts \
+            src/__tests__/lib/media-probe.integration.test.ts
+          docker run --rm --network none --entrypoint bun "$MEDIA_IMAGE" test \
             src/__tests__/lib/media-transfer.test.ts
           docker run --rm --network none --entrypoint bun "$MEDIA_IMAGE" test \
             src/__tests__/routes/recording-verification.test.ts

--- a/apps/media-server/Dockerfile
+++ b/apps/media-server/Dockerfile
@@ -11,7 +11,8 @@ RUN bun install --frozen-lockfile --production
 
 COPY apps/media-server/src ./src
 
-RUN bun test src/__tests__/lib/recording-verification.integration.test.ts src/__tests__/lib/job-manager.test.ts \
+RUN bun test src/__tests__/lib/media-size.test.ts src/__tests__/lib/media-probe.integration.test.ts \
+	&& bun test src/__tests__/lib/recording-verification.integration.test.ts src/__tests__/lib/job-manager.test.ts \
 	&& bun test src/__tests__/lib/media-transfer.test.ts \
 	&& bun test src/__tests__/routes/recording-verification.test.ts \
 	&& bun test src/__tests__/routes/video.test.ts \

--- a/apps/media-server/src/__tests__/lib/media-probe.integration.test.ts
+++ b/apps/media-server/src/__tests__/lib/media-probe.integration.test.ts
@@ -130,6 +130,7 @@ describe("mediaProbe integration tests", () => {
 
 				expect(metadata.duration).toBeGreaterThan(0);
 				expect(metadata.videoCodec).toBeTruthy();
+				expect(metadata.fileSize).toBe(videoData.length);
 			} finally {
 				await server.stop(true);
 			}

--- a/apps/media-server/src/__tests__/lib/media-size.test.ts
+++ b/apps/media-server/src/__tests__/lib/media-size.test.ts
@@ -37,7 +37,9 @@ describe("remote media size", () => {
 				},
 			});
 			try {
-				const result = getSourceSize(`${server.url}video.mp4`);
+				const result = getSourceSize(
+					`${server.url}video.mp4`.replace("http:", "HTTP:"),
+				);
 				if (sample.size === null) {
 					await expect(result).rejects.toThrow(
 						"Media input size is unavailable",

--- a/apps/media-server/src/__tests__/lib/media-size.test.ts
+++ b/apps/media-server/src/__tests__/lib/media-size.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { getSourceSize } from "../../lib/media-common";
+
+describe("remote media size", () => {
+	for (const sample of [
+		{
+			status: 206,
+			headers: { "Content-Range": "bytes 0-0/1024", "Content-Length": "1" },
+			size: 1024,
+		},
+		{ status: 200, headers: { "Content-Length": "1024" }, size: 1024 },
+		{ status: 403, headers: { "Content-Length": "1024" }, size: null },
+		{ status: 206, headers: { "Content-Length": "1" }, size: null },
+		{ status: 206, headers: { "Content-Range": "bytes 1-1/1024" }, size: null },
+		{
+			status: 206,
+			headers: { "Content-Range": "bytes 0-0/9007199254740992" },
+			size: null,
+		},
+		{ status: 200, headers: {}, size: null },
+	]) {
+		test(`validates size response ${JSON.stringify(sample)}`, async () => {
+			const server = Bun.serve({
+				port: 0,
+				fetch(request) {
+					expect(request.method).toBe("GET");
+					expect(request.headers.get("range")).toBe("bytes=0-0");
+					return new Response(
+						sample.size === 1024 && sample.status === 200
+							? new Uint8Array(1024)
+							: null,
+						{
+							status: sample.status,
+							headers: sample.headers,
+						},
+					);
+				},
+			});
+			try {
+				const result = getSourceSize(`${server.url}video.mp4`);
+				if (sample.size === null) {
+					await expect(result).rejects.toThrow(
+						"Media input size is unavailable",
+					);
+				} else {
+					expect(await result).toBe(sample.size);
+				}
+			} finally {
+				await server.stop(true);
+			}
+		});
+	}
+});

--- a/apps/media-server/src/__tests__/lib/media-transfer.test.ts
+++ b/apps/media-server/src/__tests__/lib/media-transfer.test.ts
@@ -51,6 +51,33 @@ function fetcher(
 	return Object.assign(run, { preconnect: fetch.preconnect }) as typeof fetch;
 }
 describe("bounded revision downloads", () => {
+	test("pins the descriptor with an application header and rejects changed identity", async () => {
+		process.env.MEDIA_SERVER_WEBHOOK_SECRET = "worker-secret";
+		globalThis.fetch = fetcher((_input, init) => {
+			const headers = new Headers(init?.headers);
+			expect(headers.get("if-match")).toBeNull();
+			expect(headers.get("x-cap-recording-object-identity")).toBe('"identity"');
+			return Response.json(target());
+		});
+		expect(
+			await getMediaDownloadTarget(
+				"https://cap.so/api/storage/object",
+				undefined,
+				'"identity"',
+			),
+		).toEqual(target());
+		globalThis.fetch = fetcher(() =>
+			Response.json({ ...target(), objectIdentity: '"changed"' }),
+		);
+		await expect(
+			getMediaDownloadTarget(
+				"https://cap.so/api/storage/object",
+				undefined,
+				'"identity"',
+			),
+		).rejects.toThrow("Recording object changed");
+	});
+
 	test("resumes an interrupted pinned revision without rereading completed bytes", async () => {
 		const path = await destination();
 		let calls = 0;

--- a/apps/media-server/src/__tests__/lib/recording-verification.integration.test.ts
+++ b/apps/media-server/src/__tests__/lib/recording-verification.integration.test.ts
@@ -1075,8 +1075,8 @@ describe("source-preserving recording mux", () => {
 		},
 	);
 
-	test.each([-1, 1, -23_333])(
-		"preserves a true partial final frame with duration offset %d ticks when muxing",
+	test.each([-1, 1, -23_333, 670_000])(
+		"preserves the final frame with duration offset %d ticks when muxing",
 		async (offsetTicks) => {
 			const input = await fragmentedSource(0, { last: offsetTicks });
 			const sourceEvidence = await inspectRecordingSources(input, null);
@@ -1098,12 +1098,21 @@ describe("source-preserving recording mux", () => {
 				throw new Error("Fixture has no final packet");
 			expect(sourceTail.duration).toBe(33_333 + offsetTicks);
 			expect(outputTail.duration).toBe(sourceTail.duration);
+			expect(sourceEvidence.video.duration).toBeCloseTo(
+				(sourceTail.pts + sourceTail.duration - (sourcePackets[0]?.pts ?? 0)) /
+					1_000_000,
+				9,
+			);
 			const verified = await verifyRecording(output, {
 				requireAudio: false,
 				sourceEvidence,
 			});
 			expect(verified.sourcePreserved).toBe(true);
 			expect(verified.video.frameCount).toBe(31);
+			expect(verified.video.duration).toBeCloseTo(
+				sourceEvidence.video.duration,
+				9,
+			);
 			expect(verified.integrity).toEqual(sourceEvidence.integrity);
 		},
 	);
@@ -1287,7 +1296,10 @@ describe("source-preserving recording mux", () => {
 		const output = await fragmentedSource(0, { first: 2_000_000, last: -1 });
 		const sourceEvidence = await inspectRecordingSources(input, null);
 		const outputEvidence = await inspectRecordingSources(output, null);
-		expect(outputEvidence.video).toEqual(sourceEvidence.video);
+		expect(outputEvidence.video.duration).toBeCloseTo(
+			sourceEvidence.video.duration - 0.000_001,
+			9,
+		);
 		expect(outputEvidence.integrity.video.contentSha256).toBe(
 			sourceEvidence.integrity.video.contentSha256,
 		);

--- a/apps/media-server/src/lib/media-common.ts
+++ b/apps/media-server/src/lib/media-common.ts
@@ -198,17 +198,29 @@ export function normalizeLocalPath(path: string): string {
 }
 
 export async function getSourceSize(path: string): Promise<number> {
-	try {
-		const url = new URL(path);
-		if (url.protocol === "http:" || url.protocol === "https:") {
-			const response = await mediaFetch(path, {
-				method: "HEAD",
-				signal: AbortSignal.timeout(10_000),
-			});
-			const contentLength = response.headers.get("content-length");
-			return contentLength ? Number.parseInt(contentLength, 10) || 0 : 0;
+	if (/^https?:\/\//.test(path)) {
+		const response = await mediaFetch(path, {
+			headers: { Range: "bytes=0-0" },
+			signal: AbortSignal.timeout(10_000),
+		});
+		try {
+			const length =
+				response.status === 206
+					? response.headers
+							.get("content-range")
+							?.match(/^bytes 0-0\/(\d+)$/)?.[1]
+					: response.status === 200
+						? response.headers.get("content-length")
+						: undefined;
+			const size = Number(length);
+			if (!Number.isSafeInteger(size) || size <= 0) {
+				throw new Error("Media input size is unavailable");
+			}
+			return size;
+		} finally {
+			await response.body?.cancel().catch(() => {});
 		}
-	} catch {}
+	}
 
 	try {
 		return (await stat(normalizeLocalPath(path))).size;

--- a/apps/media-server/src/lib/media-common.ts
+++ b/apps/media-server/src/lib/media-common.ts
@@ -198,7 +198,7 @@ export function normalizeLocalPath(path: string): string {
 }
 
 export async function getSourceSize(path: string): Promise<number> {
-	if (/^https?:\/\//.test(path)) {
+	if (/^https?:\/\//i.test(path)) {
 		const response = await mediaFetch(path, {
 			headers: { Range: "bytes=0-0" },
 			signal: AbortSignal.timeout(10_000),

--- a/apps/media-server/src/lib/media-transfer.ts
+++ b/apps/media-server/src/lib/media-transfer.ts
@@ -171,7 +171,9 @@ export async function getMediaDownloadTarget(
 		headers: {
 			"x-cap-internal-download": "1",
 			"x-media-server-secret": secret,
-			...(expectedIdentity ? { "if-match": expectedIdentity } : {}),
+			...(expectedIdentity
+				? { "x-cap-recording-object-identity": expectedIdentity }
+				: {}),
 		},
 		signal,
 		redirect: "manual",

--- a/apps/media-server/src/lib/recording-verification.ts
+++ b/apps/media-server/src/lib/recording-verification.ts
@@ -539,6 +539,19 @@ function validateEvidence(
 			audio: audioEvidence && audio ? integrity(audio) : null,
 		},
 	};
+	if (videoTiming?.terminalPacketCount === 1) {
+		const duration =
+			Number(
+				videoTiming.lastTimestampTicks -
+					videoTiming.firstTimestampTicks +
+					videoTiming.lastDurationTicks,
+			) / videoTiming.timeScale;
+		result.video = {
+			...result.video,
+			duration,
+			endTime: result.video.startTime + duration,
+		};
+	}
 	if (options.sourceEvidence) {
 		assertSourcePreserved(options.sourceEvidence, result);
 		result.sourcePreserved = true;

--- a/apps/web/__tests__/unit/storage-object-verification.test.ts
+++ b/apps/web/__tests__/unit/storage-object-verification.test.ts
@@ -99,26 +99,29 @@ describe("recording verification object reads", () => {
 		expect(mocks.download).not.toHaveBeenCalled();
 	});
 
-	it("authorizes an internal descriptor without downloading media", async () => {
-		mocks.download.mockReturnValue(
-			Effect.succeed({
-				version: 1,
-				url: "https://www.googleapis.com/drive/v3/files/file/revisions/revision?alt=media",
-			}),
-		);
-		const response = await request({
-			"x-cap-internal-download": "1",
-			"x-media-server-secret": "test-media-secret",
-			"if-match": '"identity"',
-		});
-		expect(response.status).toBe(200);
-		expect(response.headers.get("Cache-Control")).toBe("private, no-store");
-		expect(mocks.download).toHaveBeenCalledWith(
-			"owner/video/result.mp4",
-			expect.objectContaining({ objectIdentity: '"identity"' }),
-		);
-		expect(mocks.read).not.toHaveBeenCalled();
-	});
+	it.each(["if-match", "x-cap-recording-object-identity"])(
+		"authorizes an internal descriptor using %s without downloading media",
+		async (identityHeader) => {
+			mocks.download.mockReturnValue(
+				Effect.succeed({
+					version: 1,
+					url: "https://www.googleapis.com/drive/v3/files/file/revisions/revision?alt=media",
+				}),
+			);
+			const response = await request({
+				"x-cap-internal-download": "1",
+				"x-media-server-secret": "test-media-secret",
+				[identityHeader]: '"identity"',
+			});
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+			expect(mocks.download).toHaveBeenCalledWith(
+				"owner/video/result.mp4",
+				expect.objectContaining({ objectIdentity: '"identity"' }),
+			);
+			expect(mocks.read).not.toHaveBeenCalled();
+		},
+	);
 
 	it("does not add metadata requests to ordinary playback", async () => {
 		const response = await request();

--- a/apps/web/app/api/storage/object/route.ts
+++ b/apps/web/app/api/storage/object/route.ts
@@ -186,7 +186,10 @@ export async function GET(request: NextRequest) {
 			if (!("getInternalDownload" in storage))
 				return new Response("Unsupported storage", { status: 400 });
 			const target = yield* storage.getInternalDownload(key, {
-				objectIdentity: request.headers.get("if-match") ?? undefined,
+				objectIdentity:
+					request.headers.get("x-cap-recording-object-identity") ??
+					request.headers.get("if-match") ??
+					undefined,
 				signal: request.signal,
 			});
 			return Response.json(target, {


### PR DESCRIPTION
Two protocol mismatches and an inconsistent duration calculation were blocking valid recordings. S3 signed GET URLs reject the probe's HEAD request, so uploaded MP4 size was reported as zero. Vercel rejects If-Match on the internal Drive descriptor endpoint before our handler, even when its content identity matches.

Read complete object size using a one-byte ranged GET, validate the response, and cancel its body. Use a dedicated internal identity header for Drive descriptors; retain the same revision, size, checksum, and identity checks. The web handler accepts the new header and the old one for worker compatibility. Deploy the web handler before the updated worker. For segmented recordings, compute reported duration from the same validated container endpoint used by the preservation check. FFmpeg can report an incorrect nominal last-frame duration even when every frame, timestamp, and actual final-packet duration is preserved; this previously made the completion webhook fail its receipt check. No integrity tolerance is relaxed. No database changes.

Validation: 17 size/probe tests, 14 transfer tests, and 23 storage route tests pass. A real affected S3 source passes remote full decode, identity, size, and SHA-256 verification with the fix. Real Drive metadata confirms matching stored identities while If-Match receives a Vercel PRECONDITION_FAILED response. Both Linux production-image builds run the new regression tests.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores recording verification across S3 and Google Drive while aligning segmented-recording duration with the validated container endpoint.
- Replaces remote HEAD size probes with validated one-byte ranged GET requests and cancels response bodies.
- Introduces a dedicated Drive object-identity header while retaining legacy worker compatibility.
- Reports video duration from validated terminal packet timing when the endpoint is unambiguous.
- Adds focused media-size, transfer, timing, storage-route, integration, and container-build coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the previous mixed-case URL finding resolved and no new actionable defects identified.

Remote size probing now recognizes mixed-case HTTP schemes and validates ranged responses, Drive identity remains pinned across the service boundary, and the duration override uses container timing already bound to decoded frame timing and integrity.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/media-server/src/lib/media-common.ts | Replaces HEAD-based remote size detection with a validated ranged GET and correctly handles case-insensitive HTTP schemes. |
| apps/media-server/src/lib/media-transfer.ts | Sends expected Drive object identity through the dedicated internal application header. |
| apps/web/app/api/storage/object/route.ts | Accepts the new identity header while preserving compatibility with workers using If-Match. |
| apps/media-server/src/lib/recording-verification.ts | Derives unambiguous video duration and end time from validated container terminal-packet timing. |
| apps/media-server/src/__tests__/lib/recording-verification.integration.test.ts | Extends regression coverage for nominal final-frame duration discrepancies and preserved container endpoints. |
| apps/media-server/Dockerfile | Runs the new media-size and probe regressions as production-image build gates. |
| .github/workflows/docker-build-media-server.yml | Executes the new regression suites against both media-server container architectures. |

<sub>Reviews (4): Last reviewed commit: ["fix: report the verified recording endpo..."](https://github.com/capsoftware/cap/commit/634ad00d04a458ba3d3c9cbf422d60266e39f52f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60968833)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Media delivery services](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/media-delivery-services.md)
- Knowledge Base — [Media server and web-cluster runtime services](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/media-server-and-web-cluster.md)
- Knowledge Base — [Web API and domain services](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/web-api-and-domain-services.md)
- Knowledge Base — [Build and release automation](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/docs/build-and-release-automation.md)
- Knowledge Base — [Roll Back paid SAML SSO before enabling the Drive verification rollout](https://app.greptile.com/cap/-/custom-context/knowledge-base/capsoftware/cap/-/reverts/rollback_2204-20260903-drive-recording-verification-a3aef7c.md)
</details>


<!-- /greptile_comment -->