### PR TITLE
fix: prevent createdAt forgery, customCreatedAt leak, and password drop in video duplicate (#2223)

### DIFF
--- a/apps/web/__tests__/unit/recording-storage-lifecycle.test.ts
+++ b/apps/web/__tests__/unit/recording-storage-lifecycle.test.ts
@@ -134,13 +134,14 @@ type DatabaseMutation = {
 	values?: Record<string, unknown>;
 };
 
-function databaseFixture(video = recording()) {
+function databaseFixture(video = recording(), password?: string | null) {
 	const encoded = Schema.encodeSync(Video.Video)(video);
 	const original = {
 		...encoded,
 		bucket: encoded.bucketId,
 		createdAt: video.createdAt,
 		updatedAt: video.updatedAt,
+		password: password ?? null,
 	};
 	const rows = new Map<string, Record<string, unknown>>([[videoId, original]]);
 	const jobs = new Map<string, Record<string, unknown>>([
@@ -879,6 +880,12 @@ describe("recording storage lifecycle", () => {
 		expect(database.rows.get("duplicate-video")?.metadata).not.toHaveProperty(
 			"desktopRecordingUpload",
 		);
+		expect(database.rows.get("duplicate-video")).not.toHaveProperty(
+			"createdAt",
+		);
+		expect(database.rows.get("duplicate-video")).not.toHaveProperty(
+			"updatedAt",
+		);
 		expect(database.rows.get("owned-video")?.metadata).toHaveProperty(
 			"desktopRecordingUpload",
 		);
@@ -897,6 +904,32 @@ describe("recording storage lifecycle", () => {
 				key: `${newPrefix}preview/animated-preview.gif`,
 			},
 		]);
+	});
+
+	it("preserves password and strips customCreatedAt without copying original createdAt or updatedAt", async () => {
+		const videoWithCustomDate = Video.Video.make({
+			...recording(),
+			metadata: Option.some({
+				sourceName: "Dated recording",
+				customCreatedAt: "2020-01-01T00:00:00.000Z",
+			}),
+		});
+		const database = databaseFixture(videoWithCustomDate, "secret-pass-123");
+		await storageFixture([
+			[outputKey, "verified-video"],
+			[thumbnailKey, "verified-thumbnail"],
+			[previewKey, "verified-preview"],
+		]);
+		const result = await runVideoOperation("duplicate");
+		expect(Exit.isSuccess(result)).toBe(true);
+		const duplicated = database.rows.get("duplicate-video");
+		expect(duplicated).toBeDefined();
+		expect(duplicated).not.toHaveProperty("createdAt");
+		expect(duplicated).not.toHaveProperty("updatedAt");
+		expect(duplicated?.metadata).not.toHaveProperty("customCreatedAt");
+		expect(duplicated).toMatchObject({
+			password: "secret-pass-123",
+		});
 	});
 
 	it("does not duplicate source inventories, raw fragments, or comment attachments across pages", async () => {

--- a/packages/web-backend/src/Videos/VideosRepo.ts
+++ b/packages/web-backend/src/Videos/VideosRepo.ts
@@ -109,10 +109,16 @@ export class VideosRepo extends Effect.Service<VideosRepo>()("VideosRepo", {
 
 				yield* db.use((db) =>
 					db.transaction(async (db) => {
+						const {
+							createdAt: _createdAt,
+							updatedAt: _updatedAt,
+							id: _id,
+							...insertData
+						} = data as Record<string, unknown>;
 						const promises: MySqlInsertBase<any, any, any>[] = [
 							db.insert(Db.videos).values([
 								{
-									...data,
+									...insertData,
 									id,
 									orgId: data.orgId,
 									bucket: Option.getOrNull(data.bucketId ?? Option.none()),

--- a/packages/web-backend/src/Videos/index.ts
+++ b/packages/web-backend/src/Videos/index.ts
@@ -349,7 +349,7 @@ export class Videos extends Effect.Service<Videos>()("Videos", {
 				const maybeVideo = yield* policy.getOwnedById(videoId);
 				if (Option.isNone(maybeVideo))
 					return yield* Effect.fail(new Video.NotFoundError());
-				const [video] = maybeVideo.value;
+				const [video, password] = maybeVideo.value;
 
 				const [bucket] = yield* storage.getAccessForVideo(video);
 
@@ -410,16 +410,29 @@ export class Videos extends Effect.Service<Videos>()("Videos", {
 						}
 					} while (continuationToken);
 					publicationAttempted = true;
+					const hasPassword = Option.isSome(password);
 					yield* repo.create(
 						{
-							...video,
+							ownerId: video.ownerId,
+							orgId: video.orgId,
+							name: video.name,
+							public: video.public,
 							source:
 								publishedKeys.size > 0 ? { type: "desktopMP4" } : video.source,
 							metadata: Option.map(video.metadata, (metadata) => {
 								const copied = { ...metadata };
 								delete copied.desktopRecordingUpload;
+								delete copied.customCreatedAt;
 								return copied;
 							}),
+							bucketId: video.bucketId,
+							storageIntegrationId: video.storageIntegrationId,
+							folderId: video.folderId,
+							transcriptionStatus: video.transcriptionStatus,
+							width: video.width,
+							height: video.height,
+							duration: video.duration,
+							...(hasPassword ? { password: password.value } : {}),
 						},
 						{ id: newVideoId },
 					);


### PR DESCRIPTION
Resolves #2223
Linear: CAP-805

### Summary
`Videos.duplicate()` previously spread the source `Video.Video` entity directly into `repo.create()`. Because TypeScript does not run excess-property checks against object spreads, `createdAt` and `updatedAt` bypassed the `Omit` in `CreateVideoInput` and were inserted directly into MySQL, overriding the `.defaultNow()` column defaults. Additionally, `password` was deliberately omitted from `Video.Video` for client safety, causing password-protected videos to become public without password protection upon duplication, while pre-quota `createdAt` timestamps bypassed shareable-link limits.

### Changes
1. **Explicit Payload in `Videos.duplicate()`**:
   - Enumerated explicit properties (`ownerId`, `orgId`, `name`, `public`, `source`, `metadata`, `bucketId`, `storageIntegrationId`, `folderId`, `transcriptionStatus`, `width`, `height`, `duration`).
   - Carried forward password protection: if `Option.isSome(password)`, passes `{ password: password.value }` so the duplicate retains identical protection.
   - Cleansed metadata: stripped both `desktopRecordingUpload` and `customCreatedAt` from duplicated metadata so effective creation dates are not backdated.
2. **Defensive Filtering in `VideosRepo.create()`**:
   - Destructured and excluded `createdAt`, `updatedAt`, and `id` from incoming data prior to building the insert payload, guaranteeing MySQL `.defaultNow()` defaults are always respected regardless of caller spread.
3. **Unit Tests**:
   - Extended `recording-storage-lifecycle.test.ts` to assert that duplicated rows do not carry `createdAt`, `updatedAt`, or `customCreatedAt`.
   - Added unit test verifying that password protection is preserved on duplicate videos.

### Verification
- `vitest run __tests__/unit/recording-storage-lifecycle.test.ts`: 58/58 passed
- `vitest run __tests__/unit/videos-policy.test.ts`: 52/52 passed
- Biome formatted.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens video duplication against inherited identity and timestamp values, removes effective-date metadata that could backdate duplicates, and preserves password protection.
- Replaces the source-entity spread with an explicit duplication payload.
- Defensively strips caller-supplied IDs and timestamps in `VideosRepo.create`.
- Adds lifecycle coverage for password propagation and timestamp/metadata cleansing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness, security, or repository-rule violations identified.

The explicit payload preserves all duplicable video fields, the password value follows the repository’s stored-hash contract, and repository-level filtering ensures fresh database-generated timestamps.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/web-backend/src/Videos/index.ts | Builds an explicit duplicate payload, preserves the stored password hash, and removes backdating metadata. |
| packages/web-backend/src/Videos/VideosRepo.ts | Filters identity and timestamp properties before inserting a newly created video. |
| apps/web/__tests__/unit/recording-storage-lifecycle.test.ts | Verifies duplicate timestamp cleansing, custom-date removal, and password preservation. |

<sub>Reviews (1): Last reviewed commit: ["fix: prevent createdAt forgery, customCr..."](https://github.com/capsoftware/cap/commit/2a310a409b5ab52bd59b87ddf165cd1b8d42f4ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61362937)</sub>

<!-- /greptile_comment -->