### PR TITLE
fix: keep zoom selection on the new segment after a split

### DIFF
--- a/apps/desktop/src/routes/editor/context.ts
+++ b/apps/desktop/src/routes/editor/context.ts
@@ -112,6 +112,7 @@ import {
 	sortTrackSegments,
 } from "./timelineTracks";
 import { createProgressBar } from "./utils";
+import { splitZoomSegmentAt } from "./zoom-segments";
 
 export type ModalDialog =
 	| { type: "createPreset" }
@@ -604,26 +605,33 @@ export const [EditorContextProvider, useEditorContext] = createContextProvider(
 				});
 			},
 			splitZoomSegment: (index: number, time: number) => {
+				const segments = project.timeline?.zoomSegments;
+				const segment = segments?.[index];
+				if (!segment) return;
+
+				const newLengths = [segment.end - segment.start - time, time];
+				if (newLengths.some((l) => l < 1)) return;
+
+				let newSegmentIndex: number | null = null;
 				setProject(
 					"timeline",
 					"zoomSegments",
-					produce((segments) => {
-						const segment = segments[index];
-						if (!segment) return;
-
-						const newLengths = [segment.end - segment.start - time, time];
-
-						if (newLengths.some((l) => l < 1)) return;
-
-						segments.splice(index + 1, 0, {
-							...segment,
-							start: segment.start + time,
-							end: segment.end,
-						});
-						segments[index].end = segment.start + time;
-						sortTrackSegments(segments);
+					produce((zoomSegments) => {
+						const result = splitZoomSegmentAt(zoomSegments, index, time);
+						if (!result) return;
+						newSegmentIndex = result.newSegmentIndex;
 					}),
 				);
+
+				// The split + sort reorders the array, so the previously selected
+				// index can now point at the other half. Keep the user's selection
+				// on the new piece — the segment they were editing when they split it.
+				if (newSegmentIndex !== null)
+					setEditorState("timeline", "selection", {
+						type: "zoom",
+						indices: [newSegmentIndex],
+					});
+				else setEditorState("timeline", "selection", null);
 			},
 			deleteZoomSegments: (segmentIndices: number[]) => {
 				batch(() => {

--- a/apps/desktop/src/routes/editor/zoom-segments.test.ts
+++ b/apps/desktop/src/routes/editor/zoom-segments.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { splitZoomSegmentAt } from "./zoom-segments";
+
+type Segment = {
+	start: number;
+	end: number;
+	amount: number;
+};
+
+function segment(start: number, end: number, amount = 1.5): Segment {
+	return { start, end, amount };
+}
+
+describe("splitZoomSegmentAt", () => {
+	it("splits into left [start, start+time] and right [start+time, end]", () => {
+		const segments = [segment(10, 30)];
+		const result = splitZoomSegmentAt(segments, 0, 8);
+
+		expect(result).not.toBeNull();
+		expect(segments[0]).toMatchObject({ start: 10, end: 18 });
+		expect(segments[1]).toMatchObject({ start: 18, end: 30 });
+		expect(result?.newSegmentIndex).toBe(1);
+	});
+
+	it("preserves the segment's other properties on both halves", () => {
+		const segments = [segment(0, 10, 2.5)];
+		splitZoomSegmentAt(segments, 0, 4);
+
+		expect(segments[0].amount).toBe(2.5);
+		expect(segments[1].amount).toBe(2.5);
+	});
+
+	it("keeps the new (right) piece selectable after a re-sort around existing segments", () => {
+		const segments = [segment(0, 10), segment(20, 30), segment(40, 50)];
+		const result = splitZoomSegmentAt(segments, 1, 5);
+
+		expect(segments.map((s) => s.start)).toEqual([0, 20, 25, 40]);
+		expect(segments.map((s) => s.end)).toEqual([10, 25, 30, 50]);
+		expect(result?.newSegmentIndex).toBe(2);
+		expect(segments[result?.newSegmentIndex ?? -1]).toMatchObject({
+			start: 25,
+			end: 30,
+		});
+	});
+
+	it("rejects splits that would leave a piece shorter than one second", () => {
+		const segments = [segment(10, 30)];
+
+		expect(splitZoomSegmentAt(segments, 0, 0.5)).toBeNull();
+		expect(splitZoomSegmentAt(segments, 0, 20.5)).toBeNull();
+		expect(segments).toHaveLength(1);
+		expect(segments[0]).toMatchObject({ start: 10, end: 30 });
+	});
+
+	it("returns null for an out-of-bounds index without mutating the array", () => {
+		const segments = [segment(0, 10)];
+
+		expect(splitZoomSegmentAt(segments, 3, 5)).toBeNull();
+		expect(segments).toHaveLength(1);
+	});
+});

--- a/apps/desktop/src/routes/editor/zoom-segments.test.ts
+++ b/apps/desktop/src/routes/editor/zoom-segments.test.ts
@@ -23,6 +23,19 @@ describe("splitZoomSegmentAt", () => {
 		expect(result?.newSegmentIndex).toBe(1);
 	});
 
+	it("tracks the new piece by identity when the sort moves it past later segments", () => {
+		const segments = [segment(10, 20), segment(30, 40)];
+		const result = splitZoomSegmentAt(segments, 0, 5);
+
+		expect(segments.map((s) => s.start)).toEqual([10, 15, 30]);
+		expect(segments.map((s) => s.end)).toEqual([15, 20, 40]);
+		expect(result?.newSegmentIndex).toBe(1);
+		expect(segments[result?.newSegmentIndex ?? -1]).toMatchObject({
+			start: 15,
+			end: 20,
+		});
+	});
+
 	it("preserves the segment's other properties on both halves", () => {
 		const segments = [segment(0, 10, 2.5)];
 		splitZoomSegmentAt(segments, 0, 4);

--- a/apps/desktop/src/routes/editor/zoom-segments.ts
+++ b/apps/desktop/src/routes/editor/zoom-segments.ts
@@ -1,0 +1,39 @@
+import { sortTrackSegments } from "./timelineTracks";
+
+type ZoomSegmentLike = {
+	start: number;
+	end: number;
+};
+
+export type SplitZoomResult<ZoomSegment extends ZoomSegmentLike> = {
+	segments: ZoomSegment[];
+	// Post-sort index of the newly created (right) piece, so callers can keep
+	// the user's selection pointing at the segment they split instead of
+	// whichever piece the sort left at the old position.
+	newSegmentIndex: number;
+};
+
+export function splitZoomSegmentAt<ZoomSegment extends ZoomSegmentLike>(
+	segments: ZoomSegment[],
+	index: number,
+	time: number,
+): SplitZoomResult<ZoomSegment> | null {
+	const segment = segments[index];
+	if (!segment) return null;
+
+	const newLengths = [segment.end - segment.start - time, time];
+	if (newLengths.some((l) => l < 1)) return null;
+
+	segments.splice(index + 1, 0, {
+		...segment,
+		start: segment.start + time,
+		end: segment.end,
+	});
+	segments[index].end = segment.start + time;
+
+	const newSegmentIndex = sortTrackSegments(segments).indexOf(
+		segments[index + 1],
+	);
+
+	return { segments, newSegmentIndex };
+}

--- a/apps/desktop/src/routes/editor/zoom-segments.ts
+++ b/apps/desktop/src/routes/editor/zoom-segments.ts
@@ -31,9 +31,9 @@ export function splitZoomSegmentAt<ZoomSegment extends ZoomSegmentLike>(
 	});
 	segments[index].end = segment.start + time;
 
-	const newSegmentIndex = sortTrackSegments(segments).indexOf(
-		segments[index + 1],
-	);
+	const inserted = segments[index + 1];
+	const newSegmentIndex = sortTrackSegments(segments).indexOf(inserted);
+	if (newSegmentIndex === -1) return null;
 
 	return { segments, newSegmentIndex };
 }


### PR DESCRIPTION
## What

Splitting a zoom segment and then editing the newly created piece could silently edit the pre-split segment instead: `splitZoomSegment` re-sorted the segments array but left `editorState.timeline.selection` pointing at the old index — which after the sort can belong to the *other* half. The user then adjusts "the new zoom" while the changes land on the old one, and playback keeps zooming into the old area (#2230).

## Fix

- `splitZoomSegment` now keeps the selection on the **new (right) piece** after the split + re-sort.
- The split geometry moved into a pure helper, `zoom-segments.ts` (`splitZoomSegmentAt`), which computes the new piece's post-sort index where the mutation happens and can be unit-tested without Solid stores.
- The clip split already resets selection after re-ordering (the `didSplit` branch); zoom splits now follow the same principle instead of leaving a stale index.

## Testing

- New unit tests (`zoom-segments.test.ts`, 5 cases): split geometry, property preservation on both halves, post-sort selection index, <1s rejection, out-of-bounds no-op.
- `vitest run` in `apps/desktop`: 32 files / 270 tests pass.
- `biome check` clean on touched files; `tsc --noEmit` clean.

Fixes #2230

If the team prefers to route this through Algora as a funded bounty, happy to submit it there — otherwise glad to have it reviewed as a regular contribution.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61854752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/cap/-/pull-requests/capsoftware/cap/2254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until the helper preserves the new right piece's identity across sorting, because reordered inputs can still select the wrong segment.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Sorting loses segment identity** <a href="https://github.com/CapSoftware/Cap/pull/2254#discussion_r3963035936">▶</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/desktop/src/routes/editor/zoom-segments.ts:34-36
`sortTrackSegments` sorts the array in place before `segments[index + 1]` is evaluated. If sorting moves the newly created right piece, this lookup instead finds whichever segment now occupies that position. For example, splitting index 1 in `[0–10, 30–40, 20–25]` returns the left piece's index, so the editor selects the wrong segment and the selection bug remains.

```suggestion
	const newSegment = segments[index + 1];
	const newSegmentIndex = sortTrackSegments(segments).indexOf(newSegment);
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Preserves zoom properties and enforces the existing one-second minimum.
- Adds unit coverage for geometry, property preservation, boundaries, and a normal sorted-array case.
- The new-piece index calculation still loses the inserted object's identity when sorting changes its position, so the intended selection fix is incomplete.
</details>

<!-- /greptile_comment -->