### PR TITLE
fix: let self-hosted web builds bake their own public URL

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -12,7 +12,8 @@ COPY . .
 RUN --mount=type=cache,id=bun-1.4.0,target=/root/.bun/install/cache bun install --frozen-lockfile
 
 ARG NEXT_PUBLIC_DOCKER_BUILD=true
-ENV NEXT_PUBLIC_WEB_URL=http://localhost:3000
+ARG NEXT_PUBLIC_WEB_URL=http://localhost:3000
+ENV NEXT_PUBLIC_WEB_URL=$NEXT_PUBLIC_WEB_URL
 
 RUN bun run build:web
 

--- a/apps/web/content/docs/self-hosting.mdx
+++ b/apps/web/content/docs/self-hosting.mdx
@@ -70,6 +70,14 @@ MYSQL_PASSWORD=your-secure-password
 MINIO_ROOT_PASSWORD=your-minio-password
 ```
 
+**Building your own web image:**
+
+`CAP_URL` is read at runtime by the server, but the browser bundle gets its copy of the public URL baked in at build time from `NEXT_PUBLIC_WEB_URL`. The pre-built `ghcr.io` image bakes `http://localhost:3000`. If you build `apps/web/Dockerfile` yourself, pass your public URL as a build argument so share links, embeds and CORS work in the browser:
+
+```bash
+docker build -f apps/web/Dockerfile --build-arg NEXT_PUBLIC_WEB_URL=https://cap.yourdomain.com .
+```
+
 ### Option 2: Railway (One-Click)
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template/PwpGcf)


### PR DESCRIPTION
## Problem

`apps/web/Dockerfile` hardcodes:

```dockerfile
ENV NEXT_PUBLIC_WEB_URL=http://localhost:3000
```

Next inlines `process.env.NEXT_PUBLIC_*` into the client bundle at build time, so this value reaches the browser regardless of what `WEB_URL` / `CAP_URL` says at runtime. `packages/env/build.ts` resolves `NEXT_PUBLIC_WEB_URL` as `process.env.WEB_URL ?? process.env.NEXT_PUBLIC_WEB_URL`, which fixes the server side, but inside a client chunk `process.env.WEB_URL` is `undefined` and the fallback is whatever the Dockerfile baked. Anything client-side that reads `buildEnv.NEXT_PUBLIC_WEB_URL` (for example `components/LinkifiedText.tsx`, and the origin list seeded in `utils/cors.ts`) therefore sees `http://localhost:3000` on a self-hosted build.

A self-hoster cannot fix this with `.env` alone: dotenv does not override a variable already present in the environment, and the Dockerfile's `ENV` puts it there before `next build` runs.

## Fix

Back the `ENV` with an `ARG` carrying the same default:

```dockerfile
ARG NEXT_PUBLIC_WEB_URL=http://localhost:3000
ENV NEXT_PUBLIC_WEB_URL=$NEXT_PUBLIC_WEB_URL
```

Passing nothing is a no-op, so the published `ghcr.io/capsoftware/cap-web` image is unchanged. Anyone building the image themselves can pass `--build-arg NEXT_PUBLIC_WEB_URL=https://cap.example.com` and get the right origin in the browser bundle.

Also adds a short note to the self-hosting docs explaining the runtime vs build-time split, since `CAP_URL` looks like it should be enough and is not.

## Validation

- `docker build --check -f apps/web/Dockerfile .` reports only the pre-existing `JSONArgsRecommended` warning on the `CMD` line.
- We run this exact change in production on a self-hosted instance; a CI smoke test there greps the built client bundle for the passed origin and confirms it is present in place of `localhost:3000`.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62406747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge and preserves existing image behavior when no build argument is supplied.

<h3>Summary</h3>

- Adds a `NEXT_PUBLIC_WEB_URL` Docker build argument and exposes it during the Next.js build.
- Documents the distinction between the server's runtime URL and the browser bundle's build-time URL.
- Provides a self-hosted Docker build example using the new argument.

<sub>Reviews (1) · Last reviewed commit: ["fix: let self-hosted web builds bake the..."](https://github.com/capsoftware/cap/commit/cfbf62325e0489dfc7f76c61ba31fdc5be48e71a)</sub>

<!-- /greptile_comment -->