### PR TITLE
fix: group transcript captions into readable sentences

### DIFF
--- a/apps/web/__tests__/integration/live-transcribe-diarization.test.ts
+++ b/apps/web/__tests__/integration/live-transcribe-diarization.test.ts
@@ -1,0 +1,124 @@
+import { Effect, Option } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyLiveTranscript } from "@/lib/live-transcribe-core";
+
+const mocks = vi.hoisted(() => ({
+	queue: vi.fn(),
+	objects: new Map<string, string>(),
+	writes: [] as string[],
+}));
+const video = {
+	id: "live-video",
+	ownerId: "live-owner",
+	source: { type: "desktopSegments" },
+	transcriptionStatus: null,
+	settings: null,
+};
+vi.mock("@cap/env", () => ({
+	serverEnv: () => ({ ASSEMBLY_API_KEY: "test-key" }),
+}));
+vi.mock("@cap/database/schema", () => ({
+	videos: {
+		id: "video-id",
+		ownerId: "owner-id",
+		metadata: "metadata",
+		updatedAt: "updated-at",
+	},
+	organizations: { id: "org-id", settings: "settings" },
+	users: { id: "user-id" },
+}));
+vi.mock("@cap/database", () => ({
+	db: () => ({
+		select: () => ({
+			from: () => ({
+				leftJoin: () => ({ where: async () => [{ video, orgSettings: null }] }),
+				where: async () => [video],
+			}),
+		}),
+		update: () => ({ set: () => ({ where: async () => [] }) }),
+	}),
+}));
+vi.mock("@cap/web-backend/src/Storage/index", () => ({
+	Storage: {
+		getAccessForVideo: () =>
+			Effect.succeed([
+				{
+					getObject: (key: string) =>
+						Effect.succeed(Option.fromNullable(mocks.objects.get(key))),
+					putObject: (key: string, value: string) =>
+						Effect.sync(() => {
+							mocks.writes.push(key);
+							mocks.objects.set(key, value);
+						}),
+				},
+			]),
+	},
+}));
+vi.mock("@/lib/video-storage", () => ({ decodeStorageVideo: () => ({}) }));
+vi.mock("@/lib/workflow-runtime", () => ({
+	runWorkflowPromise: Effect.runPromise,
+}));
+vi.mock("@/lib/transcribe", () => ({ transcribeVideo: mocks.queue }));
+vi.mock("@/lib/ai-generation-entitlement", () => ({
+	isAiGenerationEnabledForUser: () => false,
+}));
+
+const artifactKey = "live-owner/live-video/transcription.live.json";
+beforeEach(() => {
+	mocks.objects.clear();
+	mocks.writes.length = 0;
+	mocks.queue.mockResolvedValue({ success: true, message: "Queued" });
+	mocks.objects.set(
+		artifactKey,
+		JSON.stringify({
+			...createEmptyLiveTranscript("2026-09-08T00:00:00.000Z"),
+			lastAudioSegmentIndex: 2,
+			transcribedDurationMs: 4000,
+		}),
+	);
+	mocks.objects.set(
+		"live-owner/live-video/segments/manifest.json",
+		JSON.stringify({
+			version: 5,
+			video_init_uploaded: true,
+			audio_init_uploaded: true,
+			video_segments: [],
+			audio_segments: [
+				{ index: 1, duration: 2 },
+				{ index: 2, duration: 2 },
+			],
+			is_complete: true,
+		}),
+	);
+});
+
+describe("live recording diarization handoff", () => {
+	it("queues a full recording pass even when provisional chunks cover every segment", async () => {
+		const { liveTranscribeWorkflow } = await import(
+			"@/workflows/live-transcribe"
+		);
+		await liveTranscribeWorkflow({ videoId: video.id, userId: video.ownerId });
+		expect(mocks.queue).toHaveBeenCalledExactlyOnceWith(
+			video.id,
+			video.ownerId,
+			false,
+			{ earlyFromSegments: true },
+		);
+		expect(mocks.writes).toEqual([artifactKey]);
+		expect(JSON.parse(mocks.objects.get(artifactKey) ?? "{}").state).toBe(
+			"complete",
+		);
+	});
+	it("surfaces queue failures so the durable workflow retries the final transcription", async () => {
+		mocks.queue.mockResolvedValue({
+			success: false,
+			message: "Queue unavailable",
+		});
+		const { liveTranscribeWorkflow } = await import(
+			"@/workflows/live-transcribe"
+		);
+		await expect(
+			liveTranscribeWorkflow({ videoId: video.id, userId: video.ownerId }),
+		).rejects.toThrow("Queue unavailable");
+	});
+});

--- a/apps/web/__tests__/integration/transcribe-workflow.test.ts
+++ b/apps/web/__tests__/integration/transcribe-workflow.test.ts
@@ -206,6 +206,9 @@ describe("transcribeVideoWorkflow", () => {
 
 		expect(result.success).toBe(true);
 		expect(mocks.transcribe).toHaveBeenCalledTimes(1);
+		expect(mocks.transcribe).toHaveBeenCalledWith(
+			expect.objectContaining({ speaker_labels: true }),
+		);
 		expect(mocks.transcribe.mock.calls[0]?.[0]).toMatchObject({
 			disfluencies: true,
 			speech_models: ["universal-3-5-pro", "universal-2"],
@@ -265,6 +268,9 @@ describe("transcribeVideoWorkflow", () => {
 			message: "Video has no spoken audio - skipped transcription",
 		});
 		expect(mocks.transcribe).toHaveBeenCalledTimes(1);
+		expect(mocks.transcribe).toHaveBeenCalledWith(
+			expect.objectContaining({ speaker_labels: true }),
+		);
 		expect(mocks.updates).toContainEqual({ transcriptionStatus: "NO_AUDIO" });
 		expect(mocks.updates).not.toContainEqual({ transcriptionStatus: "ERROR" });
 		expect(mocks.startAiGeneration).not.toHaveBeenCalled();

--- a/apps/web/__tests__/unit/caption-cues.test.ts
+++ b/apps/web/__tests__/unit/caption-cues.test.ts
@@ -20,9 +20,11 @@ describe("getActiveCaptionText", () => {
 	it("uses the latest active cue when cues overlap", () => {
 		const activeCues = createCueList([
 			{ startTime: 0, text: "First caption" },
-			{ startTime: 3.199, text: "<v Speaker>Second caption</v>" },
+			{ startTime: 3.199, text: "<v Speaker B>Second &amp; final caption</v>" },
 		]);
 
-		expect(getActiveCaptionText(activeCues)).toBe("Second caption");
+		expect(getActiveCaptionText(activeCues)).toBe(
+			"Speaker B: Second & final caption",
+		);
 	});
 });

--- a/apps/web/__tests__/unit/diarization.test.ts
+++ b/apps/web/__tests__/unit/diarization.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { formatTranscriptAsVTT } from "@/app/s/[videoId]/_components/utils/transcript-utils";
+import {
+	createEditTranscript,
+	editTranscriptWordsToCaptionVtt,
+	groupEditTranscriptWords,
+	parseEditTranscript,
+	remapEditTranscriptThroughSpec,
+	serializeEditTranscript,
+} from "@/lib/edit-transcript";
+import { formatTranscriptAsParagraphs } from "@/lib/transcript-text";
+import {
+	formatVttCueText,
+	parseVTT,
+	parseVttCueText,
+	updateVttEntryText,
+} from "@/lib/transcript-vtt";
+
+const transcript = createEditTranscript(
+	{
+		words: [
+			{ text: "Hello", start: 100, end: 300, speaker: "A" },
+			{ text: "there", start: 300, end: 600, speaker: "A" },
+			{ text: "Hi", start: 650, end: 800, speaker: "B" },
+			{ text: "again", start: 850, end: 1000, speaker: "A" },
+			{ text: "unknown", start: 1100, end: 1300, speaker: null },
+		],
+	},
+	2000,
+);
+
+describe("speaker diarization", () => {
+	it("splits captions on every speaker transition without needing punctuation or silence", () => {
+		const cues = parseVTT(editTranscriptWordsToCaptionVtt(transcript.words));
+		expect(
+			cues.map(({ text, speaker, startTime, endTime }) => ({
+				text,
+				speaker,
+				startTime,
+				endTime,
+			})),
+		).toEqual([
+			{ text: "Hello there", speaker: "A", startTime: 0.1, endTime: 0.6 },
+			{ text: "Hi", speaker: "B", startTime: 0.65, endTime: 0.8 },
+			{ text: "again", speaker: "A", startTime: 0.85, endTime: 1 },
+			{ text: "unknown", speaker: null, startTime: 1.1, endTime: 1.3 },
+		]);
+	});
+
+	it("preserves labels through storage, video cuts, caption regeneration, and download", () => {
+		const stored = parseEditTranscript(serializeEditTranscript(transcript));
+		expect(stored).not.toBeNull();
+		if (!stored) throw new Error("Missing transcript");
+		const edited = remapEditTranscriptThroughSpec(stored, {
+			version: 1,
+			sourceDuration: 2,
+			keepRanges: [{ start: 0.6, end: 2 }],
+		});
+		const cues = parseVTT(editTranscriptWordsToCaptionVtt(edited.words));
+		expect(cues[0]).toMatchObject({
+			text: "Hi",
+			speaker: "B",
+			startTime: 0.05,
+		});
+		expect(parseVTT(formatTranscriptAsVTT(cues))).toEqual(cues);
+	});
+
+	it("shows separate editor groups and text paragraphs for speakers and unknown speech", () => {
+		expect(
+			groupEditTranscriptWords(transcript.words).map(
+				({ startIndex, endIndex }) => [startIndex, endIndex],
+			),
+		).toEqual([
+			[0, 1],
+			[2, 2],
+			[3, 3],
+			[4, 4],
+		]);
+		expect(
+			formatTranscriptAsParagraphs(
+				parseVTT(editTranscriptWordsToCaptionVtt(transcript.words)),
+			),
+		).toBe(
+			"Speaker A: Hello there\n\nSpeaker B: Hi\n\nSpeaker A: again\n\nunknown",
+		);
+	});
+
+	it("preserves the voice when editing spoken text and escapes markup", () => {
+		const vtt = editTranscriptWordsToCaptionVtt(transcript.words);
+		const updated = updateVttEntryText(vtt, 2, "Yes <script> & no");
+		expect(updated.updated).toBe(true);
+		expect(updated.content).toContain(
+			"<v Speaker B>Yes &lt;script&gt; &amp; no</v>",
+		);
+		expect(parseVTT(updated.content)[1]).toMatchObject({
+			speaker: "B",
+			text: "Yes <script> & no",
+			startTime: 0.65,
+			endTime: 0.8,
+		});
+	});
+
+	it("handles multiline voice cues, legacy plain cues, and escaped labels", () => {
+		const cues = parseVTT(
+			"WEBVTT\r\n\r\n1\r\n00:00:00.125 --> 00:00:01.500\r\n<v Speaker A>Hello\r\nthere</v>\r\n\r\n2\r\n00:00:01.500 --> 00:00:02.000\r\nLegacy text\r\n",
+		);
+		expect(cues[0]).toMatchObject({
+			text: "Hello there",
+			speaker: "A",
+			startTime: 0.125,
+			endTime: 1.5,
+		});
+		expect(cues[1]).toMatchObject({ text: "Legacy text", speaker: null });
+		expect(parseVttCueText(formatVttCueText("2 < 3 & 4 > 1", "A & B"))).toEqual(
+			{ text: "2 < 3 & 4 > 1", speaker: "A & B" },
+		);
+	});
+});
+
+it("keeps speaker metadata and literal text through the agent transcript API", async () => {
+	const { parseAgentVtt, renderAgentVtt } = await import("@/lib/agent-api");
+	const cues = [
+		{ startMs: 125, endMs: 500, text: "R&D < planning", speaker: "B" },
+	];
+	expect(parseAgentVtt(renderAgentVtt(cues))).toEqual(cues);
+});

--- a/apps/web/__tests__/unit/live-transcribe-core.test.ts
+++ b/apps/web/__tests__/unit/live-transcribe-core.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
 	applyChunkToLiveTranscript,
-	canPromoteLiveTranscript,
 	createEmptyLiveTranscript,
 	isNoSpokenAudioError,
-	liveTranscriptToEditTranscript,
 	offsetChunkWords,
 	parseLiveTranscript,
 	planNextLiveChunk,
@@ -245,95 +243,6 @@ describe("live transcript artifact", () => {
 	it("rejects malformed artifacts", () => {
 		expect(parseLiveTranscript("not json")).toBeNull();
 		expect(parseLiveTranscript(JSON.stringify({ version: 99 }))).toBeNull();
-	});
-});
-
-describe("canPromoteLiveTranscript", () => {
-	const fullCoverage = (overrides = {}) => ({
-		...createEmptyLiveTranscript("2026-08-03T00:00:00.000Z"),
-		lastAudioSegmentIndex: 3,
-		transcribedDurationMs: 6000,
-		...overrides,
-	});
-	const completeManifest = {
-		...baseManifest,
-		audio_segments: [seg(1), seg(2), seg(3)],
-		is_complete: true,
-	};
-
-	it("promotes only full gap-free coverage", () => {
-		expect(canPromoteLiveTranscript(fullCoverage(), completeManifest)).toEqual({
-			ok: true,
-		});
-	});
-
-	it("declines incomplete manifests, partial coverage, and skipped chunks", () => {
-		expect(
-			canPromoteLiveTranscript(fullCoverage(), {
-				...completeManifest,
-				is_complete: false,
-			}).ok,
-		).toBe(false);
-		expect(
-			canPromoteLiveTranscript(
-				fullCoverage({ lastAudioSegmentIndex: 2 }),
-				completeManifest,
-			).ok,
-		).toBe(false);
-		expect(
-			canPromoteLiveTranscript(
-				fullCoverage({ hasGaps: true }),
-				completeManifest,
-			).ok,
-		).toBe(false);
-	});
-
-	it("declines manifests with segment index gaps", () => {
-		expect(
-			canPromoteLiveTranscript(fullCoverage({ lastAudioSegmentIndex: 4 }), {
-				...completeManifest,
-				audio_segments: [seg(1), seg(2), seg(4)],
-			}).ok,
-		).toBe(false);
-	});
-
-	it("declines recordings with no audio", () => {
-		expect(
-			canPromoteLiveTranscript(fullCoverage(), {
-				...completeManifest,
-				audio_segments: [],
-			}).ok,
-		).toBe(false);
-	});
-});
-
-describe("liveTranscriptToEditTranscript", () => {
-	it("shapes accumulated words as a canonical v3 edit transcript", () => {
-		const artifact = applyChunkToLiveTranscript(
-			createEmptyLiveTranscript("2026-08-03T00:00:00.000Z"),
-			{
-				startMs: 0,
-				durationMs: 4000,
-				lastAudioSegmentIndex: 2,
-				words: offsetChunkWords(
-					[{ text: "Hello", start: 10, end: 500 }],
-					0,
-					4000,
-				),
-				languageCode: "en",
-				nowIso: "2026-08-03T00:00:05.000Z",
-			},
-		);
-
-		const edit = liveTranscriptToEditTranscript(artifact, "universal-3-5-pro");
-		expect(edit).toMatchObject({
-			version: 3,
-			speechModelUsed: "universal-3-5-pro",
-			durationMs: 4000,
-			languageCode: "en",
-		});
-		expect(edit.words).toHaveLength(1);
-		expect(edit.words[0]).toMatchObject({ text: "Hello", startMs: 10 });
 	});
 });
 

--- a/apps/web/__tests__/unit/slack-app-manifest.test.ts
+++ b/apps/web/__tests__/unit/slack-app-manifest.test.ts
@@ -32,7 +32,7 @@ describe("Slack app manifest", () => {
 
 		expect(manifest.display_information).toMatchObject({
 			description: "Use Cap directly inside Slack.",
-			background_color: "#4785FF",
+			background_color: "#1e60e6",
 		});
 		expect(manifest.features.unfurl_domains).toEqual(["cap.so", "cap.link"]);
 		expect(manifest.oauth_config.scopes.bot).toEqual([

--- a/apps/web/__tests__/unit/transcribe-language.test.ts
+++ b/apps/web/__tests__/unit/transcribe-language.test.ts
@@ -28,6 +28,7 @@ describe("AI generation language support", () => {
 			language_detection: true,
 		});
 		expect(options.disfluencies).toBe(true);
+		expect(options.speaker_labels).toBe(true);
 		if (!("language_detection_options" in options)) {
 			throw new Error("Expected automatic language detection options");
 		}
@@ -47,4 +48,11 @@ describe("AI generation language support", () => {
 			language_code: "zh",
 		});
 	});
+});
+
+it("keeps independent live chunks free of recording-wide speaker labels", () => {
+	expect(
+		getAssemblyAITranscriptionOptions("en", { speakerLabels: false })
+			.speaker_labels,
+	).toBe(false);
 });

--- a/apps/web/__tests__/unit/transcript-sentences-ui.test.ts
+++ b/apps/web/__tests__/unit/transcript-sentences-ui.test.ts
@@ -46,6 +46,8 @@ vi.mock("@/app/s/[videoId]/_components/CaptionContext", () => ({
 	}),
 }));
 
+const originalContent = mocks.content;
+
 const data = {
 	id: "sentence-test",
 	owner: { id: "owner" },
@@ -80,6 +82,7 @@ describe("sentence transcript reading and editing", () => {
 		mocks.edit.mockClear();
 		mocks.copy.mockClear();
 		mocks.language = "original";
+		mocks.content = originalContent;
 		mocks.live = false;
 		container = document.createElement("div");
 		document.body.append(container);
@@ -128,6 +131,22 @@ describe("sentence transcript reading and editing", () => {
 		await click("Done editing");
 		expect(button("00:00Speaker AFirst, then second.")).toBeDefined();
 	});
+
+	it.each(["original", "ar"])(
+		"keeps Arabic questions separate in %s view",
+		async (language) => {
+			mocks.language = language;
+			mocks.content =
+				"WEBVTT\n\n1\n00:00:00.125 --> 00:00:01.000\nكيف حالك؟\n\n2\n00:00:02.125 --> 00:00:03.000\nأين أنت؟\n\n";
+			const seek = vi.fn();
+			await act(async () =>
+				root.render(createElement(Transcript, { data, onSeek: seek })),
+			);
+			expect(button("00:00كيف حالك؟")).toBeDefined();
+			await click("00:02أين أنت؟");
+			expect(seek).toHaveBeenCalledWith(2.125);
+		},
+	);
 
 	it("groups translated and provisional live captions", async () => {
 		mocks.language = "ru";

--- a/apps/web/__tests__/unit/transcript-sentences-ui.test.ts
+++ b/apps/web/__tests__/unit/transcript-sentences-ui.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Transcript } from "@/app/s/[videoId]/_components/tabs/Transcript";
+import type { VideoData } from "@/app/s/[videoId]/types";
+
+const mocks = vi.hoisted(() => ({
+	content:
+		"WEBVTT\n\n1\n00:00:00.125 --> 00:00:01.000\n<v Speaker A>First,</v>\n\n2\n00:00:02.000 --> 00:00:03.000\n<v Speaker A>then second.</v>\n\n3\n00:00:03.100 --> 00:00:04.000\n<v Speaker B>Yes.</v>\n\n",
+	edit: vi.fn(async () => ({ success: true })),
+	copy: vi.fn(async () => {}),
+	language: "original",
+	live: false,
+}));
+
+vi.mock("@cap/ui", () => ({ Button: "button" }));
+vi.mock("@tanstack/react-query", () => ({
+	useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+	useMutation: () => ({}),
+}));
+vi.mock("hooks/use-transcript", () => ({
+	useTranscript: () => ({ data: mocks.content, isLoading: false }),
+	useInvalidateTranscript: () => vi.fn(),
+}));
+vi.mock("hooks/use-live-transcript", () => ({
+	useLiveTranscript: () => ({
+		data: mocks.live
+			? { kind: "ready", state: "active", content: mocks.content }
+			: undefined,
+	}),
+}));
+vi.mock("@/app/Layout/AuthContext", () => ({
+	useCurrentUser: () => ({ id: "owner" }),
+}));
+vi.mock("@/actions/videos/edit-transcript", () => ({
+	editTranscriptEntry: mocks.edit,
+}));
+vi.mock("@/app/s/[videoId]/_components/CaptionContext", () => ({
+	useCaptionContext: () => ({
+		selectedLanguage: mocks.language,
+		currentVttContent: mocks.content,
+		translatedVttContent: new Map(),
+		isTranslating: false,
+	}),
+}));
+
+const data = {
+	id: "sentence-test",
+	owner: { id: "owner" },
+	transcriptionStatus: "COMPLETE",
+	createdAt: new Date(),
+} as unknown as VideoData;
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+
+function button(label: string): HTMLButtonElement {
+	const match = Array.from(container.querySelectorAll("button")).find(
+		(element) =>
+			element.textContent?.trim() === label ||
+			element.getAttribute("aria-label") === label,
+	);
+	if (!match) throw new Error(`Missing button: ${label}`);
+	return match;
+}
+
+async function click(label: string) {
+	await act(async () => button(label).click());
+}
+
+describe("sentence transcript reading and editing", () => {
+	beforeEach(() => {
+		vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+		Object.defineProperty(navigator, "clipboard", {
+			configurable: true,
+			value: { writeText: mocks.copy },
+		});
+		mocks.edit.mockClear();
+		mocks.copy.mockClear();
+		mocks.language = "original";
+		mocks.live = false;
+		container = document.createElement("div");
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(async () => {
+		await act(async () => root.unmount());
+		container.remove();
+		vi.unstubAllGlobals();
+	});
+
+	it("reads sentences, seeks precisely, and copies sentence timestamps", async () => {
+		const seek = vi.fn();
+		await act(async () =>
+			root.render(createElement(Transcript, { data, onSeek: seek })),
+		);
+		await click("00:00Speaker AFirst, then second.");
+		expect(seek).toHaveBeenCalledWith(0.125);
+		expect(
+			container.querySelectorAll('[aria-label="Edit transcript entry"]'),
+		).toHaveLength(0);
+		await click("Copy transcript");
+		const copyOption = Array.from(container.querySelectorAll("button")).find(
+			(element) => element.textContent?.startsWith("With timestamps"),
+		);
+		expect(copyOption).toBeDefined();
+		await act(async () => copyOption?.click());
+		expect(mocks.copy).toHaveBeenCalledWith(
+			"[00:00] Speaker A: First, then second.\n\n[00:03] Speaker B: Yes.",
+		);
+	});
+
+	it("edits original cue IDs and text, never a merged sentence under one cue ID", async () => {
+		await act(async () => root.render(createElement(Transcript, { data })));
+		await click("Edit transcript");
+		const editButtons = container.querySelectorAll<HTMLButtonElement>(
+			'[aria-label="Edit transcript entry"]',
+		);
+		expect(editButtons).toHaveLength(3);
+		await act(async () => editButtons[1]?.click());
+		expect(container.querySelector("textarea")?.value).toBe("then second.");
+		expect(button("Done editing").disabled).toBe(true);
+		await click("Save");
+		expect(mocks.edit).toHaveBeenCalledWith("sentence-test", 2, "then second.");
+		await click("Done editing");
+		expect(button("00:00Speaker AFirst, then second.")).toBeDefined();
+	});
+
+	it("groups translated and provisional live captions", async () => {
+		mocks.language = "ru";
+		await act(async () => root.render(createElement(Transcript, { data })));
+		expect(button("00:00Speaker AFirst, then second.")).toBeDefined();
+		expect(container.textContent).not.toContain("Edit transcript");
+		mocks.live = true;
+		await act(async () =>
+			root.render(
+				createElement(Transcript, {
+					data: { ...data, transcriptionStatus: "PROCESSING" },
+				}),
+			),
+		);
+		expect(container.textContent).toContain("Live transcript");
+		expect(button("00:00Speaker AFirst, then second.")).toBeDefined();
+	});
+});

--- a/apps/web/__tests__/unit/transcript-sentences.test.ts
+++ b/apps/web/__tests__/unit/transcript-sentences.test.ts
@@ -58,6 +58,15 @@ describe("groupTranscriptSentences", () => {
 		]);
 	});
 
+	it.each([
+		["Arabic", ["كيف حالك؟", "أين أنت؟"]],
+		["quoted Arabic", ["«كيف حالك؟»", "«أين أنت؟»"]],
+		["Hindi", ["यह पहला वाक्य है।", "यह दूसरा वाक्य है।"]],
+	])("keeps separate %s sentences", (_language, texts) => {
+		const source = entries(texts);
+		expect(groupTranscriptSentences(source)).toEqual(source);
+	});
+
 	it("keeps abbreviations and hesitation ellipses with the following phrase", () => {
 		expect(
 			groupTranscriptSentences(

--- a/apps/web/__tests__/unit/transcript-sentences.test.ts
+++ b/apps/web/__tests__/unit/transcript-sentences.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { formatToWebVTT } from "@/lib/transcribe-utils";
+import { groupTranscriptSentences } from "@/lib/transcript-sentences";
+import { parseVTT, type TranscriptEntry } from "@/lib/transcript-vtt";
+
+function entries(texts: string[], speaker: string | null = "A") {
+	return texts.map(
+		(text, index): TranscriptEntry => ({
+			id: index + 1,
+			text,
+			startTime: index * 2 + 0.125,
+			endTime: index * 2 + 1,
+			timestamp: `00:${String(index * 2).padStart(2, "0")}`,
+			speaker,
+		}),
+	);
+}
+
+describe("groupTranscriptSentences", () => {
+	it("joins comma, pause and eight-word caption breaks into a full sentence", () => {
+		const words =
+			"Immediate release, extended release, это всё одна фраза которую нужно читать целиком."
+				.split(" ")
+				.map((text, index) => ({
+					text,
+					start: index * 1_000,
+					end: index * 1_000 + 300,
+					speaker: "A",
+				}));
+		const captions = parseVTT(formatToWebVTT({ words }));
+		expect(captions.length).toBeGreaterThan(8);
+		expect(groupTranscriptSentences(captions)).toEqual([
+			{
+				...captions[0],
+				text: words.map((word) => word.text).join(" "),
+				endTime: 11.3,
+			},
+		]);
+	});
+
+	it("uses sentence punctuation, including closing quotes and CJK punctuation", () => {
+		const result = groupTranscriptSentences(
+			entries([
+				"И как бы,",
+				"сейчас,",
+				"где она здесь?",
+				"Он сказал:",
+				"«Вот это.»",
+				"真的。",
+				"Next!",
+			]),
+		);
+		expect(result.map((entry) => entry.text)).toEqual([
+			"И как бы, сейчас, где она здесь?",
+			"Он сказал: «Вот это.»",
+			"真的。",
+			"Next!",
+		]);
+	});
+
+	it("keeps abbreviations and hesitation ellipses with the following phrase", () => {
+		expect(
+			groupTranscriptSentences(
+				entries(["Dr.", "Smith said,", "I want...", "to continue."]),
+			).map((entry) => entry.text),
+		).toEqual(["Dr. Smith said, I want... to continue."]);
+	});
+
+	it("never combines different or unknown speakers", () => {
+		const source = entries(["First,", "second,", "unknown,", "fourth."]);
+		if (source[1]) source[1].speaker = "B";
+		if (source[2]) source[2].speaker = null;
+		expect(groupTranscriptSentences(source)).toEqual(source);
+	});
+
+	it("keeps the first cue identity and exact outer timestamps without mutating cues", () => {
+		const source = entries(["One,", "two."]);
+		const original = structuredClone(source);
+		expect(groupTranscriptSentences(source)[0]).toEqual({
+			...source[0],
+			text: "One, two.",
+			endTime: 3,
+		});
+		expect(source).toEqual(original);
+	});
+
+	it("breaks at long silence and overlapping cues", () => {
+		const source = entries(["Before", "after"]);
+		if (source[1]) source[1].startTime = 6;
+		expect(groupTranscriptSentences(source)).toHaveLength(2);
+		if (source[1]) source[1].startTime = 0.5;
+		expect(groupTranscriptSentences(source)).toHaveLength(2);
+	});
+
+	it("bounds unpunctuated speech and retains every fragment", () => {
+		const source = entries(
+			Array.from({ length: 100 }, () => "a long unpunctuated fragment"),
+		);
+		const grouped = groupTranscriptSentences(source);
+		expect(grouped.length).toBeGreaterThan(1);
+		expect(
+			grouped.every(
+				(entry) =>
+					entry.text.length <= 800 && entry.endTime - entry.startTime <= 45,
+			),
+		).toBe(true);
+		expect(grouped.map((entry) => entry.text).join(" ")).toBe(
+			source.map((entry) => entry.text).join(" "),
+		);
+	});
+
+	it("handles empty input and unfinished live sentences", () => {
+		expect(groupTranscriptSentences([])).toEqual([]);
+		expect(groupTranscriptSentences(entries([" "]))).toEqual([]);
+		expect(
+			groupTranscriptSentences(entries(["still", "speaking"]))[0]?.text,
+		).toBe("still speaking");
+	});
+});

--- a/apps/web/__tests__/unit/transcript-translation.test.ts
+++ b/apps/web/__tests__/unit/transcript-translation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isValidTranscriptTranslation } from "@/lib/transcript-vtt";
+
+const source =
+	"WEBVTT\n\n1\n00:00:00.125 --> 00:00:01.500\n<v Speaker A>Hello there.</v>\n\n2\n00:00:01.600 --> 00:00:03.000\n<v Speaker B>Good morning.</v>\n";
+const translated = source
+	.replace("Hello there.", "Merhaba.")
+	.replace("Good morning.", "Günaydın.");
+
+describe("translation structure validation", () => {
+	it("accepts translated speech with unchanged voices and timings", () => {
+		expect(isValidTranscriptTranslation(source, translated)).toBe(true);
+		expect(
+			isValidTranscriptTranslation(source, translated.replace(/\n/g, "\r\n")),
+		).toBe(true);
+		expect(
+			isValidTranscriptTranslation(
+				source,
+				translated.replace("Merhaba.", "Merhaba\narkadaşım."),
+			),
+		).toBe(true);
+	});
+	it.each([
+		translated.replace("<v Speaker A>", ""),
+		translated.replace("<v Speaker A>", "<v Speaker B>"),
+		translated.replace("<v Speaker A>", "<v Konuşmacı A>"),
+		translated.replace("</v>", ""),
+		translated.replace("Merhaba.", "Merhaba.<v Speaker B>Ek söz.</v>"),
+		translated.replace("00:00:00.125", "00:00:00.000"),
+		translated.replace("\n2\n", "\n3\n"),
+		translated.split("\n\n2")[0] ?? "",
+		translated.replace("Merhaba.", ""),
+		`Here is the WEBVTT:\n${translated}`,
+		`${translated}\nExtra explanation`,
+	])("rejects changed metadata or malformed cues before caching", (value) => {
+		expect(isValidTranscriptTranslation(source, value)).toBe(false);
+	});
+	it("accepts legacy captions but rejects invented speakers", () => {
+		const legacy = source.replace(/<[^>]*>/g, "");
+		expect(
+			isValidTranscriptTranslation(legacy, legacy.replace("Hello", "Merhaba")),
+		).toBe(true);
+		expect(isValidTranscriptTranslation(legacy, translated)).toBe(false);
+	});
+});

--- a/apps/web/actions/videos/translate-transcript.ts
+++ b/apps/web/actions/videos/translate-transcript.ts
@@ -12,6 +12,7 @@ import { runWithAiProviders } from "@/lib/ai/run";
 import { isRateLimited, RATE_LIMIT_IDS } from "@/lib/rate-limit";
 import * as EffectRuntime from "@/lib/server";
 import { runPromise } from "@/lib/server";
+import { isValidTranscriptTranslation } from "@/lib/transcript-vtt";
 import { decodeStorageVideo } from "@/lib/video-storage";
 import {
 	type LanguageCode,
@@ -73,27 +74,6 @@ export async function translateTranscript(
 
 	const { video } = query[0];
 
-	const translatedKey = `${video.ownerId}/${videoId}/transcription.${targetLanguage}.vtt`;
-
-	try {
-		const existingTranslation = await Effect.gen(function* () {
-			const [bucket] = yield* Storage.getAccessForVideo(
-				decodeStorageVideo(video),
-			);
-			return yield* bucket.getObject(translatedKey);
-		}).pipe(runPromise);
-
-		if (Option.isSome(existingTranslation)) {
-			return {
-				success: true,
-				translatedVtt: existingTranslation.value,
-				message: "Retrieved cached translation",
-			};
-		}
-	} catch (e) {
-		console.debug("[translateTranscript] No cached translation found:", e);
-	}
-
 	const originalVtt = await Effect.gen(function* () {
 		const [bucket] = yield* Storage.getAccessForVideo(
 			decodeStorageVideo(video),
@@ -105,6 +85,30 @@ export async function translateTranscript(
 
 	if (Option.isNone(originalVtt)) {
 		return { success: false, message: "Original transcript not found" };
+	}
+
+	const translatedKey = `${video.ownerId}/${videoId}/transcription.${targetLanguage}.vtt`;
+
+	try {
+		const existingTranslation = await Effect.gen(function* () {
+			const [bucket] = yield* Storage.getAccessForVideo(
+				decodeStorageVideo(video),
+			);
+			return yield* bucket.getObject(translatedKey);
+		}).pipe(runPromise);
+
+		if (
+			Option.isSome(existingTranslation) &&
+			isValidTranscriptTranslation(originalVtt.value, existingTranslation.value)
+		) {
+			return {
+				success: true,
+				translatedVtt: existingTranslation.value,
+				message: "Retrieved cached translation",
+			};
+		}
+	} catch (e) {
+		console.debug("[translateTranscript] No cached translation found:", e);
 	}
 
 	const translatedVtt = await translateVttContent(
@@ -167,10 +171,12 @@ ${vttContent}`;
 				...(selection.supportsTemperature ? { temperature: 0.3 } : {}),
 			});
 
-			// Validate inside the provider loop so a fulfilled response that
-			// dropped the WEBVTT header falls through to the next provider.
-			if (!response.text.includes("WEBVTT")) {
-				throw new Error("translation response did not contain WEBVTT");
+			// Validate inside the provider loop so malformed translations try the
+			// next provider without poisoning the cached captions.
+			if (!isValidTranscriptTranslation(vttContent, response.text)) {
+				throw new Error(
+					"translation changed cue structure or speaker annotations",
+				);
 			}
 
 			return response.text.trim();

--- a/apps/web/actions/videos/translate-transcript.ts
+++ b/apps/web/actions/videos/translate-transcript.ts
@@ -151,7 +151,8 @@ IMPORTANT RULES:
 4. Only translate the actual text content on each line
 5. Preserve all newlines and formatting
 6. Do not add any explanations or comments
-7. Return ONLY the translated VTT content
+7. Preserve all <v Speaker ...> and </v> voice tags exactly, including speaker labels; translate only the spoken text inside them
+8. Return ONLY the translated VTT content
 
 VTT content to translate:
 

--- a/apps/web/app/api/v1/[...route]/route.ts
+++ b/apps/web/app/api/v1/[...route]/route.ts
@@ -2528,7 +2528,14 @@ const normalizeTranscriptCues = (
 		) {
 			return null;
 		}
-		normalized.push({ startMs: cue.startMs, endMs: cue.endMs, text });
+		normalized.push({
+			startMs: cue.startMs,
+			endMs: cue.endMs,
+			text,
+			...(cue.speaker
+				? { speaker: cue.speaker.replace(/\s+/g, " ").trim() }
+				: {}),
+		});
 		previousStartMs = cue.startMs;
 	}
 	const vtt = renderAgentVtt(normalized);

--- a/apps/web/app/s/[videoId]/_components/caption-cues.ts
+++ b/apps/web/app/s/[videoId]/_components/caption-cues.ts
@@ -1,3 +1,5 @@
+import { parseVttCueText } from "@/lib/transcript-vtt";
+
 export function getActiveCaptionText(
 	activeCues: TextTrackCueList | null | undefined,
 ): string {
@@ -20,5 +22,7 @@ export function getActiveCaptionText(
 		}
 	}
 
-	return selectedCue?.text.replace(/<[^>]*>/g, "") ?? "";
+	if (!selectedCue) return "";
+	const { text, speaker } = parseVttCueText(selectedCue.text);
+	return speaker ? `Speaker ${speaker}: ${text}` : text;
 }

--- a/apps/web/app/s/[videoId]/_components/tabs/Transcript.tsx
+++ b/apps/web/app/s/[videoId]/_components/tabs/Transcript.tsx
@@ -21,6 +21,7 @@ import {
 	SUPPORTED_LANGUAGES,
 } from "@/actions/videos/translation-languages";
 import { useCurrentUser } from "@/app/Layout/AuthContext";
+import { groupTranscriptSentences } from "@/lib/transcript-sentences";
 import { formatTranscriptAsParagraphs } from "@/lib/transcript-text";
 import {
 	formatVttCueText,
@@ -51,6 +52,7 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 	const [transcriptData, setTranscriptData] = useState<TranscriptEntry[]>([]);
 	const [selectedEntry, setSelectedEntry] = useState<number | null>(null);
 	const [retryTriggered, setRetryTriggered] = useState(false);
+	const [isEditingTranscript, setIsEditingTranscript] = useState(false);
 	const [editingEntry, setEditingEntry] = useState<number | null>(null);
 	const [editText, setEditText] = useState<string>("");
 	const [isSaving, setIsSaving] = useState(false);
@@ -163,7 +165,10 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 	const isLiveTranscriptActive =
 		liveTranscript?.kind === "ready" && liveTranscript.state === "active";
 	const liveTranscriptData = useMemo(
-		() => (liveTranscriptContent ? parseVTT(liveTranscriptContent) : []),
+		() =>
+			liveTranscriptContent
+				? groupTranscriptSentences(parseVTT(liveTranscriptContent))
+				: [],
 		[liveTranscriptContent],
 	);
 
@@ -215,6 +220,11 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 			setTranscriptData(parsed);
 		}
 	}, [captionContext.currentVttContent, transcriptContent, selectedLanguage]);
+
+	const sentenceData = useMemo(
+		() => groupTranscriptSentences(transcriptData),
+		[transcriptData],
+	);
 
 	const handleLanguageChange = async (language: CaptionLanguage) => {
 		setShowLanguageMenu(false);
@@ -384,7 +394,7 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 
 	const copyTimestampedTranscript = () => {
 		if (transcriptData.length === 0) return;
-		void copyTranscriptText(formatTranscriptForClipboard(transcriptData));
+		void copyTranscriptText(formatTranscriptForClipboard(sentenceData));
 	};
 
 	const triggerTranscriptDownload = (
@@ -429,6 +439,8 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 	};
 
 	const canEdit = user?.id === data.owner.id && selectedLanguage === "original";
+	const showEditingControls = canEdit && isEditingTranscript;
+	const displayedEntries = showEditingControls ? transcriptData : sentenceData;
 
 	const liveTranscriptView = showLiveTranscript ? (
 		<div className="flex flex-col h-full">
@@ -634,7 +646,11 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 				<div className="relative" ref={languageMenuRef}>
 					<button
 						onClick={() => setShowLanguageMenu(!showLanguageMenu)}
-						disabled={isTranslating || transcriptData.length === 0}
+						disabled={
+							isTranslating ||
+							editingEntry !== null ||
+							transcriptData.length === 0
+						}
 						className="inline-flex h-7 items-center gap-1.5 rounded-full border border-gray-4 bg-gray-1 pl-2.5 pr-2 text-[11px] font-medium text-gray-11 transition hover:bg-gray-2 hover:text-gray-12 disabled:cursor-not-allowed disabled:opacity-50"
 						type="button"
 					>
@@ -690,6 +706,17 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 				</div>
 
 				<div className="flex items-center gap-1">
+					{canEdit && (
+						<button
+							type="button"
+							aria-pressed={showEditingControls}
+							disabled={editingEntry !== null || transcriptData.length === 0}
+							onClick={() => setIsEditingTranscript((value) => !value)}
+							className="inline-flex min-h-11 items-center rounded-full px-2 text-[11px] font-medium text-gray-11 transition hover:bg-gray-3 disabled:opacity-50"
+						>
+							{showEditingControls ? "Done editing" : "Edit transcript"}
+						</button>
+					)}
 					<div className="relative" ref={copyMenuRef}>
 						<button
 							type="button"
@@ -736,7 +763,7 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 										With timestamps
 									</span>
 									<span className="mt-0.5 block text-[10px] text-gray-9">
-										[0:12] caption lines
+										[0:12] sentence timestamps
 									</span>
 								</button>
 							</div>
@@ -807,7 +834,7 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 					</div>
 				)}
 				<div className="px-3 py-3">
-					{transcriptData.map((entry) => (
+					{displayedEntries.map((entry) => (
 						<div
 							key={entry.id}
 							className={`group flex items-start gap-1 rounded-lg px-2 transition-colors ${
@@ -875,7 +902,7 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 											{entry.text}
 										</span>
 									</button>
-									{canEdit && (
+									{showEditingControls && (
 										<button
 											onClick={(e) => {
 												e.stopPropagation();

--- a/apps/web/app/s/[videoId]/_components/tabs/Transcript.tsx
+++ b/apps/web/app/s/[videoId]/_components/tabs/Transcript.tsx
@@ -22,7 +22,12 @@ import {
 } from "@/actions/videos/translation-languages";
 import { useCurrentUser } from "@/app/Layout/AuthContext";
 import { formatTranscriptAsParagraphs } from "@/lib/transcript-text";
-import { normalizeTranscriptCueText } from "@/lib/transcript-vtt";
+import {
+	formatVttCueText,
+	normalizeTranscriptCueText,
+	parseVTT,
+	type TranscriptEntry,
+} from "@/lib/transcript-vtt";
 import type { VideoData } from "../../types";
 import { type CaptionLanguage, useCaptionContext } from "../CaptionContext";
 
@@ -31,116 +36,6 @@ interface TranscriptProps {
 	onSeek?: (time: number) => void;
 	user?: { id: string } | null;
 }
-
-interface TranscriptEntry {
-	id: number;
-	timestamp: string;
-	text: string;
-	startTime: number;
-	endTime: number;
-}
-
-const parseVTT = (vttContent: string): TranscriptEntry[] => {
-	const lines = vttContent.split("\n");
-	const entries: TranscriptEntry[] = [];
-	let currentEntry: Partial<TranscriptEntry & { startTime: number }> = {};
-	let currentId = 0;
-
-	const timeToSeconds = (timeStr: string): number | null => {
-		const parts = timeStr.split(":");
-		if (parts.length !== 3) return null;
-
-		const [hoursStr, minutesStr, secondsStr] = parts;
-		if (!hoursStr || !minutesStr || !secondsStr) return null;
-
-		const hours = parseInt(hoursStr, 10);
-		const minutes = parseInt(minutesStr, 10);
-		const seconds = parseInt(secondsStr, 10);
-
-		if (Number.isNaN(hours) || Number.isNaN(minutes) || Number.isNaN(seconds))
-			return null;
-
-		return hours * 3600 + minutes * 60 + seconds;
-	};
-
-	const parseTimestamp = (
-		timestamp: string,
-	): { mm_ss: string; totalSeconds: number } | null => {
-		const parts = timestamp.split(":");
-		if (parts.length !== 3) return null;
-
-		const [hoursStr, minutesStr, secondsWithMs] = parts;
-		if (!hoursStr || !minutesStr || !secondsWithMs) return null;
-
-		const secondsPart = secondsWithMs.split(".")[0];
-		if (!secondsPart) return null;
-
-		const totalSeconds = timeToSeconds(
-			`${hoursStr}:${minutesStr}:${secondsPart}`,
-		);
-		if (totalSeconds === null) return null;
-
-		const fractionPart = secondsWithMs.split(".")[1];
-		const fraction = fractionPart ? Number(`0.${fractionPart}`) : 0;
-
-		return {
-			mm_ss: `${minutesStr}:${secondsPart}`,
-			totalSeconds: totalSeconds + (Number.isFinite(fraction) ? fraction : 0),
-		};
-	};
-
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i];
-		if (!line?.trim()) continue;
-
-		const trimmedLine = line.trim();
-
-		if (trimmedLine === "WEBVTT") continue;
-
-		if (/^\d+$/.test(trimmedLine)) {
-			currentId = parseInt(trimmedLine, 10);
-			continue;
-		}
-
-		if (trimmedLine.includes("-->")) {
-			const [startTimeStr, endTimeStr] = trimmedLine.split(" --> ");
-			if (!startTimeStr || !endTimeStr) continue;
-
-			const startTimestamp = parseTimestamp(startTimeStr);
-			const endTimestamp = parseTimestamp(endTimeStr);
-			if (startTimestamp) {
-				currentEntry = {
-					id: currentId,
-					timestamp: startTimestamp.mm_ss,
-					startTime: startTimestamp.totalSeconds,
-					endTime: endTimestamp?.totalSeconds ?? startTimestamp.totalSeconds,
-				};
-			}
-			continue;
-		}
-
-		if (currentEntry.timestamp && !currentEntry.text) {
-			const textContent =
-				trimmedLine.startsWith('"') && trimmedLine.endsWith('"')
-					? trimmedLine.slice(1, -1)
-					: trimmedLine;
-
-			currentEntry.text = textContent;
-			if (
-				currentEntry.id !== undefined &&
-				currentEntry.timestamp &&
-				currentEntry.text &&
-				currentEntry.startTime !== undefined
-			) {
-				entries.push(currentEntry as TranscriptEntry);
-			}
-			currentEntry = {};
-		}
-	}
-
-	const sortedEntries = entries.sort((a, b) => a.startTime - b.startTime);
-	return sortedEntries;
-};
 
 /** Module-level so the last live transcript survives component remounts and
  * router refreshes during the live→canonical handoff. */
@@ -428,7 +323,10 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 
 	const formatTranscriptForClipboard = (entries: TranscriptEntry[]): string => {
 		return entries
-			.map((entry) => `[${entry.timestamp}] ${entry.text}`)
+			.map(
+				(entry) =>
+					`[${entry.timestamp}] ${entry.speaker ? `Speaker ${entry.speaker}: ` : ""}${entry.text}`,
+			)
 			.join("\n\n");
 	};
 
@@ -438,7 +336,8 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 		const vttEntries = entries.map((entry, index) => {
 			const startSeconds = entry.startTime;
 			const nextEntry = entries[index + 1];
-			const endSeconds = nextEntry ? nextEntry.startTime : startSeconds + 3;
+			const endSeconds =
+				entry.endTime ?? (nextEntry ? nextEntry.startTime : startSeconds + 3);
 
 			const formatTime = (seconds: number): string => {
 				const hours = Math.floor(seconds / 3600);
@@ -455,7 +354,7 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 
 			return `${entry.id}\n${formatTime(startSeconds)} --> ${formatTime(
 				endSeconds,
-			)}\n${entry.text}\n`;
+			)}\n${formatVttCueText(entry.text, entry.speaker)}\n`;
 		});
 
 		return vttHeader + vttEntries.join("\n");
@@ -565,6 +464,11 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 									{entry.timestamp}
 								</span>
 								<span className="min-w-0 flex-1 text-[13px] leading-[22px] text-gray-11">
+									{entry.speaker && (
+										<span className="block text-[11px] font-semibold text-gray-12">
+											Speaker {entry.speaker}
+										</span>
+									)}
 									{entry.text}
 								</span>
 							</button>
@@ -963,6 +867,11 @@ export const Transcript: React.FC<TranscriptProps> = ({ data, onSeek }) => {
 											{entry.timestamp}
 										</span>
 										<span className="min-w-0 flex-1 text-[13px] leading-[22px] text-gray-11">
+											{entry.speaker && (
+												<span className="block text-[11px] font-semibold text-gray-12">
+													Speaker {entry.speaker}
+												</span>
+											)}
 											{entry.text}
 										</span>
 									</button>

--- a/apps/web/app/s/[videoId]/_components/utils/transcript-utils.ts
+++ b/apps/web/app/s/[videoId]/_components/utils/transcript-utils.ts
@@ -1,3 +1,6 @@
+import { formatVttCueText } from "@/lib/transcript-vtt";
+
+export { parseVTT } from "@/lib/transcript-vtt";
 // Utility functions for transcript formatting
 
 export interface TranscriptEntry {
@@ -5,6 +8,8 @@ export interface TranscriptEntry {
 	timestamp: string | number; // Allow both string and number types
 	text: string;
 	startTime: number;
+	endTime?: number;
+	speaker?: string | null;
 }
 
 export const formatTime = (seconds: number): string => {
@@ -37,11 +42,12 @@ export const formatTranscriptAsVTT = (entries: TranscriptEntry[]): string => {
 	const vttEntries = entries.map((entry, index) => {
 		const startSeconds = entry.startTime;
 		const nextEntry = entries[index + 1];
-		const endSeconds = nextEntry ? nextEntry.startTime : startSeconds + 3;
+		const endSeconds =
+			entry.endTime ?? (nextEntry ? nextEntry.startTime : startSeconds + 3);
 
 		return `${entry.id}\n${formatTime(startSeconds)} --> ${formatTime(
 			endSeconds,
-		)}\n${entry.text}\n`;
+		)}\n${formatVttCueText(entry.text, entry.speaker)}\n`;
 	});
 
 	return vttHeader + vttEntries.join("\n");
@@ -76,103 +82,6 @@ export function formatChaptersAsVTT(
 	return vttContent;
 }
 
-export const parseVTT = (vttContent: string): TranscriptEntry[] => {
-	const lines = vttContent.split("\n");
-	const entries: TranscriptEntry[] = [];
-	let currentEntry: Partial<TranscriptEntry & { startTime: number }> = {};
-	let currentId = 0;
-
-	const timeToSeconds = (timeStr: string): number | null => {
-		const parts = timeStr.split(":");
-		if (parts.length !== 3) return null;
-
-		const [hoursStr, minutesStr, secondsStr] = parts;
-		if (!hoursStr || !minutesStr || !secondsStr) return null;
-
-		const hours = parseInt(hoursStr, 10);
-		const minutes = parseInt(minutesStr, 10);
-		const seconds = parseInt(secondsStr, 10);
-
-		if (Number.isNaN(hours) || Number.isNaN(minutes) || Number.isNaN(seconds))
-			return null;
-
-		return hours * 3600 + minutes * 60 + seconds;
-	};
-
-	const parseTimestamp = (
-		timestamp: string,
-	): { mm_ss: string; totalSeconds: number } | null => {
-		const parts = timestamp.split(":");
-		if (parts.length !== 3) return null;
-
-		const [hoursStr, minutesStr, secondsWithMs] = parts;
-		if (!hoursStr || !minutesStr || !secondsWithMs) return null;
-
-		const secondsPart = secondsWithMs.split(".")[0];
-		if (!secondsPart) return null;
-
-		const totalSeconds = timeToSeconds(
-			`${hoursStr}:${minutesStr}:${secondsPart}`,
-		);
-		if (totalSeconds === null) return null;
-
-		return {
-			mm_ss: `${minutesStr}:${secondsPart}`,
-			totalSeconds,
-		};
-	};
-
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i];
-		if (!line?.trim()) continue;
-
-		const trimmedLine = line.trim();
-
-		if (trimmedLine === "WEBVTT") continue;
-
-		if (/^\d+$/.test(trimmedLine)) {
-			currentId = parseInt(trimmedLine, 10);
-			continue;
-		}
-
-		if (trimmedLine.includes("-->")) {
-			const [startTimeStr, endTimeStr] = trimmedLine.split(" --> ");
-			if (!startTimeStr || !endTimeStr) continue;
-
-			const startTimestamp = parseTimestamp(startTimeStr);
-			if (startTimestamp) {
-				currentEntry = {
-					id: currentId,
-					timestamp: startTimestamp.mm_ss,
-					startTime: startTimestamp.totalSeconds,
-				};
-			}
-			continue;
-		}
-
-		if (currentEntry.timestamp && !currentEntry.text) {
-			const textContent =
-				trimmedLine.startsWith('"') && trimmedLine.endsWith('"')
-					? trimmedLine.slice(1, -1)
-					: trimmedLine;
-
-			currentEntry.text = textContent;
-			if (
-				currentEntry.id !== undefined &&
-				currentEntry.timestamp &&
-				currentEntry.text &&
-				currentEntry.startTime !== undefined
-			) {
-				entries.push(currentEntry as TranscriptEntry);
-			}
-			currentEntry = {};
-		}
-	}
-
-	const sortedEntries = entries.sort((a, b) => a.startTime - b.startTime);
-	return sortedEntries;
-};
-
 /**
  * Formats transcript entries for clipboard copying
  */
@@ -180,6 +89,9 @@ export const formatTranscriptForClipboard = (
 	entries: TranscriptEntry[],
 ): string => {
 	return entries
-		.map((entry) => `[${entry.timestamp}] ${entry.text}`)
+		.map(
+			(entry) =>
+				`[${entry.timestamp}] ${entry.speaker ? `Speaker ${entry.speaker}: ` : ""}${entry.text}`,
+		)
 		.join("\n\n");
 };

--- a/apps/web/app/s/[videoId]/edit/TranscriptSidebar.tsx
+++ b/apps/web/app/s/[videoId]/edit/TranscriptSidebar.tsx
@@ -161,6 +161,11 @@ const TranscriptGroupRow = memo(function TranscriptGroupRow({
 				{formatTimestamp(group.startMs)}
 			</button>
 			<p className="min-w-0 flex-1 select-none text-[13.5px] leading-[26px] text-gray-11">
+				{words[group.startIndex]?.speaker && (
+					<span className="block text-[11px] font-semibold text-gray-12">
+						Speaker {words[group.startIndex]?.speaker}
+					</span>
+				)}
 				{words
 					.slice(group.startIndex, group.endIndex + 1)
 					.map((word, groupWordIndex) => {

--- a/apps/web/lib/agent-api.ts
+++ b/apps/web/lib/agent-api.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { VideoMetadata } from "@cap/database/types";
 import type { Agent } from "@cap/web-domain";
+import { formatVttCueText, parseVttCueText } from "@/lib/transcript-vtt";
 
 export type AgentCursor = {
 	updatedAt: string;
@@ -110,28 +111,6 @@ const parseVttTimestamp = (value: string) => {
 	return ((hours * 60 + minutes) * 60 + seconds) * 1000 + milliseconds;
 };
 
-const stripVttCueTags = (value: string) => {
-	const text: string[] = [];
-	let insideTag = false;
-
-	for (const character of value) {
-		if (character === "<") {
-			insideTag = true;
-			continue;
-		}
-		if (insideTag) {
-			if (character === ">") insideTag = false;
-			continue;
-		}
-		text.push(character);
-	}
-
-	return text.join("");
-};
-
-const normalizeCueText = (lines: string[]) =>
-	stripVttCueTags(lines.join("\n")).trim();
-
 export const parseAgentVtt = (
 	vtt: string,
 ): (typeof Agent.AgentTranscriptCue)["Type"][] => {
@@ -163,8 +142,9 @@ export const parseAgentVtt = (
 			if (cueIndex === lines.length - 1) index = cueIndex;
 		}
 
-		const text = normalizeCueText(textLines);
-		if (text) cues.push({ startMs, endMs, text });
+		const { text, speaker } = parseVttCueText(textLines.join("\n"));
+		if (text)
+			cues.push({ startMs, endMs, text, ...(speaker ? { speaker } : {}) });
 	}
 
 	return cues;
@@ -191,7 +171,7 @@ export const renderAgentVtt = (
 		...cues.flatMap((cue, index) => [
 			String(index + 1),
 			`${formatVttTimestamp(cue.startMs)} --> ${formatVttTimestamp(cue.endMs)}`,
-			cue.text.replace(/\s+/g, " ").trim(),
+			formatVttCueText(cue.text, cue.speaker),
 			"",
 		]),
 	].join("\n");

--- a/apps/web/lib/assemblyai.ts
+++ b/apps/web/lib/assemblyai.ts
@@ -39,10 +39,12 @@ export const ASSEMBLYAI_SUPPORTED_LANGUAGES = [
 
 export function getAssemblyAITranscriptionOptions(
 	language: AiGenerationLanguage,
+	{ speakerLabels = true }: { speakerLabels?: boolean } = {},
 ) {
 	const baseOptions = {
 		speech_models: [...ASSEMBLYAI_SPEECH_MODELS],
 		format_text: true,
+		speaker_labels: speakerLabels,
 		punctuate: true,
 		// Verbatim words: the single transcription pass feeds both the word-level
 		// edit transcript and the caption VTT (which strips fillers itself).

--- a/apps/web/lib/edit-transcript.ts
+++ b/apps/web/lib/edit-transcript.ts
@@ -365,6 +365,7 @@ export function editTranscriptWordsToCaptionVtt(
 				text: word.text,
 				start: word.startMs,
 				end: word.endMs,
+				speaker: word.speaker,
 			})),
 	});
 }
@@ -428,10 +429,7 @@ export function groupEditTranscriptWords(
 		const punctuationBreak = /[.!?]$/.test(word.text);
 		const silenceBreak = nextWord ? nextWord.startMs - word.endMs >= 800 : true;
 		const speakerBreak =
-			nextWord !== undefined &&
-			word.speaker !== null &&
-			nextWord.speaker !== null &&
-			word.speaker !== nextWord.speaker;
+			nextWord !== undefined && word.speaker !== nextWord.speaker;
 
 		if (
 			nextWord &&

--- a/apps/web/lib/live-transcribe-core.ts
+++ b/apps/web/lib/live-transcribe-core.ts
@@ -1,7 +1,5 @@
 import type { Video } from "@cap/web-domain";
 import {
-	EDIT_TRANSCRIPT_VERSION,
-	type EditTranscript,
 	type EditTranscriptWord,
 	editTranscriptWordsToCaptionVtt,
 } from "@/lib/edit-transcript";
@@ -193,9 +191,7 @@ export interface LiveTranscriptArtifact {
 	words: EditTranscriptWord[];
 	vtt: string;
 	updatedAt: string;
-	/** A chunk was skipped after repeated failures, so some speech is missing.
-	 * Disqualifies the artifact from being promoted to the canonical
-	 * transcript; the full-pass fallback covers the recording instead. */
+
 	hasGaps?: boolean;
 }
 
@@ -255,69 +251,6 @@ export function parseLiveTranscript(
 	} catch {
 		return null;
 	}
-}
-
-/**
- * Whether the live transcript fully and faithfully covers the recording, so
- * it can be promoted to the canonical transcript instead of paying for a
- * second full transcription pass. Anything short of complete gap-free
- * coverage means the full-pass fallback runs exactly as before.
- */
-export function canPromoteLiveTranscript(
-	artifact: LiveTranscriptArtifact,
-	manifest: Video.SegmentManifestType,
-): { ok: true } | { ok: false; reason: string } {
-	if (!manifest.is_complete) {
-		return { ok: false, reason: "manifest is not complete" };
-	}
-	if (artifact.hasGaps) {
-		return { ok: false, reason: "live transcript has skipped chunks" };
-	}
-
-	const plan = planSegmentsAudioExtraction(manifest);
-	if (plan.status === "no-audio") {
-		return { ok: false, reason: "recording has no audio" };
-	}
-	if (plan.status !== "ok") {
-		return { ok: false, reason: plan.reason };
-	}
-
-	const lastIndex = plan.entries[plan.entries.length - 1]?.index;
-	if (lastIndex === undefined || artifact.lastAudioSegmentIndex !== lastIndex) {
-		return {
-			ok: false,
-			reason: `covered up to segment ${artifact.lastAudioSegmentIndex} of ${lastIndex}`,
-		};
-	}
-
-	// A manifest index gap means audio the recording had but we never saw.
-	let expected = plan.entries[0]?.index ?? 1;
-	for (const entry of plan.entries) {
-		if (entry.index !== expected) {
-			return { ok: false, reason: `segment gap at index ${expected}` };
-		}
-		expected++;
-	}
-
-	return { ok: true };
-}
-
-/**
- * Shape the accumulated live words as a canonical edit transcript (v3). The
- * caption VTT derives from the same words via editTranscriptWordsToCaptionVtt,
- * exactly as the full-pass path does.
- */
-export function liveTranscriptToEditTranscript(
-	artifact: LiveTranscriptArtifact,
-	speechModelUsed: string,
-): EditTranscript {
-	return {
-		version: EDIT_TRANSCRIPT_VERSION,
-		speechModelUsed,
-		durationMs: Math.max(0, Math.round(artifact.transcribedDurationMs)),
-		languageCode: artifact.languageCode,
-		words: artifact.words,
-	};
 }
 
 /**

--- a/apps/web/lib/transcribe-utils.ts
+++ b/apps/web/lib/transcribe-utils.ts
@@ -1,8 +1,11 @@
+import { formatVttCueText } from "@/lib/transcript-vtt";
+
 export interface AssemblyAIWord {
 	text: string;
 	start: number;
 	end: number;
 	confidence?: number;
+	speaker?: string | null;
 }
 
 export interface AssemblyAIResult {
@@ -35,6 +38,7 @@ export function formatToWebVTT(result: AssemblyAIResult): string {
 	let group: string[] = [];
 	let start = formatTimestamp(words[0]?.start ?? 0);
 	let wordCount = 0;
+	let speaker = words[0]?.speaker ?? null;
 
 	for (let i = 0; i < words.length; i++) {
 		const word = words[i];
@@ -47,15 +51,17 @@ export function formatToWebVTT(result: AssemblyAIResult): string {
 		const shouldBreak =
 			/[,.!?;:]$/.test(word.text) ||
 			(nextWord && nextWord.start - word.end > 500) ||
-			wordCount === 8;
+			wordCount === 8 ||
+			(nextWord && (nextWord.speaker ?? null) !== (word.speaker ?? null));
 
 		if (shouldBreak) {
 			const end = formatTimestamp(word.end);
-			output += `${captionIndex}\n${start} --> ${end}\n${group.join(" ")}\n\n`;
+			output += `${captionIndex}\n${start} --> ${end}\n${formatVttCueText(group.join(" "), speaker)}\n\n`;
 			captionIndex++;
 			group = [];
 			start = nextWord ? formatTimestamp(nextWord.start) : start;
 			wordCount = 0;
+			speaker = nextWord?.speaker ?? null;
 		}
 	}
 
@@ -63,7 +69,7 @@ export function formatToWebVTT(result: AssemblyAIResult): string {
 		const lastWord = words[words.length - 1];
 		if (lastWord) {
 			const end = formatTimestamp(lastWord.end);
-			output += `${captionIndex}\n${start} --> ${end}\n${group.join(" ")}\n\n`;
+			output += `${captionIndex}\n${start} --> ${end}\n${formatVttCueText(group.join(" "), speaker)}\n\n`;
 		}
 	}
 

--- a/apps/web/lib/transcribe.ts
+++ b/apps/web/lib/transcribe.ts
@@ -124,9 +124,8 @@ export async function transcribeVideo(
 	}
 
 	// A live transcription that is provably still running (its claim is
-	// freshness-stamped every chunk) is seconds away from promoting itself to
-	// canonical; claiming now would race it and transcribe the same audio
-	// twice. A stale stamp means the workflow died - proceed normally. The
+	// freshness-stamped every chunk) owns scheduling the final full pass.
+	// Claiming now could start it before the recording is complete. A stale stamp means the workflow died - proceed normally. The
 	// live workflow's own full-pass fallback uses earlyFromSegments, which is
 	// exempt so it can never deadlock against its opener.
 	if (!options.earlyFromSegments) {

--- a/apps/web/lib/transcript-sentences.ts
+++ b/apps/web/lib/transcript-sentences.ts
@@ -1,0 +1,46 @@
+import type { TranscriptEntry } from "@/lib/transcript-vtt";
+
+function endsSentence(text: string): boolean {
+	const ending = text.trim().replace(/["'”’»）)\]}]+$/u, "");
+	if (/(?:\.{2,}|…)$/.test(ending)) return false;
+	if (
+		/(?:\b(?:Mr|Mrs|Ms|Dr|Prof|Sr|Jr|St|vs|etc)|\b[A-ZА-Я])\.$/iu.test(ending)
+	)
+		return false;
+	return /[.!?。！？]$/u.test(ending);
+}
+
+export function groupTranscriptSentences(
+	entries: readonly TranscriptEntry[],
+): TranscriptEntry[] {
+	const sentences: TranscriptEntry[] = [];
+	let current: TranscriptEntry | undefined;
+	let previous: TranscriptEntry | undefined;
+
+	for (const entry of entries) {
+		if (!entry.text.trim()) continue;
+		if (
+			current &&
+			previous &&
+			((previous.speaker ?? null) !== (entry.speaker ?? null) ||
+				endsSentence(previous.text) ||
+				entry.startTime - previous.endTime >= 5 ||
+				entry.startTime < previous.endTime ||
+				current.text.length + entry.text.length + 1 > 800 ||
+				entry.endTime - current.startTime > 45)
+		) {
+			sentences.push(current);
+			current = undefined;
+		}
+		current = current
+			? {
+					...current,
+					text: `${current.text} ${entry.text.trim()}`,
+					endTime: entry.endTime,
+				}
+			: { ...entry, text: entry.text.trim() };
+		previous = entry;
+	}
+	if (current) sentences.push(current);
+	return sentences;
+}

--- a/apps/web/lib/transcript-sentences.ts
+++ b/apps/web/lib/transcript-sentences.ts
@@ -7,7 +7,7 @@ function endsSentence(text: string): boolean {
 		/(?:\b(?:Mr|Mrs|Ms|Dr|Prof|Sr|Jr|St|vs|etc)|\b[A-ZА-Я])\.$/iu.test(ending)
 	)
 		return false;
-	return /[.!?。！？]$/u.test(ending);
+	return /\p{Sentence_Terminal}$/u.test(ending);
 }
 
 export function groupTranscriptSentences(

--- a/apps/web/lib/transcript-text.ts
+++ b/apps/web/lib/transcript-text.ts
@@ -2,6 +2,7 @@ export type TranscriptTextEntry = {
 	text: string;
 	startTime: number;
 	endTime: number;
+	speaker?: string | null;
 };
 
 const PARAGRAPH_GAP_SECONDS = 1.75;
@@ -30,12 +31,17 @@ export function formatTranscriptAsParagraphs(
 		const text = entry.text.trim();
 		if (!text) continue;
 
-		current = current ? `${current} ${text}` : text;
+		current = current
+			? `${current} ${text}`
+			: `${entry.speaker ? `Speaker ${entry.speaker}: ` : ""}${text}`;
 
 		const next = entries[index + 1];
 		if (!next) break;
 
-		if (current.length >= HARD_PARAGRAPH_CHAR_LIMIT) {
+		if (
+			(entry.speaker ?? null) !== (next.speaker ?? null) ||
+			current.length >= HARD_PARAGRAPH_CHAR_LIMIT
+		) {
 			paragraphs.push(current);
 			current = "";
 			continue;

--- a/apps/web/lib/transcript-vtt.ts
+++ b/apps/web/lib/transcript-vtt.ts
@@ -244,3 +244,45 @@ export const parseVTT = (vttContent: string): TranscriptEntry[] => {
 	const sortedEntries = entries.sort((a, b) => a.startTime - b.startTime);
 	return sortedEntries;
 };
+
+function getTranslationCueStructure(content: string) {
+	const blocks = content
+		.trim()
+		.replace(/\r\n?/g, "\n")
+		.split(/\n[\t ]*\n/);
+	if (blocks.shift() !== "WEBVTT" || blocks.length === 0) return null;
+	const cues: { id: string; timing: string; voices: string[] }[] = [];
+	for (const block of blocks) {
+		const [id, timing, ...payload] = block.split("\n");
+		if (
+			!id ||
+			!/^\d+$/.test(id) ||
+			!timing ||
+			!/^\d{2,}:\d{2}:\d{2}\.\d{3} --> \d{2,}:\d{2}:\d{2}\.\d{3}(?:[ \t].*)?$/.test(
+				timing,
+			)
+		)
+			return null;
+		const text = payload.join("\n");
+		if (!parseVttCueText(text).text) return null;
+		cues.push({
+			id,
+			timing,
+			voices: text.match(/<\/?v(?:[.\s][^>]*)?>/g) ?? [],
+		});
+	}
+	return cues;
+}
+
+export function isValidTranscriptTranslation(
+	source: string,
+	translated: string,
+): boolean {
+	const sourceCues = getTranslationCueStructure(source);
+	const translatedCues = getTranslationCueStructure(translated);
+	return (
+		sourceCues !== null &&
+		translatedCues !== null &&
+		JSON.stringify(sourceCues) === JSON.stringify(translatedCues)
+	);
+}

--- a/apps/web/lib/transcript-vtt.ts
+++ b/apps/web/lib/transcript-vtt.ts
@@ -1,3 +1,55 @@
+export function escapeVttText(text: string): string {
+	return text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;");
+}
+
+export function decodeVttText(text: string): string {
+	return text.replace(/&(amp|lt|gt|nbsp|lrm|rlm);/g, (entity) => {
+		switch (entity) {
+			case "&amp;":
+				return "&";
+			case "&lt;":
+				return "<";
+			case "&gt;":
+				return ">";
+			case "&nbsp;":
+				return "\u00a0";
+			case "&lrm;":
+				return "\u200e";
+			case "&rlm;":
+				return "\u200f";
+			default:
+				return entity;
+		}
+	});
+}
+
+export function parseVttCueText(payload: string): {
+	text: string;
+	speaker: string | null;
+} {
+	const voice = payload.match(/^\s*<v(?:\.[^\s>]*)?\s+([^>]+)>/);
+	const annotation = voice?.[1]?.trim();
+	return {
+		text: decodeVttText(payload.replace(/<[^>]*(?:>|$)/g, "")).trim(),
+		speaker: annotation
+			? decodeVttText(annotation).replace(/^Speaker /, "")
+			: null,
+	};
+}
+
+export function formatVttCueText(
+	text: string,
+	speaker?: string | null,
+): string {
+	const escapedText = escapeVttText(normalizeTranscriptCueText(text));
+	return speaker
+		? `<v Speaker ${escapeVttText(normalizeTranscriptCueText(speaker))}>${escapedText}</v>`
+		: escapedText;
+}
+
 export function normalizeTranscriptCueText(text: string): string {
 	return text.replace(/\s+/g, " ").trim();
 }
@@ -54,7 +106,13 @@ export function updateVttEntryText(
 			continue;
 		}
 
-		updatedLines.push(...cueLines.slice(0, timingIndex + 1), normalizedText);
+		const { speaker } = parseVttCueText(
+			cueLines.slice(timingIndex + 1).join(" "),
+		);
+		updatedLines.push(
+			...cueLines.slice(0, timingIndex + 1),
+			formatVttCueText(normalizedText, speaker),
+		);
 		if (cueEnd < lines.length) {
 			updatedLines.push(lines[cueEnd] ?? "");
 		}
@@ -67,3 +125,122 @@ export function updateVttEntryText(
 		updated,
 	};
 }
+
+export interface TranscriptEntry {
+	id: number;
+	timestamp: string;
+	text: string;
+	startTime: number;
+	endTime: number;
+	speaker?: string | null;
+}
+
+export const parseVTT = (vttContent: string): TranscriptEntry[] => {
+	const lines = vttContent.split("\n");
+	const entries: TranscriptEntry[] = [];
+	let currentEntry: Partial<TranscriptEntry & { startTime: number }> = {};
+	let currentId = 0;
+
+	const timeToSeconds = (timeStr: string): number | null => {
+		const parts = timeStr.split(":");
+		if (parts.length !== 3) return null;
+
+		const [hoursStr, minutesStr, secondsStr] = parts;
+		if (!hoursStr || !minutesStr || !secondsStr) return null;
+
+		const hours = parseInt(hoursStr, 10);
+		const minutes = parseInt(minutesStr, 10);
+		const seconds = parseInt(secondsStr, 10);
+
+		if (Number.isNaN(hours) || Number.isNaN(minutes) || Number.isNaN(seconds))
+			return null;
+
+		return hours * 3600 + minutes * 60 + seconds;
+	};
+
+	const parseTimestamp = (
+		timestamp: string,
+	): { mm_ss: string; totalSeconds: number } | null => {
+		const parts = timestamp.split(":");
+		if (parts.length !== 3) return null;
+
+		const [hoursStr, minutesStr, secondsWithMs] = parts;
+		if (!hoursStr || !minutesStr || !secondsWithMs) return null;
+
+		const secondsPart = secondsWithMs.split(".")[0];
+		if (!secondsPart) return null;
+
+		const totalSeconds = timeToSeconds(
+			`${hoursStr}:${minutesStr}:${secondsPart}`,
+		);
+		if (totalSeconds === null) return null;
+
+		const fractionPart = secondsWithMs.split(".")[1];
+		const fraction = fractionPart ? Number(`0.${fractionPart}`) : 0;
+
+		return {
+			mm_ss: `${minutesStr}:${secondsPart}`,
+			totalSeconds: totalSeconds + (Number.isFinite(fraction) ? fraction : 0),
+		};
+	};
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		if (!line?.trim()) continue;
+
+		const trimmedLine = line.trim();
+
+		if (trimmedLine === "WEBVTT") continue;
+
+		if (/^\d+$/.test(trimmedLine)) {
+			currentId = parseInt(trimmedLine, 10);
+			continue;
+		}
+
+		if (trimmedLine.includes("-->")) {
+			const [startTimeStr, endTimeStr] = trimmedLine.split(" --> ");
+			if (!startTimeStr || !endTimeStr) continue;
+
+			const startTimestamp = parseTimestamp(startTimeStr);
+			const endTimestamp = parseTimestamp(endTimeStr);
+			if (startTimestamp) {
+				currentEntry = {
+					id: currentId,
+					timestamp: startTimestamp.mm_ss,
+					startTime: startTimestamp.totalSeconds,
+					endTime: endTimestamp?.totalSeconds ?? startTimestamp.totalSeconds,
+				};
+			}
+			continue;
+		}
+
+		if (currentEntry.timestamp && !currentEntry.text) {
+			const payload = [trimmedLine];
+			while (
+				i + 1 < lines.length &&
+				lines[i + 1]?.trim() &&
+				!lines[i + 1]?.includes("-->")
+			) {
+				i++;
+				payload.push(lines[i]?.trim() ?? "");
+			}
+			const rawText = payload.join(" ");
+			const text =
+				rawText.startsWith('"') && rawText.endsWith('"')
+					? rawText.slice(1, -1)
+					: rawText;
+			Object.assign(currentEntry, parseVttCueText(text));
+			if (
+				currentEntry.id !== undefined &&
+				currentEntry.startTime !== undefined &&
+				currentEntry.text
+			) {
+				entries.push(currentEntry as TranscriptEntry);
+			}
+			currentEntry = {};
+		}
+	}
+
+	const sortedEntries = entries.sort((a, b) => a.startTime - b.startTime);
+	return sortedEntries;
+};

--- a/apps/web/workflows/live-transcribe.ts
+++ b/apps/web/workflows/live-transcribe.ts
@@ -1,5 +1,5 @@
 import { db } from "@cap/database";
-import { organizations, users, videoEdits, videos } from "@cap/database/schema";
+import { organizations, users, videos } from "@cap/database/schema";
 import { serverEnv } from "@cap/env";
 import { Storage } from "@cap/web-backend/src/Storage/index";
 import {
@@ -9,30 +9,21 @@ import {
 	Video,
 } from "@cap/web-domain";
 import { AssemblyAI } from "assemblyai";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { Either, Option, Schema } from "effect";
 import { isAiGenerationEnabledForUser } from "@/lib/ai-generation-entitlement";
 import {
-	ASSEMBLYAI_SPEECH_MODELS,
 	ASSEMBLYAI_SUPPORTED_LANGUAGES,
 	getAssemblyAITranscriptionOptions,
 } from "@/lib/assemblyai";
 import {
-	getEditTranscriptObjectKey,
-	serializeEditTranscript,
-} from "@/lib/edit-transcript";
-import { encryptEditTranscriptObject } from "@/lib/edit-transcript-storage";
-import { startAiGeneration } from "@/lib/generate-ai";
-import {
 	applyChunkToLiveTranscript,
-	canPromoteLiveTranscript,
 	createEmptyLiveTranscript,
 	getLiveTranscriptObjectKey,
 	isNoSpokenAudioError,
 	LIVE_TRANSCRIBE,
 	LIVE_TRANSCRIPT_NO_SEGMENTS,
 	type LiveTranscriptState,
-	liveTranscriptToEditTranscript,
 	offsetChunkWords,
 	parseLiveTranscript,
 	planNextLiveChunk,
@@ -64,7 +55,7 @@ type ChunkStepResult =
 			transcribedDurationMs: number;
 			languageCode: string | null;
 			/** This chunk was the recording's final one: the manifest is complete
-			 * and coverage is now full, so promotion can start immediately
+			 * and coverage is now full, so final transcription can start immediately
 			 * without another poll round-trip. */
 			recordingComplete?: boolean;
 	  }
@@ -75,18 +66,8 @@ type ChunkStepResult =
 	| { outcome: "canonical-done" }
 	| { outcome: "gone" };
 
-/**
- * Live transcription for an instant-mode recording. Polls the segment
- * manifest the desktop app continuously re-uploads, transcribes new audio in
- * chunks, and maintains `transcription.live.json` for the share page.
- *
- * While recording, this never touches `videos.transcriptionStatus` or any
- * canonical artifact. At completion, IF the chunks cover the whole recording
- * gap-free, promoteLiveTranscript claims the canonical slot atomically and
- * writes the canonical transcript from the accumulated words — skipping the
- * duplicate full transcription pass. Anything less than perfect coverage
- * falls back to the normal full-pass pipeline unchanged.
- */
+// Speaker IDs are scoped to one AssemblyAI request. Chunk transcripts cannot
+// establish identity across a recording, so final diarization needs a full pass.
 export async function liveTranscribeWorkflow(
 	payload: LiveTranscribeWorkflowPayload,
 ) {
@@ -179,27 +160,15 @@ export async function liveTranscribeWorkflow(
 		throw error;
 	}
 
-	if (outcome === "done") {
-		// Full gap-free coverage: promote the live transcript to canonical and
-		// skip the duplicate full transcription pass entirely. On any failure
-		// the full-pass fallback is queued so transcription still lands fast.
-		const promotion = await promoteLiveTranscript(videoId, userId);
-		if (promotion.promoted) {
-			return {
-				success: true,
-				message: "Live transcription promoted to canonical",
-			};
-		}
-		console.warn(
-			`[liveTranscribe] Promotion declined for ${videoId}: ${promotion.reason}`,
-		);
-	}
-
 	await finishLiveTranscription(
 		videoId,
 		userId,
 		outcome === "done" ? "complete" : "stopped",
 	);
+
+	if (outcome === "done") {
+		await queueFullRecordingTranscription(videoId, userId);
+	}
 
 	return { success: true, message: `Live transcription ${outcome}` };
 }
@@ -284,7 +253,7 @@ async function processNextLiveChunk(options: {
 }): Promise<ChunkStepResult> {
 	"use step";
 
-	const { videoId, userId, lastProcessedIndex, targetSeconds } = options;
+	const { videoId, lastProcessedIndex, targetSeconds } = options;
 
 	const [video] = await db()
 		.select()
@@ -366,8 +335,8 @@ async function processNextLiveChunk(options: {
 		console.warn(
 			`[liveTranscribe] Skipping poison chunk ${lastProcessedIndex + 1}..${chunkEndIndex} for ${videoId}`,
 		);
-		// The gap MUST be durably recorded before the cursor advances, or a
-		// later promotion could ship a transcript that silently misses speech.
+		// Persist skipped audio before advancing so the provisional transcript
+		// remains honest about gaps until the full-recording pass finishes.
 		try {
 			const artifactKey = getLiveTranscriptObjectKey(video.ownerId, videoId);
 			const existing = await bucket
@@ -443,7 +412,7 @@ async function processNextLiveChunk(options: {
 			: ("auto" as AiGenerationLanguage);
 		const transcript = await client.transcripts.transcribe({
 			audio: audioBuffer,
-			...getAssemblyAITranscriptionOptions(language),
+			...getAssemblyAITranscriptionOptions(language, { speakerLabels: false }),
 			disfluencies: true,
 		});
 
@@ -506,7 +475,7 @@ async function processNextLiveChunk(options: {
 		await touchLiveClaim(videoId);
 
 		// If this chunk completed full coverage of a finished recording, tell
-		// the workflow to promote right away instead of paying another poll
+		// the workflow to queue final transcription without another poll
 		// round-trip - this latency is the stop-to-final-transcript feel.
 		const next = decodedManifest
 			? planNextLiveChunk({
@@ -567,235 +536,28 @@ async function touchLiveClaim(videoId: string): Promise<void> {
 	}
 }
 
-type PromotionResult = { promoted: boolean; reason?: string };
-
-/**
- * Promote the completed live transcript to the canonical transcript: write
- * transcription.vtt + the encrypted edit transcript from the accumulated
- * words, claim transcriptionStatus, queue AI generation, and clean up the
- * provisional artifact. Never throws. Any failure releases the claim (if
- * held) and queues the normal full-pass so the video still transcribes.
- */
-async function promoteLiveTranscript(
-	videoId: string,
-	userId: string,
-): Promise<PromotionResult> {
-	"use step";
-
-	try {
-		const [video] = await db()
-			.select()
-			.from(videos)
-			.where(eq(videos.id, videoId as Video.VideoId));
-
-		if (!video || video.ownerId !== userId) {
-			return { promoted: false, reason: "video not found" };
-		}
-		if (video.transcriptionStatus !== null) {
-			return {
-				promoted: false,
-				reason: `canonical status is ${video.transcriptionStatus}`,
-			};
-		}
-
-		const [bucket] = await Storage.getAccessForVideo(
-			decodeStorageVideo(video),
-		).pipe(runWorkflowPromise);
-		const segSource = new Video.SegmentsSource({
-			videoId,
-			ownerId: video.ownerId,
-		});
-
-		const manifestContent = await bucket
-			.getObject(segSource.getManifestKey())
-			.pipe(runWorkflowPromise);
-		const manifestJson = Option.getOrNull(manifestContent);
-		if (!manifestJson) {
-			return { promoted: false, reason: "manifest missing" };
-		}
-		const decoded = Schema.decodeUnknownEither(Video.SegmentManifest)(
-			JSON.parse(manifestJson),
-		);
-		if (Either.isLeft(decoded)) {
-			return { promoted: false, reason: "manifest invalid" };
-		}
-
-		const artifactKey = getLiveTranscriptObjectKey(video.ownerId, videoId);
-		const existing = await bucket
-			.getObject(artifactKey)
-			.pipe(runWorkflowPromise);
-		const artifact = Option.isSome(existing)
-			? parseLiveTranscript(existing.value)
-			: null;
-		if (!artifact) {
-			return { promoted: false, reason: "live artifact missing" };
-		}
-
-		const eligible = canPromoteLiveTranscript(artifact, decoded.right);
-		if (!eligible.ok) {
-			await queueFullPassFallback(videoId, userId);
-			return { promoted: false, reason: eligible.reason };
-		}
-
-		const claim = await db()
-			.update(videos)
-			.set({ transcriptionStatus: "PROCESSING" })
-			.where(
-				and(
-					eq(videos.id, videoId as Video.VideoId),
-					isNull(videos.transcriptionStatus),
-				),
-			);
-		const affectedRows = Array.isArray(claim)
-			? ((claim[0] as { affectedRows?: number } | undefined)?.affectedRows ?? 0)
-			: ((claim as { affectedRows?: number } | undefined)?.affectedRows ?? 0);
-		if (affectedRows === 0) {
-			return { promoted: false, reason: "canonical claim held elsewhere" };
-		}
-
-		try {
-			await bucket
-				.putObject(
-					`${video.ownerId}/${videoId}/transcription.vtt`,
-					artifact.vtt,
-					{ contentType: "text/vtt" },
-				)
-				.pipe(runWorkflowPromise);
-
-			// Same rule as the full-pass save: the word transcript must describe
-			// the original media, so edited videos keep their own.
-			const [edit] = await db()
-				.select({ videoId: videoEdits.videoId })
-				.from(videoEdits)
-				.where(eq(videoEdits.videoId, videoId as Video.VideoId));
-			if (!edit) {
-				await bucket
-					.putObject(
-						getEditTranscriptObjectKey(video.ownerId, videoId),
-						encryptEditTranscriptObject(
-							serializeEditTranscript(
-								liveTranscriptToEditTranscript(
-									artifact,
-									ASSEMBLYAI_SPEECH_MODELS[0],
-								),
-							),
-							video.ownerId,
-							videoId,
-						),
-						{ contentType: "application/octet-stream" },
-					)
-					.pipe(runWorkflowPromise);
-			}
-
-			await db()
-				.update(videos)
-				.set({ transcriptionStatus: "COMPLETE" })
-				.where(
-					and(
-						eq(videos.id, videoId as Video.VideoId),
-						eq(videos.transcriptionStatus, "PROCESSING"),
-					),
-				);
-		} catch (error) {
-			// Release the claim so the fallback can transcribe from scratch.
-			await db()
-				.update(videos)
-				.set({ transcriptionStatus: null })
-				.where(
-					and(
-						eq(videos.id, videoId as Video.VideoId),
-						eq(videos.transcriptionStatus, "PROCESSING"),
-					),
-				);
-			await queueFullPassFallback(videoId, userId);
-			return {
-				promoted: false,
-				reason: error instanceof Error ? error.message : String(error),
-			};
-		}
-
-		// Post-COMPLETE housekeeping: never fatal, never releases the claim.
-		try {
-			await bucket.deleteObject(artifactKey).pipe(runWorkflowPromise);
-		} catch (error) {
-			console.warn(
-				`[liveTranscribe] Failed to delete promoted artifact for ${videoId}`,
-				error,
-			);
-		}
-		try {
-			await db()
-				.update(videos)
-				.set({
-					metadata: sql`JSON_REMOVE(COALESCE(${videos.metadata}, JSON_OBJECT()), '$.liveTranscript')`,
-					updatedAt: sql`${videos.updatedAt}`,
-				})
-				.where(eq(videos.id, videoId as Video.VideoId));
-		} catch (error) {
-			console.warn(
-				`[liveTranscribe] Failed to clear live flag for ${videoId}`,
-				error,
-			);
-		}
-		try {
-			const [owner] = await db()
-				.select({
-					email: users.email,
-					stripeSubscriptionStatus: users.stripeSubscriptionStatus,
-					thirdPartyStripeSubscriptionId: users.thirdPartyStripeSubscriptionId,
-				})
-				.from(users)
-				.where(eq(users.id, userId as User.UserId));
-			if (isAiGenerationEnabledForUser(owner)) {
-				await startAiGeneration(videoId as Video.VideoId, userId);
-			}
-		} catch (error) {
-			console.warn(
-				`[liveTranscribe] Failed to queue AI generation for ${videoId}`,
-				error,
-			);
-		}
-
-		return { promoted: true };
-	} catch (error) {
-		return {
-			promoted: false,
-			reason: error instanceof Error ? error.message : String(error),
-		};
-	}
-}
-
-/**
- * When promotion can't happen, immediately queue the normal full
- * transcription (early-from-segments) instead of waiting for the post-mux
- * queue, so a declined promotion costs seconds, not a minute.
- */
-async function queueFullPassFallback(
+async function queueFullRecordingTranscription(
 	videoId: string,
 	userId: string,
 ): Promise<void> {
-	try {
-		const [owner] = await db()
-			.select({
-				email: users.email,
-				stripeSubscriptionStatus: users.stripeSubscriptionStatus,
-				thirdPartyStripeSubscriptionId: users.thirdPartyStripeSubscriptionId,
-			})
-			.from(users)
-			.where(eq(users.id, userId as User.UserId));
+	"use step";
 
-		await transcribeVideo(
-			videoId as Video.VideoId,
-			userId,
-			isAiGenerationEnabledForUser(owner),
-			{ earlyFromSegments: true },
-		);
-	} catch (error) {
-		console.warn(
-			`[liveTranscribe] Full-pass fallback queue failed for ${videoId}`,
-			error,
-		);
-	}
+	const [owner] = await db()
+		.select({
+			email: users.email,
+			stripeSubscriptionStatus: users.stripeSubscriptionStatus,
+			thirdPartyStripeSubscriptionId: users.thirdPartyStripeSubscriptionId,
+		})
+		.from(users)
+		.where(eq(users.id, userId as User.UserId));
+
+	const result = await transcribeVideo(
+		videoId as Video.VideoId,
+		userId,
+		isAiGenerationEnabledForUser(owner),
+		{ earlyFromSegments: true },
+	);
+	if (!result.success) throw new Error(result.message);
 }
 
 async function finishLiveTranscription(

--- a/packages/web-domain/src/Agent.ts
+++ b/packages/web-domain/src/Agent.ts
@@ -281,6 +281,7 @@ export const AgentChapter = Schema.Struct({
 });
 
 export const AgentTranscriptCue = Schema.Struct({
+	speaker: Schema.optional(Schema.NullOr(Schema.String)),
 	startMs: Schema.Number,
 	endMs: Schema.Number,
 	text: Schema.String,


### PR DESCRIPTION
The Transcript tab currently renders every subtitle cue as a separate row, splitting speech at commas, short pauses, and every eight words. This groups adjacent cues into sentence rows while preserving speaker boundaries and exact outer timestamps. Existing transcripts, translated captions, and provisional live transcripts benefit without retranscription.

Subtitle files retain their original timing. Owners can select **Edit transcript** to expose the original cues for precise corrections; edits never save a merged sentence under a single cue ID. Timestamped copying uses the readable sentence rows. Grouping also stops at long silence, overlaps, and bounded length/duration when punctuation is missing.

**Depends on #2243 (AssemblyAI diarization).** This branch is based on that PR's head, `2766dc0`; merge that PR first. Until then, GitHub's cumulative diff includes the prerequisite. [Review only this follow-up's four files](https://github.com/pavzagor/Cap/compare/2766dc045466734e72c6ec9e4fba6012e2bd00ff...decfd40ecf8a86e4581165f51f74a7e37d6ca86c).

### English before/after proof

A fresh AssemblyAI transcription of [NASA's public JFK archival clip](https://heasarc.gsfc.nasa.gov/docs/heasarc/videos/historical.html) produces **12 caption fragments before → 3 sentence rows after**, preserving all 72 words. Selecting the matching row on either side seeks the embedded source video to **12.850 seconds**.

[Watch/download the before/after MP4](https://raw.githubusercontent.com/pavzagor/Cap/62891fa78e49fb1c7b8596576dd0e754db39ec8d/english-before-after.mp4) · [GitHub video page](https://github.com/pavzagor/Cap/blob/62891fa78e49fb1c7b8596576dd0e754db39ec8d/english-before-after.mp4) · [Source clip](https://github.com/pavzagor/Cap/blob/62891fa78e49fb1c7b8596576dd0e754db39ec8d/jfk-source.mp4) · [All proof files and methodology](https://github.com/pavzagor/Cap/blob/b0adff78bb3a78829cd3a3f52387fe6c9b8b6864/README.md)

![English transcript before and after](https://raw.githubusercontent.com/pavzagor/Cap/62891fa78e49fb1c7b8596576dd0e754db39ec8d/english-before-after.png)

The proof uses the actual old/new React components and real ASR output, with storage/auth hooks mocked. It is not production footage or proof of a persisted backend edit. Full local share-page verification was blocked by unavailable MySQL at `127.0.0.1:3306`. NASA's clip splices two speeches; A/B are the unmodified ASR labels.

### Validation

- 91 focused tests passed: sentence grouping/UI, diarization, VTT, text formatting, translation, caption generation, and transcript editing.
- Scoped Biome check and `git diff --check` passed.
- Web `tsc --noEmit` passed in the existing development checkout; the isolated checkout reused dependencies and was unsuitable for the workspace reference type check.
- Browser checked sentence seeking, fragment editing controls, and 360px/393px layouts without horizontal overflow. Timestamped copying is covered by the UI tests.
- No migration, new environment variable, or paid reprocessing is required by this change.




### Review fix: multilingual sentence endings

Addressed the Arabic question-mark finding in `decfd40` with Unicode `Sentence_Terminal`. Regression tests cover Arabic, quoted Arabic and Hindi, plus original/translated Arabic rendering and exact seeking. All 91 focused tests, TypeScript, scoped Biome and whitespace checks pass. The approved English output remains byte-for-byte equivalent as parsed sentence entries (12 fragments → 3 sentences).

[Review-fix walkthrough](https://raw.githubusercontent.com/pavzagor/Cap/b0adff78bb3a78829cd3a3f52387fe6c9b8b6864/unicode-review-fix.mp4) · [Validation log](https://github.com/pavzagor/Cap/blob/b0adff78bb3a78829cd3a3f52387fe6c9b8b6864/unicode-tests.log) · [English parity check](https://github.com/pavzagor/Cap/blob/b0adff78bb3a78829cd3a3f52387fe6c9b8b6864/english-parity.json)

![Arabic and Hindi sentence boundaries before and after](https://raw.githubusercontent.com/pavzagor/Cap/b0adff78bb3a78829cd3a3f52387fe6c9b8b6864/unicode-review-fix.png)

This additional proof uses the actual component with a synthetic multilingual fixture and mocked storage/auth.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62135987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with the previously reported multilingual sentence-boundary issue fully resolved.

<h3>Summary</h3>

- Groups adjacent caption cues into sentence-level rows while retaining cue-level editing and exact outer timestamps.
- Preserves diarization metadata through transcription, VTT parsing and serialization, translation, editing, downloads, and agent APIs.
- Runs a recording-wide transcription pass after provisional live transcription so speaker identities remain consistent.
- Extends sentence-ending detection to Unicode sentence terminators, fixing Arabic and Hindi boundaries.

<sub>Reviews (2) · Last reviewed commit: ["fix: recognize multilingual sentence ter..."](https://github.com/capsoftware/cap/commit/decfd40ecf8a86e4581165f51f74a7e37d6ca86c)</sub>

<!-- /greptile_comment -->