### PR TITLE
fix(share): return to video after signing in from denied share page (#2192)

### DIFF
--- a/apps/web/__tests__/unit/share-policy-denied.test.ts
+++ b/apps/web/__tests__/unit/share-policy-denied.test.ts
@@ -1,0 +1,70 @@
+import { isValidElement, type ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+import { PolicyDeniedView } from "../../app/s/[videoId]/_components/PolicyDeniedView";
+
+describe("PolicyDeniedView", () => {
+	it("renders private video sign in link and button with next param", () => {
+		const videoId = "vid12345";
+		const view = PolicyDeniedView({ videoId });
+		expect(isValidElement(view)).toBe(true);
+
+		const children = (view as ReactElement<{ children: ReactElement[] }>).props
+			.children;
+		const titleElement = children[1];
+		const buttonElement = children[3];
+
+		expect(titleElement.props.children).toBe("This video is private");
+		expect(buttonElement).toBeDefined();
+
+		const linkChild = buttonElement.props.children;
+		expect(linkChild.props.href).toBe("/login?next=%2Fs%2Fvid12345");
+	});
+
+	it("renders email restriction login required with next param", () => {
+		const videoId = "restricted987";
+		const view = PolicyDeniedView({
+			videoId,
+			reason: "email_restriction_login_required",
+		});
+		expect(isValidElement(view)).toBe(true);
+
+		const children = (view as ReactElement<{ children: ReactElement[] }>).props
+			.children;
+		const titleElement = children[1];
+		const buttonElement = children[3];
+
+		expect(titleElement.props.children).toBe("This video requires sign-in");
+		expect(buttonElement).toBeDefined();
+
+		const linkChild = buttonElement.props.children;
+		expect(linkChild.props.href).toBe("/login?next=%2Fs%2Frestricted987");
+	});
+
+	it("renders email restriction denied without sign in button", () => {
+		const videoId = "restricted987";
+		const view = PolicyDeniedView({
+			videoId,
+			reason: "email_restriction_denied",
+		});
+		expect(isValidElement(view)).toBe(true);
+
+		const children = (
+			view as ReactElement<{ children: (ReactElement | boolean)[] }>
+		).props.children;
+		const titleElement = children[1] as ReactElement;
+		const buttonElement = children[3];
+
+		expect(titleElement.props.children).toBe("Access restricted");
+		expect(buttonElement).toBe(false);
+	});
+
+	it("falls back to /login when videoId is not provided", () => {
+		const view = PolicyDeniedView({});
+		const children = (view as ReactElement<{ children: ReactElement[] }>).props
+			.children;
+		const buttonElement = children[3];
+		expect(buttonElement).toBeDefined();
+		const linkChild = buttonElement.props.children;
+		expect(linkChild.props.href).toBe("/login");
+	});
+});

--- a/apps/web/app/s/[videoId]/_components/PolicyDeniedView.tsx
+++ b/apps/web/app/s/[videoId]/_components/PolicyDeniedView.tsx
@@ -1,0 +1,56 @@
+import { Button, Logo } from "@cap/ui";
+import Link from "next/link";
+import type React from "react";
+
+export interface PolicyDeniedViewProps {
+	videoId?: string;
+	reason?: string;
+}
+
+export function PolicyDeniedView({ videoId, reason }: PolicyDeniedViewProps) {
+	const loginHref = videoId
+		? `/login?next=${encodeURIComponent(`/s/${videoId}`)}`
+		: "/login";
+	let title = "This video is private";
+	let description: React.ReactNode = (
+		<>
+			If you own this video, please{" "}
+			<Link href={loginHref} className="underline">
+				sign in
+			</Link>{" "}
+			to manage sharing.
+		</>
+	);
+	let showLoginButton = true;
+
+	if (reason === "email_restriction_login_required") {
+		title = "This video requires sign-in";
+		description = (
+			<>
+				The owner of this video has restricted access. Please{" "}
+				<Link href={loginHref} className="underline">
+					sign in
+				</Link>{" "}
+				with an authorized email address to view.
+			</>
+		);
+	} else if (reason === "email_restriction_denied") {
+		title = "Access restricted";
+		description =
+			"Your email address does not meet the requirements set by the video owner.";
+		showLoginButton = false;
+	}
+
+	return (
+		<div className="flex flex-col justify-center items-center p-4 min-h-screen text-center">
+			<Logo className="size-32" />
+			<h1 className="mb-2 text-2xl font-semibold">{title}</h1>
+			<p className="text-gray-400">{description}</p>
+			{showLoginButton && (
+				<Button asChild className="mt-6">
+					<Link href={loginHref}>Sign in</Link>
+				</Button>
+			)}
+		</div>
+	);
+}

--- a/apps/web/app/s/[videoId]/page.tsx
+++ b/apps/web/app/s/[videoId]/page.tsx
@@ -15,7 +15,6 @@ import {
 } from "@cap/database/schema";
 import type { VideoMetadata } from "@cap/database/types";
 import { buildEnv, serverEnv } from "@cap/env";
-import { Logo } from "@cap/ui";
 import { userIsPro } from "@cap/utils";
 import {
 	Database,
@@ -36,7 +35,6 @@ import { and, eq, type InferSelectModel, isNull, sql } from "drizzle-orm";
 import { Effect, Option } from "effect";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getVideoAnalytics } from "@/actions/videos/get-analytics";
 import {
@@ -76,6 +74,7 @@ import { optionFromTOrFirst } from "@/utils/effect";
 import { isAiGenerationEnabled } from "@/utils/flags";
 import { PasswordOverlay } from "./_components/PasswordOverlay";
 import { PendingRecordingShare } from "./_components/PendingRecordingShare";
+import { PolicyDeniedView } from "./_components/PolicyDeniedView";
 import { ShareHeader } from "./_components/ShareHeader";
 import { Share } from "./Share";
 
@@ -184,41 +183,10 @@ async function getSharedSpacesForVideo(videoId: Video.VideoId) {
 	};
 }
 
-function PolicyDeniedView({ reason }: { reason?: string }) {
-	let title = "This video is private";
-	let description: React.ReactNode = (
-		<>
-			If you own this video, please <Link href="/login">sign in</Link> to manage
-			sharing.
-		</>
-	);
-
-	if (reason === "email_restriction_login_required") {
-		title = "This video requires sign-in";
-		description = (
-			<>
-				The owner of this video has restricted access. Please{" "}
-				<Link href="/login">sign in</Link> with an authorized email address to
-				view.
-			</>
-		);
-	} else if (reason === "email_restriction_denied") {
-		title = "Access restricted";
-		description =
-			"Your email address does not meet the requirements set by the video owner.";
-	}
-
-	return (
-		<div className="flex flex-col justify-center items-center p-4 min-h-screen text-center">
-			<Logo className="size-32" />
-			<h1 className="mb-2 text-2xl font-semibold">{title}</h1>
-			<p className="text-gray-400">{description}</p>
-		</div>
-	);
-}
-
 const renderPolicyDenied = (videoId: Video.VideoId, reason?: string) =>
-	Effect.succeed(<PolicyDeniedView key={videoId} reason={reason} />);
+	Effect.succeed(
+		<PolicyDeniedView key={videoId} videoId={videoId} reason={reason} />,
+	);
 
 const renderNoSuchElement = (awaitRecording: boolean) =>
 	awaitRecording


### PR DESCRIPTION
Resolves #2192

### Summary
When a viewer lands on a restricted share page (`/s/{videoId}` with `email_restriction_login_required` or a private video), `PolicyDeniedView` previously linked to `/login` without a `next` redirect query parameter. After authenticating, the viewer was redirected to `/dashboard` rather than back to the requested video.

This PR:
1. Passes `videoId` into `PolicyDeniedView` and constructs `loginHref = videoId ? `/login?next=${encodeURIComponent(`/s/${videoId}`)}` : "/login"`.
2. Adds a prominent "Sign in" button using `@cap/ui` `Button` (with `asChild`) for restricted access and private video views.
3. Keeps `email_restriction_denied` copy-only (omits sign-in button since the viewer is already logged in with an unauthorized domain).
4. Extracts `PolicyDeniedView` into `apps/web/app/s/[videoId]/_components/PolicyDeniedView.tsx` following the modular structure of `_components/`.

### Testing
- Added unit tests in `apps/web/__tests__/unit/share-policy-denied.test.ts` covering:
  - Private video view generating `/login?next=%2Fs%2F{videoId}` links and sign-in button.
  - `email_restriction_login_required` generating return links and sign-in button.
  - `email_restriction_denied` rendering copy-only without sign-in button.
  - Graceful fallback to `/login` when `videoId` is omitted.
- Verified all unit tests pass cleanly (4/4 tests passing).
- Validated with Biome (0 lint / formatting errors).


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63487191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with non-blocking improvements recommended for the authenticated private-video experience and test robustness.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Authenticated sign\-in loops** <a href="https://github.com/CapSoftware/Cap/pull/2287#discussion_r3997524779">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Tests depend on child order** <a href="https://github.com/CapSoftware/Cap/pull/2287#discussion_r3997524784">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
apps/web/app/s/[videoId]/_components/PolicyDeniedView.tsx:10-13
A signed-in non-owner can reach this private-video view, but both sign-in links send them to `/login?next=/s/{videoId}`. Because the login page detects the existing session and immediately returns them to the same denied page, this action creates a no-op redirect loop. This is non-blocking, but the sign-in option should only appear for anonymous viewers, or authenticated viewers should get an account-switch path.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

### Issue 2
apps/web/__tests__/unit/share-policy-denied.test.ts:11-18
These tests inspect unrendered React children through fixed array positions. An unrelated markup reorder will break them, while they do not verify the actual anchor produced by `Button`, Radix `Slot`, and Next.js `Link`. This makes the tests brittle and gives less confidence in the rendered behavior; render the component to static markup and assert its visible text and anchor attributes instead. The same pattern also appears in the other tests in this file.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- Passes the video ID into the denial view and encodes the share route in the login `next` parameter.
- Adds a prominent sign-in button for private and login-required views.
- Keeps domain-denied views copy-only.
- Adds unit coverage for denial reasons and generated destinations.

<sub>Reviews (1) · Last reviewed commit: ["fix(share): redirect back to video after..."](https://github.com/capsoftware/cap/commit/5e42833530da4c02ac57f4b527d1e3ea9fceec85)</sub>

<!-- /greptile_comment -->