### PR TITLE
fix: serve public assets on self-hosted deployments

### DIFF
--- a/apps/web/__tests__/unit/proxy-self-hosted.test.ts
+++ b/apps/web/__tests__/unit/proxy-self-hosted.test.ts
@@ -52,6 +52,7 @@ describe("self-hosted proxy routes", () => {
 		"/rive/main.riv",
 		"/fonts/Geist-Regular.woff2",
 		"/site.webmanifest",
+		"/.well-known/atproto-did",
 	])("serves the public asset %s instead of redirecting", (path) =>
 		expectServed(path),
 	);

--- a/apps/web/__tests__/unit/proxy-self-hosted.test.ts
+++ b/apps/web/__tests__/unit/proxy-self-hosted.test.ts
@@ -25,6 +25,20 @@ vi.mock("@cap/env", () => ({
 const request = (path: string) =>
 	proxy(new NextRequest(`https://cap.example.com${path}`));
 
+const expectServed = async (path: string) => {
+	const response = await request(path);
+	expect(response.status).toBe(200);
+	expect(response.headers.get("location")).toBeNull();
+};
+
+const expectLoginRedirect = async (path: string) => {
+	const response = await request(path);
+	expect(response.status).toBe(307);
+	expect(response.headers.get("location")).toBe(
+		"https://cap.example.com/login",
+	);
+};
+
 describe("self-hosted proxy routes", () => {
 	it("allows browser-based CLI authorization pages", () => {
 		const source = readFileSync(join(process.cwd(), "proxy.ts"), "utf8");
@@ -33,30 +47,29 @@ describe("self-hosted proxy routes", () => {
 
 	it.each([
 		"/logos/browsers/google-chrome.svg",
-		"/illustrations/mask-bg.webp",
-		"/sounds/recording-start.mp3",
+		"/illustrations/app.webp",
+		"/sounds/start-recording.ogg",
 		"/rive/main.riv",
-		"/fonts/Inter.woff2",
-	])("serves the public asset %s instead of redirecting", async (path) => {
-		const response = await request(path);
+		"/fonts/Geist-Regular.woff2",
+		"/site.webmanifest",
+	])("serves the public asset %s instead of redirecting", (path) =>
+		expectServed(path),
+	);
 
-		expect(response.status).toBe(200);
-		expect(response.headers.get("location")).toBeNull();
-	});
+	it("still redirects page routes to /login", () =>
+		expectLoginRedirect("/pricing"));
 
-	it("still redirects unauthenticated page routes to /login", async () => {
-		const response = await request("/pricing");
+	it("still redirects extension-suffixed route handlers to /login", () =>
+		expectLoginRedirect("/install-cli.sh"));
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(
-			"https://cap.example.com/login",
-		);
-	});
+	it("does not let a missing file through", () =>
+		expectLoginRedirect("/logos/missing.svg"));
 
-	it("does not treat a share link as a static asset", async () => {
-		const response = await request("/s/video123");
+	it("does not let a directory through", () => expectLoginRedirect("/logos"));
 
-		expect(response.status).toBe(200);
-		expect(response.headers.get("location")).toBeNull();
-	});
+	it("rejects path traversal out of public/", () =>
+		expectLoginRedirect("/logos/..%2F..%2Fproxy.ts"));
+
+	it("does not treat a share link as an asset", () =>
+		expectServed("/s/video123"));
 });

--- a/apps/web/__tests__/unit/proxy-self-hosted.test.ts
+++ b/apps/web/__tests__/unit/proxy-self-hosted.test.ts
@@ -1,10 +1,62 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { describe, expect, it, vi } from "vitest";
+import { proxy } from "../../proxy";
+
+vi.mock("@cap/database", () => ({
+	db: () => {
+		throw new Error("Database should not be reached on self-hosted routes");
+	},
+}));
+
+vi.mock("@cap/database/schema", () => ({ organizations: {} }));
+
+vi.mock("@cap/env", () => ({
+	buildEnv: { NEXT_PUBLIC_IS_CAP: "false" },
+	serverEnv: () => ({
+		WEB_URL: "https://cap.example.com",
+		VERCEL_URL_HOST: undefined,
+		VERCEL_BRANCH_URL_HOST: undefined,
+		VERCEL_PROJECT_PRODUCTION_URL_HOST: undefined,
+	}),
+}));
+
+const request = (path: string) =>
+	proxy(new NextRequest(`https://cap.example.com${path}`));
 
 describe("self-hosted proxy routes", () => {
 	it("allows browser-based CLI authorization pages", () => {
 		const source = readFileSync(join(process.cwd(), "proxy.ts"), "utf8");
 		expect(source).toContain('path.startsWith("/cli/")');
+	});
+
+	it.each([
+		"/logos/browsers/google-chrome.svg",
+		"/illustrations/mask-bg.webp",
+		"/sounds/recording-start.mp3",
+		"/rive/main.riv",
+		"/fonts/Inter.woff2",
+	])("serves the public asset %s instead of redirecting", async (path) => {
+		const response = await request(path);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("location")).toBeNull();
+	});
+
+	it("still redirects unauthenticated page routes to /login", async () => {
+		const response = await request("/pricing");
+
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(
+			"https://cap.example.com/login",
+		);
+	});
+
+	it("does not treat a share link as a static asset", async () => {
+		const response = await request("/s/video123");
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("location")).toBeNull();
 	});
 });

--- a/apps/web/__tests__/unit/proxy-self-hosted.test.ts
+++ b/apps/web/__tests__/unit/proxy-self-hosted.test.ts
@@ -71,6 +71,11 @@ describe("self-hosted proxy routes", () => {
 	it("rejects path traversal out of public/", () =>
 		expectLoginRedirect("/logos/..%2F..%2Fproxy.ts"));
 
+	it.each(["/%00", "/favicon.ico/nested.svg", `/${"a".repeat(5000)}.svg`])(
+		"treats a filesystem lookup failure for %s as not an asset",
+		(path) => expectLoginRedirect(path),
+	);
+
 	it("does not treat a share link as an asset", () =>
 		expectServed("/s/video123"));
 });

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -54,8 +54,12 @@ export async function proxy(request: NextRequest) {
 	const hostname = url.hostname;
 
 	if (buildEnv.NEXT_PUBLIC_IS_CAP !== "true") {
+		// Files under public/ have no route of their own, so without this every
+		// <img src="/logos/..."> on a self-hosted instance redirects to /login.
+		const isStaticAsset = /\.[a-z0-9]+$/i.test(path);
 		if (
 			!(
+				isStaticAsset ||
 				path.startsWith("/s/") ||
 				path.startsWith("/c/") ||
 				path.startsWith("/cli/") ||

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -16,15 +16,13 @@ const addHttps = (s?: string) => {
 const publicDir = resolve(process.cwd(), "public");
 
 const isPublicAsset = (path: string) => {
-	let decoded: string;
 	try {
-		decoded = decodeURIComponent(path);
+		const file = resolve(publicDir, `.${decodeURIComponent(path)}`);
+		if (!file.startsWith(`${publicDir}${sep}`)) return false;
+		return statSync(file, { throwIfNoEntry: false })?.isFile() ?? false;
 	} catch {
 		return false;
 	}
-	const file = resolve(publicDir, `.${decoded}`);
-	if (!file.startsWith(`${publicDir}${sep}`)) return false;
-	return statSync(file, { throwIfNoEntry: false })?.isFile() ?? false;
 };
 
 const mainOrigins = [

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,3 +1,5 @@
+import { statSync } from "node:fs";
+import { resolve, sep } from "node:path";
 import { db } from "@cap/database";
 import { organizations } from "@cap/database/schema";
 import { buildEnv, serverEnv } from "@cap/env";
@@ -9,6 +11,20 @@ import { getShareIframeRedirectUrl } from "@/lib/share-iframe-navigation";
 const addHttps = (s?: string) => {
 	if (!s) return s;
 	return `https://${s}`;
+};
+
+const publicDir = resolve(process.cwd(), "public");
+
+const isPublicAsset = (path: string) => {
+	let decoded: string;
+	try {
+		decoded = decodeURIComponent(path);
+	} catch {
+		return false;
+	}
+	const file = resolve(publicDir, `.${decoded}`);
+	if (!file.startsWith(`${publicDir}${sep}`)) return false;
+	return statSync(file, { throwIfNoEntry: false })?.isFile() ?? false;
 };
 
 const mainOrigins = [
@@ -56,10 +72,9 @@ export async function proxy(request: NextRequest) {
 	if (buildEnv.NEXT_PUBLIC_IS_CAP !== "true") {
 		// Files under public/ have no route of their own, so without this every
 		// <img src="/logos/..."> on a self-hosted instance redirects to /login.
-		const isStaticAsset = /\.[a-z0-9]+$/i.test(path);
 		if (
 			!(
-				isStaticAsset ||
+				isPublicAsset(path) ||
 				path.startsWith("/s/") ||
 				path.startsWith("/c/") ||
 				path.startsWith("/cli/") ||


### PR DESCRIPTION
## Problem

On a self-hosted deployment (`NEXT_PUBLIC_IS_CAP` unset), `proxy.ts` redirects every path outside its allowlist to `/login`, and the matcher only exempts `favicon.ico`, `robots.txt` and `sitemap.xml`. Every other file under `apps/web/public/` therefore 307s to `/login`, so `<img src="/logos/browsers/google-chrome.svg">` on onboarding, the OS/browser logos, illustrations, sounds, Rive files and fonts all render broken. cap.so never sees this because it takes the `IS_CAP` branch.

Reproduced on a Docker build of `24e3c74`:

```
GET /logos/browsers/google-chrome.svg -> 307 /login
GET /logos/cap.svg                    -> 307 /login
GET /icons/logo.png                   -> 307 /login
GET /favicon.ico                      -> 200
```

## Fix

In the self-hosted branch, let a path through when it resolves to an existing file under `apps/web/public/`. The proxy already runs in the Node runtime (it imports the database), so this is a `statSync` on a resolved path, with traversal out of `public/` rejected.

This avoids maintaining an extension list, which is where #2127 was flagged for still missing `.riv` and the recorder sounds, and it does not widen the bypass to non-asset routes: `/install-cli.sh` and the docs catch-all keep their current behaviour because they are not files in `public/`.

Related: #2127 takes the extension-allowlist approach for the same bug.

## Tests

`apps/web/__tests__/unit/proxy-self-hosted.test.ts` now calls `proxy()` directly with `NEXT_PUBLIC_IS_CAP` mocked off and asserts:

- real `.svg`, `.webp`, `.ogg`, `.riv`, `.woff2` and root-level `site.webmanifest` assets return 200 with no redirect
- `/pricing` still redirects to `/login`
- `/install-cli.sh`, an extension-suffixed route handler, still redirects
- a missing file, a directory, and `..%2F` traversal all still redirect
- `/s/video123` is unaffected

Confirmed the asset cases fail on `main` and pass with the change.

## Validation

```
bun run biome check --write apps/web/proxy.ts apps/web/__tests__/unit/proxy-self-hosted.test.ts
cd apps/web && bun run vitest run __tests__/unit/proxy-self-hosted.test.ts __tests__/unit/share-iframe-navigation.test.ts
```






<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62394858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the current implementation addresses all previous findings without introducing a new actionable defect.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Extensionless Asset Still Redirects** <a href="https://github.com/CapSoftware/Cap/pull/2266#discussion_r3974440839">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Malformed Paths Can Throw** <a href="https://github.com/CapSoftware/Cap/pull/2266#discussion_r3974466205">▶</a>
3. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Filesystem Errors Escape Proxy** <a href="https://github.com/CapSoftware/Cap/pull/2266#discussion_r3974466360">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
apps/web/proxy.ts:undefined-59
The extension-only check does not match the existing public file `public/.well-known/atproto-did`, and the separate allowlist only covers `/.well-known/workflow/`. On self-hosted deployments, requests for this well-known resource therefore still redirect to `/login` instead of serving the file, leaving the public-asset fix incomplete.

### Issue 2
apps/web/proxy.ts:undefined-27
A request path containing an encoded NUL byte, such as `/%00`, is decoded and passed to `statSync`. Node rejects that path with `ERR_INVALID_ARG_VALUE`, which `throwIfNoEntry: false` does not suppress. Because this call is outside the later error handler, the self-hosted proxy throws instead of redirecting the request to `/login`. Catch filesystem validation errors and treat them as a non-asset path.

### Issue 3
apps/web/proxy.ts:undefined-27
A request pathname can make `statSync` fail for reasons other than a missing entry-for example, an overlong decoded path can produce `ENAMETOOLONG`. Since this call is outside a catch block, the error escapes `proxy()` and returns a 500 instead of following the existing `/login` redirect behavior. Treat filesystem lookup failures as “not a public asset.”

```suggestion
	try {
		return statSync(file, { throwIfNoEntry: false })?.isFile() ?? false;
	} catch {
		return false;
	}
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- Uses canonical path resolution and a public-directory boundary check to reject traversal.
- Treats malformed paths and filesystem lookup failures as non-assets.
- Adds direct proxy tests for common asset formats, an extensionless well-known file, route preservation, traversal, directories, missing files, and malformed paths.
- The three previous findings are fully addressed by the current implementation and regression coverage.

<sub>Reviews (4) · Last reviewed commit: ["fix: treat filesystem lookup failures as..."](https://github.com/capsoftware/cap/commit/c17e012b4403db1fedc778b749076dc45e385bd7)</sub>

<!-- /greptile_comment -->