### PR TITLE
fix: keep the site header identical across pages

### DIFF
--- a/apps/web/app/(site)/Navbar.tsx
+++ b/apps/web/app/(site)/Navbar.tsx
@@ -12,7 +12,7 @@ interface NavbarProps {
 export const Navbar = ({ stars }: NavbarProps) => {
 	return (
 		<NavbarFrame>
-			<div className="flex gap-4 justify-between items-center px-5 mx-auto h-[68px] max-w-[1440px] group-data-[flat=true]:max-w-none group-data-[island=true]:h-[60px] group-data-[island=true]:px-4 lg:h-[76px] lg:px-8 lg:group-data-[island=true]:h-[64px] lg:group-data-[island=true]:px-5 xl:gap-6">
+			<div className="flex gap-4 justify-between items-center px-5 mx-auto h-[68px] group-data-[island=true]:h-[60px] group-data-[island=true]:px-4 lg:h-[76px] lg:px-8 lg:group-data-[island=true]:h-[64px] lg:group-data-[island=true]:px-5 xl:gap-6">
 				<div className="flex gap-2 items-center lg:gap-3 xl:gap-6">
 					<Link passHref href="/home" className="shrink-0">
 						<Logo

--- a/apps/web/app/(site)/NavbarFrame.tsx
+++ b/apps/web/app/(site)/NavbarFrame.tsx
@@ -1,25 +1,53 @@
 "use client";
 
 import { classNames } from "@cap/utils/helpers";
-import { usePathname } from "next/navigation";
-import { type ReactNode, useEffect, useState } from "react";
+import {
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+	useSyncExternalStore,
+} from "react";
 
-const FLAT_HEADER_ROUTES = new Set(["/", "/home"]);
 const EASE = "cubic-bezier(0.22, 1, 0.36, 1)";
 const SLIDE_MS = 560;
 const DOCK_AT = 80;
 
 type Phase = "docked" | "entering" | "floating" | "leaving";
 
+const readSentinel = () => document.querySelector("[data-header-sentinel]");
+const noSentinel = () => null;
+
+// The page declares the flat treatment with `data-header-flat` on its root, a
+// sibling of this header, and `:has(~ ...)` applies it in the prerendered HTML.
+// The island is driven by the page's `data-header-sentinel`, re-read whenever
+// the sibling page changes. Neither depends on `usePathname()`: Next prerenders
+// `/` with pathname `/index`, so a route-keyed header rendered the fixed bar on
+// the server and React kept those attributes after hydration.
 export const NavbarFrame = ({ children }: { children: ReactNode }) => {
-	const pathname = usePathname();
-	const flat = FLAT_HEADER_ROUTES.has(pathname);
+	const headerRef = useRef<HTMLElement>(null);
 	const [phase, setPhase] = useState<Phase>("docked");
 
-	useEffect(() => {
-		if (!FLAT_HEADER_ROUTES.has(pathname)) return;
-		const sentinel = document.querySelector("[data-header-sentinel]");
-		if (!sentinel) return;
+	const subscribeToPage = useCallback((onChange: () => void) => {
+		const slot = headerRef.current?.parentElement;
+		if (!slot) return () => {};
+		const observer = new MutationObserver(onChange);
+		observer.observe(slot, { childList: true });
+		return () => observer.disconnect();
+	}, []);
+	const sentinel = useSyncExternalStore(
+		subscribeToPage,
+		readSentinel,
+		noSentinel,
+	);
+
+	useLayoutEffect(() => {
+		if (!sentinel) {
+			setPhase("docked");
+			return;
+		}
 		const io = new IntersectionObserver(([entry]) => {
 			const past = entry
 				? !entry.isIntersecting && entry.boundingClientRect.top < 0
@@ -37,7 +65,7 @@ export const NavbarFrame = ({ children }: { children: ReactNode }) => {
 		});
 		io.observe(sentinel);
 		return () => io.disconnect();
-	}, [pathname]);
+	}, [sentinel]);
 
 	useEffect(() => {
 		if (phase === "entering") {
@@ -64,23 +92,23 @@ export const NavbarFrame = ({ children }: { children: ReactNode }) => {
 		}
 	}, [phase]);
 
-	const island = flat && phase !== "docked";
+	const island = sentinel !== null && phase !== "docked";
 	const shown = phase === "floating";
 
 	return (
 		<header
-			data-flat={flat ? "true" : "false"}
+			ref={headerRef}
 			data-island={island ? "true" : "false"}
 			className={classNames(
-				"group pointer-events-none inset-x-0 top-0 z-[51]",
-				flat && !island ? "absolute" : "fixed",
+				"group pointer-events-none inset-x-0 top-0 z-[51] fixed",
+				!island && "has-[~[data-header-flat]]:absolute",
 			)}
 		>
 			<div
 				className={classNames(
 					"pointer-events-auto mx-auto",
-					!flat && "max-w-none border-b border-zinc-200/70 bg-white",
-					flat && !island && "bg-transparent",
+					!island &&
+						"border-b border-zinc-200/70 bg-white group-has-[~[data-header-flat]]:border-b-0 group-has-[~[data-header-flat]]:bg-transparent",
 					island &&
 						"mt-3 max-w-[calc(100%-24px)] rounded-[18px] bg-white/90 shadow-[0_0_0_1px_rgba(17,17,17,0.06)] backdrop-blur-xl lg:mt-4 lg:max-w-[min(1200px,calc(100%-32px))]",
 				)}

--- a/apps/web/components/pages/HomeTwo/index.tsx
+++ b/apps/web/components/pages/HomeTwo/index.tsx
@@ -23,6 +23,7 @@ export function HomeTwoPage() {
 	// over them instead.
 	return (
 		<div
+			data-header-flat
 			className={`${htSans.className} ${htSans.variable} ${htSerif.variable} ${htMono.variable} text-[#111111]`}
 			style={grainBg(SHELL)}
 		>


### PR DESCRIPTION
## What

- The navbar row was clamped to 1440px on every page except the homepage, which was full-bleed. On wide screens the logo and buttons jumped by ~240px when navigating between `/home` and `/pricing`. The clamp is gone, so the header row is full-bleed everywhere.
- The flat homepage treatment was keyed on `usePathname()`. Next prerenders `/` with pathname `/index`, so production served the root page with the fixed white bar in the HTML, and React kept those attributes after hydration (see the live root vs `/home` markup). The page now declares the treatment with `data-header-flat` on its root and the header applies it with `:has(~ [data-header-flat])`, so the prerendered HTML is correct with no JS. The island logic re-reads the page's sentinel whenever the sibling page changes instead of watching the pathname.

## Verified

- Live production at 1920px: logo at x=272 on `/` and `/pricing`, x=32 on `/home`. Root page HTML has `data-flat="false"`.
- Local dev at 1920px with the fix: logo at x=32 on `/`, `/home`, `/pricing`; identical with JavaScript disabled; client navigation in both directions does not move the header; island still appears on scroll, dismisses on navigation, and re-attaches after navigating back.
- Biome clean, no tsc errors in the touched files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the marketing-site header layout consistent across routes and replaces pathname-based homepage styling with prerender-safe DOM markers.
- Removes the navbar’s 1440px width clamp.
- Declares the flat header treatment from HomeTwoPage markup.
- Re-evaluates the island sentinel when site page content changes.
- The implementation appears behaviorally sound, with automated regression coverage remaining the primary improvement.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only non-blocking regression-test coverage recommended for the new DOM-driven header lifecycle.

Both homepage routes render the marked page root as the header’s following sibling, and current navigation replaces an observed top-level child, so no concrete behavioral failure remains; the sole finding is missing automated coverage for this production-sensitive fix.

**Files Needing Attention:** apps/web/app/(site)/NavbarFrame.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/app/(site)/Navbar.tsx | Removes the navbar row’s maximum width so positioning remains full-bleed across marketing pages. |
| apps/web/app/(site)/NavbarFrame.tsx | Replaces pathname-dependent styling with sibling selectors and mutation-driven sentinel state; behavior is sound but lacks regression coverage. |
| apps/web/components/pages/HomeTwo/index.tsx | Adds the page-level marker that opts HomeTwo routes into the flat header treatment. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/app/(site)/NavbarFrame.tsx:40-44
**Missing Header Regression Coverage**

The new header behavior depends on a page-level DOM marker and a parent mutation observer, but no automated test covers the initial render or client navigation between flat and standard pages. A focused regression test for `/`, `/home`, and a standard site route would help prevent future layout or lifecycle changes from restoring the header jump or leaving stale island state.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: let the homepage declare its flat h..."](https://github.com/capsoftware/cap/commit/a6daa8aece548b10f7c2af29372600db3d8babb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61555135)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->