### PR TITLE
fix: start share previews and playback without extra waits

### DIFF
--- a/apps/web/__tests__/unit/initial-playback-url.test.ts
+++ b/apps/web/__tests__/unit/initial-playback-url.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { resolveInitialPlaybackUrl } from "@/app/s/[videoId]/_components/initial-playback-url";
+
+const url = "https://cap.so/api/storage/object?token=example";
+
+function streamedPromise(promise: Promise<string | null>) {
+	return new Proxy(promise, {
+		get(target, property, receiver) {
+			if (property === "then") {
+				return (
+					resolve: (value: string | null) => void,
+					reject: (error: unknown) => void,
+				) => {
+					void target.then(resolve, reject);
+				};
+			}
+			return Reflect.get(target, property, receiver);
+		},
+	});
+}
+
+describe("initial share playback URL", () => {
+	it("reads a streamed promise whose then and catch do not return a promise", async () => {
+		const streamed = streamedPromise(Promise.resolve(url));
+		expect(streamed.catch(() => null)).toBeUndefined();
+		await expect(resolveInitialPlaybackUrl(streamed)).resolves.toBe(url);
+	});
+
+	it("waits for a URL that arrives in a later server chunk", async () => {
+		let sendUrl: (value: string) => void = () => {};
+		const streamed = streamedPromise(
+			new Promise((resolve) => {
+				sendUrl = resolve;
+			}),
+		);
+		const resolved = resolveInitialPlaybackUrl(streamed);
+		sendUrl(url);
+		await expect(resolved).resolves.toBe(url);
+	});
+
+	it("falls back when server signing rejects", async () => {
+		const streamed = streamedPromise(Promise.reject(new Error("Unavailable")));
+		await expect(resolveInitialPlaybackUrl(streamed)).resolves.toBeNull();
+	});
+
+	it("accepts ordinary promises and preserves absent URLs", async () => {
+		await expect(resolveInitialPlaybackUrl(Promise.resolve(url))).resolves.toBe(
+			url,
+		);
+		await expect(
+			resolveInitialPlaybackUrl(Promise.resolve(null)),
+		).resolves.toBeNull();
+		await expect(resolveInitialPlaybackUrl(undefined)).resolves.toBeUndefined();
+	});
+});

--- a/apps/web/__tests__/unit/video-preview-gif.test.ts
+++ b/apps/web/__tests__/unit/video-preview-gif.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import { act, type ComponentProps, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VideoPreviewGif } from "@/app/s/[videoId]/_components/VideoPreviewGif";
+
+vi.mock("next/image", () => ({
+	default: ({
+		fill: _fill,
+		unoptimized: _unoptimized,
+		...props
+	}: ComponentProps<"img"> & { fill?: boolean; unoptimized?: boolean }) =>
+		createElement("img", props),
+}));
+
+type PreviewProps = ComponentProps<typeof VideoPreviewGif>;
+
+const videoId = "w941rez2vj5aq98" as PreviewProps["videoId"];
+
+describe("share video preview startup", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeEach(() => {
+		vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+		container = document.createElement("div");
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(async () => {
+		await act(async () => root.unmount());
+		container.remove();
+		vi.unstubAllGlobals();
+	});
+
+	const render = (props: Partial<PreviewProps> = {}) =>
+		act(async () => {
+			root.render(
+				createElement(VideoPreviewGif, {
+					videoId,
+					visible: false,
+					preload: true,
+					...props,
+				}),
+			);
+		});
+
+	it("exposes the GIF in server HTML before the video is ready", () => {
+		const html = renderToStaticMarkup(
+			createElement(VideoPreviewGif, {
+				videoId,
+				visible: false,
+				preload: true,
+			}),
+		);
+		expect(html).toContain("/api/video/preview?videoId=w941rez2vj5aq98");
+		expect(html).toContain('loading="eager"');
+		expect(html).toContain('fetchPriority="high"');
+		expect(html).toContain("opacity-0");
+	});
+
+	it("loads once while hidden and reveals the same image when playback is ready", async () => {
+		await render();
+		const image = container.querySelector("img");
+		expect(image).not.toBeNull();
+		await act(async () => image?.dispatchEvent(new Event("load")));
+		expect(image?.className).toContain("opacity-0");
+		await render({ visible: true });
+		expect(container.querySelector("img")).toBe(image);
+		expect(image?.className).toContain("opacity-100");
+	});
+
+	it("does not fetch a disabled preview and removes it after playback begins", async () => {
+		await render({ preload: false });
+		expect(container.querySelector("img")).toBeNull();
+		await render({ visible: true });
+		expect(container.querySelector("img")).not.toBeNull();
+		await render({ preload: false });
+		expect(container.querySelector("img")).toBeNull();
+	});
+
+	it("keeps a missing GIF out of the player and retries for a different video", async () => {
+		await render();
+		await act(async () =>
+			container.querySelector("img")?.dispatchEvent(new Event("error")),
+		);
+		await render({ visible: true });
+		expect(container.querySelector("img")).toBeNull();
+		await render({
+			videoId: "another-video" as PreviewProps["videoId"],
+			visible: true,
+		});
+		const image = container.querySelector("img");
+		expect(image?.src).toContain("videoId=another-video");
+		expect(image?.className).toContain("opacity-0");
+		await act(async () => image?.dispatchEvent(new Event("load")));
+		expect(image?.className).toContain("opacity-100");
+	});
+});

--- a/apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx
+++ b/apps/web/app/s/[videoId]/_components/CapVideoPlayer.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 import { retryVideoProcessing } from "@/actions/video/retry-processing";
 import CommentStamp from "./CommentStamp";
 import { bindCaptionTrackCueText } from "./caption-tracks";
+import { resolveInitialPlaybackUrl } from "./initial-playback-url";
 import {
 	AVC_LEVEL_IOS_HARDWARE_CEILING,
 	createLevelPatchedMp4ObjectUrl,
@@ -254,7 +255,7 @@ export function CapVideoPlayer({
 					return resolvePlaybackSource({
 						videoSrc,
 						initialUrl: useInitialUrl
-							? await initialPlaybackUrl?.catch(() => null)
+							? await resolveInitialPlaybackUrl(initialPlaybackUrl)
 							: undefined,
 						rawFallbackSrc,
 						enableCrossOrigin,
@@ -712,6 +713,13 @@ export function CapVideoPlayer({
 			)}
 			<VideoPreviewGif
 				videoId={videoId}
+				preload={
+					!disablePreviewGif &&
+					!hasActiveUpload &&
+					!hasPlayedOnce &&
+					!showUploadFailureOverlay &&
+					!showPlaybackResolutionError
+				}
 				visible={
 					!disablePreviewGif &&
 					videoLoaded &&

--- a/apps/web/app/s/[videoId]/_components/HLSVideoPlayer.tsx
+++ b/apps/web/app/s/[videoId]/_components/HLSVideoPlayer.tsx
@@ -743,6 +743,13 @@ export function HLSVideoPlayer({
 			</AnimatePresence>
 			<VideoPreviewGif
 				videoId={videoId}
+				preload={
+					!hasActiveUpload &&
+					!hasPlayedOnce &&
+					!hasFailedOrError &&
+					!isLiveSegments &&
+					!isBackgroundPreview
+				}
 				visible={
 					videoLoaded &&
 					!hasPlayedOnce &&

--- a/apps/web/app/s/[videoId]/_components/VideoPreviewGif.tsx
+++ b/apps/web/app/s/[videoId]/_components/VideoPreviewGif.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 interface VideoPreviewGifProps {
 	videoId: Video.VideoId;
 	visible: boolean;
+	preload?: boolean;
 	className?: string;
 }
 
@@ -18,28 +19,46 @@ function getPreviewGifSrc(videoId: Video.VideoId) {
 export function VideoPreviewGif({
 	videoId,
 	visible,
+	preload = visible,
+	className,
+}: VideoPreviewGifProps) {
+	if (!preload && !visible) return null;
+
+	return (
+		<PreviewGifImage
+			key={videoId}
+			videoId={videoId}
+			visible={visible}
+			className={className}
+		/>
+	);
+}
+
+function PreviewGifImage({
+	videoId,
+	visible,
 	className,
 }: VideoPreviewGifProps) {
 	const [status, setStatus] = useState<"loading" | "loaded" | "error">(
 		"loading",
 	);
 
-	if (!visible || status === "error") return null;
+	if (status === "error") return null;
 
 	return (
 		<Image
-			key={videoId}
 			src={getPreviewGifSrc(videoId)}
 			alt=""
 			aria-hidden="true"
 			unoptimized
 			fill
 			sizes="(max-width: 768px) 100vw, 75vw"
-			priority
+			loading="eager"
+			fetchPriority="high"
 			draggable={false}
 			className={clsx(
 				"object-contain absolute inset-0 z-[5] w-full h-full pointer-events-none transition-opacity duration-200",
-				status === "loaded" ? "opacity-100" : "opacity-0",
+				visible && status === "loaded" ? "opacity-100" : "opacity-0",
 				className,
 			)}
 			onLoad={() => setStatus("loaded")}

--- a/apps/web/app/s/[videoId]/_components/initial-playback-url.ts
+++ b/apps/web/app/s/[videoId]/_components/initial-playback-url.ts
@@ -1,0 +1,9 @@
+export async function resolveInitialPlaybackUrl(
+	url: PromiseLike<string | null> | undefined,
+) {
+	try {
+		return await url;
+	} catch {
+		return null;
+	}
+}


### PR DESCRIPTION
Share pages waited for video readiness before requesting their GIF, and the server-provided playback URL was lost because React streamed promises do not return a chained value from `.catch()`. Await the streamed URL directly with error handling and preload eligible GIFs while the video initializes. Existing preview visibility, controls, upload gates and playback fallbacks remain in place.

Validation: 49 focused tests, the current main playback resolver suite (27 tests), TypeScript and scoped Biome pass. In two controlled Chromium comparisons on the reported 41-second recording, average preview visibility improved from 3.54s to 2.24s and video readiness from 2.72s to 2.24s. Both candidate runs requested one GIF and skipped the playlist API call, with no browser errors. Playback, seek and Timeline were checked using isolated browser response overrides with matching server image markup; this is not a deployed benchmark. Safari, Firefox and native iOS were not tested.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62099859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/cap/-/pull-requests/capsoftware/cap/2258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no outstanding correctness, security, or repository-rule issues identified.

<details><summary><h3>Summary</h3></summary>

- Resolves streamed playback thenables without relying on chained `.catch()` return values.
- Preloads preview GIFs while preserving visibility, upload, failure, and playback gates.
- Adds focused coverage for streamed URL resolution and preview-image lifecycle behavior.
</details>

<!-- /greptile_comment -->