### PR TITLE
fix(auth): burn email OTP verification token on attempt to prevent brute force (#2221)

### DIFF
--- a/apps/web/__tests__/unit/use-verification-token.test.ts
+++ b/apps/web/__tests__/unit/use-verification-token.test.ts
@@ -1,0 +1,165 @@
+import type { MySql2Database } from "drizzle-orm/mysql2";
+import { describe, expect, it, vi } from "vitest";
+import { DrizzleAdapter } from "../../../../packages/database/auth/drizzle-adapter";
+
+describe("DrizzleAdapter.useVerificationToken", () => {
+	it("burns token immediately and returns null on wrong token guess", async () => {
+		const targetEmail = "victim@example.com";
+		const realToken = "847291";
+		const wrongGuess = "123456";
+		const expires = new Date(Date.now() + 600_000);
+
+		let deleted = false;
+		const mockDb = {
+			select: vi.fn(() => ({
+				from: vi.fn(() => ({
+					where: vi.fn(() => ({
+						limit: vi.fn(() =>
+							Promise.resolve([
+								{
+									identifier: targetEmail,
+									token: realToken,
+									expires,
+								},
+							]),
+						),
+					})),
+				})),
+			})),
+			delete: vi.fn(() => ({
+				where: vi.fn(() => {
+					deleted = true;
+					return Promise.resolve([]);
+				}),
+			})),
+		} as unknown as MySql2Database;
+
+		const adapter = DrizzleAdapter(mockDb, { getSsoIdentity: () => null });
+		if (!adapter.useVerificationToken)
+			throw new Error("useVerificationToken not implemented");
+
+		const result = await adapter.useVerificationToken({
+			identifier: targetEmail,
+			token: wrongGuess,
+		});
+
+		expect(result).toBeNull();
+		expect(deleted).toBe(true);
+		expect(mockDb.delete).toHaveBeenCalledTimes(1);
+	});
+
+	it("burns token and returns null when token has expired", async () => {
+		const targetEmail = "user@example.com";
+		const token = "654321";
+		const expiredDate = new Date(Date.now() - 10_000);
+
+		let deleted = false;
+		const mockDb = {
+			select: vi.fn(() => ({
+				from: vi.fn(() => ({
+					where: vi.fn(() => ({
+						limit: vi.fn(() =>
+							Promise.resolve([
+								{
+									identifier: targetEmail,
+									token,
+									expires: expiredDate,
+								},
+							]),
+						),
+					})),
+				})),
+			})),
+			delete: vi.fn(() => ({
+				where: vi.fn(() => {
+					deleted = true;
+					return Promise.resolve([]);
+				}),
+			})),
+		} as unknown as MySql2Database;
+
+		const adapter = DrizzleAdapter(mockDb, { getSsoIdentity: () => null });
+		if (!adapter.useVerificationToken)
+			throw new Error("useVerificationToken not implemented");
+
+		const result = await adapter.useVerificationToken({
+			identifier: targetEmail,
+			token: token,
+		});
+
+		expect(result).toBeNull();
+		expect(deleted).toBe(true);
+	});
+
+	it("burns token and returns valid token object when token and identifier match", async () => {
+		const targetEmail = "User@Example.Com";
+		const validToken = "998877";
+		const expires = new Date(Date.now() + 600_000);
+
+		let deleted = false;
+		const mockDb = {
+			select: vi.fn(() => ({
+				from: vi.fn(() => ({
+					where: vi.fn(() => ({
+						limit: vi.fn(() =>
+							Promise.resolve([
+								{
+									identifier: targetEmail.toLowerCase(),
+									token: validToken,
+									expires,
+								},
+							]),
+						),
+					})),
+				})),
+			})),
+			delete: vi.fn(() => ({
+				where: vi.fn(() => {
+					deleted = true;
+					return Promise.resolve([]);
+				}),
+			})),
+		} as unknown as MySql2Database;
+
+		const adapter = DrizzleAdapter(mockDb, { getSsoIdentity: () => null });
+		if (!adapter.useVerificationToken)
+			throw new Error("useVerificationToken not implemented");
+
+		const result = await adapter.useVerificationToken({
+			identifier: targetEmail,
+			token: validToken,
+		});
+
+		expect(result).not.toBeNull();
+		expect(result?.token).toBe(validToken);
+		expect(result?.identifier).toBe(targetEmail.toLowerCase());
+		expect(deleted).toBe(true);
+	});
+
+	it("returns null without deleting when no token exists for identifier", async () => {
+		const mockDb = {
+			select: vi.fn(() => ({
+				from: vi.fn(() => ({
+					where: vi.fn(() => ({
+						limit: vi.fn(() => Promise.resolve([])),
+					})),
+				})),
+			})),
+			delete: vi.fn(() => ({
+				where: vi.fn(() => Promise.resolve([])),
+			})),
+		} as unknown as MySql2Database;
+
+		const adapter = DrizzleAdapter(mockDb, { getSsoIdentity: () => null });
+		if (!adapter.useVerificationToken)
+			throw new Error("useVerificationToken not implemented");
+
+		const result = await adapter.useVerificationToken({
+			identifier: "nonexistent@example.com",
+			token: "111111",
+		});
+
+		expect(result).toBeNull();
+		expect(mockDb.delete).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/__tests__/unit/use-verification-token.test.ts
+++ b/apps/web/__tests__/unit/use-verification-token.test.ts
@@ -2,6 +2,43 @@ import type { MySql2Database } from "drizzle-orm/mysql2";
 import { describe, expect, it, vi } from "vitest";
 import { DrizzleAdapter } from "../../../../packages/database/auth/drizzle-adapter";
 
+function createMockDb(initialRow?: {
+	identifier: string;
+	token: string;
+	expires: Date;
+}) {
+	let row = initialRow;
+	let deleted = false;
+
+	const createChain = () => {
+		const chain = {
+			for: vi.fn(() => chain),
+			limit: vi.fn(() => Promise.resolve(row ? [row] : [])),
+		};
+		return chain;
+	};
+
+	const db = {
+		select: vi.fn(() => ({
+			from: vi.fn(() => ({
+				where: vi.fn(() => createChain()),
+			})),
+		})),
+		delete: vi.fn(() => ({
+			where: vi.fn(() => {
+				deleted = true;
+				row = undefined;
+				return Promise.resolve([]);
+			}),
+		})),
+	} as unknown as MySql2Database;
+
+	return {
+		db,
+		wasDeleted: () => deleted,
+	};
+}
+
 describe("DrizzleAdapter.useVerificationToken", () => {
 	it("burns token immediately and returns null on wrong token guess", async () => {
 		const targetEmail = "victim@example.com";
@@ -9,32 +46,13 @@ describe("DrizzleAdapter.useVerificationToken", () => {
 		const wrongGuess = "123456";
 		const expires = new Date(Date.now() + 600_000);
 
-		let deleted = false;
-		const mockDb = {
-			select: vi.fn(() => ({
-				from: vi.fn(() => ({
-					where: vi.fn(() => ({
-						limit: vi.fn(() =>
-							Promise.resolve([
-								{
-									identifier: targetEmail,
-									token: realToken,
-									expires,
-								},
-							]),
-						),
-					})),
-				})),
-			})),
-			delete: vi.fn(() => ({
-				where: vi.fn(() => {
-					deleted = true;
-					return Promise.resolve([]);
-				}),
-			})),
-		} as unknown as MySql2Database;
+		const mock = createMockDb({
+			identifier: targetEmail,
+			token: realToken,
+			expires,
+		});
 
-		const adapter = DrizzleAdapter(mockDb, { getSsoIdentity: () => null });
+		const adapter = DrizzleAdapter(mock.db, { getSsoIdentity: () => null });
 		if (!adapter.useVerificationToken)
 			throw new Error("useVerificationToken not implemented");
 
@@ -44,8 +62,7 @@ describe("DrizzleAdapter.useVerificationToken", () => {
 		});
 
 		expect(result).toBeNull();
-		expect(deleted).toBe(true);
-		expect(mockDb.delete).toHaveBeenCalledTimes(1);
+		expect(mock.wasDeleted()).toBe(true);
 	});
 
 	it("burns token and returns null when token has expired", async () => {
@@ -53,42 +70,23 @@ describe("DrizzleAdapter.useVerificationToken", () => {
 		const token = "654321";
 		const expiredDate = new Date(Date.now() - 10_000);
 
-		let deleted = false;
-		const mockDb = {
-			select: vi.fn(() => ({
-				from: vi.fn(() => ({
-					where: vi.fn(() => ({
-						limit: vi.fn(() =>
-							Promise.resolve([
-								{
-									identifier: targetEmail,
-									token,
-									expires: expiredDate,
-								},
-							]),
-						),
-					})),
-				})),
-			})),
-			delete: vi.fn(() => ({
-				where: vi.fn(() => {
-					deleted = true;
-					return Promise.resolve([]);
-				}),
-			})),
-		} as unknown as MySql2Database;
+		const mock = createMockDb({
+			identifier: targetEmail,
+			token,
+			expires: expiredDate,
+		});
 
-		const adapter = DrizzleAdapter(mockDb, { getSsoIdentity: () => null });
+		const adapter = DrizzleAdapter(mock.db, { getSsoIdentity: () => null });
 		if (!adapter.useVerificationToken)
 			throw new Error("useVerificationToken not implemented");
 
 		const result = await adapter.useVerificationToken({
 			identifier: targetEmail,
-			token: token,
+			token,
 		});
 
 		expect(result).toBeNull();
-		expect(deleted).toBe(true);
+		expect(mock.wasDeleted()).toBe(true);
 	});
 
 	it("burns token and returns valid token object when token and identifier match", async () => {
@@ -96,32 +94,13 @@ describe("DrizzleAdapter.useVerificationToken", () => {
 		const validToken = "998877";
 		const expires = new Date(Date.now() + 600_000);
 
-		let deleted = false;
-		const mockDb = {
-			select: vi.fn(() => ({
-				from: vi.fn(() => ({
-					where: vi.fn(() => ({
-						limit: vi.fn(() =>
-							Promise.resolve([
-								{
-									identifier: targetEmail.toLowerCase(),
-									token: validToken,
-									expires,
-								},
-							]),
-						),
-					})),
-				})),
-			})),
-			delete: vi.fn(() => ({
-				where: vi.fn(() => {
-					deleted = true;
-					return Promise.resolve([]);
-				}),
-			})),
-		} as unknown as MySql2Database;
+		const mock = createMockDb({
+			identifier: targetEmail.toLowerCase(),
+			token: validToken,
+			expires,
+		});
 
-		const adapter = DrizzleAdapter(mockDb, { getSsoIdentity: () => null });
+		const adapter = DrizzleAdapter(mock.db, { getSsoIdentity: () => null });
 		if (!adapter.useVerificationToken)
 			throw new Error("useVerificationToken not implemented");
 
@@ -133,24 +112,13 @@ describe("DrizzleAdapter.useVerificationToken", () => {
 		expect(result).not.toBeNull();
 		expect(result?.token).toBe(validToken);
 		expect(result?.identifier).toBe(targetEmail.toLowerCase());
-		expect(deleted).toBe(true);
+		expect(mock.wasDeleted()).toBe(true);
 	});
 
 	it("returns null without deleting when no token exists for identifier", async () => {
-		const mockDb = {
-			select: vi.fn(() => ({
-				from: vi.fn(() => ({
-					where: vi.fn(() => ({
-						limit: vi.fn(() => Promise.resolve([])),
-					})),
-				})),
-			})),
-			delete: vi.fn(() => ({
-				where: vi.fn(() => Promise.resolve([])),
-			})),
-		} as unknown as MySql2Database;
+		const mock = createMockDb(undefined);
 
-		const adapter = DrizzleAdapter(mockDb, { getSsoIdentity: () => null });
+		const adapter = DrizzleAdapter(mock.db, { getSsoIdentity: () => null });
 		if (!adapter.useVerificationToken)
 			throw new Error("useVerificationToken not implemented");
 
@@ -160,6 +128,83 @@ describe("DrizzleAdapter.useVerificationToken", () => {
 		});
 
 		expect(result).toBeNull();
-		expect(mockDb.delete).not.toHaveBeenCalled();
+		expect(mock.wasDeleted()).toBe(false);
+	});
+
+	it("ensures atomic single consumption under concurrent verification attempts", async () => {
+		const targetEmail = "concurrent@example.com";
+		const validToken = "554433";
+		const expires = new Date(Date.now() + 600_000);
+
+		let tokenRecord:
+			| {
+					identifier: string;
+					token: string;
+					expires: Date;
+			  }
+			| undefined = {
+			identifier: targetEmail,
+			token: validToken,
+			expires,
+		};
+
+		let lock = Promise.resolve();
+
+		const mockDb = {
+			transaction: vi.fn(
+				async (cb: (tx: MySql2Database) => Promise<unknown>) => {
+					const currentLock = lock;
+					let releaseLock: () => void = () => {};
+					lock = new Promise((resolve) => {
+						releaseLock = resolve;
+					});
+					await currentLock;
+					try {
+						const tx = {
+							select: vi.fn(() => ({
+								from: vi.fn(() => ({
+									where: vi.fn(() => ({
+										for: vi.fn(() => ({
+											limit: vi.fn(() =>
+												Promise.resolve(tokenRecord ? [tokenRecord] : []),
+											),
+										})),
+									})),
+								})),
+							})),
+							delete: vi.fn(() => ({
+								where: vi.fn(() => {
+									tokenRecord = undefined;
+									return Promise.resolve([]);
+								}),
+							})),
+						} as unknown as MySql2Database;
+						return await cb(tx);
+					} finally {
+						releaseLock();
+					}
+				},
+			),
+		} as unknown as MySql2Database;
+
+		const adapter = DrizzleAdapter(mockDb, { getSsoIdentity: () => null });
+		if (!adapter.useVerificationToken)
+			throw new Error("useVerificationToken not implemented");
+
+		const [result1, result2] = await Promise.all([
+			adapter.useVerificationToken({
+				identifier: targetEmail,
+				token: validToken,
+			}),
+			adapter.useVerificationToken({
+				identifier: targetEmail,
+				token: validToken,
+			}),
+		]);
+
+		const successCount = [result1, result2].filter((r) => r !== null).length;
+		const nullCount = [result1, result2].filter((r) => r === null).length;
+		expect(successCount).toBe(1);
+		expect(nullCount).toBe(1);
 	});
 });

--- a/packages/database/auth/drizzle-adapter.ts
+++ b/packages/database/auth/drizzle-adapter.ts
@@ -456,30 +456,49 @@ export function DrizzleAdapter(
 			return row;
 		},
 		async useVerificationToken({ identifier, token }) {
-			const rows = await db
-				.select()
-				.from(verificationTokens)
-				.where(eq(verificationTokens.token, token))
-				.limit(1);
+			const normalizedIdentifier = identifier?.toLowerCase() ?? "";
+			const rows = normalizedIdentifier
+				? await db
+						.select()
+						.from(verificationTokens)
+						.where(eq(verificationTokens.identifier, normalizedIdentifier))
+						.limit(1)
+				: await db
+						.select()
+						.from(verificationTokens)
+						.where(eq(verificationTokens.token, token))
+						.limit(1);
 			const row = rows[0];
 			if (!row) {
 				console.warn("[useVerificationToken] No token found");
 				return null;
 			}
-			const normalizedIdentifier = identifier?.toLowerCase() ?? "";
-			const storedIdentifier = row.identifier?.toLowerCase() ?? "";
-			if (normalizedIdentifier !== storedIdentifier) {
-				console.warn("[useVerificationToken] Identifier mismatch");
-				return null;
-			}
+
 			await db
 				.delete(verificationTokens)
 				.where(
 					and(
-						eq(verificationTokens.token, token),
 						eq(verificationTokens.identifier, row.identifier),
+						eq(verificationTokens.token, row.token),
 					),
 				);
+
+			const storedIdentifier = row.identifier?.toLowerCase() ?? "";
+			if (normalizedIdentifier && normalizedIdentifier !== storedIdentifier) {
+				console.warn("[useVerificationToken] Identifier mismatch");
+				return null;
+			}
+
+			if (row.expires.valueOf() < Date.now()) {
+				console.warn("[useVerificationToken] Token expired");
+				return null;
+			}
+
+			if (row.token !== token) {
+				console.warn("[useVerificationToken] Token mismatch");
+				return null;
+			}
+
 			return { ...row, identifier: storedIdentifier };
 		},
 	};

--- a/packages/database/auth/drizzle-adapter.ts
+++ b/packages/database/auth/drizzle-adapter.ts
@@ -457,49 +457,79 @@ export function DrizzleAdapter(
 		},
 		async useVerificationToken({ identifier, token }) {
 			const normalizedIdentifier = identifier?.toLowerCase() ?? "";
-			const rows = normalizedIdentifier
-				? await db
-						.select()
-						.from(verificationTokens)
-						.where(eq(verificationTokens.identifier, normalizedIdentifier))
-						.limit(1)
-				: await db
-						.select()
-						.from(verificationTokens)
-						.where(eq(verificationTokens.token, token))
-						.limit(1);
-			const row = rows[0];
-			if (!row) {
-				console.warn("[useVerificationToken] No token found");
-				return null;
-			}
+			const runVerification = async (tx: MySql2Database) => {
+				const builder = normalizedIdentifier
+					? tx
+							.select()
+							.from(verificationTokens)
+							.where(eq(verificationTokens.identifier, normalizedIdentifier))
+					: tx
+							.select()
+							.from(verificationTokens)
+							.where(eq(verificationTokens.token, token));
 
-			await db
-				.delete(verificationTokens)
-				.where(
-					and(
-						eq(verificationTokens.identifier, row.identifier),
-						eq(verificationTokens.token, row.token),
-					),
-				);
+				const lockedQuery =
+					typeof (builder as unknown as { for: unknown }).for === "function"
+						? (
+								builder as unknown as {
+									for: (mode: string) => unknown;
+								}
+							).for("update")
+						: builder;
 
-			const storedIdentifier = row.identifier?.toLowerCase() ?? "";
-			if (normalizedIdentifier && normalizedIdentifier !== storedIdentifier) {
-				console.warn("[useVerificationToken] Identifier mismatch");
-				return null;
-			}
+				const limitedQuery =
+					typeof (lockedQuery as unknown as { limit: unknown }).limit ===
+					"function"
+						? (
+								lockedQuery as unknown as {
+									limit: (
+										n: number,
+									) => Promise<Array<typeof verificationTokens.$inferSelect>>;
+								}
+							).limit(1)
+						: lockedQuery;
 
-			if (row.expires.valueOf() < Date.now()) {
-				console.warn("[useVerificationToken] Token expired");
-				return null;
-			}
+				const rows = await (limitedQuery as Promise<
+					Array<typeof verificationTokens.$inferSelect>
+				>);
 
-			if (row.token !== token) {
-				console.warn("[useVerificationToken] Token mismatch");
-				return null;
-			}
+				const row = rows[0];
+				if (!row) {
+					console.warn("[useVerificationToken] No token found");
+					return null;
+				}
 
-			return { ...row, identifier: storedIdentifier };
+				await tx
+					.delete(verificationTokens)
+					.where(
+						and(
+							eq(verificationTokens.identifier, row.identifier),
+							eq(verificationTokens.token, row.token),
+						),
+					);
+
+				const storedIdentifier = row.identifier?.toLowerCase() ?? "";
+				if (normalizedIdentifier && normalizedIdentifier !== storedIdentifier) {
+					console.warn("[useVerificationToken] Identifier mismatch");
+					return null;
+				}
+
+				if (row.expires.valueOf() < Date.now()) {
+					console.warn("[useVerificationToken] Token expired");
+					return null;
+				}
+
+				if (row.token !== token) {
+					console.warn("[useVerificationToken] Token mismatch");
+					return null;
+				}
+
+				return { ...row, identifier: storedIdentifier };
+			};
+
+			return db.transaction
+				? await db.transaction(runVerification)
+				: await runVerification(db);
 		},
 	};
 }


### PR DESCRIPTION
Resolves #2221

### Summary
`useVerificationToken` in `packages/database/auth/drizzle-adapter.ts` previously queried exclusively by `verificationTokens.token`. On an incorrect 6-digit code guess, no row was matched, leaving the active token untouched in the database for its full 10-minute TTL and exposing email OTP logins to brute-force attacks.

This fix aligns NextAuth email OTP verification with the security invariant already enforced in the mobile login route (`apps/web/app/api/mobile/[...route]/route.ts:543-548`):
1. Looks up the verification record by `normalizedIdentifier` (falling back to `token` if identifier is absent).
2. Deletes the verification row from the database immediately upon the attempt, burning the code on the first wrong attempt.
3. Evaluates identifier match, expiration, and token equality. Returns `null` on any mismatch or expiration with the token safely burned.

### Testing
Added unit tests in `apps/web/__tests__/unit/use-verification-token.test.ts`:
- Token is immediately burned and returns `null` on an incorrect token guess.
- Token is burned and returns `null` when expired.
- Token is burned and returns valid token record on matching credentials.
- Returns `null` without attempting deletion when no token exists for identifier.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63486590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 1/5</h2>

This PR is not safe to merge until arbitrary OTP invalidation and non-atomic concurrent consumption are addressed.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Arbitrary OTP invalidation** <a href="https://github.com/CapSoftware/Cap/pull/2286#discussion_r3997519645">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Token consumption remains non\-atomic** <a href="https://github.com/CapSoftware/Cap/pull/2286#discussion_r3997519647">▶</a>
3. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Mocks ignore database predicates** <a href="https://github.com/CapSoftware/Cap/pull/2286#discussion_r3997519651">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
packages/database/auth/drizzle-adapter.ts:460-465
An unauthenticated caller can submit a victim’s email with any incorrect code. The identifier-only lookup finds the victim’s active verification row and deletes it before checking whether the supplied code matches. Because the email callback has no server-side attempt limit, repeated requests can continuously invalidate newly issued codes and prevent the victim from signing in.

**How this was verified:** The unauthenticated email callback forwards the supplied identifier and token to this adapter, which selects by identifier and deletes using the stored token before comparing it with the supplied token.

### Issue 2
packages/database/auth/drizzle-adapter.ts:477-484
Concurrent callbacks can both read the live row before either deletes it. Since the deletion result is ignored, a request whose deletion affected no rows still validates and returns its previously read token. This allows parallel redemption of a nominally single-use code and lets concurrent guesses race the intended burn. Require deletion of exactly one row, or consume the token atomically, before returning it.

**How this was verified:** The code performs separate pooled SELECT and DELETE statements and returns the previously selected row without checking whether its DELETE removed anything.

### Issue 3
apps/web/__tests__/unit/use-verification-token.test.ts:16-33
The SELECT mock always returns its configured row without checking the WHERE clause, and the DELETE mock only records that it was called. These tests would therefore still pass if the implementation queried or deleted the wrong row-for example, if it queried by the incorrect guessed token and a real database would leave the active token untouched. Assert the predicates against seeded rows or use a data-backed database fixture so the tests protect the security behavior.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- Adds first-attempt token burning for incorrect and expired codes.
- Adds unit coverage for successful, incorrect, expired, and missing-token cases.
- The resulting path permits arbitrary invalidation of another user’s token and does not atomically enforce single consumption.
- The test doubles do not validate the database predicates central to the fix.

<sub>Reviews (1) · Last reviewed commit: ["fix(auth): burn verification token on ve..."](https://github.com/capsoftware/cap/commit/3a05910815c75e9b1d1fb8e70fedfb774de21877)</sub>

<!-- /greptile_comment -->