### PR TITLE
fix: recover valid audio probes and classify no-speech transcription

### DIFF
--- a/apps/media-server/Dockerfile
+++ b/apps/media-server/Dockerfile
@@ -15,6 +15,7 @@ RUN bun test src/__tests__/lib/audio-quality-policy.test.ts src/__tests__/lib/au
 	&& bun test src/__tests__/lib/audio-quality-formats.integration.test.ts src/__tests__/lib/audio-quality-benchmark.test.ts \
 	&& bun test src/__tests__/lib/drive-resumable-upload.test.ts src/__tests__/lib/storage-upload.test.ts src/__tests__/lib/container-memory.test.ts \
 	&& bun test src/__tests__/lib/media-size.test.ts src/__tests__/lib/media-probe.integration.test.ts \
+	&& bun test src/__tests__/lib/media-audio.integration.test.ts \
 	&& bun test src/__tests__/lib/recording-verification.integration.test.ts src/__tests__/lib/job-manager.test.ts \
 	&& bun test src/__tests__/lib/media-transfer.test.ts \
 	&& bun test src/__tests__/routes/recording-verification.test.ts \

--- a/apps/media-server/src/__tests__/lib/media-audio.integration.test.ts
+++ b/apps/media-server/src/__tests__/lib/media-audio.integration.test.ts
@@ -104,6 +104,48 @@ describe("mediaAudio integration tests", () => {
 			expect(hasAudio).toBe(false);
 		});
 
+		test.each([
+			[90, true],
+			[-90, true],
+			[180, true],
+			[90, false],
+		] as const)(
+			"detects audio with display rotation %i and audio=%s",
+			async (rotation, hasAudio) => {
+				const dirPath = await mkdtemp(join(tmpdir(), "cap-audio-rotation-"));
+				const outputPath = join(dirPath, "rotated.mp4");
+				try {
+					const proc = Bun.spawn({
+						cmd: [
+							"ffmpeg",
+							"-v",
+							"error",
+							"-display_rotation",
+							String(rotation),
+							"-i",
+							hasAudio ? TEST_VIDEO_WITH_AUDIO : TEST_VIDEO_NO_AUDIO,
+							"-c",
+							"copy",
+							outputPath,
+						],
+						stdout: "ignore",
+						stderr: "pipe",
+					});
+					const [stderr, exitCode] = await Promise.all([
+						new Response(proc.stderr).text(),
+						proc.exited,
+					]);
+					expect(stderr).toBe("");
+					expect(exitCode).toBe(0);
+					expect(await checkHasAudioTrack(`file://${outputPath}`)).toBe(
+						hasAudio,
+					);
+				} finally {
+					await rm(dirPath, { recursive: true, force: true });
+				}
+			},
+		);
+
 		test("inherits signed queries for relative HLS segments", async () => {
 			const dirPath = await createHlsFixture();
 			const requests: string[] = [];
@@ -130,6 +172,21 @@ describe("mediaAudio integration tests", () => {
 				expect(requests).toContain("/segment-000.ts?token=signed");
 			} finally {
 				await server.stop(true);
+				await rm(dirPath, { recursive: true, force: true });
+			}
+		});
+
+		test("still rejects audio-only inputs without leaking an operation", async () => {
+			const beforeCount = getActiveProcessCount();
+			const dirPath = await mkdtemp(join(tmpdir(), "cap-audio-only-"));
+			const outputPath = join(dirPath, "audio.mp3");
+			try {
+				await Bun.write(outputPath, await extractAudio(TEST_VIDEO_WITH_AUDIO));
+				await expect(
+					checkHasAudioTrack(`file://${outputPath}`),
+				).rejects.toThrow("No video stream found");
+				await waitForAudioOperations(beforeCount);
+			} finally {
 				await rm(dirPath, { recursive: true, force: true });
 			}
 		});

--- a/apps/media-server/src/lib/media-audio.ts
+++ b/apps/media-server/src/lib/media-audio.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { type Subprocess, spawn } from "bun";
+import { z } from "zod";
 import { withTimeout } from "./media-common";
 import {
 	canAcceptNewAudioOperation,
@@ -31,6 +32,9 @@ const MAX_AUDIO_SIZE_BYTES = 100 * 1024 * 1024;
 const MAX_STDERR_BYTES = 64 * 1024;
 const AUDIO_PROBE_MAX_ATTEMPTS = 3;
 const AUDIO_PROBE_RETRY_BASE_MS = 250;
+const AUDIO_PROBE_SCHEMA = z.object({
+	streams: z.array(z.object({ codec_type: z.string().optional() })),
+});
 
 const DEFAULT_OPTIONS: Required<AudioExtractionOptions> = {
 	format: "mp3",
@@ -144,7 +148,7 @@ function getAudioProbeArgs(inputPath: string): string[] {
 			"0",
 		);
 	}
-	args.push("-show_entries", "stream=codec_type", "-of", "csv=p=0", inputPath);
+	args.push("-show_entries", "stream=codec_type", "-of", "json", inputPath);
 	return args;
 }
 
@@ -224,10 +228,8 @@ async function probeAudioTracks(
 			const safeStderrText = redactProcessOutput(stderrText, sourceUrl);
 
 			if (exitCode === 0) {
-				const trackTypes = stdoutText
-					.split(/\r?\n/)
-					.map((value) => value.trim())
-					.filter(Boolean);
+				const { streams } = AUDIO_PROBE_SCHEMA.parse(JSON.parse(stdoutText));
+				const trackTypes = streams.map((stream) => stream.codec_type);
 				if (!trackTypes.includes("video")) {
 					throw new Error("No video stream found");
 				}

--- a/apps/web/__tests__/integration/transcribe-workflow.test.ts
+++ b/apps/web/__tests__/integration/transcribe-workflow.test.ts
@@ -98,9 +98,12 @@ vi.mock("drizzle-orm", () => ({
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("workflow", () => ({
-	FatalError: class FatalError extends Error {},
-}));
+vi.mock("workflow", async () => {
+	const { runInNewContext } = await import("node:vm");
+	return {
+		FatalError: runInNewContext("(class FatalError extends Error {})"),
+	};
+});
 
 vi.mock("workflow/api", () => ({
 	start: vi.fn(),
@@ -245,7 +248,9 @@ describe("transcribeVideoWorkflow", () => {
 		expect(mocks.updates.at(-1)).toEqual({ transcriptionStatus: "COMPLETE" });
 	});
 
-	it("marks audio without speech as skipped without retrying transcription", async () => {
+	it("handles no-speech errors across workflow realms without retrying transcription", async () => {
+		const { FatalError } = await import("workflow");
+		expect(new FatalError("no spoken audio")).not.toBeInstanceOf(Error);
 		mocks.transcribe.mockResolvedValueOnce({
 			id: "silent-transcript",
 			status: "error",
@@ -268,6 +273,7 @@ describe("transcribeVideoWorkflow", () => {
 		expect(mocks.updates).toContainEqual({ transcriptionStatus: "NO_AUDIO" });
 		expect(mocks.updates).not.toContainEqual({ transcriptionStatus: "ERROR" });
 		expect(mocks.startAiGeneration).not.toHaveBeenCalled();
+		expect(mocks.deleteObject).toHaveBeenCalledTimes(1);
 	});
 
 	it("preserves transcription failures unrelated to missing speech", async () => {

--- a/apps/web/workflows/transcribe.ts
+++ b/apps/web/workflows/transcribe.ts
@@ -162,7 +162,10 @@ export async function transcribeVideoWorkflow(
 		await saveTranscription(videoId, userId, videoData.video, transcription);
 	} catch (error) {
 		if (
-			error instanceof Error &&
+			typeof error === "object" &&
+			error !== null &&
+			"message" in error &&
+			typeof error.message === "string" &&
 			error.message.toLowerCase().includes("no spoken audio")
 		) {
 			await markNoAudio(videoId);


### PR DESCRIPTION
Valid MP4 uploads with display-matrix side data can fail transcription with `No video stream found`: FFprobe's CSV writer emits `video,`, which fails the exact-line comparison. Read and validate structured stream metadata instead. Keep the existing missing-video rejection, no-audio result, retries, deadlines, and cleanup.

Separately, Workflow reconstructs step failures outside the workflow VM. Its error is not an instance of the VM's `Error`, so AssemblyAI's `no spoken audio` response was incorrectly persisted as `ERROR`. Check the error's message structurally so these results reach the existing `NO_AUDIO` and cleanup path. Other failures still propagate.

The production investigation correlated 20 extraction errors to three recordings across five workflow runs, plus five separate no-speech results. Both defects predate the latest processing rollout. This patch adds no downloads, encoding passes, paid transcription calls, or migrations.

Validation:

- Reproduced both bugs before the fix: four generated rotation cases failed the old audio probe; the no-speech workflow test failed when the error came from a separate VM realm.
- The affected production file now passes the full streaming extraction endpoint; all 114 seconds of extracted audio decode successfully, the original SHA-256 is unchanged, and no active audio operation remains.
- Compared 21 production source samples before and after: only the failing recording changes; the other 20 retain their previous audio-detection result. Samples remain outside the repository.
- Docker production build: 398 passing tests, including the added audio integration gate and existing long-recording/transfer performance gates. Another 21 audio-route tests and six workflow tests pass.
- Scoped Biome and media TypeScript checks pass. Next route type generation and the web TypeScript project build pass.

No production recordings were retried or modified during validation. Deployment and recovery of the already-failed jobs remain separate actions.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes audio-track probing resilient to ffprobe display-matrix output by parsing structured JSON metadata and fixes no-speech transcription classification across workflow VM realms.
- Changes ffprobe stream detection from line-based CSV parsing to schema-validated JSON.
- Adds rotation, audio-only rejection, cleanup, cross-realm error, and no-speech cleanup coverage.
- Adds the media-audio integration suite to the media-server Docker build gate.
- Preserves propagation of transcription errors unrelated to missing speech.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the targeted probe and cross-realm transcription fixes supported by focused regression coverage.

No actionable failure remains: structured probing preserves the existing video/audio classifications, cleanup boundaries remain intact, and unrelated transcription failures continue to propagate.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/media-server/src/lib/media-audio.ts | Replaces fragile CSV stream parsing with validated JSON while preserving video and audio checks. |
| apps/media-server/src/__tests__/lib/media-audio.integration.test.ts | Adds integration coverage for rotated MP4s, silent video, audio-only rejection, and operation cleanup. |
| apps/media-server/Dockerfile | Adds the media-audio integration tests to the image build test gate. |
| apps/web/workflows/transcribe.ts | Uses structural error-message narrowing so cross-realm no-speech failures reach the existing NO_AUDIO path. |
| apps/web/__tests__/integration/transcribe-workflow.test.ts | Reproduces cross-realm Error behavior and verifies NO_AUDIO persistence, cleanup, and unrelated-error propagation. |

<sub>Reviews (1): Last reviewed commit: ["fix: classify no-speech errors across wo..."](https://github.com/capsoftware/cap/commit/94e883891fd2f54f29c8b6063a1a77443e66cf75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61606639)</sub>

<!-- /greptile_comment -->