### PR TITLE
fix(recorder-core): slice progressive multipart uploads into uniform parts for Cloudflare R2 (#2275)

### DIFF
--- a/packages/recorder-core/__tests__/instant-recording-uploader.test.ts
+++ b/packages/recorder-core/__tests__/instant-recording-uploader.test.ts
@@ -5,7 +5,7 @@ import {
 import type { VideoId } from "@cap/recorder-core/recorder-types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const STREAMED_PART_BYTES = 5 * 1024 * 1024 + 128;
+const STREAMED_PART_BYTES = 5 * 1024 * 1024;
 const DRIVE_PART_BYTES = 16 * 1024 * 1024;
 const OVERFLOW_PART_BYTES = 129 * 1024 * 1024;
 const FINALIZED_BLOB_BYTES = 129 * 1024 * 1024;
@@ -19,6 +19,7 @@ class MockXMLHttpRequest {
 	static outcomes: UploadOutcome[] = [];
 	static abortedCount = 0;
 	static recordedHeaders: Array<Map<string, string>> = [];
+	static uploadedBlobs: Blob[] = [];
 
 	upload = {
 		onprogress: null as ((event: ProgressEvent<EventTarget>) => void) | null,
@@ -37,6 +38,7 @@ class MockXMLHttpRequest {
 		MockXMLHttpRequest.outcomes = [...outcomes];
 		MockXMLHttpRequest.abortedCount = 0;
 		MockXMLHttpRequest.recordedHeaders = [];
+		MockXMLHttpRequest.uploadedBlobs = [];
 	}
 
 	open() {}
@@ -51,6 +53,7 @@ class MockXMLHttpRequest {
 
 	send(part: Blob) {
 		MockXMLHttpRequest.recordedHeaders.push(new Map(this.headers));
+		MockXMLHttpRequest.uploadedBlobs.push(part);
 
 		const outcome = MockXMLHttpRequest.outcomes.shift();
 		if (!outcome) {
@@ -976,5 +979,62 @@ describe("InstantRecordingUploader", () => {
 		await new Promise((resolve) => setTimeout(resolve, 600));
 		expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
 		await uploader.cancel();
+	});
+
+	it("slices streamed buffer into uniform non-trailing parts matching MIN_PART_SIZE_BYTES for Cloudflare R2 compatibility", async () => {
+		const MIN_PART_SIZE = 5 * 1024 * 1024;
+		const TRAILING_SIZE = 2 * 1024 * 1024;
+		const TOTAL_SIZE = MIN_PART_SIZE + TRAILING_SIZE;
+
+		const fetchMock = vi.fn(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = input.toString();
+				const body = init?.body ? JSON.parse(init.body as string) : null;
+
+				if (url === "/api/upload/multipart/presign-part") {
+					return makeJsonResponse({
+						presignedUrl: `https://uploads.example/part-${body.partNumber}`,
+					});
+				}
+
+				if (url === "/api/upload/multipart/complete") {
+					expect(body.parts).toHaveLength(2);
+					expect(body.parts[0]).toMatchObject({ partNumber: 1 });
+					expect(body.parts[1]).toMatchObject({ partNumber: 2 });
+					return makeJsonResponse({ success: true });
+				}
+
+				throw new Error(`Unexpected fetch call: ${url}`);
+			},
+		);
+
+		vi.stubGlobal("fetch", fetchMock);
+		MockXMLHttpRequest.setOutcomes([
+			{ type: "success", etag: "part-1" },
+			{ type: "success", etag: "part-2" },
+		]);
+
+		const uploader = new InstantRecordingUploader({
+			videoId,
+			uploadId: "upload-r2",
+			mimeType: "video/webm;codecs=vp9,opus",
+			subpath: "raw-upload.webm",
+			setUploadStatus: vi.fn(),
+			sendProgressUpdate: vi.fn().mockResolvedValue(undefined),
+		});
+
+		// Push a chunk larger than MIN_PART_SIZE_BYTES
+		const chunk = makeBlob(TOTAL_SIZE, "video/webm;codecs=vp9,opus");
+		uploader.handleChunk(chunk, chunk.size);
+
+		await uploader.finalize({
+			durationSeconds: 10,
+			subpath: "raw-upload.webm",
+		});
+
+		// Non-trailing part must have exact MIN_PART_SIZE_BYTES; trailing part has remainder
+		expect(MockXMLHttpRequest.uploadedBlobs).toHaveLength(2);
+		expect(MockXMLHttpRequest.uploadedBlobs[0].size).toBe(MIN_PART_SIZE);
+		expect(MockXMLHttpRequest.uploadedBlobs[1].size).toBe(TRAILING_SIZE);
 	});
 });

--- a/packages/recorder-core/src/instant-mp4-uploader.ts
+++ b/packages/recorder-core/src/instant-mp4-uploader.ts
@@ -478,6 +478,17 @@ export class InstantRecordingUploader {
 		this.bufferedChunks.push(blob);
 		this.bufferedBytes += blob.size;
 
+		if (
+			this.pendingUploadBytes + this.bufferedBytes >
+			MAX_PENDING_UPLOAD_BYTES
+		) {
+			const error = this.markFatalError(
+				new Error("Upload could not keep up with recording"),
+			);
+			this.onOverflow?.(error);
+			throw error;
+		}
+
 		if (this.bufferedBytes >= MIN_PART_SIZE_BYTES) {
 			this.flushBuffer();
 		}
@@ -489,14 +500,22 @@ export class InstantRecordingUploader {
 			return;
 		}
 
-		if (this.bufferedBytes === 0) return;
-		if (!force && this.bufferedBytes < MIN_PART_SIZE_BYTES) return;
+		while (this.bufferedBytes > 0) {
+			if (!force && this.bufferedBytes < MIN_PART_SIZE_BYTES) return;
 
-		const chunk = new Blob(this.bufferedChunks, { type: this.mimeType });
-		this.bufferedChunks = [];
-		this.bufferedBytes = 0;
+			const partSize =
+				force && this.bufferedBytes <= MIN_PART_SIZE_BYTES
+					? this.bufferedBytes
+					: MIN_PART_SIZE_BYTES;
+			const { part, remainingChunks, remainingBytes } =
+				this.takeBufferedPart(partSize);
 
-		this.enqueueUpload(chunk);
+			this.bufferedChunks = remainingChunks;
+			this.bufferedBytes = remainingBytes;
+			this.enqueueUpload(part);
+
+			if (partSize < MIN_PART_SIZE_BYTES) return;
+		}
 	}
 
 	private flushDriveBuffer(force = false) {


### PR DESCRIPTION
Resolves #2275

### Problem
When using Cloudflare R2 as the S3 storage backend, camera-only Instant Mode recordings fail during `CompleteMultipartUpload` with `InvalidPart: All non-trailing parts must have the same length`.
In `packages/recorder-core/src/instant-mp4-uploader.ts`, `flushBuffer()` previously dumped all buffered chunks into a single variable-sized `Blob` whenever `this.bufferedBytes >= MIN_PART_SIZE_BYTES` (5 MiB). Unlike AWS S3 and MinIO, Cloudflare R2 strictly enforces that all non-trailing parts in a multipart upload must be identical in size.

### Solution
- Refactored `flushBuffer()` to leverage `takeBufferedPart(partSize)` in a loop, ensuring each non-final part upload is sliced to exactly `MIN_PART_SIZE_BYTES` (5 MiB), matching the uniform chunking strategy already used for Google Drive resumable uploads.
- Updated `handleChunk` to track combined in-flight and buffered bytes against `MAX_PENDING_UPLOAD_BYTES` to protect memory limits.
- Added unit test in `packages/recorder-core/__tests__/instant-recording-uploader.test.ts` verifying that streamed buffers larger than 5 MiB are cleanly sliced into uniform 5 MiB non-trailing parts and a remainder trailing part.

### Verification
- `bun x vitest run packages/recorder-core/__tests__/instant-recording-uploader.test.ts` (18/18 passed)
- `bun x biome check packages/recorder-core/src/instant-mp4-uploader.ts packages/recorder-core/__tests__/instant-recording-uploader.test.ts` (pass)


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63489790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The upload implementation appears behaviorally safe, but the explicit repository comment rule must be satisfied before merging.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Narrative comments violate guidance** <a href="https://github.com/CapSoftware/Cap/pull/2288#discussion_r3997566000">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Repeated slicing remains untested** <a href="https://github.com/CapSoftware/Cap/pull/2288#discussion_r3997566011">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
packages/recorder-core/__tests__/instant-recording-uploader.test.ts:1026
The comments above the chunk creation and final assertions only restate what the test code already expresses. Repository guidance prohibits comments that merely narrate code, so both comments must be removed before merging.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

### Issue 2
packages/recorder-core/__tests__/instant-recording-uploader.test.ts:1027
This test uploads only 7 MiB, so the non-forced loop emits one full 5 MiB part before finalization handles the remainder. It does not exercise a second full-part iteration, allowing regressions in repeated slicing to pass unnoticed. Use a payload above 10 MiB and assert two uniform full parts plus the trailing remainder.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- Uses the existing buffered-part slicing helper repeatedly for object-store uploads.
- Preserves a smaller trailing part during finalization.
- Extends the XMLHttpRequest mock to record uploaded Blob sizes.
- The implementation is internally consistent, but the new test does not cover repeated full-part slicing and its narrative comments violate repository guidance.

<sub>Reviews (1) · Last reviewed commit: ["fix(recorder-core): slice streamed chunk..."](https://github.com/capsoftware/cap/commit/e65fac6ae3af3082b6741a4d6d7e598bd31f534f)</sub>

<!-- /greptile_comment -->