### PR TITLE
fix(billing): validate priceId against allowlist and sanitize quantity at checkout endpoints (#2222)

### DIFF
--- a/apps/web/__tests__/unit/mobile-checkout.test.ts
+++ b/apps/web/__tests__/unit/mobile-checkout.test.ts
@@ -22,6 +22,7 @@ vi.mock("@cap/utils", () => ({
 			sessions: { create: checkoutMocks.create },
 		},
 	}),
+	isValidStripePlanPriceId: (id: string) => id === "price_pro",
 }));
 
 vi.mock("@/lib/server-analytics", () => ({
@@ -77,6 +78,19 @@ describe("checkout redirects", () => {
 				guestCheckout: "true",
 			},
 		});
+	});
+
+	it("rejects non-allowlisted arbitrary priceId with 400", async () => {
+		const response = await startGuestCheckout(
+			makeGuestCheckoutRequest({
+				priceId: "price_arbitrary_attacker_id",
+				quantity: 1,
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: "Invalid priceId" });
+		expect(checkoutMocks.create).not.toHaveBeenCalled();
 	});
 
 	it("sends mobile checkout results through the HTTPS completion route", () => {

--- a/apps/web/__tests__/unit/subscribe-checkout.test.ts
+++ b/apps/web/__tests__/unit/subscribe-checkout.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isValidStripePlanPriceId, STRIPE_PLAN_IDS } from "@cap/utils";
+import { POST as subscribe } from "@/app/api/settings/billing/subscribe/route";
+
+const checkoutMocks = vi.hoisted(() => ({
+	create: vi.fn(),
+	track: vi.fn(() => Promise.resolve()),
+	getCurrentUser: vi.fn(),
+	dbUpdate: vi.fn(),
+}));
+
+vi.mock("@cap/env", () => ({
+	buildEnv: { NEXT_PUBLIC_IS_CAP: "true" },
+	serverEnv: () => ({ WEB_URL: "https://cap.so" }),
+}));
+
+vi.mock("@cap/database/auth/session", () => ({
+	getCurrentUser: checkoutMocks.getCurrentUser,
+}));
+
+vi.mock("@cap/database", () => ({
+	db: () => ({
+		update: () => ({
+			set: () => ({
+				where: checkoutMocks.dbUpdate,
+			}),
+		}),
+	}),
+}));
+
+vi.mock("@cap/database/schema", () => ({
+	users: { id: "id" },
+}));
+
+vi.mock("@cap/utils", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@cap/utils")>();
+	return {
+		...actual,
+		stripe: () => ({
+			customers: {
+				list: vi.fn().mockResolvedValue({ data: [] }),
+				create: vi.fn().mockResolvedValue({ id: "cus_new" }),
+				update: vi.fn().mockResolvedValue({ id: "cus_new" }),
+			},
+			checkout: {
+				sessions: { create: checkoutMocks.create },
+			},
+		}),
+		userIsPro: vi.fn().mockReturnValue(false),
+	};
+});
+
+vi.mock("@/lib/server-analytics", () => ({
+	trackServerEvent: checkoutMocks.track,
+}));
+
+const makeSubscribeRequest = (body: Record<string, unknown>) =>
+	new Request("https://cap.so/api/settings/billing/subscribe", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	}) as unknown as import("next/server").NextRequest;
+
+describe("Stripe plan allowlist", () => {
+	it("accepts only legitimate Pro plan price IDs", () => {
+		expect(isValidStripePlanPriceId(STRIPE_PLAN_IDS.development.yearly)).toBe(
+			true,
+		);
+		expect(isValidStripePlanPriceId(STRIPE_PLAN_IDS.development.monthly)).toBe(
+			true,
+		);
+		expect(isValidStripePlanPriceId(STRIPE_PLAN_IDS.production.yearly)).toBe(
+			true,
+		);
+		expect(isValidStripePlanPriceId(STRIPE_PLAN_IDS.production.monthly)).toBe(
+			true,
+		);
+
+		expect(isValidStripePlanPriceId("price_arbitrary_attacker_id")).toBe(false);
+		expect(isValidStripePlanPriceId("price_free_tier")).toBe(false);
+		expect(isValidStripePlanPriceId("")).toBe(false);
+	});
+});
+
+describe("POST /api/settings/billing/subscribe", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		checkoutMocks.getCurrentUser.mockResolvedValue({
+			id: "user_123",
+			email: "user@example.test",
+			stripeCustomerId: "cus_123",
+		});
+		checkoutMocks.create.mockResolvedValue({
+			id: "cs_test",
+			url: "https://pay.cap.so/session",
+		});
+	});
+
+	it("rejects arbitrary price IDs with 400", async () => {
+		const response = await subscribe(
+			makeSubscribeRequest({
+				priceId: "price_arbitrary_malicious",
+				quantity: 1,
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({
+			error: true,
+			message: "Invalid priceId",
+		});
+		expect(checkoutMocks.create).not.toHaveBeenCalled();
+	});
+
+	it("accepts valid Pro plan price ID and creates checkout session", async () => {
+		const response = await subscribe(
+			makeSubscribeRequest({
+				priceId: STRIPE_PLAN_IDS.development.monthly,
+				quantity: 2,
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(checkoutMocks.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customer: "cus_123",
+				line_items: [
+					{ price: STRIPE_PLAN_IDS.development.monthly, quantity: 2 },
+				],
+				mode: "subscription",
+			}),
+		);
+	});
+});

--- a/apps/web/__tests__/unit/subscribe-checkout.test.ts
+++ b/apps/web/__tests__/unit/subscribe-checkout.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { isValidStripePlanPriceId, STRIPE_PLAN_IDS } from "@cap/utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { POST as subscribe } from "@/app/api/settings/billing/subscribe/route";
 
 const checkoutMocks = vi.hoisted(() => ({
@@ -79,6 +79,31 @@ describe("Stripe plan allowlist", () => {
 		expect(isValidStripePlanPriceId("price_arbitrary_attacker_id")).toBe(false);
 		expect(isValidStripePlanPriceId("price_free_tier")).toBe(false);
 		expect(isValidStripePlanPriceId("")).toBe(false);
+	});
+
+	it("validates price IDs against specific deployment environments", () => {
+		expect(
+			isValidStripePlanPriceId(
+				STRIPE_PLAN_IDS.development.yearly,
+				"development",
+			),
+		).toBe(true);
+		expect(
+			isValidStripePlanPriceId(
+				STRIPE_PLAN_IDS.production.yearly,
+				"development",
+			),
+		).toBe(false);
+
+		expect(
+			isValidStripePlanPriceId(STRIPE_PLAN_IDS.production.yearly, "production"),
+		).toBe(true);
+		expect(
+			isValidStripePlanPriceId(
+				STRIPE_PLAN_IDS.development.yearly,
+				"production",
+			),
+		).toBe(false);
 	});
 });
 

--- a/apps/web/app/api/desktop/[...route]/root.ts
+++ b/apps/web/app/api/desktop/[...route]/root.ts
@@ -10,8 +10,8 @@ import {
 } from "@cap/database/schema";
 import { serverEnv } from "@cap/env";
 import {
-	isValidStripePlanPriceId,
 	isProSubscription,
+	isValidStripePlanPriceId,
 	STRIPE_AVAILABLE,
 	stripe,
 	userIsPro,
@@ -706,9 +706,20 @@ app.post(
 	zValidator(
 		"json",
 		z.object({
-			priceId: z.string().refine((id) => isValidStripePlanPriceId(id), {
-				message: "Invalid priceId",
-			}),
+			priceId: z
+				.string()
+				.refine(
+					(id) =>
+						isValidStripePlanPriceId(
+							id,
+							serverEnv().VERCEL_ENV === "production"
+								? "production"
+								: "development",
+						),
+					{
+						message: "Invalid priceId",
+					},
+				),
 			platform: z.literal("mobile").optional(),
 		}),
 	),

--- a/apps/web/app/api/desktop/[...route]/root.ts
+++ b/apps/web/app/api/desktop/[...route]/root.ts
@@ -10,6 +10,7 @@ import {
 } from "@cap/database/schema";
 import { serverEnv } from "@cap/env";
 import {
+	isValidStripePlanPriceId,
 	isProSubscription,
 	STRIPE_AVAILABLE,
 	stripe,
@@ -705,7 +706,9 @@ app.post(
 	zValidator(
 		"json",
 		z.object({
-			priceId: z.string(),
+			priceId: z.string().refine((id) => isValidStripePlanPriceId(id), {
+				message: "Invalid priceId",
+			}),
 			platform: z.literal("mobile").optional(),
 		}),
 	),

--- a/apps/web/app/api/settings/billing/guest-checkout/route.ts
+++ b/apps/web/app/api/settings/billing/guest-checkout/route.ts
@@ -1,5 +1,5 @@
 import { serverEnv } from "@cap/env";
-import { stripe } from "@cap/utils";
+import { isValidStripePlanPriceId, stripe } from "@cap/utils";
 import type { NextRequest } from "next/server";
 import { getCheckoutRedirectUrls } from "@/lib/mobile-checkout";
 import { trackServerEvent } from "@/lib/server-analytics";
@@ -11,10 +11,22 @@ export async function POST(request: NextRequest) {
 
 	console.log("Received guest checkout request:", { priceId, quantity });
 
-	if (!priceId) {
-		console.error("Missing required priceId");
-		return Response.json({ error: "priceId is required" }, { status: 400 });
+	if (
+		!priceId ||
+		typeof priceId !== "string" ||
+		!isValidStripePlanPriceId(priceId)
+	) {
+		console.error("Invalid or missing priceId");
+		return Response.json({ error: "Invalid priceId" }, { status: 400 });
 	}
+
+	const safeQuantity =
+		typeof quantity === "number" &&
+		Number.isInteger(quantity) &&
+		quantity >= 1 &&
+		quantity <= 1000
+			? quantity
+			: 1;
 
 	try {
 		console.log("Creating guest checkout session");
@@ -23,7 +35,7 @@ export async function POST(request: NextRequest) {
 			serverEnv().WEB_URL,
 		);
 		const checkoutSession = await stripe().checkout.sessions.create({
-			line_items: [{ price: priceId, quantity: quantity || 1 }],
+			line_items: [{ price: priceId, quantity: safeQuantity }],
 			mode: "subscription",
 			success_url: redirects.successUrl,
 			cancel_url: redirects.cancelUrl,

--- a/apps/web/app/api/settings/billing/guest-checkout/route.ts
+++ b/apps/web/app/api/settings/billing/guest-checkout/route.ts
@@ -11,10 +11,13 @@ export async function POST(request: NextRequest) {
 
 	console.log("Received guest checkout request:", { priceId, quantity });
 
+	const environment =
+		serverEnv().VERCEL_ENV === "production" ? "production" : "development";
+
 	if (
 		!priceId ||
 		typeof priceId !== "string" ||
-		!isValidStripePlanPriceId(priceId)
+		!isValidStripePlanPriceId(priceId, environment)
 	) {
 		console.error("Invalid or missing priceId");
 		return Response.json({ error: "Invalid priceId" }, { status: 400 });

--- a/apps/web/app/api/settings/billing/subscribe/route.ts
+++ b/apps/web/app/api/settings/billing/subscribe/route.ts
@@ -2,7 +2,7 @@ import { db } from "@cap/database";
 import { getCurrentUser } from "@cap/database/auth/session";
 import { users } from "@cap/database/schema";
 import { serverEnv } from "@cap/env";
-import { stripe, userIsPro } from "@cap/utils";
+import { isValidStripePlanPriceId, stripe, userIsPro } from "@cap/utils";
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 import type Stripe from "stripe";
@@ -13,10 +13,25 @@ export async function POST(request: NextRequest) {
 	let customerId = user?.stripeCustomerId;
 	const { priceId, quantity, isOnBoarding } = await request.json();
 
-	if (!priceId) {
-		console.error("Price ID not found");
-		return Response.json({ error: true }, { status: 400 });
+	if (
+		!priceId ||
+		typeof priceId !== "string" ||
+		!isValidStripePlanPriceId(priceId)
+	) {
+		console.error("Invalid or missing priceId");
+		return Response.json(
+			{ error: true, message: "Invalid priceId" },
+			{ status: 400 },
+		);
 	}
+
+	const safeQuantity =
+		typeof quantity === "number" &&
+		Number.isInteger(quantity) &&
+		quantity >= 1 &&
+		quantity <= 1000
+			? quantity
+			: 1;
 
 	if (!user) {
 		console.error("User not found");
@@ -65,7 +80,7 @@ export async function POST(request: NextRequest) {
 
 		const checkoutSession = await stripe().checkout.sessions.create({
 			customer: customerId as string,
-			line_items: [{ price: priceId, quantity: quantity }],
+			line_items: [{ price: priceId, quantity: safeQuantity }],
 			mode: "subscription",
 			success_url: isOnBoarding
 				? `${serverEnv().WEB_URL}/dashboard/settings/organization?upgrade=true&session_id={CHECKOUT_SESSION_ID}`
@@ -84,7 +99,7 @@ export async function POST(request: NextRequest) {
 		if (checkoutSession.url) {
 			trackServerEvent(user.id, "checkout_started", {
 				price_id: priceId,
-				quantity: quantity,
+				quantity: safeQuantity,
 				platform: "web",
 			});
 

--- a/apps/web/app/api/settings/billing/subscribe/route.ts
+++ b/apps/web/app/api/settings/billing/subscribe/route.ts
@@ -13,10 +13,13 @@ export async function POST(request: NextRequest) {
 	let customerId = user?.stripeCustomerId;
 	const { priceId, quantity, isOnBoarding } = await request.json();
 
+	const environment =
+		serverEnv().VERCEL_ENV === "production" ? "production" : "development";
+
 	if (
 		!priceId ||
 		typeof priceId !== "string" ||
-		!isValidStripePlanPriceId(priceId)
+		!isValidStripePlanPriceId(priceId, environment)
 	) {
 		console.error("Invalid or missing priceId");
 		return Response.json(

--- a/packages/utils/src/constants/plans.ts
+++ b/packages/utils/src/constants/plans.ts
@@ -27,10 +27,19 @@ export const isValidStripePlanPriceId = (
 	priceId: string,
 	environment?: "development" | "production",
 ): boolean => {
-	if (environment) {
-		const envPlans = STRIPE_PLAN_IDS[environment];
+	const env =
+		environment ??
+		(process.env.VERCEL_ENV === "production"
+			? "production"
+			: process.env.VERCEL_ENV
+				? "development"
+				: undefined);
+
+	if (env) {
+		const envPlans = STRIPE_PLAN_IDS[env];
 		return priceId === envPlans.yearly || priceId === envPlans.monthly;
 	}
+
 	return VALID_STRIPE_PLAN_PRICE_IDS.has(priceId);
 };
 

--- a/packages/utils/src/constants/plans.ts
+++ b/packages/utils/src/constants/plans.ts
@@ -16,6 +16,24 @@ export const STRIPE_PLAN_IDS = {
 	},
 };
 
+export const VALID_STRIPE_PLAN_PRICE_IDS = new Set<string>([
+	STRIPE_PLAN_IDS.development.yearly,
+	STRIPE_PLAN_IDS.development.monthly,
+	STRIPE_PLAN_IDS.production.yearly,
+	STRIPE_PLAN_IDS.production.monthly,
+]);
+
+export const isValidStripePlanPriceId = (
+	priceId: string,
+	environment?: "development" | "production",
+): boolean => {
+	if (environment) {
+		const envPlans = STRIPE_PLAN_IDS[environment];
+		return priceId === envPlans.yearly || priceId === envPlans.monthly;
+	}
+	return VALID_STRIPE_PLAN_PRICE_IDS.has(priceId);
+};
+
 export const STRIPE_SIGNED_BAA_PRICE_IDS: Record<string, string> = {
 	development: "price_1U5xKIFJxA1XpeSsdg4Q8H3Z",
 	production: "price_1U6C99FJxA1XpeSsUg1rXHo2",


### PR DESCRIPTION
Resolves #2222
Linear: CAP-804

### Summary
`priceId` and `quantity` were previously passed from untrusted client requests directly to `stripe.checkout.sessions.create` across `guest-checkout`, `subscribe`, and desktop `POST /subscribe`. This permitted arbitrary Stripe price IDs to be submitted.

### Changes
1. **Allowlist Helpers (`packages/utils/src/constants/plans.ts`)**:
   - Added `VALID_STRIPE_PLAN_PRICE_IDS` containing official Pro subscription plan price IDs.
   - Added `isValidStripePlanPriceId(priceId, environment?)` validator.
2. **Endpoint Validation**:
   - `apps/web/app/api/settings/billing/guest-checkout/route.ts`: Validates `priceId` and bounds `quantity` to `[1, 1000]`.
   - `apps/web/app/api/settings/billing/subscribe/route.ts`: Validates `priceId` and bounds `quantity` to `[1, 1000]`.
   - `apps/web/app/api/desktop/[...route]/root.ts`: Refined Zod schema on `priceId` via `isValidStripePlanPriceId`.
3. **Automated Tests**:
   - Added `apps/web/__tests__/unit/subscribe-checkout.test.ts` verifying allowlist enforcement.
   - Extended `apps/web/__tests__/unit/mobile-checkout.test.ts` verifying rejection of arbitrary price IDs with HTTP 400.

### Verification
- `vitest run __tests__/unit/subscribe-checkout.test.ts __tests__/unit/mobile-checkout.test.ts`: 11/11 passed
- Biome formatted.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a shared Stripe Pro-price allowlist, applies it to guest, authenticated web, and desktop checkout endpoints, normalizes web checkout quantities, and adds allowlist-focused unit coverage.
- Arbitrary Stripe price IDs are now rejected before checkout-session creation.
- Quantity validation limits Stripe checkout quantities to integer values from 1 through 1000, defaulting invalid values to 1.
- Environment-specific Stripe validation remains incomplete because the endpoints accept known IDs from both test and live modes.
- Guest checkout analytics still reports the raw quantity rather than the normalized value sent to Stripe.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until checkout validation is restricted to the active Stripe environment; the guest analytics discrepancy is lower-impact but should also be corrected.

Known opposite-environment price IDs pass all three new validators and then fail during Stripe session creation, so the intended input validation remains incomplete and can produce failed checkouts and server errors. Guest checkout additionally records quantities that can differ from those actually submitted to Stripe.

**Files Needing Attention:** packages/utils/src/constants/plans.ts; apps/web/app/api/settings/billing/guest-checkout/route.ts; apps/web/app/api/settings/billing/subscribe/route.ts; apps/web/app/api/desktop/[...route]/root.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/utils/src/constants/plans.ts | Adds the shared plan-price allowlist and validator, but its default branch accepts both development and production IDs regardless of the active Stripe mode. |
| apps/web/app/api/settings/billing/guest-checkout/route.ts | Adds price and quantity validation; checkout uses the normalized quantity while analytics still records the raw input. |
| apps/web/app/api/settings/billing/subscribe/route.ts | Adds plan validation and consistently uses the normalized quantity for both Stripe and analytics, though validation is not deployment-specific. |
| apps/web/app/api/desktop/[...route]/root.ts | Adds allowlist refinement to desktop subscription requests, but accepts known price IDs from the opposite Stripe mode. |
| apps/web/__tests__/unit/subscribe-checkout.test.ts | Covers arbitrary-ID rejection and valid checkout creation, while explicitly codifying cross-environment acceptance. |
| apps/web/__tests__/unit/mobile-checkout.test.ts | Covers guest-checkout rejection of arbitrary IDs but does not verify normalized analytics quantity. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/app/api/settings/billing/guest-checkout/route.ts`, line 57 ([link](https://github.com/capsoftware/cap/blob/a802d7103db3c0bbbade9a75ddf4a3c42119c670/apps/web/app/api/settings/billing/guest-checkout/route.ts#L57)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Analytics records unsafe quantity**

   Stripe receives `safeQuantity`, but the `guest_checkout_started` event records `quantity || 1`. For inputs such as `-5`, `1.5`, `"abc"`, or `2000`, billing uses 1 while analytics records the invalid raw value. This makes checkout telemetry disagree with the session that was actually created.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/app/api/settings/billing/guest-checkout/route.ts
   Line: 57

   Comment:
   **Analytics records unsafe quantity**

   Stripe receives `safeQuantity`, but the `guest_checkout_started` event records `quantity || 1`. For inputs such as `-5`, `1.5`, `"abc"`, or `2000`, billing uses 1 while analytics records the invalid raw value. This makes checkout telemetry disagree with the session that was actually created.

   

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/utils/src/constants/plans.ts:33
**Cross-environment prices pass validation**

The fallback allowlist accepts both test and live price IDs, and all three checkout endpoints call it without specifying the deployment environment. A production request containing a known development price ID therefore passes validation before Stripe rejects it against the live secret key, causing checkout to fail with a server error. Development and preview deployments have the inverse problem. Please validate against the deployment-specific price IDs.

### Issue 2
apps/web/app/api/settings/billing/guest-checkout/route.ts:57
**Analytics records unsafe quantity**

Stripe receives `safeQuantity`, but the `guest_checkout_started` event records `quantity || 1`. For inputs such as `-5`, `1.5`, `"abc"`, or `2000`, billing uses 1 while analytics records the invalid raw value. This makes checkout telemetry disagree with the session that was actually created.

```suggestion
					quantity: safeQuantity,
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): validate priceId against a..."](https://github.com/capsoftware/cap/commit/a802d7103db3c0bbbade9a75ddf4a3c42119c670) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61363516)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->