### PR TITLE
fix: preserve editor handoff across equivalent Windows paths

### DIFF
--- a/crates/editor/src/completed_audio.rs
+++ b/crates/editor/src/completed_audio.rs
@@ -1,6 +1,9 @@
 use cap_audio::DecodedAudio;
 use cap_project::{AudioGapSummary, AudioMeta, RecordingMeta, StudioRecordingMeta};
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 #[derive(Clone, Default)]
 pub(crate) struct CompletedAudioSegment {
@@ -50,6 +53,14 @@ fn audio_identities(meta: &StudioRecordingMeta) -> Vec<SegmentAudioIdentity> {
     }
 }
 
+fn same_project_path(left: &Path, right: &Path) -> bool {
+    left == right
+        || matches!(
+            (left.canonicalize(), right.canonicalize()),
+            (Ok(left), Ok(right)) if left == right
+        )
+}
+
 #[derive(Clone)]
 pub struct CompletedAudioHandoff {
     project_path: PathBuf,
@@ -63,7 +74,10 @@ impl CompletedAudioHandoff {
         expected_finalized_metadata: &RecordingMeta,
         segments: Vec<CompletedAudioSegment>,
     ) -> Result<Self, String> {
-        if source_metadata.project_path != expected_finalized_metadata.project_path {
+        if !same_project_path(
+            &source_metadata.project_path,
+            &expected_finalized_metadata.project_path,
+        ) {
             return Err("Completed audio belongs to a different project".into());
         }
         let source = audio_identities(
@@ -107,7 +121,7 @@ impl CompletedAudioHandoff {
         recording_meta: &RecordingMeta,
         meta: &StudioRecordingMeta,
     ) -> Option<Vec<CompletedAudioSegment>> {
-        (self.project_path == recording_meta.project_path
+        (same_project_path(&self.project_path, &recording_meta.project_path)
             && self.identities == audio_identities(meta))
         .then_some(self.segments)
     }
@@ -225,6 +239,98 @@ pub(crate) mod tests {
         assert!(Arc::ptr_eq(matched[0].mic.as_ref().unwrap(), &audio));
         assert!(matched[0].system_audio.is_none());
         assert!(matched[1].mic.is_none());
+    }
+
+    #[test]
+    fn completed_cache_accepts_equivalent_project_paths_and_preserves_pcm() {
+        let directory = tempfile::tempdir().unwrap();
+        let entry = directory.path().join("editor-entry");
+        std::fs::create_dir(&entry).unwrap();
+        let mut original = metadata();
+        original.project_path = entry.join("..");
+        let mut finalized = original.clone();
+        finalized.project_path = directory.path().canonicalize().unwrap();
+        assert_ne!(original.project_path, finalized.project_path);
+        let audio = audio();
+        for expected in [&original, &finalized] {
+            let cache = CompletedAudioHandoff::from_completed_tracks(
+                &original,
+                expected,
+                completed(&audio),
+            )
+            .unwrap();
+            let matched = cache
+                .into_matching(&finalized, finalized.studio_meta().unwrap())
+                .unwrap();
+            assert!(Arc::ptr_eq(matched[0].mic.as_ref().unwrap(), &audio));
+        }
+    }
+
+    #[test]
+    fn silent_completed_cache_accepts_canonical_editor_paths() {
+        let directory = tempfile::tempdir().unwrap();
+        let entry = directory.path().join("editor-entry");
+        std::fs::create_dir(&entry).unwrap();
+        for count in [1, 2] {
+            let mut original = metadata();
+            original.project_path = entry.join("..");
+            let segments = segments_mut(&mut original);
+            segments.truncate(count);
+            for segment in segments {
+                segment.mic = None;
+                segment.system_audio = None;
+            }
+            let cache = CompletedAudioHandoff::from_completed_tracks(
+                &original,
+                &original,
+                vec![CompletedAudioSegment::default(); count],
+            )
+            .unwrap();
+            let mut finalized = original.clone();
+            finalized.project_path = directory.path().canonicalize().unwrap();
+            let matched = cache
+                .into_matching(&finalized, finalized.studio_meta().unwrap())
+                .unwrap();
+            assert_eq!(matched.len(), count);
+            assert!(
+                matched
+                    .iter()
+                    .all(|segment| segment.mic.is_none() && segment.system_audio.is_none())
+            );
+        }
+    }
+
+    #[test]
+    fn completed_cache_rejects_different_or_unresolvable_project_paths() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut original = metadata();
+        original.project_path = directory.path().join("original.cap");
+        std::fs::create_dir(&original.project_path).unwrap();
+        let mut other = original.clone();
+        other.project_path = directory.path().join("other.cap");
+        std::fs::create_dir(&other.project_path).unwrap();
+        let audio = audio();
+        for missing in [false, true] {
+            if missing {
+                original.project_path = directory.path().join("missing-original.cap");
+                other.project_path = directory.path().join("missing-other.cap");
+            }
+            assert!(
+                CompletedAudioHandoff::from_completed_tracks(&original, &other, completed(&audio))
+                    .is_err()
+            );
+            let cache = CompletedAudioHandoff::from_completed_tracks(
+                &original,
+                &original,
+                completed(&audio),
+            )
+            .unwrap();
+            assert!(
+                cache
+                    .into_matching(&other, other.studio_meta().unwrap())
+                    .is_none()
+            );
+        }
     }
 
     #[test]

--- a/crates/editor/src/preparing_preview/native_tests.rs
+++ b/crates/editor/src/preparing_preview/native_tests.rs
@@ -1160,7 +1160,10 @@ async fn native_handoff_reuses_pcm_preserves_audio_across_candidate_disposal_and
     use std::sync::atomic::AtomicUsize;
 
     let fixture = handoff_fixture();
-    let root = fixture.metadata.project_path.clone();
+    let entry = fixture.metadata.project_path.join("editor-entry");
+    std::fs::create_dir(&entry).unwrap();
+    let root = entry.join("..");
+    assert_ne!(root, fixture.metadata.project_path);
     let nonzero = Arc::new(AtomicUsize::new(0));
     let tapped = nonzero.clone();
     let output = Arc::new(crate::AudioOutput::new_headless(Box::new(
@@ -1325,6 +1328,141 @@ async fn native_handoff_reuses_pcm_preserves_audio_across_candidate_disposal_and
     drop(session);
     drop(fixture.source);
     assert!(fixture.released.load(Ordering::Acquire));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_silent_handoff_opens_and_renders_through_an_equivalent_editor_path() {
+    for count in [1, 2] {
+        let mut fixture = handoff_fixture();
+        let segments = crate::completed_audio::tests::segments_mut(&mut fixture.metadata);
+        segments.truncate(count);
+        for segment in segments {
+            segment.mic = None;
+            segment.system_audio = None;
+            segment.camera = None;
+        }
+        fixture.project.clips.truncate(count);
+        fixture
+            .project
+            .timeline
+            .as_mut()
+            .unwrap()
+            .segments
+            .truncate(count);
+        fixture.metadata.save_for_project().unwrap();
+        fixture
+            .project
+            .write(&fixture.metadata.project_path)
+            .unwrap();
+        let metadata = fixture.metadata.studio_meta().unwrap();
+        let input = PreparingPreviewInput {
+            recording_meta: fixture.metadata.clone(),
+            project: fixture.project.clone(),
+            segments: (0..count)
+                .map(|index| PreparingPreviewSegment {
+                    video: ManagedSegmentVideoInput::new(
+                        index,
+                        metadata,
+                        ManagedVideoTrackInput::new(
+                            fixture.source.clone(),
+                            fixture.display.clone(),
+                        )
+                        .unwrap(),
+                        None,
+                    )
+                    .unwrap(),
+                    cursor: fixture.cursor.clone(),
+                })
+                .collect(),
+            cursor_assets: fixture.assets.clone(),
+        };
+        let output = Arc::new(crate::AudioOutput::new_headless(Box::new(|_, _| {})));
+        let session = crate::PreparingPlaybackSession::spawn(
+            input,
+            (0..count)
+                .map(|_| crate::PreparingAudioSegmentInput {
+                    mic: None,
+                    system_audio: None,
+                    timing_repair: Default::default(),
+                })
+                .collect(),
+            crate::PreparingPlaybackOptions {
+                preview: PreparingPreviewOptions::default(),
+                fps: 30,
+                resolution: XY::new(320, 240),
+            },
+            output.clone(),
+            Box::new(|_, _, _| {}),
+        )
+        .unwrap();
+        let handoff = session.handoff_handle();
+        let completed_audio =
+            tokio::time::timeout(Duration::from_secs(30), handoff.take_completed_audio())
+                .await
+                .unwrap()
+                .unwrap();
+        let entry = fixture.metadata.project_path.join("editor-entry");
+        std::fs::create_dir(&entry).unwrap();
+        let (frames, mut received) = watch::channel(None);
+        let candidate = crate::EditorInstance::new_with_startup_inputs(
+            entry.join(".."),
+            |_| {},
+            Box::new(move |output, _| {
+                let frame = match output {
+                    crate::EditorFrameOutput::Rgba(frame) => frame.frame_number,
+                    crate::EditorFrameOutput::Nv12(frame) => frame.frame_number,
+                    #[cfg(target_os = "macos")]
+                    crate::EditorFrameOutput::Surface(frame) => frame.frame_number,
+                };
+                frames.send_replace(Some(frame));
+            }),
+            None,
+            crate::EditorFrameFormat::Rgba,
+            output,
+            crate::EditorStartupInputs {
+                recordings: None,
+                completed_audio: Some(completed_audio),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(candidate.segment_medias.len(), count);
+        let mut updates = session.updates();
+        tokio::time::timeout(Duration::from_secs(30), async {
+            while !updates.borrow_and_update().progress.preview_available {
+                updates.changed().await.unwrap();
+            }
+        })
+        .await
+        .unwrap();
+        candidate.install_preparing_handoff(&handoff).await.unwrap();
+        candidate
+            .preview_tx
+            .send(Some((0, 30, XY::new(320, 240))))
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                if received
+                    .borrow_and_update()
+                    .is_some_and(|frame| candidate.commit_preparing_frame(frame, 30))
+                {
+                    break;
+                }
+                received.changed().await.unwrap();
+            }
+        })
+        .await
+        .unwrap();
+        assert!(handoff.committed());
+        candidate.dispose().await;
+        let exit = handoff.stop_and_wait().await;
+        assert!(!exit.cleanup_failed, "{:?}", exit.error);
+        drop(candidate);
+        drop(handoff);
+        drop(session);
+        drop(fixture.source);
+        assert!(fixture.released.load(Ordering::Acquire));
+    }
 }
 
 async fn failed_handoff_installation_retires_native_candidate(cancelled: bool) {

--- a/crates/recording/src/studio_recording.rs
+++ b/crates/recording/src/studio_recording.rs
@@ -521,9 +521,16 @@ impl Actor {
         }
         let result = self.handle_stop_inner(discard, ctx).await;
         if let Some(mut diagnostic) = self.diagnostic.take() {
+            let segment_count = match &result {
+                Ok(recording) => match &recording.meta {
+                    StudioRecordingMeta::SingleSegment { .. } => 1,
+                    StudioRecordingMeta::MultipleSegments { inner } => inner.segments.len(),
+                },
+                Err(_) => self.segments.len(),
+            };
             diagnostic.field(cap_utils::operation_diagnostics::Field::number(
                 "segments",
-                self.segments.len() as u64,
+                segment_count as u64,
             ));
             diagnostic.finish(result.is_ok());
         }

--- a/crates/recording/src/studio_recording.rs
+++ b/crates/recording/src/studio_recording.rs
@@ -511,27 +511,29 @@ impl Actor {
         }
     }
 
+    fn update_diagnostic_segment_count(&mut self) {
+        if let Some(diagnostic) = &mut self.diagnostic {
+            diagnostic.field(cap_utils::operation_diagnostics::Field::number(
+                "segments",
+                self.segments.len() as u64,
+            ));
+        }
+    }
+
     async fn handle_stop(
         &mut self,
         discard: bool,
         ctx: &mut Context<Self, anyhow::Result<CompletedRecording>>,
     ) -> anyhow::Result<CompletedRecording> {
+        self.update_diagnostic_segment_count();
         if let Some(diagnostic) = &mut self.diagnostic {
             diagnostic.stage(if discard { "discarding" } else { "finalizing" });
         }
         let result = self.handle_stop_inner(discard, ctx).await;
-        if let Some(mut diagnostic) = self.diagnostic.take() {
-            let segment_count = match &result {
-                Ok(recording) => match &recording.meta {
-                    StudioRecordingMeta::SingleSegment { .. } => 1,
-                    StudioRecordingMeta::MultipleSegments { inner } => inner.segments.len(),
-                },
-                Err(_) => self.segments.len(),
-            };
-            diagnostic.field(cap_utils::operation_diagnostics::Field::number(
-                "segments",
-                segment_count as u64,
-            ));
+        if !self.segments.is_empty() {
+            self.update_diagnostic_segment_count();
+        }
+        if let Some(diagnostic) = self.diagnostic.take() {
             diagnostic.finish(result.is_ok());
         }
         result
@@ -620,6 +622,7 @@ impl Actor {
             })
         };
 
+        self.update_diagnostic_segment_count();
         let recording = stop_recording(
             self.recording_dir.clone(),
             std::mem::take(&mut self.segments),
@@ -3680,6 +3683,124 @@ mod tests {
             minimum_segment_stop_deadline(false, segment_start),
             Some(segment_start + Duration::from_secs(1))
         );
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    #[tokio::test]
+    async fn stop_diagnostics_retain_segment_counts_when_final_metadata_cannot_be_saved() {
+        use cap_utils::operation_diagnostics::{Operation, snapshot};
+
+        for fail_metadata in [false, true] {
+            for count in [1, 2] {
+                let directory = tempfile::tempdir().unwrap();
+                let root = directory.path();
+                if fail_metadata {
+                    std::fs::create_dir(root.join("recording-meta.json")).unwrap();
+                }
+                let (completion_tx, _) = watch::channel(None);
+                let segment_factory = SegmentPipelineFactory::new(
+                    root.join("content/segments"),
+                    root.join("content/cursors"),
+                    RecordingBaseInputs {
+                        capture_target: screen_capture::ScreenCaptureTarget::CameraOnly,
+                        capture_system_audio: false,
+                        mic_feed: None,
+                        camera_feed: None,
+                        #[cfg(target_os = "macos")]
+                        shareable_content: None,
+                        #[cfg(target_os = "macos")]
+                        excluded_windows: Vec::new(),
+                    },
+                    false,
+                    false,
+                    false,
+                    false,
+                    30,
+                    crate::StudioQuality::Balanced,
+                    completion_tx.clone(),
+                );
+                let timestamps = Timestamps::now();
+                let segments = (0..count)
+                    .map(|index| {
+                        let path = root.join(format!("display-{index}.mp4"));
+                        std::fs::write(&path, b"preserved capture").unwrap();
+                        RecordingSegment {
+                            start: index as f64,
+                            end: index as f64 + 1.0,
+                            pipeline: FinishedPipeline {
+                                start_time: timestamps,
+                                screen: test_finished_output_pipeline_at(
+                                    path,
+                                    Timestamp::Instant(timestamps.instant()),
+                                    Some(test_video_info()),
+                                    30,
+                                ),
+                                microphone: None,
+                                camera: None,
+                                system_audio: None,
+                                cursor: None,
+                                track_failures: Vec::new(),
+                            },
+                            camera_device_id: None,
+                            mic_device_id: None,
+                        }
+                    })
+                    .collect();
+                let diagnostic = Operation::start("studio_recording", &[]);
+                let operation_id = serde_json::to_value(diagnostic.id()).unwrap();
+                let actor = Actor::spawn(Actor {
+                    diagnostic: Some(diagnostic),
+                    recording_dir: root.to_path_buf(),
+                    state: Some(ActorState::Paused {
+                        next_index: count,
+                        cursors: Default::default(),
+                        next_cursor_id: 0,
+                    }),
+                    all_tracks_stopped: true,
+                    terminal_stop_failure: None,
+                    #[cfg(windows)]
+                    cancel_error: None,
+                    segment_factory,
+                    segments,
+                    completion_tx,
+                    display_notch: None,
+                });
+                let result = actor.ask(Stop).await;
+                if fail_metadata {
+                    assert!(result.is_err());
+                } else {
+                    assert!(result.is_ok());
+                }
+                let snapshot = serde_json::to_value(snapshot()).unwrap();
+                let record = snapshot["records"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .find(|record| record["operationId"] == operation_id)
+                    .unwrap();
+                assert_eq!(
+                    record["outcome"],
+                    if fail_metadata {
+                        "returned_error"
+                    } else {
+                        "returned_ok"
+                    }
+                );
+                let segments = record["fields"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .find(|field| field["name"] == "segments")
+                    .unwrap();
+                assert_eq!(segments["value"].as_u64(), Some(u64::from(count)));
+                for index in 0..count {
+                    assert_eq!(
+                        std::fs::read(root.join(format!("display-{index}.mp4"))).unwrap(),
+                        b"preserved capture"
+                    );
+                }
+            }
+        }
     }
 
     #[cfg(any(target_os = "macos", windows))]


### PR DESCRIPTION
Stopping a Windows Studio recording can show “Preparing audio does not match this editor's completed sources or output” even though reopening it succeeds. The preparation and editor paths refer to the same folder with different Windows path spellings. Resolve unequal project paths before comparing them in the shared editor handoff used by GPUI and Tauri, while retaining strict track and output identity checks. Also preserve the segment count before transferring sources to finalization, so successful and failed stops both report the recorded segments.

Validation: 87 focused audio/preparation/diagnostic tests passed on macOS, including native rendering of silent one- and two-clip recordings and audio reuse through equivalent editor paths. The path-identity and metadata-save-failure regressions fail before the fix and pass afterward; the failure test also checks that source files remain unchanged. Scoped cargo check, formatting, and diff checks passed. Native Windows and Linux UI replay of the fixed binary remains unverified.

Strict Clippy remains blocked by pre-existing lints in unchanged `preparing_audio/output.rs` and `recovery/preparing_projection.rs`; no lint errors were reported in changed files.






<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63409340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no new actionable findings and the previously reported diagnostic-count issue resolved.

<h3>Summary</h3>

- Adds equivalent-path handling and regression coverage for populated and silent audio handoffs.
- Adds native preview coverage for one- and two-segment silent recordings opened through equivalent paths.
- Preserves diagnostic segment counts across successful stops and metadata-save failures.

<sub>Reviews (3) · Last reviewed commit: ["fix: retain segment diagnostics when fin..."](https://github.com/capsoftware/cap/commit/b1b081d9d4a86bb7c413d40db5e3b3f4948d15a3)</sub>

<!-- /greptile_comment -->